### PR TITLE
Regex consumers, searchers, and backwards too!

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -64,7 +64,7 @@ let package = Package(
             dependencies: ["PTCaRet", "Util"]),
         .target(
             name: "Algorithms",
-            dependencies: []),
+            dependencies: ["Regex", "PEG"]),
         .testTarget(
             name: "AlgorithmsTests",
             dependencies: ["Algorithms"]),

--- a/Sources/Algorithms/Algorithms/FirstRange.swift
+++ b/Sources/Algorithms/Algorithms/FirstRange.swift
@@ -8,7 +8,7 @@ extension Collection {
 extension BidirectionalCollection {
   public func lastRange<S: BackwardCollectionSearcher>(_ searcher: S) -> Range<Index>? where S.Searched == Self {
     var state = searcher.initialState(self)
-    return searcher.search(self, &state)
+    return searcher.searchBack(self, &state)
   }
 }
 

--- a/Sources/Algorithms/Algorithms/Ranges.swift
+++ b/Sources/Algorithms/Algorithms/Ranges.swift
@@ -1,5 +1,5 @@
 extension Collection {
-  func ranges<S: CollectionSearcher>(_ searcher: S) -> RangesSequence<Self, S> {
+  public func ranges<S: CollectionSearcher>(_ searcher: S) -> RangesSequence<Self, S> {
     RangesSequence(base: self, searcher: searcher)
   }
 }

--- a/Sources/Algorithms/Algorithms/StartsWith.swift
+++ b/Sources/Algorithms/Algorithms/StartsWith.swift
@@ -1,11 +1,11 @@
 extension Collection {
-  func starts<C: CollectionConsumer>(with consumer: C) -> Bool where C.Consumed == Self {
+  public func starts<C: CollectionConsumer>(with consumer: C) -> Bool where C.Consumed == Self {
     consumer.consume(self) != nil
   }
 }
 
 extension BidirectionalCollection {
-  func ends<C: BackwardCollectionConsumer>(with consumer: C) -> Bool where C.Consumed == Self {
+  public func ends<C: BackwardCollectionConsumer>(with consumer: C) -> Bool where C.Consumed == Self {
     consumer.consumeBack(self) != nil
   }
 }

--- a/Sources/Algorithms/Algorithms/Trim.swift
+++ b/Sources/Algorithms/Algorithms/Trim.swift
@@ -43,7 +43,7 @@ extension RangeReplaceableCollection where Self: BidirectionalCollection {
 }
 
 extension BidirectionalCollection {
-  func trimming<C: BidirectionalCollectionConsumer>(_ consumer: C) -> SubSequence where C.Consumed == Self {
+  public func trimming<C: BidirectionalCollectionConsumer>(_ consumer: C) -> SubSequence where C.Consumed == Self {
     let start = consumer.consume(self) ?? startIndex
     let end = consumer.consumeBack(self, subrange: start..<endIndex) ?? endIndex
     return self[start..<end]

--- a/Sources/Algorithms/Consumers/RegexConsumer.swift
+++ b/Sources/Algorithms/Consumers/RegexConsumer.swift
@@ -1,0 +1,106 @@
+import Regex
+
+public struct RegexConsumer: CollectionConsumer {
+  // NOTE: existential
+  let vm: VirtualMachine
+  let referenceVM: VirtualMachine
+
+  public init(regex: String, options: REOptions = .none) {
+    let code = try! compile(regex, options: options)
+    self.vm = HareVM(code)
+    self.referenceVM = TortoiseVM(code)
+  }
+
+  public func consume(
+    _ consumed: String, subrange: Range<String.Index>
+  ) -> String.Index? {
+    let result = vm.execute(
+      input: consumed, in: subrange, .partialFromFront)
+    assert(result?.matched ==
+           referenceVM.execute(
+            input: consumed, in: subrange, .partialFromFront
+           )?.matched)
+
+    return result?.matched.upperBound
+  }
+}
+
+extension RegexConsumer: StatelessCollectionSearcher {
+  public typealias Searched = String
+
+  // TODO: We'll want to bake search into the engine so it can
+  // take advantage of the structure of the regex itself and
+  // its own internal state
+  public func search(
+    _ searched: String, subrange: Range<String.Index>
+  ) -> Range<String.Index>? {
+    // TODO: This definition should be available to any
+    // consumer conformer that wants it.
+    // TODO: What about empty consumes?
+    var (start, end) = subrange.destructure
+    while start != end {
+      if let result = consume(searched, subrange: start..<end) {
+        return start ..< result
+      }
+      searched.formIndex(after: &start)
+    }
+
+    return nil
+  }
+
+}
+
+// TODO: We'll want to bake backwards into the engine
+extension RegexConsumer: BidirectionalCollectionConsumer {
+  private func findSearchStart(
+    _ consumed: String, subrange: Range<String.Index>
+  ) -> String.Index? {
+    // TODO: This definition should be available to any
+    // consumer conformer that wants it.
+    // TODO: What about empty consumes?
+    let end = subrange.upperBound
+    var start = end
+    repeat { // FIXME: empty subrange?
+      consumed.formIndex(before: &start)
+      if consume(consumed, subrange: start..<end) != nil {
+        return start
+      }
+    } while start != subrange.lowerBound
+    return nil
+  }
+
+  public func consumeBack(
+    _ consumed: String, subrange: Range<String.Index>
+  ) -> String.Index? {
+
+    if let r = searchBack(consumed, subrange: subrange),
+       r.upperBound == subrange.upperBound
+    {
+      return r.lowerBound
+    }
+    return nil
+  }
+}
+
+// TODO: Bake in search-back to engine too
+extension RegexConsumer: StatelessBackwardCollectionSearcher {
+  public func searchBack(
+    _ searched: String, subrange: Range<String.Index>
+  ) -> Range<String.Index>? {
+    // TODO: This definition should be available to any
+    // consumer conformer that wants it.
+    // TODO: What about empty consumes?
+    let end = subrange.upperBound
+    var start = end
+    repeat { // FIXME: empty subrange?
+      searched.formIndex(before: &start)
+      if let upper = consume(searched, subrange: start..<end) {
+        return start..<upper
+      }
+    } while start != subrange.lowerBound
+
+    return nil
+  }
+
+
+}

--- a/Sources/Regex/RECode.swift
+++ b/Sources/Regex/RECode.swift
@@ -1,0 +1,192 @@
+import Util
+
+/// Object code for a regex program, to be interpreted by a VM
+///
+/// Consists of an instruction list and metadata tracking:
+///   - Locations of labels (branch destinations)
+///   - Locations of splits (branches)
+///   - Total number of captures
+///   - Various options (case-insensitive, etc)
+///
+public struct RECode {
+  public typealias InstructionList = [Instruction]
+  var instructions: InstructionList
+  var labels: [InstructionAddress]
+  var splits: [InstructionAddress]
+  var numCaptures: Int
+  var options: REOptions
+}
+
+extension RECode {
+  /// A RECode instruction.
+  public enum Instruction: Hashable {
+    /// NOP (currently unused)
+    case nop
+
+    /// Denote a sucessful match. (currently used only at the end of a program)
+    case accept
+
+    /// Consume and try to match a unit of input
+    case character(Character)
+
+    /// Consume and try to match a unit of input against a character class
+    case characterClass(CharacterClass)
+
+    case unicodeScalar(UnicodeScalar)
+
+    /// Consume any unit of input
+    case any
+
+    /// Split execution. Favored path will fall through while disfavored will branch to `disfavoring`
+    case split(disfavoring: LabelId)
+
+    /// Branch to `label`
+    case goto(label: LabelId)
+
+    /// The target of a branch, executed as a NOP
+    case label(LabelId)
+
+    /// Begin a numbered capture
+    case beginCapture(CaptureId)
+
+    /// End a numbered capture
+    case endCapture(CaptureId)
+
+    var isAccept: Bool {
+      switch self {
+      case .accept:
+        return true
+      default:
+        return false
+      }
+    }
+
+    // Future instructions
+    //    case ratchet
+    //    case peekAhead([CharacterClass])
+    //    case peekBehind([CharacterClass])
+  }
+}
+
+// Conveniences
+extension RECode.Instruction {
+  /// Fetch the label from a label instruction, else `nil`
+  var label: LabelId? {
+    guard case .label(let id) = self else { return nil }
+    return id
+  }
+
+  /// Whether this instruction particpcates in matching
+  var isMatching: Bool {
+    switch self {
+    case .accept: return true
+    case .character(_): return true
+    case .unicodeScalar(_): return true
+    case .characterClass(_): return true
+    case .any: return true
+    default: return false
+    }
+  }
+
+  /// Whether this instruction consumes the input
+  var isConsuming: Bool {
+    switch self {
+    case .any: return true
+    case .character(_): return true
+    case .unicodeScalar(_): return true
+    case .characterClass(_): return true
+    default: return false
+    }
+  }
+
+  // Convenience constructors
+  static func beginCapture(_ i: Int) -> Self { .beginCapture(CaptureId(i)) }
+  static func endCapture(_ i: Int) -> Self { .endCapture(CaptureId(i)) }
+
+  static func label(_ i: Int) -> Self { .label(LabelId(i)) }
+}
+
+public struct REOptions: OptionSet {
+  public let rawValue: Int
+
+  public static var none = REOptions(rawValue: 0)
+  public static var caseInsensitive = REOptions(rawValue: 1 << 0)
+  // Future options
+  //    ratcheting
+  //    ??? partial
+  //    ??? newlineTerminated
+
+
+  public init() {
+    self = .none
+  }
+  public init(rawValue: Int) {
+    self.rawValue = rawValue
+  }
+}
+
+// RECode as a RAC of instructions. We might want to make this instead be
+// `InstructionList` if that graduates from being an array.
+extension RECode: RandomAccessCollection {
+  public typealias Element = Instruction
+  public typealias Index = InstructionAddress
+
+  public var startIndex: Index { return Index(instructions.startIndex) }
+  public var endIndex: Index { return Index(instructions.endIndex) }
+  public subscript(_ i: Index) -> Element { return instructions[i.rawValue] }
+
+  public func index(after i: Index) -> Index {
+    return Index(i.rawValue + 1)
+  }
+  public func index(before i: Index) -> Index {
+    return Index(i.rawValue - 1)
+  }
+  public func index(_ i: Index, offsetBy n: Int) -> Index {
+    return Index(i.rawValue + n)
+  }
+}
+
+extension RECode {
+  public func withMatchLevel(_ level: CharacterClass.MatchLevel) -> RECode {
+    var result = self
+    result.instructions = result.instructions.map { inst in
+      switch inst {
+      case .characterClass(var cc):
+        cc.matchLevel = level
+        return .characterClass(cc)
+      default:
+        return inst
+      }
+    }
+    return result
+  }
+}
+
+extension RECode {
+  /// Lookup the location of a label
+  public func lookup(_ id: LabelId) -> InstructionAddress {
+    let result = labels[id.rawValue]
+    guard case .label(let lid) = self[result], lid == id else {
+      fatalError("malformed program: labels not hooked up correctly")
+    }
+    return result
+  }
+}
+
+extension RECode.Instruction: CustomStringConvertible {
+  public var description: String {
+    switch self {
+    case .nop: return "<NOP>"
+    case .accept: return "<ACC>"
+    case .any: return "<ANY>"
+    case .characterClass(let kind): return "<CHAR CLASS \(kind)>"
+    case .character(let c): return c.halfWidthCornerQuoted
+    case .unicodeScalar(let u): return u.halfWidthCornerQuoted
+    case .split(let i): return "<SPLIT disfavoring \(i)>"
+    case .goto(let label): return "<GOTO \(label)>"
+    case .label(let i): return "<\(i)>"
+    case .beginCapture(let id): return "<CAP \(id)>"
+    case .endCapture(let id): return "<END CAP \(id)>"
+    }
+  }
+}

--- a/Sources/Regex/RegexCompile.swift
+++ b/Sources/Regex/RegexCompile.swift
@@ -132,3 +132,5 @@ public func compile(
   let ast = try parse(regex)
   return try compile(ast, options: options)
 }
+
+

--- a/Sources/Regex/RegexCompile.swift
+++ b/Sources/Regex/RegexCompile.swift
@@ -1,7 +1,7 @@
 import Util
 
 public func compile(
-  _ ast: AST, options: Options = .none
+  _ ast: AST, options: REOptions = .none
 ) throws -> RECode {
   var currentLabel = 0
   func createLabel() -> RECode.Instruction {
@@ -127,7 +127,7 @@ public func compile(
 }
 
 public func compile(
-  _ regex: String, options: Options = .none
+  _ regex: String, options: REOptions = .none
 ) throws -> RECode {
   let ast = try parse(regex)
   return try compile(ast, options: options)

--- a/Sources/Regex/VirtualMachine.swift
+++ b/Sources/Regex/VirtualMachine.swift
@@ -1,177 +1,50 @@
+public enum MatchMode {
+  case wholeString
+  case partialFromFront
+}
+
+public struct MatchResult {
+  public var matched: Range<String.Index>
+  public var captures: [CaptureStack]
+
+  public var destructure: (
+    matched: Range<String.Index>, captures: [CaptureStack]
+  ) {
+    (matched, captures)
+  }
+
+  public init(
+    _ matched: Range<String.Index>, _ captures: [CaptureStack]
+  ) {
+    self.matched = matched
+    self.captures = captures
+  }
+}
+
+/// VMs load RECode and run over Strings.
+public protocol VirtualMachine {
+  /// Declare this VM's motto and general life philosophy
+  static var motto: String { get }
+
+  /// Load some RECode and prepare to match
+  init(_: RECode)
+
+  /// Match `input`
+  func execute(input: String, in range: Range<String.Index>, _ mode: MatchMode) -> MatchResult?
+}
+
+extension VirtualMachine {
+  /// Match `input`
+  public func execute(
+    input: String, _ mode: MatchMode = .wholeString
+  ) -> MatchResult? {
+    execute(input: input, in: input.startIndex..<input.endIndex, mode)
+  }
+}
+
 import Util
 
-/// Object code for a regex program, to be interpreted by a VM
-///
-/// Consists of an instruction list and metadata tracking:
-///   - Locations of labels (branch destinations)
-///   - Locations of splits (branches)
-///   - Total number of captures
-///   - Various options (case-insensitive, etc)
-///
-public struct RECode {
-  public typealias InstructionList = [Instruction]
-  var instructions: InstructionList
-  var labels: [InstructionAddress]
-  var splits: [InstructionAddress]
-  var numCaptures: Int
-  var options: Options
-}
-
 extension RECode {
-  /// A RECode instruction.
-  public enum Instruction: Hashable {
-    /// NOP (currently unused)
-    case nop
-
-    /// Denote a sucessful match. (currently used only at the end of a program)
-    case accept
-
-    /// Consume and try to match a unit of input
-    case character(Character)
-
-    /// Consume and try to match a unit of input against a character class
-    case characterClass(CharacterClass)
-
-    case unicodeScalar(UnicodeScalar)
-    
-    /// Consume any unit of input
-    case any
-
-    /// Split execution. Favored path will fall through while disfavored will branch to `disfavoring`
-    case split(disfavoring: LabelId)
-
-    /// Branch to `label`
-    case goto(label: LabelId)
-
-    /// The target of a branch, executed as a NOP
-    case label(LabelId)
-
-    /// Begin a numbered capture
-    case beginCapture(CaptureId)
-
-    /// End a numbered capture
-    case endCapture(CaptureId)
-
-    var isAccept: Bool {
-      switch self {
-      case .accept:
-        return true
-      default:
-        return false
-      }
-    }
-    
-    // Future instructions
-    //    case ratchet
-    //    case peekAhead([CharacterClass])
-    //    case peekBehind([CharacterClass])
-  }
-}
-
-// Conveniences
-extension RECode.Instruction {
-  /// Fetch the label from a label instruction, else `nil`
-  var label: LabelId? {
-    guard case .label(let id) = self else { return nil }
-    return id
-  }
-
-  /// Whether this instruction particpcates in matching
-  var isMatching: Bool {
-    switch self {
-    case .accept: return true
-    case .character(_): return true
-    case .unicodeScalar(_): return true
-    case .characterClass(_): return true
-    case .any: return true
-    default: return false
-    }
-  }
-
-  /// Whether this instruction consumes the input
-  var isConsuming: Bool {
-    switch self {
-    case .any: return true
-    case .character(_): return true
-    case .unicodeScalar(_): return true
-    case .characterClass(_): return true
-    default: return false
-    }
-  }
-
-  // Convenience constructors
-  static func beginCapture(_ i: Int) -> Self { .beginCapture(CaptureId(i)) }
-  static func endCapture(_ i: Int) -> Self { .endCapture(CaptureId(i)) }
-
-  static func label(_ i: Int) -> Self { .label(LabelId(i)) }
-}
-
-public struct Options: OptionSet {
-  public let rawValue: Int
-
-  public static var none = Options(rawValue: 0)
-  public static var caseInsensitive = Options(rawValue: 1 << 0)
-  // Future options
-  //    ratcheting
-  //    ??? partial
-  //    ??? newlineTerminated
-
-
-  public init() {
-    self = .none
-  }
-  public init(rawValue: Int) {
-    self.rawValue = rawValue
-  }
-}
-
-// RECode as a RAC of instructions. We might want to make this instead be
-// `InstructionList` if that graduates from being an array.
-extension RECode: RandomAccessCollection {
-  public typealias Element = Instruction
-  public typealias Index = InstructionAddress
-
-  public var startIndex: Index { return Index(instructions.startIndex) }
-  public var endIndex: Index { return Index(instructions.endIndex) }
-  public subscript(_ i: Index) -> Element { return instructions[i.rawValue] }
-
-  public func index(after i: Index) -> Index {
-    return Index(i.rawValue + 1)
-  }
-  public func index(before i: Index) -> Index {
-    return Index(i.rawValue - 1)
-  }
-  public func index(_ i: Index, offsetBy n: Int) -> Index {
-    return Index(i.rawValue + n)
-  }
-}
-
-extension RECode {
-  public func withMatchLevel(_ level: CharacterClass.MatchLevel) -> RECode {
-    var result = self
-    result.instructions = result.instructions.map { inst in
-      switch inst {
-      case .characterClass(var cc):
-        cc.matchLevel = level
-        return .characterClass(cc)
-      default:
-        return inst
-      }
-    }
-    return result
-  }
-}
-
-extension RECode {
-  /// Lookup the location of a label
-  public func lookup(_ id: LabelId) -> InstructionAddress {
-    let result = labels[id.rawValue]
-    guard case .label(let lid) = self[result], lid == id else {
-      fatalError("malformed program: labels not hooked up correctly")
-    }
-    return result
-  }
-
   /// A convenient VM thread "core" abstraction
   public struct ThreadCore {
     public var pc: InstructionAddress
@@ -243,41 +116,6 @@ public struct CaptureStack {
   }
   public func asStrings(from str: String) -> [String] {
     return stack.stack.map { str[$0.0..<$0.1] }.map { String($0) }
-  }
-}
-
-public enum MatchMode {
-  case wholeString
-  case partialFromFront
-}
-
-/// VMs load RECode and run over Strings.
-public protocol VirtualMachine {
-  /// Declare this VM's motto and general life philosophy
-  static var motto: String { get }
-
-  /// Load some RECode and prepare to match
-  init(_: RECode)
-
-  /// Match `input`
-  func execute(input: String, _ mode: MatchMode) -> (String.Index, [CaptureStack])?
-}
-
-extension RECode.Instruction: CustomStringConvertible {
-  public var description: String {
-    switch self {
-    case .nop: return "<NOP>"
-    case .accept: return "<ACC>"
-    case .any: return "<ANY>"
-    case .characterClass(let kind): return "<CHAR CLASS \(kind)>"
-    case .character(let c): return c.halfWidthCornerQuoted
-    case .unicodeScalar(let u): return u.halfWidthCornerQuoted
-    case .split(let i): return "<SPLIT disfavoring \(i)>"
-    case .goto(let label): return "<GOTO \(label)>"
-    case .label(let i): return "<\(i)>"
-    case .beginCapture(let id): return "<CAP \(id)>"
-    case .endCapture(let id): return "<END CAP \(id)>"
-    }
   }
 }
 

--- a/Sources/Regex/VirtualMachine.swift
+++ b/Sources/Regex/VirtualMachine.swift
@@ -116,6 +116,7 @@ public struct Options: OptionSet {
   //    ??? partial
   //    ??? newlineTerminated
 
+
   public init() {
     self = .none
   }
@@ -245,6 +246,11 @@ public struct CaptureStack {
   }
 }
 
+public enum MatchMode {
+  case wholeString
+  case partialFromFront
+}
+
 /// VMs load RECode and run over Strings.
 public protocol VirtualMachine {
   /// Declare this VM's motto and general life philosophy
@@ -254,7 +260,7 @@ public protocol VirtualMachine {
   init(_: RECode)
 
   /// Match `input`
-  func execute(input: String) -> (Bool, [CaptureStack])
+  func execute(input: String, _ mode: MatchMode) -> (String.Index, [CaptureStack])?
 }
 
 extension RECode.Instruction: CustomStringConvertible {

--- a/Sources/RegexDSL/Core.swift
+++ b/Sources/RegexDSL/Core.swift
@@ -74,8 +74,7 @@ extension RegexProtocol {
     using engine: VirtualMachine.Type
   ) -> RegexMatch<CaptureValue>? {
     let vm = engine.init(regex.program.executable)
-    let (didMatch, captures) = vm.execute(input: input)
-    guard didMatch else {
+    guard let (_, captures) = vm.execute(input: input, .wholeString) else {
       return nil
     }
     return RegexMatch(capturedSubstrings: captures.map { $0.asSubstrings(from: input) })

--- a/Sources/RegexDSL/Core.swift
+++ b/Sources/RegexDSL/Core.swift
@@ -74,7 +74,8 @@ extension RegexProtocol {
     using engine: VirtualMachine.Type
   ) -> RegexMatch<CaptureValue>? {
     let vm = engine.init(regex.program.executable)
-    guard let (_, captures) = vm.execute(input: input, .wholeString) else {
+    guard let (_, captures) = vm.execute(input: input)?.destructure
+    else {
       return nil
     }
     return RegexMatch(capturedSubstrings: captures.map { $0.asSubstrings(from: input) })

--- a/Sources/Util/Misc.swift
+++ b/Sources/Util/Misc.swift
@@ -73,3 +73,15 @@ extension BidirectionalCollection {
     return startIndex ..< endIndex
   }
 }
+
+extension Collection {
+  public func idx(_ i: Int) -> Index {
+    index(startIndex, offsetBy: i)
+  }
+  public func split(
+    around r: Range<Index>
+  ) -> (prefix: SubSequence, SubSequence, suffix: SubSequence) {
+    (self[..<r.lowerBound], self[r], self[r.upperBound...])
+  }
+}
+

--- a/Sources/Util/Misc.swift
+++ b/Sources/Util/Misc.swift
@@ -47,3 +47,29 @@ extension Sequence {
     return false
   }
 }
+
+extension Range {
+  public var destructure: (
+    lowerBound: Bound, upperBound: Bound
+  ) {
+    (lowerBound, upperBound)
+  }
+}
+
+public typealias Offsets = (lower: Int, upper: Int)
+extension BidirectionalCollection {
+  public func mapOffsets(_ offsets: Offsets) -> Range<Index> {
+    assert(offsets.lower >= 0 && offsets.upper <= 0)
+    let lower = index(startIndex, offsetBy: offsets.lower)
+    let upper = index(endIndex, offsetBy: offsets.upper)
+    return lower ..< upper
+  }
+
+  // Is this the right name?
+  public func flatmapOffsets(_ offsets: Offsets?) -> Range<Index> {
+    if let o = offsets {
+      return mapOffsets(o)
+    }
+    return startIndex ..< endIndex
+  }
+}

--- a/Tests/AlgorithmsTests/AlgorithmsTests.swift
+++ b/Tests/AlgorithmsTests/AlgorithmsTests.swift
@@ -1,1 +1,53 @@
+import Algorithms
+import XCTest
+import Util
+
+// TODO: Protocol-powered testing
+class AlgorithmTests: XCTestCase {
+
+}
+
+var enablePrinting = false
+func output<T>(_ s: @autoclosure () -> T) {
+  if enablePrinting {
+    print(s())
+  }
+}
+
+class RegexConsumerTests: XCTestCase {
+
+  func testAdHoc() {
+
+    let r = RegexConsumer(regex: "a|b+")
+
+// TODO: Why isn't there `contains`?
+//    XCTAssert("palindrome".contains(r))
+//    XCTAssert("botany".contains(r))
+//    XCTAssert("antiquing".contains(r))
+//    XCTAssertFalse("cdef".contains(r))
+
+    let str = "a string with the letter b in it"
+    let (first, last) = (str.firstRange(r), str.lastRange(r))
+    let (expectFirst, expectLast) = (str.idx(0)..<str.idx(1), str.idx(25)..<str.idx(26))
+    output(str.split(around: first!))
+    output(str.split(around: last!))
+
+    XCTAssertEqual(expectFirst, first)
+    XCTAssertEqual(expectLast, last)
+
+    // FIXME: Doesn't terminate, haven't explored where bug is
+//    XCTAssertEqual(
+//      [expectFirst, expectLast], Array(str.ranges(r)))
+
+    XCTAssertTrue(str.starts(with: r))
+    XCTAssertFalse(str.ends(with: r))
+    
+    XCTAssertEqual(str.dropFirst(), str.trimming(r))
+    XCTAssertEqual("x", "axb".trimming(r))
+    // Bug: XCTAssertEqual("x", "axbb".trimming(r))
+
+  }
+
+}
+
 


### PR DESCRIPTION
Here is regex with subrange and partial-matching capabilities.

I added a conformance to forwards and backwards consumers and searchers and a simple test case for every algorithm present. Backwards conformance is naive, but (maybe) works.

The most important thing is to unblock upcoming pitches and getting what's presented in the overview actually running. Speaking of which, I need to get back to that 😅. Towards that aim, @timvermeulen, could you hep :

- Write tests and pull in more missing algorithms
- Add, update, or fix regex conformance tests
	- File issue (or investigate) for bugs in regex engine
- Pull in Foundation conformers from my prototype

Blocking:

- Need tested alorithms taking regex
- Need NSRegularExpression conformer for simple grapheme-semantic comparisons

Not blocking:

- Protocol heirarchies
- Other conformers
- Efficient search algorithms

Thanks!