### PR TITLE
Add Quantifer and Group to AST

### DIFF
--- a/Sources/Regex/AST.swift
+++ b/Sources/Regex/AST.swift
@@ -1,19 +1,20 @@
 /// A regex abstract syntax tree
-public enum AST: Hashable {
-  indirect case alternation([AST]) // alternation(AST, AST?)
+public enum AST: ASTEntity {
+
+  /// ... | ... | ...
+  indirect case alternation([AST])
+
+  /// ... ...
   indirect case concatenation([AST])
-  indirect case group(AST)
-  indirect case capturingGroup(AST, transform: CaptureTransform? = nil)
 
-  // Post-fix modifiers
-  indirect case many(AST)
-  indirect case zeroOrOne(AST)
-  indirect case oneOrMore(AST)
+  /// (...)
+  indirect case group(Group, AST)
 
-  // Lazy versions of quantifiers
-  indirect case lazyMany(AST)
-  indirect case lazyZeroOrOne(AST)
-  indirect case lazyOneOrMore(AST)
+  /// Group with a registered transform
+  indirect case groupTransform(
+    Group, AST, transform: CaptureTransform)
+
+  indirect case quantification(Quantifier, AST)
 
   case character(Character)
   case unicodeScalar(UnicodeScalar)
@@ -22,27 +23,21 @@ public enum AST: Hashable {
   case empty
 }
 
-extension AST: CustomStringConvertible {
-  public var description: String {
-    switch self {
-    case .alternation(let rest): return ".alt(\(rest))"
-    case .concatenation(let rest): return ".concat(\(rest))"
-    case .group(let rest): return ".group(\(rest))"
-    case .capturingGroup(let rest, let transform):
-      return """
-          .capturingGroup(\(rest), transform: \(transform.map(String.init(describing:)) ?? "nil")
-          """
-    case .many(let rest): return ".many(\(rest))"
-    case .zeroOrOne(let rest): return ".zeroOrOne(\(rest))"
-    case .oneOrMore(let rest): return ".oneOrMore(\(rest))"
-    case .lazyMany(let rest): return ".lazyMany(\(rest))"
-    case .lazyZeroOrOne(let rest): return ".lazyZeroOrOne(\(rest))"
-    case .lazyOneOrMore(let rest): return ".lazyOneOrMore(\(rest))"
-    case .character(let c): return c.halfWidthCornerQuoted
-    case .unicodeScalar(let u): return u.halfWidthCornerQuoted
-    case .characterClass(let cc): return ".characterClass(\(cc))"
-    case .any: return ".any"
-    case .empty: return "".halfWidthCornerQuoted
-    }
+// MARK: - Convenience constructors
+extension AST {
+  public static func zeroOrMore(
+    _ kind: Quantifier.Kind, _ a: AST
+  ) -> AST {
+    .quantification(.zeroOrMore(kind), a)
+  }
+  public static func oneOrMore(
+    _ kind: Quantifier.Kind, _ a: AST
+  ) -> AST {
+    .quantification(.oneOrMore(kind), a)
+  }
+  public static func zeroOrOne(
+    _ kind: Quantifier.Kind, _ a: AST
+  ) -> AST {
+    .quantification(.zeroOrOne(kind), a)
   }
 }

--- a/Sources/Regex/ASTPrinting.swift
+++ b/Sources/Regex/ASTPrinting.swift
@@ -1,0 +1,65 @@
+
+// MARK: - Printing
+
+/// AST entities can be pretty-printed or dumped
+///
+/// Alternative: just use `description` for pretty-print
+/// and `debugDescription` for dump
+public protocol _ASTPrintable:
+  CustomStringConvertible,
+  CustomDebugStringConvertible
+{
+  func _print() -> String
+  func _dump() -> String
+}
+extension _ASTPrintable {
+  public var description: String { _print() }
+  public var debugDescription: String { _dump() }
+}
+
+public protocol _ASTPrintableNested: _ASTPrintable {
+  func _printNested(_ child: String) -> String
+  func _dumpNested(_ child: String) -> String
+}
+extension _ASTPrintableNested {
+  public func _print() -> String { _printNested("") }
+  public func _dump() -> String { _dumpNested("") }
+}
+
+public protocol ASTEntity: _ASTPrintable, Hashable {
+}
+
+public protocol ASTParentEntity: ASTEntity, _ASTPrintableNested {
+  // TODO: variadic access to children?
+}
+
+// MARK: - AST's conformance
+
+extension AST {
+  public func _print() -> String {
+    // TODO: printable version?
+    _dump()
+  }
+
+  public func _dump() -> String {
+    switch self {
+    case let .alternation(rest): return ".alt(\(rest))"
+    case let .concatenation(rest): return ".concat(\(rest))"
+    case let .group(g, rest):
+      return g._dumpNested(rest._dump())
+    case let .groupTransform(g, rest, transform):
+      return g._dumpNested("""
+        \(rest._dump()), transform: \(
+          String(describing: transform)))
+        """)
+    case let .quantification(q, rest):
+      return q._dumpNested(rest._dump())
+
+    case .character(let c):       return c.halfWidthCornerQuoted
+    case .unicodeScalar(let u):   return u.halfWidthCornerQuoted
+    case .characterClass(let cc): return ".characterClass(\(cc))"
+    case .any: return ".any"
+    case .empty: return "".halfWidthCornerQuoted
+    }
+  }
+}

--- a/Sources/Regex/Capture.swift
+++ b/Sources/Regex/Capture.swift
@@ -42,11 +42,10 @@ extension AST {
     switch self {
     case let .alternation(child), let .concatenation(child):
       return child.any(\.hasCaptures)
-    case .capturingGroup, .group:
-      return true
-    case let .many(child), let .zeroOrOne(child), let .oneOrMore(child),
-         let .lazyMany(child), let .lazyOneOrMore(child),
-         let .lazyZeroOrOne(child):
+    case let .group(g, child), let .groupTransform(g, child, _):
+      return g.isCapturing || child.hasCaptures
+      || true // WIP: preserves old behavior
+    case .quantification(_, let child):
       return child.hasCaptures
     case .character, .unicodeScalar, .characterClass, .any, .empty:
       return false

--- a/Sources/Regex/Group.swift
+++ b/Sources/Regex/Group.swift
@@ -1,0 +1,101 @@
+public struct Group: ASTParentEntity {
+  public let name: String?
+  public let kind: Kind
+
+  public init(_ kind: Kind, _ name: String? = nil) {
+    self.name = name
+    self.kind = kind
+  }
+}
+
+extension Group {
+  public enum Kind: ASTEntity {
+    // (...)
+    case capture
+
+    // (?<name>...) (?'name'...) (?P<name>...)
+    case namedCapture
+
+    // (?:...)
+    case nonCapture
+
+    // (?|...)
+    case nonCaptureReset
+
+    // (?>...)
+    case atomicNonCapturing // TODO: is Oniguruma capturing?
+
+    // (?#....)
+    case comment
+
+    // (?=...) (?!...)
+    case lookahead(inverted: Bool)
+
+    // (?<=...) (?<!...)
+    case lookbehind(inverted: Bool)
+  }
+}
+
+// MARK: - Convenience constructors
+
+extension Group {
+  public static var capture: Group { Group(.capture) }
+  public static var nonCapture: Group { Group(.nonCapture) }
+}
+
+// MARK: - API
+
+extension Group {
+  public var isCapturing: Bool {
+    return kind == .capture || kind == .namedCapture
+  }
+}
+
+
+// MARK: - Printing
+
+extension Group.Kind {
+  // Note that this printing setup doesn't naturally support
+  // nesting, but I think it's ok because all groups terminate
+  // the same.
+  //
+  // Also, pretty-print uses our preferred syntax, and a different print
+  // could use the originally provided syntax.
+  public func _print() -> String {
+    switch self {
+    case .capture:            return "("
+    case .comment:            return "(?#."
+    case .atomicNonCapturing: return "(?>"
+    case .namedCapture:       return "(?<"
+    case .nonCapture:         return "(?:"
+    case .nonCaptureReset:    return "(?|"
+    case .lookahead(let invert):  return invert ? "(?!" : "(?="
+    case .lookbehind(let invert): return invert ? "(?<!" :"(?<="
+    }
+  }
+
+  public func _dump() -> String {
+    fatalError()
+  }
+}
+extension Group {
+  public func _printNested(_ child: String) -> String {
+    var res = kind._print()
+    if let n = name {
+      res += "\(n)>"
+    }
+    res += child
+    res += ")"
+    return res
+  }
+
+  public func _dumpNested(_ child: String) -> String {
+    var res = kind._dump()
+    if let n = name {
+      res += "\(n)>" // syntax?
+    }
+    res += child
+    res += ")"
+    return res
+  }
+}

--- a/Sources/Regex/Quantifier.swift
+++ b/Sources/Regex/Quantifier.swift
@@ -1,0 +1,103 @@
+public struct Quantifier: ASTParentEntity {
+  public let amount: Amount
+  public let kind: Kind
+
+  public init(_ a: Amount, _ k: Kind) {
+    self.amount = a
+    self.kind = k
+  }
+}
+
+extension Quantifier {
+  public enum Amount: ASTEntity {
+    case zeroOrMore   // *
+    case oneOrMore    // +
+    case zeroOrOne    // ?
+    case exactly(Int) // {n}
+    case nOrMore(Int) // {n,}
+    case upToN(Int)   // {,n}
+    case range(       // {n,m}
+      atLeast: Int, atMost: Int)
+  }
+
+  public enum Kind: String, ASTEntity {
+    case greedy     = ""
+    case reluctant  = "?"
+    case possessive = "+"
+  }
+}
+ 
+// MARK: - Convenience constructors
+
+extension Quantifier {
+  public static func zeroOrMore(_ k: Kind) -> Self {
+    Self(.zeroOrMore, k)
+  }
+  public static func oneOrMore(_ k: Kind) -> Self {
+    Self(.oneOrMore, k)
+  }
+  public static func zeroOrOne(_ k: Kind) -> Self {
+    Self(.zeroOrOne, k)
+  }
+  public static func exactly(_ k: Kind, _ i: Int) -> Self {
+    Self(.exactly(i), k)
+  }
+  public static func nOrMore(_ k: Kind, _ i: Int) -> Self {
+    Self(.nOrMore(i), k)
+  }
+  public static func upToN(_ k: Kind, _ i: Int) -> Self {
+    Self(.upToN(i), k)
+  }
+  public static func range(
+    _ k: Kind, atLeast: Int, atMost: Int
+  ) -> Self {
+    Self(.range(atLeast: atLeast, atMost: atMost), k)
+  }
+}
+
+// MARK: - Printing
+
+extension Quantifier.Amount: _ASTPrintable {
+  public func _print() -> String {
+    switch self {
+    case .zeroOrMore: return "*"
+    case .oneOrMore:  return "+"
+    case .zeroOrOne:  return "?"
+    case let .exactly(n):  return "{\(n)}"
+    case let .nOrMore(n):  return "{\(n),}"
+    case let .upToN(n):    return "{,\(n)}"
+    case let .range(n, m): return "{\(n),\(m)}"
+    }
+  }
+  public func _dump() -> String {
+    switch self {
+    case .zeroOrMore: return ".zeroOrMore"
+    case .oneOrMore:  return ".oneOrMore"
+    case .zeroOrOne:  return ".zeroOrOne"
+    case let .exactly(n):  return ".exactly(\(n))"
+    case let .nOrMore(n):  return ".nOrMore(\(n))"
+    case let .upToN(n):    return ".uptoN(\(n))"
+    case let .range(n, m): return ".range(\(n),\(m))"
+    }
+  }
+}
+extension Quantifier.Kind: _ASTPrintable {
+  public func _print() -> String { rawValue }
+  public func _dump() -> String {
+    switch self {
+    case .greedy: return ".greedy"
+    case .reluctant: return ".reluctant"
+    case .possessive: return ".possessive"
+    }
+  }
+}
+
+extension Quantifier: _ASTPrintable {
+  public func _printNested(_ child: String) -> String {
+    "<?:\(child)>\(amount._print())\(kind._print())"
+  }
+
+  public func _dumpNested(_ child: String) -> String {
+    "\(amount._dump())_\(kind._dump())(\(child)"
+  }
+}

--- a/Sources/Regex/Quantifier.swift
+++ b/Sources/Regex/Quantifier.swift
@@ -10,14 +10,13 @@ public struct Quantifier: ASTParentEntity {
 
 extension Quantifier {
   public enum Amount: ASTEntity {
-    case zeroOrMore   // *
-    case oneOrMore    // +
-    case zeroOrOne    // ?
-    case exactly(Int) // {n}
-    case nOrMore(Int) // {n,}
-    case upToN(Int)   // {,n}
-    case range(       // {n,m}
-      atLeast: Int, atMost: Int)
+    case zeroOrMore              // *
+    case oneOrMore               // +
+    case zeroOrOne               // ?
+    case exactly(Int)            // {n}
+    case nOrMore(Int)            // {n,}
+    case upToN(Int)              // {,n}
+    case range(ClosedRange<Int>) // {n,m}
   }
 
   public enum Kind: String, ASTEntity {
@@ -49,9 +48,9 @@ extension Quantifier {
     Self(.upToN(i), k)
   }
   public static func range(
-    _ k: Kind, atLeast: Int, atMost: Int
+    _ k: Kind, _ r: ClosedRange<Int>
   ) -> Self {
-    Self(.range(atLeast: atLeast, atMost: atMost), k)
+    Self(.range(r), k)
   }
 }
 
@@ -60,24 +59,26 @@ extension Quantifier {
 extension Quantifier.Amount: _ASTPrintable {
   public func _print() -> String {
     switch self {
-    case .zeroOrMore: return "*"
-    case .oneOrMore:  return "+"
-    case .zeroOrOne:  return "?"
+    case .zeroOrMore:      return "*"
+    case .oneOrMore:       return "+"
+    case .zeroOrOne:       return "?"
     case let .exactly(n):  return "{\(n)}"
     case let .nOrMore(n):  return "{\(n),}"
     case let .upToN(n):    return "{,\(n)}"
-    case let .range(n, m): return "{\(n),\(m)}"
+    case let .range(r):
+      return "{\(r.lowerBound),\(r.upperBound)}"
     }
   }
   public func _dump() -> String {
     switch self {
-    case .zeroOrMore: return ".zeroOrMore"
-    case .oneOrMore:  return ".oneOrMore"
-    case .zeroOrOne:  return ".zeroOrOne"
+    case .zeroOrMore:      return ".zeroOrMore"
+    case .oneOrMore:       return ".oneOrMore"
+    case .zeroOrOne:       return ".zeroOrOne"
     case let .exactly(n):  return ".exactly(\(n))"
     case let .nOrMore(n):  return ".nOrMore(\(n))"
     case let .upToN(n):    return ".uptoN(\(n))"
-    case let .range(n, m): return ".range(\(n),\(m))"
+    case let .range(r):
+      return ".range(\(r.lowerBound),\(r.upperBound))"
     }
   }
 }
@@ -85,8 +86,8 @@ extension Quantifier.Kind: _ASTPrintable {
   public func _print() -> String { rawValue }
   public func _dump() -> String {
     switch self {
-    case .greedy: return ".greedy"
-    case .reluctant: return ".reluctant"
+    case .greedy:     return ".greedy"
+    case .reluctant:  return ".reluctant"
     case .possessive: return ".possessive"
     }
   }

--- a/Sources/RegexDSL/DSL.swift
+++ b/Sources/RegexDSL/DSL.swift
@@ -48,7 +48,8 @@ public struct OneOrMore<Component: RegexProtocol>: RegexProtocol {
   public let regex: Regex<Capture>
 
   public init(_ component: Component) {
-    self.regex = .init(ast: .oneOrMore(component.regex.ast))
+    self.regex = .init(
+      ast: .oneOrMore(.greedy, component.regex.ast))
   }
 
   public init(@RegexBuilder _ content: () -> Component) {
@@ -68,7 +69,8 @@ public struct Repeat<Component: RegexProtocol>: RegexProtocol {
   public let regex: Regex<Capture>
 
   public init(_ component: Component) {
-    self.regex = .init(ast: .many(component.regex.ast))
+    self.regex = .init(
+      ast: .zeroOrMore(.greedy, component.regex.ast))
   }
 
   public init(@RegexBuilder _ content: () -> Component) {
@@ -88,7 +90,8 @@ public struct Optionally<Component: RegexProtocol>: RegexProtocol {
   public let regex: Regex<Capture>
 
   public init(_ component: Component) {
-    self.regex = .init(ast: .zeroOrOne(component.regex.ast))
+    self.regex = .init(
+      ast: .zeroOrOne(.greedy, component.regex.ast))
   }
 
   public init(@RegexBuilder _ content: () -> Component) {
@@ -137,16 +140,21 @@ public struct CapturingGroup<Capture>: RegexProtocol {
   init<Component: RegexProtocol>(
     _ component: Component
   ) {
-    self.regex = .init(ast: .capturingGroup(component.regex.ast))
+    self.regex = .init(
+      ast: .group(.capture, component.regex.ast))
   }
 
   init<NewCapture, Component: RegexProtocol>(
     _ component: Component,
     transform: @escaping (Substring) -> NewCapture
   ) {
-    self.regex = .init(ast: .capturingGroup(component.regex.ast, transform: CaptureTransform {
-      transform($0) as Any
-    }))
+    self.regex = .init(
+      ast: .groupTransform(
+        .capture,
+        component.regex.ast,
+        transform: CaptureTransform {
+          transform($0) as Any
+        }))
   }
 }
 


### PR DESCRIPTION
Add in richer Quantifier and Group types to the AST.

Update the Lexer design (partially), as the parser most of
the time knows what kinds of tokens to be pulling in.