### PR TITLE
Add regex result builder DSL prototype.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -43,6 +43,12 @@ let package = Package(
             name: "RegexTests",
             dependencies: ["Regex"]),
         .target(
+            name: "RegexDSL",
+            dependencies: ["Regex"]),
+        .testTarget(
+            name: "RegexDSLTests",
+            dependencies: ["RegexDSL"]),
+        .target(
             name: "PEG",
             dependencies: ["Util", "MatchingEngine"]),
         .testTarget(

--- a/Sources/Regex/CharacterClass.swift
+++ b/Sources/Regex/CharacterClass.swift
@@ -1,0 +1,34 @@
+public enum CharacterClass {
+  // Any character
+  case any
+  // Character.isDigit
+  case digit
+  // Character.isHexDigit
+  case hexDigit
+  // Character.isWhitespace
+  case whitespace
+  // Character.isLetter or Character.isDigit or Character == "_"
+  case word
+
+  public func matches(_ c: Character) -> Bool {
+    switch self {
+    case .any: return true
+    case .digit: return c.isNumber
+    case .hexDigit: return c.isHexDigit
+    case .whitespace: return c.isWhitespace
+    case .word: return c.isLetter || c.isNumber || c == "_"
+    }
+  }
+}
+
+extension CharacterClass: CustomStringConvertible {
+  public var description: String {
+    switch self {
+    case .any: return "<any>"
+    case .digit: return "<digit>"
+    case .hexDigit: return "<hex digit>"
+    case .whitespace: return "<whitespace>"
+    case .word: return "<word>"
+    }
+  }
+}

--- a/Sources/Regex/HareVM.swift
+++ b/Sources/Regex/HareVM.swift
@@ -113,6 +113,21 @@ public struct HareVM: VirtualMachine {
         bunny.nibble(on: input)
         bunny.hop()
 
+      case .characterClass(let cc):
+        assert(bunny.sp < input.endIndex)
+        guard cc.matches(input[bunny.sp]) else {
+          // If there are no more alternatives to try, we failed
+          guard !stack.isEmpty else {
+            return (false, [])
+          }
+
+          // Continue with the next alternative
+          bunny = stack.restore()
+          continue
+        }
+        bunny.nibble(on: input)
+        bunny.hop()
+
       case .split(let disfavoring):
         var disfavoredBunny = bunny
         disfavoredBunny.hop(to: code.lookup(disfavoring))
@@ -136,5 +151,3 @@ public struct HareVM: VirtualMachine {
     }
   }
 }
-
-

--- a/Sources/Regex/RegexCompile.swift
+++ b/Sources/Regex/RegexCompile.swift
@@ -1,7 +1,7 @@
 import Util
 
 public func compile(
-  _ regex: String, options: Options = .none
+  _ ast: AST, options: Options = .none
 ) throws -> RECode {
   var currentLabel = 0
   func createLabel() -> RECode.Instruction {
@@ -15,6 +15,9 @@ public func compile(
     case .empty: return
     case .character(let c):
       instructions.append(.character(c))
+      return
+    case .characterClass(let cc):
+      instructions.append(.characterClass(cc))
       return
     case .any:
       instructions.append(.any)
@@ -95,7 +98,6 @@ public func compile(
     }
   }
 
-  let ast = try parse(regex)
   compileNode(ast)
   instructions.append(.accept)
 
@@ -119,4 +121,11 @@ public func compile(
     splits: splits,
     numCaptures: numCaptures,
     options: options)
+}
+
+public func compile(
+  _ regex: String, options: Options = .none
+) throws -> RECode {
+  let ast = try parse(regex)
+  return try compile(ast, options: options)
 }

--- a/Sources/Regex/RegexParse.swift
+++ b/Sources/Regex/RegexParse.swift
@@ -31,6 +31,7 @@ public enum AST: Hashable {
   indirect case oneOrMore(AST)
 
   case character(Character)
+  case characterClass(CharacterClass)
   case any
   case empty
 }
@@ -46,6 +47,7 @@ extension AST: CustomStringConvertible {
     case .zeroOrOne(let rest): return ".zeroOrOne(\(rest))"
     case .oneOrMore(let rest): return ".oneOrMore(\(rest))"
     case .character(let str): return str.halfWidthCornerQuoted
+    case .characterClass(let cc): return ".characterClass(\(cc))"
     case .any: return ".any"
     case .empty: return "".halfWidthCornerQuoted
     }

--- a/Sources/Regex/TortoiseVM.swift
+++ b/Sources/Regex/TortoiseVM.swift
@@ -99,11 +99,20 @@ extension TortoiseVM {
     }
     return result
   }
