### PR TITLE
Regex scalar classes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,12 +39,12 @@ playground.xcworkspace
 # Add this line if you want to avoid checking in source code from Swift Package Manager dependencies.
 # Packages/
 # Package.pins
-# Package.resolved
+Package.resolved
 # *.xcodeproj
 #
 # Xcode automatically generates this directory with a .xcworkspacedata file and xcuserdata
 # hence it is not needed unless you have added a package configuration file to your project
-# .swiftpm
+.swiftpm
 
 .build/
 

--- a/Sources/Regex/CharacterClass.swift
+++ b/Sources/Regex/CharacterClass.swift
@@ -1,27 +1,80 @@
-public enum CharacterClass {
-  // Any character
-  case any
-  // Character.isDigit
-  case digit
-  // Character.isHexDigit
-  case hexDigit
-  // Character.isWhitespace
-  case whitespace
-  // Character.isLetter or Character.isDigit or Character == "_"
-  case word
+public struct CharacterClass: Hashable {
+  /// The actual character class to match.
+  var cc: Representation
+  
+  /// The level (character or Unicode scalar) at which to match.
+  var matchLevel: MatchLevel
+  
+  public enum Representation {
+    // Any character
+    case any
+    // Character.isDigit
+    case digit
+    // Character.isHexDigit
+    case hexDigit
+    // Character.isWhitespace
+    case whitespace
+    // Character.isLetter or Character.isDigit or Character == "_"
+    case word
+  }
+  
+  public enum MatchLevel {
+    /// Match at the extended grapheme cluster level.
+    case character
+    /// Match at the Unicode scalar level.
+    case unicodeScalar
+  }
 
-  public func matches(_ c: Character) -> Bool {
-    switch self {
-    case .any: return true
-    case .digit: return c.isNumber
-    case .hexDigit: return c.isHexDigit
-    case .whitespace: return c.isWhitespace
-    case .word: return c.isLetter || c.isNumber || c == "_"
+  /// Returns the end of the match of this character class in `str`, if
+  /// it matches.
+  public func matches(in str: String, at i: String.Index) -> String.Index? {
+    switch matchLevel {
+    case .character:
+      let c = str[i]
+      let next = str.index(after: i)
+      switch cc {
+      case .any: return next
+      case .digit: return c.isNumber ? next : nil
+      case .hexDigit: return c.isHexDigit ? next : nil
+      case .whitespace: return c.isWhitespace ? next : nil
+      case .word: return c.isLetter || c.isNumber || c == "_"
+        ? next : nil
+      }
+    case .unicodeScalar:
+      let c = str.unicodeScalars[i]
+      let next = str.unicodeScalars.index(after: i)
+      switch cc {
+      case .any: return next
+      case .digit: return c.properties.numericType != nil ? next : nil
+      case .hexDigit: return Character(c).isHexDigit ? next : nil
+      case .whitespace: return c.properties.isWhitespace ? next : nil
+      case .word: return c.properties.isAlphabetic || c == "_" ? next : nil
+      }
     }
   }
 }
 
 extension CharacterClass {
+  public static var any: CharacterClass {
+    .init(cc: .any, matchLevel: .character)
+  }
+  
+  public static var whitespace: CharacterClass {
+    .init(cc: .whitespace, matchLevel: .character)
+  }
+  
+  public static var digit: CharacterClass {
+    .init(cc: .digit, matchLevel: .character)
+  }
+  
+  public static var hexDigit: CharacterClass {
+    .init(cc: .hexDigit, matchLevel: .character)
+  }
+  
+  public static var word: CharacterClass {
+    .init(cc: .word, matchLevel: .character)
+  }
+  
   init?(_ ch: Character) {
     switch ch {
     case "s": self = .whitespace
@@ -35,7 +88,7 @@ extension CharacterClass {
 
 extension CharacterClass: CustomStringConvertible {
   public var description: String {
-    switch self {
+    switch cc {
     case .any: return "<any>"
     case .digit: return "<digit>"
     case .hexDigit: return "<hex digit>"

--- a/Sources/Regex/CharacterClass.swift
+++ b/Sources/Regex/CharacterClass.swift
@@ -6,15 +6,15 @@ public struct CharacterClass: Hashable {
   var matchLevel: MatchLevel
   
   public enum Representation {
-    // Any character
+    /// Any character
     case any
-    // Character.isDigit
+    /// Character.isDigit
     case digit
-    // Character.isHexDigit
+    /// Character.isHexDigit
     case hexDigit
-    // Character.isWhitespace
+    /// Character.isWhitespace
     case whitespace
-    // Character.isLetter or Character.isDigit or Character == "_"
+    /// Character.isLetter or Character.isDigit or Character == "_"
     case word
   }
   

--- a/Sources/Regex/CharacterClass.swift
+++ b/Sources/Regex/CharacterClass.swift
@@ -21,6 +21,18 @@ public enum CharacterClass {
   }
 }
 
+extension CharacterClass {
+  init?(_ ch: Character) {
+    switch ch {
+    case "s": self = .whitespace
+    case "d": self = .digit
+    case "w": self = .word
+      
+    default: return nil
+    }
+  }
+}
+
 extension CharacterClass: CustomStringConvertible {
   public var description: String {
     switch self {

--- a/Sources/Regex/CharacterClass.swift
+++ b/Sources/Regex/CharacterClass.swift
@@ -20,16 +20,28 @@ public struct CharacterClass: Hashable {
   
   public enum MatchLevel {
     /// Match at the extended grapheme cluster level.
-    case character
+    case graphemeCluster
     /// Match at the Unicode scalar level.
     case unicodeScalar
   }
 
+  public var scalarSemantic: Self {
+    var result = self
+    result.matchLevel = .unicodeScalar
+    return result
+  }
+  
+  public var graphemeClusterSemantic: Self {
+    var result = self
+    result.matchLevel = .graphemeCluster
+    return result
+  }
+  
   /// Returns the end of the match of this character class in `str`, if
   /// it matches.
   public func matches(in str: String, at i: String.Index) -> String.Index? {
     switch matchLevel {
-    case .character:
+    case .graphemeCluster:
       let c = str[i]
       let next = str.index(after: i)
       switch cc {
@@ -56,23 +68,23 @@ public struct CharacterClass: Hashable {
 
 extension CharacterClass {
   public static var any: CharacterClass {
-    .init(cc: .any, matchLevel: .character)
+    .init(cc: .any, matchLevel: .graphemeCluster)
   }
   
   public static var whitespace: CharacterClass {
-    .init(cc: .whitespace, matchLevel: .character)
+    .init(cc: .whitespace, matchLevel: .graphemeCluster)
   }
   
   public static var digit: CharacterClass {
-    .init(cc: .digit, matchLevel: .character)
+    .init(cc: .digit, matchLevel: .graphemeCluster)
   }
   
   public static var hexDigit: CharacterClass {
-    .init(cc: .hexDigit, matchLevel: .character)
+    .init(cc: .hexDigit, matchLevel: .graphemeCluster)
   }
   
   public static var word: CharacterClass {
-    .init(cc: .word, matchLevel: .character)
+    .init(cc: .word, matchLevel: .graphemeCluster)
   }
   
   init?(_ ch: Character) {

--- a/Sources/Regex/HareVM.swift
+++ b/Sources/Regex/HareVM.swift
@@ -60,7 +60,7 @@ public struct HareVM: VirtualMachine {
   }
 
   public func execute(input: String) -> (Bool, [CaptureStack]) {
-    assert(.accept == code.last!)
+    assert(code.last!.isAccept)
     var bunny = Leveret(
       code.startIndex, input.startIndex, numCaptures: code.numCaptures)
     var stack = BunnyStack()

--- a/Sources/Regex/RegexCompile.swift
+++ b/Sources/Regex/RegexCompile.swift
@@ -16,6 +16,9 @@ public func compile(
     case .character(let c):
       instructions.append(.character(c))
       return
+    case .unicodeScalar(let u):
+      instructions.append(.unicodeScalar(u))
+      return
     case .characterClass(let cc):
       instructions.append(.characterClass(cc))
       return

--- a/Sources/Regex/RegexParse.swift
+++ b/Sources/Regex/RegexParse.swift
@@ -126,31 +126,14 @@ extension Parser {
     case .character(let c, isEscaped: false):
       lexer.eat()
       partialResult = .character(c)
-
-    case .character("u", isEscaped: true):
+      
+    case .unicodeScalar(let u):
       lexer.eat()
-      var digits = ""
-      for _ in 0..<4 {
-        guard let tok = lexer.eat(),
-          case .character(let dig, isEscaped: false) = tok else {
-          try report("4 hex digits required after \\u")
-        }
-        digits.append(dig)
-      }
-      guard let value = UInt32(digits, radix: 16),
-            let scalar = UnicodeScalar(value)
-      else {
-        try report("invalid hex value after \\u: \(digits)")
-      }
-      partialResult = .unicodeScalar(scalar)
+      partialResult = .unicodeScalar(u)
       
     case .character(let c, isEscaped: true):
       lexer.eat()
-      if Token.MetaCharacter(rawValue: c) != nil {
-        // Escaped metacharacters have their literal values
-        partialResult = .character(c)
-
-      } else if let cc = CharacterClass(c) {
+      if let cc = CharacterClass(c) {
         // Other characters either match a character class...
         partialResult = .characterClass(cc)
 

--- a/Sources/Regex/TortoiseVM.swift
+++ b/Sources/Regex/TortoiseVM.swift
@@ -52,7 +52,7 @@ public struct TortoiseVM: VirtualMachine {
       bale = advance(input, idx, bale)
     }
     for hatchling in bale {
-      if .accept == code[hatchling.pc] {
+      if code[hatchling.pc].isAccept {
         return (true, hatchling.core.captures)
       }
     }

--- a/Sources/Regex/VirtualMachine.swift
+++ b/Sources/Regex/VirtualMachine.swift
@@ -32,6 +32,8 @@ extension RECode {
     /// Consume and try to match a unit of input against a character class
     case characterClass(CharacterClass)
 
+    case unicodeScalar(UnicodeScalar)
+    
     /// Consume any unit of input
     case any
 
@@ -79,6 +81,7 @@ extension RECode.Instruction {
     switch self {
     case .accept: return true
     case .character(_): return true
+    case .unicodeScalar(_): return true
     case .characterClass(_): return true
     case .any: return true
     default: return false
@@ -90,6 +93,8 @@ extension RECode.Instruction {
     switch self {
     case .any: return true
     case .character(_): return true
+    case .unicodeScalar(_): return true
+    case .characterClass(_): return true
     default: return false
     }
   }
@@ -137,6 +142,22 @@ extension RECode: RandomAccessCollection {
   }
   public func index(_ i: Index, offsetBy n: Int) -> Index {
     return Index(i.rawValue + n)
+  }
+}
+
+extension RECode {
+  public func withMatchLevel(_ level: CharacterClass.MatchLevel) -> RECode {
+    var result = self
+    result.instructions = result.instructions.map { inst in
+      switch inst {
+      case .characterClass(var cc):
+        cc.matchLevel = level
+        return .characterClass(cc)
+      default:
+        return inst
+      }
+    }
+    return result
   }
 }
 
@@ -244,7 +265,7 @@ extension RECode.Instruction: CustomStringConvertible {
     case .any: return "<ANY>"
     case .characterClass(let kind): return "<CHAR CLASS \(kind)>"
     case .character(let c): return c.halfWidthCornerQuoted
-    case .characterClass(let cc): return "<CLASS \(cc)>"
+    case .unicodeScalar(let u): return u.halfWidthCornerQuoted
     case .split(let i): return "<SPLIT disfavoring \(i)>"
     case .goto(let label): return "<GOTO \(label)>"
     case .label(let i): return "<\(i)>"

--- a/Sources/Regex/VirtualMachine.swift
+++ b/Sources/Regex/VirtualMachine.swift
@@ -50,8 +50,16 @@ extension RECode {
     /// End a numbered capture
     case endCapture(CaptureId)
 
+    var isAccept: Bool {
+      switch self {
+      case .accept:
+        return true
+      default:
+        return false
+      }
+    }
+    
     // Future instructions
-    //    case characterClass(CharacterClass)
     //    case ratchet
     //    case peekAhead([CharacterClass])
     //    case peekBehind([CharacterClass])
@@ -236,6 +244,7 @@ extension RECode.Instruction: CustomStringConvertible {
     case .any: return "<ANY>"
     case .characterClass(let kind): return "<CHAR CLASS \(kind)>"
     case .character(let c): return c.halfWidthCornerQuoted
+    case .characterClass(let cc): return "<CLASS \(cc)>"
     case .split(let i): return "<SPLIT disfavoring \(i)>"
     case .goto(let label): return "<GOTO \(label)>"
     case .label(let i): return "<\(i)>"

--- a/Sources/RegexDSL/Core.swift
+++ b/Sources/RegexDSL/Core.swift
@@ -1,5 +1,5 @@
 import Regex
-@_exported import enum Regex.CharacterClass
+@_exported import struct Regex.CharacterClass
 
 fileprivate typealias DefaultEngine = TortoiseVM
 

--- a/Tests/RegexTests/RegexTests.swift
+++ b/Tests/RegexTests/RegexTests.swift
@@ -226,6 +226,14 @@ class RegexTests: XCTestCase {
        ["abc", "cdef", "abcde", "abcdeff"]),
       ("ab(c|def)+", ["abc", "abdef", "abcdef", "abdefdefcdefc"],
        ["ab", "c", "abca"]),
+      
+      ("a\\sb", ["a b"], ["ab", "a  b"]),
+      ("a\\s+b", ["a b", "a    b"], ["ab", "a    c"]),
+      ("a\\dbc", ["a1bc"], ["ab2", "a1b", "a11b2", "a1b22"]),
+      // assertion failure at HareVM.swift line 117
+      // ("a\\db\\dc", ["a1b3c"], ["ab2", "a1b", "a11b2", "a1b22"]),
+      ("a\\d\\db\\dc", ["a12b3c"], ["ab2", "a1b", "a11b2", "a1b22"]),
+
       // Pathological (at least for HareVM and for now Tortoise too)
       //            ("(a*)*", ["a"], ["b"])
     ]

--- a/Tests/RegexTests/RegexTests.swift
+++ b/Tests/RegexTests/RegexTests.swift
@@ -59,6 +59,10 @@ class RegexTests: XCTestCase {
                 .leftParen, "b", .pipe, "c", .rightParen, .question, "d")
     performTest("a|b?c", "a", .pipe, "b", .question, "c")
     performTest("(?a|b)c", .leftParen, .question, "a", .pipe, "b", .rightParen, "c")
+    performTest("a\\u0065b\\u{65}c\\x65d",
+                "a", .unicodeScalar("e"),
+                "b", .unicodeScalar("e"),
+                "c", .unicodeScalar("e"), "d")
 
     // Gramatically invalid (yet lexically valid)
     performTest("|*\\\\", .pipe, .star, "\\")
@@ -104,6 +108,12 @@ class RegexTests: XCTestCase {
     performTest("a|b?c", alt("a", concat(.zeroOrOne("b"), "c")))
     performTest("(?a|b)c", concat(.capturingGroup(alt("a", "b")), "c"))
     performTest("(?.)*(?.*)", concat(.many(.capturingGroup(.characterClass(.any))), .capturingGroup(.many(.characterClass(.any)))))
+    performTest("abc\\d",concat("a", "b", "c", .characterClass(.digit)))
+    performTest("a\\u0065b\\u{00000065}c\\x65d\\U00000065",
+                concat("a", .unicodeScalar("e"),
+                       "b", .unicodeScalar("e"),
+                       "c", .unicodeScalar("e"),
+                       "d", .unicodeScalar("e")))
 
     // TODO: failure tests
   }
@@ -233,8 +243,9 @@ class RegexTests: XCTestCase {
       ("a\\db\\dc", ["a1b3c"], ["ab2", "a1b", "a11b2", "a1b22"]),
       ("a\\d\\db\\dc", ["a12b3c"], ["ab2", "a1b", "a11b2", "a1b22"]),
 
-      ("Caf\\u0065\\u0301", ["Cafe\u{301}"], ["Café", "Cafe"])
-      
+      ("Caf\\u{65}\\u0301", ["Cafe\u{301}"], ["Café", "Cafe"]),
+      ("Caf\\x65\\u0301", ["Cafe\u{301}"], ["Café", "Cafe"]),
+
       // Pathological (at least for HareVM and for now Tortoise too)
       //            ("(a*)*", ["a"], ["b"])
     ]


### PR DESCRIPTION
This also includes support for literal metacharacters like `\d` and `\w`, and a `\uhhhh` metacharacter sequence for specifying a literal Unicode scalar that doesn't combine when matching.
