### PR TITLE
Align regex parser with PCRE capture syntax.

### DIFF
--- a/Sources/Regex/RegexLex.swift
+++ b/Sources/Regex/RegexLex.swift
@@ -29,6 +29,7 @@ public enum Token {
     case lparen = "("
     case rparen = ")"
     case dot = "."
+    case colon = ":"
   }
 
   case meta(MetaCharacter)
@@ -43,6 +44,7 @@ public enum Token {
   public static var star: Token { .meta(.star) }
   public static var plus: Token { .meta(.plus) }
   public static var dot: Token { .meta(.dot) }
+  public static var colon: Token { .meta(.colon) }
 
   // Note: We do each character individually, as post-fix modifiers bind
   // tighter than concatenation. "abc*" is "a" -> "b" -> "c*"

--- a/Sources/Regex/RegexParse.swift
+++ b/Sources/Regex/RegexParse.swift
@@ -16,8 +16,8 @@ extension String: Error {}
 ///     Concatenation -> Quantification Quantification*
 ///     Quantification -> (Group | Atom) <token: qualifier>?
 ///     Atom -> <token: .character> | <any> | ... character classes ...
-///     Group -> '(' Capture? RE ')'
-///     Capture -> '?'
+///     CaptureGroup -> '(' RE ')'
+///     Group -> '(' '?' ':' RE ')'
 ///
 public enum AST: Hashable {
   indirect case alternation([AST]) // alternation(AST, AST?)
@@ -116,10 +116,9 @@ extension Parser {
     switch lexer.peek() {
     case .leftParen?:
       lexer.eat()
-      let isCapturing: Bool
+      var isCapturing = true
       if lexer.eat(.question) {
-        isCapturing = true
-      } else {
+        try lexer.eat(expecting: .colon)
         isCapturing = false
       }
       let child = try parse()


### PR DESCRIPTION
Before:
- `(abc)`: Non-capturing group
- `(?abc)`: Capturing group

PCRE:
- `(abc)`: Capturing group
- `(?:abc)` Non-capturing group