+
   func advance(_ input: String, _ sp: String.Index, _ bale: Bale) -> Bale {
     var result = Bale()
     guard bale.all({ code[$0.pc].isMatching }) else {
       fatalError("should of been readThrough")
     }
+
+    func advance(_ hatchling: inout Hatchling) {
+      hatchling.plod()
+      // TODO: this is double calculated
+      let sp = input.index(after: sp)
+      result.append(contentsOf: readThrough(sp, hatchling))
+    }
+
     for hatchling in bale {
       var hatchling = hatchling
       switch code[hatchling.pc] {
@@ -112,12 +121,14 @@ extension TortoiseVM {
 
       case .character(let c):
         guard input[sp] == c else { break }
-        fallthrough
+        advance(&hatchling)
+
+      case .characterClass(let cc):
+        guard cc.matches(input[sp]) else { break }
+        advance(&hatchling)
+
       case .any:
-        hatchling.plod()
-        // TODO: this is double calculated
-        let sp = input.index(after: sp)
-        result.append(contentsOf: readThrough(sp, hatchling))
+        advance(&hatchling)
 
       default: fatalError("should of been caught by isMatching")
       }

--- a/Sources/Regex/VirtualMachine.swift
+++ b/Sources/Regex/VirtualMachine.swift
@@ -29,6 +29,9 @@ extension RECode {
     /// Consume and try to match a unit of input
     case character(Character)
 
+    /// Consume and try to match a unit of input against a character class
+    case characterClass(CharacterClass)
+
     /// Consume any unit of input
     case any
 
@@ -68,6 +71,7 @@ extension RECode.Instruction {
     switch self {
     case .accept: return true
     case .character(_): return true
+    case .characterClass(_): return true
     case .any: return true
     default: return false
     }
@@ -230,6 +234,7 @@ extension RECode.Instruction: CustomStringConvertible {
     case .nop: return "<NOP>"
     case .accept: return "<ACC>"
     case .any: return "<ANY>"
+    case .characterClass(let kind): return "<CHAR CLASS \(kind)>"
     case .character(let c): return c.halfWidthCornerQuoted
     case .split(let i): return "<SPLIT disfavoring \(i)>"
     case .goto(let label): return "<GOTO \(label)>"

--- a/Sources/RegexDSL/Builder.swift
+++ b/Sources/RegexDSL/Builder.swift
@@ -1,0 +1,54 @@
+@resultBuilder
+public enum RegexBuilder {
+  public static func buildBlock<R0: RegexProtocol>(_ r0: R0) -> R0 {
+    r0
+  }
+
+  public static func buildBlock<R0: RegexProtocol, R1: RegexProtocol>(_ r0: R0, _ r1: R1) -> Concatenate2<R0, R1> {
+    .init(r0, r1)
+  }
+
+  public static func buildBlock<R0: RegexProtocol, R1: RegexProtocol, R2: RegexProtocol>(_ r0: R0, _ r1: R1, _ r2: R2) -> Concatenate3<R0, R1, R2> {
+    .init(r0, r1, r2)
+  }
+
+  public static func buildBlock<R0: RegexProtocol, R1: RegexProtocol, R2: RegexProtocol, R3: RegexProtocol>(_ r0: R0, _ r1: R1, _ r2: R2, _ r3: R3) -> Concatenate4<R0, R1, R2, R3> {
+    .init(r0, r1, r2, r3)
+  }
+
+  public static func buildBlock<R0: RegexProtocol, R1: RegexProtocol, R2: RegexProtocol, R3: RegexProtocol, R4: RegexProtocol>(_ r0: R0, _ r1: R1, _ r2: R2, _ r3: R3, _ r4: R4) -> Concatenate5<R0, R1, R2, R3, R4> {
+    .init(r0, r1, r2, r3, r4)
+  }
+
+  public static func buildBlock<R0: RegexProtocol, R1: RegexProtocol, R2: RegexProtocol, R3: RegexProtocol, R4: RegexProtocol, R5: RegexProtocol>(_ r0: R0, _ r1: R1, _ r2: R2, _ r3: R3, _ r4: R4, _ r5: R5) -> Concatenate6<R0, R1, R2, R3, R4, R5> {
+    .init(r0, r1, r2, r3, r4, r5)
+  }
+
+  public static func buildBlock<R0: RegexProtocol, R1: RegexProtocol, R2: RegexProtocol, R3: RegexProtocol, R4: RegexProtocol, R5: RegexProtocol, R6: RegexProtocol>(_ r0: R0, _ r1: R1, _ r2: R2, _ r3: R3, _ r4: R4, _ r5: R5, _ r6: R6) -> Concatenate7<R0, R1, R2, R3, R4, R5, R6> {
+    .init(r0, r1, r2, r3, r4, r5, r6)
+  }
+
+  public static func buildBlock<R0: RegexProtocol, R1: RegexProtocol, R2: RegexProtocol, R3: RegexProtocol, R4: RegexProtocol, R5: RegexProtocol, R6: RegexProtocol, R7: RegexProtocol>(_ r0: R0, _ r1: R1, _ r2: R2, _ r3: R3, _ r4: R4, _ r5: R5, _ r6: R6, _ r7: R7) -> Concatenate8<R0, R1, R2, R3, R4, R5, R6, R7> {
+    .init(r0, r1, r2, r3, r4, r5, r6, r7)
+  }
+
+  public static func buildBlock<R0: RegexProtocol, R1: RegexProtocol, R2: RegexProtocol, R3: RegexProtocol, R4: RegexProtocol, R5: RegexProtocol, R6: RegexProtocol, R7: RegexProtocol, R8: RegexProtocol>(_ r0: R0, _ r1: R1, _ r2: R2, _ r3: R3, _ r4: R4, _ r5: R5, _ r6: R6, _ r7: R7, _ r8: R8) -> Concatenate9<R0, R1, R2, R3, R4, R5, R6, R7, R8> {
+    .init(r0, r1, r2, r3, r4, r5, r6, r7, r8)
+  }
+
+  public static func buildBlock<R0: RegexProtocol, R1: RegexProtocol, R2: RegexProtocol, R3: RegexProtocol, R4: RegexProtocol, R5: RegexProtocol, R6: RegexProtocol, R7: RegexProtocol, R8: RegexProtocol, R9: RegexProtocol>(_ r0: R0, _ r1: R1, _ r2: R2, _ r3: R3, _ r4: R4, _ r5: R5, _ r6: R6, _ r7: R7, _ r8: R8, _ r9: R9) -> Concatenate10<R0, R1, R2, R3, R4, R5, R6, R7, R8, R9> {
+    .init(r0, r1, r2, r3, r4, r5, r6, r7, r8, r9)
+  }
+
+  public static func buildEither<R: RegexProtocol>(first component: R) -> R {
+    component
+  }
+
+  public static func buildEither<R: RegexProtocol>(second component: R) -> R {
+    component
+  }
+
+  public static func buildLimitedAvailability<R: RegexProtocol>(_ component: R) -> Optionally<R> {
+    .init(component)
+  }
+}

--- a/Sources/RegexDSL/Core.swift
+++ b/Sources/RegexDSL/Core.swift
@@ -1,0 +1,102 @@
+import Regex
+@_exported import enum Regex.CharacterClass
+
+fileprivate typealias DefaultEngine = TortoiseVM
+
+public struct RegexMatch<CapturedValue> {
+  // TODO: Add transformed captures.
+  public let capturedSubstrings: [[Substring]]
+}
+
+/// A compiled regular expression.
+internal class RegexProgram {
+  let ast: AST
+  lazy private(set) var executable: RECode = {
+    do {
+      return try compile(ast)
+    } catch {
+      fatalError("Regex engine internal error: \(String(describing: error))")
+    }
+  }()
+
+  init(ast: AST) {
+    self.ast = ast
+  }
+}
+
+/// A type that represents a regular expression.
+public protocol RegexProtocol {
+  associatedtype CaptureValue
+  var regex: Regex<CaptureValue> { get }
+}
+
+/// A regular expression.
+public struct Regex<CaptureValue>: RegexProtocol {
+  let program: RegexProgram
+  var ast: AST { program.ast }
+
+  init(ast: AST) {
+    self.program = RegexProgram(ast: ast)
+  }
+
+  public init<Content: RegexProtocol>(
+    _ content: Content
+  ) where Content.CaptureValue == CaptureValue {
+    self = content.regex
+  }
+
+  public init<Content: RegexProtocol>(
+    @RegexBuilder _ content: () -> Content
+  ) where Content.CaptureValue == CaptureValue {
+    self.init(content())
+  }
+
+  public var regex: Regex<CaptureValue> {
+    self
+  }
+}
+
+extension RegexProtocol {
+  public func match(in input: String) -> RegexMatch<CaptureValue>? {
+    match(in: input, using: DefaultEngine.self)
+  }
+
+  // TODO: Support anything that conforms to `StringProtocol` rather than just `String`.
+  internal func match(
+    in input: String,
+    using engine: VirtualMachine.Type
+  ) -> RegexMatch<CaptureValue>? {
+    let vm = engine.init(regex.program.executable)
+    let (didMatch, captures) = vm.execute(input: input)
+    guard didMatch else {
+      return nil
+    }
+    return RegexMatch(capturedSubstrings: captures.map { $0.asSubstrings(from: input) })
+  }
+}
+
+extension String {
+  public func match<R: RegexProtocol>(_ regex: R) -> RegexMatch<R.CaptureValue>? {
+    regex.match(in: self)
+  }
+
+  internal func match<R: RegexProtocol>(
+    _ regex: R,
+    using engine: VirtualMachine.Type
+  ) -> RegexMatch<R.CaptureValue>? {
+    regex.match(in: self, using: engine)
+  }
+
+  public func match<R: RegexProtocol>(
+    @RegexBuilder _ content: () -> R
+  ) -> RegexMatch<R.CaptureValue>? {
+    match(content())
+  }
+
+  internal func match<R: RegexProtocol>(
+    using engine: VirtualMachine.Type,
+    @RegexBuilder _ content: () -> R
+  ) -> RegexMatch<R.CaptureValue>? {
+    match(content(), using: engine)
+  }
+}

--- a/Sources/RegexDSL/DSL.swift
+++ b/Sources/RegexDSL/DSL.swift
@@ -1,0 +1,220 @@
+import Regex
+
+// MARK: - Primitives
+
+extension String: RegexProtocol {
+  public typealias CaptureValue = ()
+
+  public var regex: Regex<CaptureValue> {
+    .init(ast: .concatenation(map(AST.character)))
+  }
+}
+
+extension Character: RegexProtocol {
+  public typealias CaptureValue = ()
+
+  public var regex: Regex<CaptureValue> {
+    .init(ast: .character(self))
+  }
+}
+
+extension CharacterClass: RegexProtocol {
+  public typealias CaptureValue = ()
+
+  public var regex: Regex<CaptureValue> {
+    .init(ast: .characterClass(self))
+  }
+}
+
+// MARK: - Combinators
+
+// MARK: Concatenation
+
+public struct Concatenate2<R0: RegexProtocol, R1: RegexProtocol>: RegexProtocol {
+  public let regex: Regex<(R0.CaptureValue, R1.CaptureValue)>
+
+  public init(_ r0: R0, _ r1: R1) {
+    regex = .init(ast: .concatenation([r0.regex.ast, r1.regex.ast]))
+  }
+}
+
+public struct Concatenate3<R0: RegexProtocol, R1: RegexProtocol, R2: RegexProtocol>: RegexProtocol {
+  public let regex: Regex<(R0.CaptureValue, R1.CaptureValue, R2.CaptureValue)>
+
+  public init(_ r0: R0, _ r1: R1, _ r2: R2) {
+    regex = .init(ast: .concatenation([r0.regex.ast, r1.regex.ast, r2.regex.ast]))
+  }
+}
+
+public struct Concatenate4<R0: RegexProtocol, R1: RegexProtocol, R2: RegexProtocol, R3: RegexProtocol>: RegexProtocol {
+  public let regex: Regex<(R0.CaptureValue, R1.CaptureValue, R2.CaptureValue, R3.CaptureValue)>
+
+  public init(_ r0: R0, _ r1: R1, _ r2: R2, _ r3: R3) {
+    regex = .init(ast: .concatenation([r0.regex.ast, r1.regex.ast, r2.regex.ast, r3.regex.ast]))
+  }
+}
+
+public struct Concatenate5<R0: RegexProtocol, R1: RegexProtocol, R2: RegexProtocol, R3: RegexProtocol, R4: RegexProtocol>: RegexProtocol {
+  public let regex: Regex<(R0.CaptureValue, R1.CaptureValue, R2.CaptureValue, R3.CaptureValue, R4.CaptureValue)>
+
+  public init(_ r0: R0, _ r1: R1, _ r2: R2, _ r3: R3, _ r4: R4) {
+    regex = .init(ast: .concatenation([r0.regex.ast, r1.regex.ast, r2.regex.ast, r3.regex.ast, r4.regex.ast]))
+  }
+}
+
+public struct Concatenate6<R0: RegexProtocol, R1: RegexProtocol, R2: RegexProtocol, R3: RegexProtocol, R4: RegexProtocol, R5: RegexProtocol>: RegexProtocol {
+  public let regex: Regex<(R0.CaptureValue, R1.CaptureValue, R2.CaptureValue, R3.CaptureValue, R4.CaptureValue)>
+
+  public init(_ r0: R0, _ r1: R1, _ r2: R2, _ r3: R3, _ r4: R4, _ r5: R5) {
+    regex = .init(ast: .concatenation([r0.regex.ast, r1.regex.ast, r2.regex.ast, r3.regex.ast, r4.regex.ast, r5.regex.ast]))
+  }
+}
+
+public struct Concatenate7<R0: RegexProtocol, R1: RegexProtocol, R2: RegexProtocol, R3: RegexProtocol, R4: RegexProtocol, R5: RegexProtocol, R6: RegexProtocol>: RegexProtocol {
+  public let regex: Regex<(R0.CaptureValue, R1.CaptureValue, R2.CaptureValue, R3.CaptureValue, R4.CaptureValue, R5.CaptureValue, R6.CaptureValue)>
+
+  public init(_ r0: R0, _ r1: R1, _ r2: R2, _ r3: R3, _ r4: R4, _ r5: R5, _ r6: R6) {
+    regex = .init(ast: .concatenation([r0.regex.ast, r1.regex.ast, r2.regex.ast, r3.regex.ast, r4.regex.ast, r5.regex.ast, r6.regex.ast]))
+  }
+}
+
+public struct Concatenate8<R0: RegexProtocol, R1: RegexProtocol, R2: RegexProtocol, R3: RegexProtocol, R4: RegexProtocol, R5: RegexProtocol, R6: RegexProtocol, R7: RegexProtocol>: RegexProtocol {
+  public let regex: Regex<(R0.CaptureValue, R1.CaptureValue, R2.CaptureValue, R3.CaptureValue, R4.CaptureValue, R5.CaptureValue, R6.CaptureValue, R7.CaptureValue)>
+
+  public init(_ r0: R0, _ r1: R1, _ r2: R2, _ r3: R3, _ r4: R4, _ r5: R5, _ r6: R6, _ r7: R7) {
+    regex = .init(ast: .concatenation([r0.regex.ast, r1.regex.ast, r2.regex.ast, r3.regex.ast, r4.regex.ast, r5.regex.ast, r6.regex.ast, r7.regex.ast]))
+  }
+}
+
+public struct Concatenate9<R0: RegexProtocol, R1: RegexProtocol, R2: RegexProtocol, R3: RegexProtocol, R4: RegexProtocol, R5: RegexProtocol, R6: RegexProtocol, R7: RegexProtocol, R8: RegexProtocol>: RegexProtocol {
+  public let regex: Regex<(R0.CaptureValue, R1.CaptureValue, R2.CaptureValue, R3.CaptureValue, R4.CaptureValue, R5.CaptureValue, R6.CaptureValue, R7.CaptureValue, R8.CaptureValue)>
+
+  public init(_ r0: R0, _ r1: R1, _ r2: R2, _ r3: R3, _ r4: R4, _ r5: R5, _ r6: R6, _ r7: R7, _ r8: R8) {
+    regex = .init(ast: .concatenation([r0.regex.ast, r1.regex.ast, r2.regex.ast, r3.regex.ast, r4.regex.ast, r5.regex.ast, r6.regex.ast, r7.regex.ast, r8.regex.ast]))
+  }
+}
+
+public struct Concatenate10<R0: RegexProtocol, R1: RegexProtocol, R2: RegexProtocol, R3: RegexProtocol, R4: RegexProtocol, R5: RegexProtocol, R6: RegexProtocol, R7: RegexProtocol, R8: RegexProtocol, R9: RegexProtocol>: RegexProtocol {
+  public let regex: Regex<(R0.CaptureValue, R1.CaptureValue, R2.CaptureValue, R3.CaptureValue, R4.CaptureValue, R5.CaptureValue, R6.CaptureValue, R7.CaptureValue, R8.CaptureValue, R9.CaptureValue)>
+
+  public init(_ r0: R0, _ r1: R1, _ r2: R2, _ r3: R3, _ r4: R4, _ r5: R5, _ r6: R6, _ r7: R7, _ r8: R8, _ r9: R9) {
+    regex = .init(ast: .concatenation([r0.regex.ast, r1.regex.ast, r2.regex.ast, r3.regex.ast, r4.regex.ast, r5.regex.ast, r6.regex.ast, r7.regex.ast, r8.regex.ast, r9.regex.ast]))
+  }
+}
+
+// TODO: We want variadic generics!
+// public struct Concatenate<R...: RegexContent>: RegexContent {
+//   public let regex: Regex<(R...).filter { $0 != Void.self }>
+//
+//   public init(_ components: R...) {
+//     regex = .init(ast: .concatenation([#splat(components...)]))
+//   }
+// }
+
+// MARK: Repetition
+
+/// A regular expression.
+public struct OneOrMore<Component: RegexProtocol>: RegexProtocol {
+  public typealias CaptureValue = [Component.CaptureValue]
+
+  public let regex: Regex<CaptureValue>
+
+  public init(_ component: Component) {
+    self.regex = .init(ast: .oneOrMore(component.regex.ast))
+  }
+
+  public init(@RegexBuilder _ content: () -> Component) {
+    self.init(content())
+  }
+}
+
+postfix operator .+
+
+public postfix func .+ <R: RegexProtocol>(lhs: R) -> OneOrMore<R> {
+  .init(lhs)
+}
+
+public struct Repeat<Component: RegexProtocol>: RegexProtocol {
+  public typealias CaptureValue = [Component.CaptureValue]
+
+  public let regex: Regex<CaptureValue>
+
+  public init(_ component: Component) {
+    self.regex = .init(ast: .many(component.regex.ast))
+  }
+
+  public init(@RegexBuilder _ content: () -> Component) {
+    self.init(content())
+  }
+}
+
+postfix operator .*
+
+public postfix func .* <R: RegexProtocol>(lhs: R) -> Repeat<R> {
+  .init(lhs)
+}
+
+public struct Optionally<Component: RegexProtocol>: RegexProtocol {
+  public typealias CaptureValue = Component.CaptureValue?
+
+  public let regex: Regex<CaptureValue>
+
+  public init(_ component: Component) {
+    self.regex = .init(ast: .zeroOrOne(component.regex.ast))
+  }
+
+  public init(@RegexBuilder _ content: () -> Component) {
+    self.init(content())
+  }
+}
+
+postfix operator .?
+
+public postfix func .? <R: RegexProtocol>(lhs: R) -> Optionally<R> {
+  .init(lhs)
+}
+
+public struct Alternation<First: RegexProtocol, Second: RegexProtocol>: RegexProtocol {
+  public enum CaptureValue {
+    case first(First)
+    case second(Second)
+  }
+
+  public let regex: Regex<CaptureValue>
+
+  public init(_ first: First, _ second: Second) {
+    regex = .init(ast: .alternation([first.regex.ast, second.regex.ast]))
+  }
+
+  public init(@RegexBuilder _ content: () -> Alternation<First, Second>) {
+    self = content()
+  }
+}
+
+public func | <First: RegexProtocol, Second: RegexProtocol>(
+  lhs: First, rhs: Second
+) -> Alternation<First, Second> {
+  .init(lhs, rhs)
+}
+
+// MARK: - Capture
+
+public struct CapturingGroup<Component: RegexProtocol>: RegexProtocol {
+  public typealias CaptureValue = Component.CaptureValue
+
+  public let regex: Regex<CaptureValue>
+
+  public init(_ component: Component) {
+    self.regex = .init(ast: .capturingGroup(component.regex.ast))
+  }
+
+  public init(@RegexBuilder _ content: () -> Component) {
+    self.init(content())
+  }
+}
+
+extension RegexProtocol {
+  public func capture() -> CapturingGroup<Self> {
+    .init(self)
+  }
+}

--- a/Tests/RegexDSLTests/RegexDSLTests.swift
+++ b/Tests/RegexDSLTests/RegexDSLTests.swift
@@ -1,0 +1,116 @@
+import XCTest
+@testable import RegexDSL
+import Regex
+import Util
+
+class RegexDSLTests: XCTestCase {
+  static let engines: [VirtualMachine.Type] = [HareVM.self, TortoiseVM.self]
+
+  func forEachEngine(
+    except exceptions: VirtualMachine.Type...,
+    do body: (VirtualMachine.Type) throws -> Void
+  ) rethrows -> Void {
+    for engine in Self.engines {
+      if !exceptions.contains(where: { $0 == engine }) {
+        try body(engine)
+      }
+    }
+  }
+
+  func testSimpleStrings() throws {
+    try forEachEngine { engine in
+      let maybeMatch = "abc".match(using: engine) {
+        "a"
+        "b".capture()
+        "c".capture()
+      }
+      let match = try XCTUnwrap(maybeMatch)
+      XCTAssertEqual(match.capturedSubstrings, [["b"], ["c"]])
+    }
+  }
+
+  func testCharacterClasses() throws {
+    try forEachEngine { engine in
+      let maybeMatch = "a c".match(using: engine) {
+        CharacterClass.any
+        CharacterClass.whitespace.capture()
+        "c".capture()
+      }
+      let match = try XCTUnwrap(maybeMatch)
+      XCTAssertEqual(match.capturedSubstrings, [[" "], ["c"]])
+    }
+  }
+
+  func testCombinators() throws {
+    try forEachEngine { engine in
+      let maybeMatch = "aaaabccccdddk".match {
+        "a".+
+        OneOrMore("b").capture()
+        Repeat("c").capture()
+        "d".capture().*
+        "e".?
+        ("t" | "k").capture()
+      }
+      let match = try XCTUnwrap(maybeMatch)
+      XCTAssertEqual(match.capturedSubstrings, [["b"], ["cccc"], ["d", "d", "d"], ["k"]])
+    }
+  }
+
+  func testNestedGroups() throws {
+    try forEachEngine { engine in
+      let maybeMatch = "aaaabccccddd".match(using: engine) {
+        "a".+
+        OneOrMore {
+          OneOrMore("b").capture()
+          Repeat("c").capture()
+          "d".capture().*
+          "e".?
+        }.capture()
+      }
+      let match = try XCTUnwrap(maybeMatch)
+      XCTAssertEqual(match.capturedSubstrings, [["bccccddd"], ["b"], ["cccc"], ["d", "d", "d"]])
+    }
+  }
+
+  func testUnicodeScalarPostProcessing() throws {
+    // FIXME: HareVM currently fails at assertion `assert(bunny.sp < input.endIndex)`.
+    try forEachEngine(except: HareVM.self) { engine in
+      let spaces = Regex {
+        Repeat {
+          CharacterClass.whitespace
+        }
+      }
+
+      let unicodeScalar = Regex {
+        OneOrMore {
+          CharacterClass.hexDigit
+        }
+        spaces
+      }
+
+      let unicodeData = Regex {
+        unicodeScalar
+        Optionally {
+          ".."
+          unicodeScalar
+        }
+
+        ";"
+        spaces
+
+        OneOrMore {
+          CharacterClass.word
+        }.capture()
+
+        Repeat {
+          CharacterClass.any
+        }
+      }
+
+      let unicodeLine =
+        "1BCA0..1BCA3  ; Control # Cf   [4] SHORTHAND FORMAT LETTER OVERLAP..SHORTHAND FORMAT UP STEP"
+      let match = try XCTUnwrap(unicodeLine.match(unicodeData, using: engine))
+      XCTAssertEqual(match.capturedSubstrings, [["Control"]])
+    }
+  }
+}


### PR DESCRIPTION
This patch includes:
- Combinators: concatenation (up to 10-ary), repetition (`OneOrMore`/`.+`, `Repeat`/`.*`), optionality (`Optionally`/`.?`), alternation (`Alternation`/`|`)
- Result builders: blocks (up to 10-ary), if-else, availability.
- Some basic character classes.

Note:
- Typed captures are not supported yet. I've made `Regex` generic over captured value types. Once variadic generics are supported, it will be important to filter out `()` capture types from the concatenated type sequence.
- Tests are run on both `HareVM` and `TortoiseVM`. `HareVM` may have a bug (see FIXME) so I've made the default engine be `TortoiseVM` for now.
- Based on some prototypes and fixes by @ishantheperson.