### PR TITLE
Flexible classes

### DIFF
--- a/Sources/Regex/CharacterClass.swift
+++ b/Sources/Regex/CharacterClass.swift
@@ -7,9 +7,9 @@ public struct CharacterClass: Hashable {
   var isInverted: Bool = false
 
   public enum Representation: Hashable {
-    /// Any single elements
+    /// Any single element, re the current matching semantics
     case any
-    /// Any grapheme cluster, even in non-grapheme-cluster mode
+    /// Any grapheme cluster, even when in a non-grapheme-cluster mode
     case anyGraphemeCluster
     /// Character.isDigit
     case digit

--- a/Sources/Regex/CharacterClass.swift
+++ b/Sources/Regex/CharacterClass.swift
@@ -206,6 +206,10 @@ extension CharacterClass {
     .init(cc: .word, matchLevel: .graphemeCluster)
   }
 
+  public static var anyGraphemeCluster: CharacterClass {
+    .init(cc: .anyGraphemeCluster, matchLevel: .graphemeCluster)
+  }
+  
   public static func custom(
     _ components: [CharacterSetComponent]
   ) -> CharacterClass {
@@ -219,7 +223,8 @@ extension CharacterClass {
     case "w": self = .word
     case "S", "D", "W":
       self = Self(Character(ch.lowercased()))!.inverted
-
+    case "X": self = .anyGraphemeCluster
+      
     default: return nil
     }
   }

--- a/Sources/Regex/RECode.swift
+++ b/Sources/Regex/RECode.swift
@@ -131,6 +131,13 @@ public struct REOptions: OptionSet {
   //    ??? partial
   //    ??? newlineTerminated
 
+  public static var graphemeClusterSemantics = REOptions(rawValue: 1 << 1)
+  public static var unicodeScalarSemantics = REOptions(rawValue: 1 << 2)
+  public static var utf8Semantics = REOptions(rawValue: 1 << 3)
+  internal static var allSemantics: REOptions =
+    [.graphemeClusterSemantics, .unicodeScalarSemantics, .utf8Semantics]
+  
+  public static var asciiCharacterClasses = REOptions(rawValue: 1 << 4)
 
   public init() {
     self = .none
@@ -164,14 +171,11 @@ extension RECode: RandomAccessCollection {
 extension RECode {
   public func withMatchLevel(_ level: CharacterClass.MatchLevel) -> RECode {
     var result = self
-    result.instructions = result.instructions.map { inst in
-      switch inst {
-      case .characterClass(var cc):
-        cc.matchLevel = level
-        return .characterClass(cc)
-      default:
-        return inst
-      }
+    result.options.remove(.allSemantics)
+    switch level {
+    case .graphemeCluster: result.options.insert(.graphemeClusterSemantics)
+    case .unicodeScalar: result.options.insert(.unicodeScalarSemantics)
+    case .utf8CodeUnit: result.options.insert(.utf8Semantics)
     }
     return result
   }

--- a/Sources/Regex/RegexParse.swift
+++ b/Sources/Regex/RegexParse.swift
@@ -232,6 +232,8 @@ extension Parser {
       return meta.rawValue
     case .character(let c, isEscaped: _):
       return c
+    case .unicodeScalar(let s):
+      return Character(s)
     default:
       try report("expected a character or a ']'")
     }

--- a/Sources/Regex/RegexParse.swift
+++ b/Sources/Regex/RegexParse.swift
@@ -155,13 +155,29 @@ extension Parser {
       try lexer.eat(expecting: .rightParen)
       return isCapturing ? .capturingGroup(child) : .group(child)
 
-    case .character(let c, isEscaped: false):
+    case .character(var c, isEscaped: false):
       lexer.eat()
+      while case .unicodeScalar(let u) = lexer.peek() {
+        let s = "\(c)\(u)"
+        guard s.count == 1 else { break }
+        lexer.eat()
+        c = s.first!
+      }
+      
       return .character(c)
-
+      
     case .unicodeScalar(let u):
       lexer.eat()
-      return .unicodeScalar(u)
+      var c = Character(u)
+      
+      while case .unicodeScalar(let u) = lexer.peek() {
+        let s = "\(c)\(u)"
+        guard s.count == 1 else { break }
+        lexer.eat()
+        c = s.first!
+      }
+      
+      return .character(c)
 
     case .character(let c, isEscaped: true):
       lexer.eat()

--- a/Sources/Regex/TortoiseVM.swift
+++ b/Sources/Regex/TortoiseVM.swift
@@ -124,9 +124,19 @@ extension TortoiseVM {
     return result
   }
 
+  func position(after position: String.Index, in str: String, options: REOptions) -> String.Index {
+    if options.contains(.unicodeScalarSemantics) {
+      return str.unicodeScalars.index(after: position)
+    } else if options.contains(.utf8Semantics) {
+      return str.utf8.index(after: position)
+    } else {
+      return str.index(after: position)
+    }
+  }
+  
   func advance(_ input: String, _ sp: String.Index, _ bale: Bale) -> (Bale, String.Index) {
     var result = Bale()
-    var nextPosition = input.index(after: sp)
+    var nextPosition = position(after: sp, in: input, options: code.options)
     
     guard bale.all({ code[$0.pc].isMatching }) else {
       fatalError("should of been readThrough")
@@ -140,7 +150,8 @@ extension TortoiseVM {
     }
 
     func advance(_ hatchling: inout Hatchling) {
-      advance(&hatchling, to: input.index(after: sp))
+      let i = position(after: sp, in: input, options: code.options)
+      advance(&hatchling, to: i)
     }
 
     for hatchling in bale {
@@ -158,7 +169,7 @@ extension TortoiseVM {
         advance(&hatchling, to: input.unicodeScalars.index(after: sp))
 
       case .characterClass(let cc):
-        guard let nextSp = cc.matches(in: input, at: sp) else { break }
+        guard let nextSp = cc.matches(in: input, at: sp, options: code.options) else { break }
         advance(&hatchling, to: nextSp)
 
       case .any:

--- a/Sources/Util/Misc.swift
+++ b/Sources/Util/Misc.swift
@@ -100,7 +100,24 @@ extension Collection {
   >(_ idx: Index, in c: C) -> C.Index {
     c.idx(offset(of: idx))
   }
+}
 
+extension Collection where Element: Equatable {
+  public func eat<S: Sequence>(_ other: S) -> Index?
+    where S.Element == Element
+  {
+    var current = startIndex
+    var otherIterator = other.makeIterator()
+    while current < endIndex {
+      guard let otherElement = otherIterator.next() else {
+        return current
+      }
+      guard otherElement == self[current] else { return nil }
+      formIndex(after: &current)
+    }
+    if otherIterator.next() == nil { return current }
+    return nil
+  }
 }
 
 extension UnsafeMutableRawPointer {

--- a/Tests/RegexTests/RegexTests.swift
+++ b/Tests/RegexTests/RegexTests.swift
@@ -263,10 +263,12 @@ class RegexTests: XCTestCase {
     performTest("(.)*(.*)", concat(.many(.capturingGroup(.characterClass(.any))), .capturingGroup(.many(.characterClass(.any)))))
     performTest("abc\\d",concat("a", "b", "c", .characterClass(.digit)))
     performTest("a\\u0065b\\u{00000065}c\\x65d\\U00000065",
-                concat("a", .unicodeScalar("e"),
-                       "b", .unicodeScalar("e"),
-                       "c", .unicodeScalar("e"),
-                       "d", .unicodeScalar("e")))
+                concat("a", "e",
+                       "b", "e",
+                       "c", "e",
+                       "d", "e"))
+    performTest("e\\u{301}e",
+                concat("é", "e"))
 
     performTest("[-|$^:?+*())(*-+-]",
                 charClass("-", "|", "$", "^", ":", "?", "+", "*", "(", ")", ")",
@@ -509,8 +511,8 @@ class RegexTests: XCTestCase {
       ("a\\db\\dc", ["a1b3c"], ["ab2", "a1b", "a11b2", "a1b22"]),
       ("a\\d\\db\\dc", ["a12b3c"], ["ab2", "a1b", "a11b2", "a1b22"]),
 
-      ("Caf\\u{65}\\u0301", ["Cafe\u{301}"], ["Café", "Cafe"]),
-      ("Caf\\x65\\u0301", ["Cafe\u{301}"], ["Café", "Cafe"]),
+      ("Caf\\u{65}\\u0301", ["Cafe\u{301}", "Café"], ["Cafe"]),
+      ("Caf\\x65\\u0301", ["Cafe\u{301}", "Café"], ["Cafe"]),
 
       ("[^abc]", ["x", "0", "*", " "], ["a", "b", "c"]),
       ("\\D\\s\\W", ["a *", "* -"], ["0 *", "000", "a a", "a 8", "aaa", "***"]),

--- a/Tests/UtilTests/UtilTests.swift
+++ b/Tests/UtilTests/UtilTests.swift
@@ -24,4 +24,13 @@ class UtilTests: XCTestCase {
     XCTAssertEqual(tuple1.1, [true, false])
     XCTAssertEqual(tuple1.2, [3.0, 4.0])
   }
+  
+  func testEatOther() {
+    XCTAssertEqual(4, (1..<10).eat(1..<4))
+    XCTAssertEqual(1, (1..<10).eat(0..<0))
+    
+    XCTAssertNil((1..<1).eat(1..<2))
+    XCTAssertNil((1..<10).eat(2..<10))
+    XCTAssertNil((1..<10).eat(1..<11))
+  }
 }


### PR DESCRIPTION
This changes the regex parse stage to build grapheme clusters out of a character followed by a Unicode scalar literal or a series of Unicode scalar literals that comprise a grapheme cluster. This preserves the order of the Unicode scalars, so that if Unicode scalar matching semantics are required, the characters can be "exploded" into sequences of scalars.

This also moves the matching level up into `REOptions` instead of staying within each character class instance.

Still to do:
- match characters at the right level — `/e\{301}/` should match both `"é"` and `"e\u{301}"` at the grapheme cluster level, but only `"e\u{301}"` at the unicode scalar and UTF8 levels.
- figure out the right behavior for custom classes at non-grapheme-cluster levels, if they're always ranges of characters