### PR TITLE
Quants, Quotes, Caps, and Comments

### DIFF
--- a/Sources/Regex/AST.swift
+++ b/Sources/Regex/AST.swift
@@ -24,7 +24,7 @@ public enum AST: ASTValue, ASTAction {
   case any
   case empty
 
-  case trivia
+  case trivia // TODO: track any comments
 }
 
 // Note that we're not yet an ASTEntity, would need to be a struct.

--- a/Sources/Regex/AST.swift
+++ b/Sources/Regex/AST.swift
@@ -17,6 +17,7 @@ public enum AST: ASTValue, ASTAction {
 
   indirect case quantification(Quantifier, AST)
 
+  case quote(String)
   case character(Character)
   case unicodeScalar(UnicodeScalar)
   case characterClass(CharacterClass)
@@ -70,7 +71,7 @@ extension AST {
       return .quantification(q, c)
 
     case .character, .unicodeScalar, .characterClass,
-        .any, .empty, .trivia:
+        .any, .empty, .trivia, .quote:
       return f(self) ? self : nil
     }
   }

--- a/Sources/Regex/Capture.swift
+++ b/Sources/Regex/Capture.swift
@@ -48,7 +48,7 @@ extension AST {
     case .quantification(_, let child):
       return child.hasCaptures
     case .character, .unicodeScalar, .characterClass, .any, .empty,
-        .trivia:
+        .trivia, .quote:
       return false
 
     }

--- a/Sources/Regex/Group.swift
+++ b/Sources/Regex/Group.swift
@@ -31,15 +31,15 @@ extension Group {
 
     // (?>...)
     case atomicNonCapturing // TODO: is Oniguruma capturing?
-
-    // (?#....)
-    case comment
-
     // (?=...) (?!...)
     case lookahead(inverted: Bool)
 
     // (?<=...) (?<!...)
     case lookbehind(inverted: Bool)
+
+    // NOTE: Comments appear to be groups, but are not parsed
+    // the same. They parse more like quotes so are not listed
+    // here.
   }
 }
 
@@ -75,7 +75,7 @@ extension Group.Kind {
   public func _print() -> String {
     switch self {
     case .capture:            return "("
-    case .comment:            return "(?#."
+//    case .comment:            return "(?#."
     case .atomicNonCapturing: return "(?>"
     case .namedCapture:       return "(?<"
     case .nonCapture:         return "(?:"

--- a/Sources/Regex/Group.swift
+++ b/Sources/Regex/Group.swift
@@ -49,9 +49,28 @@ extension Group {
   public static func capture(_ sr: SourceRange? = nil) -> Group {
     Group(.capture, sr)
   }
+  public static func named(
+    _ s: String, _ sr: SourceRange? = nil
+  ) -> Group {
+    Group(.capture, name: s, sr)
+  }
   public static func nonCapture(_ sr: SourceRange? = nil) -> Group {
     Group(.nonCapture, sr)
   }
+  public static func nonCaptureReset(_ sr: SourceRange? = nil) -> Group {
+    Group(.nonCaptureReset, sr)
+  }
+  public static func atomicNonCapturing(_ sr: SourceRange? = nil) -> Group {
+    Group(.atomicNonCapturing, sr)
+  }
+  public static func lookahead(inverted: Bool, _ sr: SourceRange? = nil) -> Group {
+    Group(.lookahead(inverted: inverted), sr)
+  }
+  public static func lookbehind(inverted: Bool, _ sr: SourceRange? = nil) -> Group {
+    Group(.lookbehind(inverted: inverted), sr)
+  }
+
+
 }
 
 // MARK: - API
@@ -86,7 +105,7 @@ extension Group.Kind {
   }
 
   public func _dump() -> String {
-    fatalError()
+    _print()
   }
 }
 extension Group {
@@ -119,9 +138,34 @@ extension AST {
   ) -> AST {
     .group(.capture(sr), a)
   }
+  public static func namedCapture(
+    _ name: String, _ a: AST, _ sr: SourceRange? = nil
+  ) -> AST {
+    .group(.named(name, sr), a)
+  }
   public static func nonCapture(
     _ a: AST, _ sr: SourceRange? = nil
   ) -> AST {
     .group(.nonCapture(sr), a)
+  }
+  public static func nonCaptureReset(
+    _ a: AST, _ sr: SourceRange? = nil
+  ) -> AST {
+    .group(.nonCaptureReset(sr), a)
+  }
+  public static func atomicNonCapturing(
+    _ a: AST, _ sr: SourceRange? = nil
+  ) -> AST {
+    .group(.atomicNonCapturing(sr), a)
+  }
+  public static func lookahead(
+    inverted: Bool, _ a: AST, _ sr: SourceRange? = nil
+  ) -> AST {
+    .group(.lookahead(inverted: inverted, sr), a)
+  }
+  public static func lookbehind(
+    inverted: Bool, _ a: AST, _ sr: SourceRange? = nil
+  ) -> AST {
+    .group(.lookbehind(inverted: inverted, sr), a)
   }
 }

--- a/Sources/Regex/Legacy/LegacyCompile.swift
+++ b/Sources/Regex/Legacy/LegacyCompile.swift
@@ -13,6 +13,10 @@ public func compile(
     switch ast {
     case .empty, .trivia: return
 
+    case .quote(let s):
+      s.forEach { instructions.append(.character($0)) }
+      return
+
     case .character(let c):
       instructions.append(.character(c))
       return

--- a/Sources/Regex/Parse/Parse.swift
+++ b/Sources/Regex/Parse/Parse.swift
@@ -126,6 +126,9 @@ extension Parser {
       lexer.eat()
       return .characterClass(.any)
 
+    case .startQuote?:
+      return parseQuoted()
+
     // Correct terminations
 
     case .trivia?:
@@ -138,6 +141,25 @@ extension Parser {
     default:
       try report("expected a character or group")
     }
+  }
+
+  mutating func parseQuoted() -> AST {
+    lexer.eat(asserting: .startQuote)
+
+    var result = ""
+    while !lexer.tryEat(.endQuote) {
+      if lexer.isEmpty {
+        fatalError("Error: expected end of quote")
+      }
+      switch lexer.eat() {
+      case let .character(c, isEscaped):
+        assert(isEscaped) // For now, this is how we model it
+        result.append(c)
+      default:
+        fatalError("Non-character in quote; is this possible?")
+      }
+    }
+    return .quote(result)
   }
 
   typealias CharacterSetComponent = CharacterClass.CharacterSetComponent

--- a/Sources/Regex/Parse/Parse.swift
+++ b/Sources/Regex/Parse/Parse.swift
@@ -146,7 +146,12 @@ extension Parser {
     case .rightParen, .pipe:
       return nil
 
-    default:
+    // For now, map comments to trivia
+    case .comment(_):
+      lexer.eat()
+      return .trivia
+
+    case .meta, .setOperator:
       try report("expected a character or group")
     }
   }

--- a/Sources/Regex/Parse/Parse.swift
+++ b/Sources/Regex/Parse/Parse.swift
@@ -93,7 +93,12 @@ extension Parser {
 
     switch nextTok {
     case .leftParen:
-      fatalError("Shouldn't be possible anymore")
+      fatalError("Shouldn't be possible anymore: '(")
+    case .leftCurlyBracket:
+      fatalError("Shouldn't be possible anymore: '{'")
+    case .rightCurlyBracket:
+      fatalError("Shouldn't be possible anymore: '}'")
+
     case .character(let c, isEscaped: false):
       lexer.eat()
       return .character(c)
@@ -152,7 +157,7 @@ extension Parser {
       return .trivia
 
     case .meta, .setOperator:
-      try report("expected a character or group")
+      fatalError("expected a character or group: \(nextTok)")
     }
   }
 

--- a/Sources/Regex/Parse/Token.swift
+++ b/Sources/Regex/Parse/Token.swift
@@ -49,6 +49,7 @@ extension Token {
     case rightCurlyBracket = "}"
     case leftCurlyBracket = "{"
     case comma = ","
+    case lessThan = "<"
   }
 
 
@@ -82,6 +83,8 @@ extension Token {
   static var rightCurlyBracket: Self { .meta(.rightCurlyBracket) }
   static var leftCurlyBracket: Self { .meta(.leftCurlyBracket) }
   static var comma: Self { .meta(.comma) }
+
+  static var lessThan: Self { .meta(.lessThan) }
 
 }
 

--- a/Sources/Regex/Parse/Token.swift
+++ b/Sources/Regex/Parse/Token.swift
@@ -21,6 +21,7 @@ enum Token: Hashable {
   case unicodeScalar(UnicodeScalar)
 
   case quote(String)
+  case comment(String)
 
   case trivia // comments, ignored stuff, etc
 
@@ -89,6 +90,7 @@ extension Token: CustomStringConvertible {
     case .character(let c, _): return c.halfWidthCornerQuoted
     case .unicodeScalar(let u): return "U\(u.halfWidthCornerQuoted)"
     case .quote(let s): return "\\Q\(s.halfWidthCornerQuoted)\\E"
+    case .comment(let s): return "(?#.\(s.halfWidthCornerQuoted))"
     case .trivia: return ""
     }
   }

--- a/Sources/Regex/Parse/Token.swift
+++ b/Sources/Regex/Parse/Token.swift
@@ -99,25 +99,3 @@ extension Token: CustomStringConvertible {
 extension Character {
   var isEscape: Bool { return self == "\\" }
 }
-
-extension Lexer {
-  /// Classify a given terminal character
-  func classifyTerminal(
-    _ t: Character,
-    fromEscape escaped: Bool
-  ) -> Token {
-    assert(!t.isEscape || escaped)
-    if !escaped {
-      // TODO: figure out best way to organize options logic...
-      if syntax.ignoreWhitespace, t == " " {
-        return .trivia
-      }
-
-      if let mc = Token.MetaCharacter(rawValue: t) {
-        return .meta(mc)
-      }
-    }
-
-    return .character(t, isEscaped: escaped)
-  }
-}

--- a/Sources/Regex/Parse/Token.swift
+++ b/Sources/Regex/Parse/Token.swift
@@ -49,9 +49,12 @@ extension Token {
     case rightCurlyBracket = "}"
     case leftCurlyBracket = "{"
     case comma = ","
-    case lessThan = "<"
+    case leftAngle = "<"
+    case rightAngle = ">"
+    case equals = "="
+    case underscore = "_"
+    case bang = "!"
   }
-
 
   enum SetOperator: String, Hashable {
     case doubleAmpersand = "&&"
@@ -84,7 +87,9 @@ extension Token {
   static var leftCurlyBracket: Self { .meta(.leftCurlyBracket) }
   static var comma: Self { .meta(.comma) }
 
-  static var lessThan: Self { .meta(.lessThan) }
+  static var leftAngle: Self { .meta(.leftAngle) }
+  static var rightAngle: Self { .meta(.rightAngle) }
+  static var equals: Self { .meta(.equals) }
 
 }
 

--- a/Sources/Regex/Parse/Token.swift
+++ b/Sources/Regex/Parse/Token.swift
@@ -20,8 +20,7 @@ enum Token: Hashable {
   case character(Character, isEscaped: Bool)
   case unicodeScalar(UnicodeScalar)
 
-  case startQuote // \Q
-  case endQuote   // \E
+  case quote(String)
 
   case trivia // comments, ignored stuff, etc
 
@@ -89,8 +88,7 @@ extension Token: CustomStringConvertible {
     case .setOperator(let op): return op.description
     case .character(let c, _): return c.halfWidthCornerQuoted
     case .unicodeScalar(let u): return "U\(u.halfWidthCornerQuoted)"
-    case .startQuote: return "\\Q"
-    case .endQuote: return "\\E"
+    case .quote(let s): return "\\Q\(s.halfWidthCornerQuoted)\\E"
     case .trivia: return ""
     }
   }

--- a/Sources/Regex/Parse/Token.swift
+++ b/Sources/Regex/Parse/Token.swift
@@ -45,6 +45,10 @@ extension Token {
     case minus = "-"
     case caret = "^"
     case dollar = "$"
+
+    case rightCurlyBracket = "}"
+    case leftCurlyBracket = "{"
+    case comma = ","
   }
 
 
@@ -74,6 +78,11 @@ extension Token {
   static var rightSquareBracket: Self { .meta(.rsquare) }
   static var minus: Self { .meta(.minus) }
   static var caret: Self { .meta(.caret) }
+
+  static var rightCurlyBracket: Self { .meta(.rightCurlyBracket) }
+  static var leftCurlyBracket: Self { .meta(.leftCurlyBracket) }
+  static var comma: Self { .meta(.comma) }
+
 }
 
 extension Token.MetaCharacter: CustomStringConvertible {

--- a/Sources/Regex/Parse/Token.swift
+++ b/Sources/Regex/Parse/Token.swift
@@ -20,6 +20,9 @@ enum Token: Hashable {
   case character(Character, isEscaped: Bool)
   case unicodeScalar(UnicodeScalar)
 
+  case startQuote // \Q
+  case endQuote   // \E
+
   case trivia // comments, ignored stuff, etc
 
   var isSemantic: Bool { self != .trivia }
@@ -86,6 +89,8 @@ extension Token: CustomStringConvertible {
     case .setOperator(let op): return op.description
     case .character(let c, _): return c.halfWidthCornerQuoted
     case .unicodeScalar(let u): return "U\(u.halfWidthCornerQuoted)"
+    case .startQuote: return "\\Q"
+    case .endQuote: return "\\E"
     case .trivia: return ""
     }
   }

--- a/Sources/Regex/SyntaxOptions.swift
+++ b/Sources/Regex/SyntaxOptions.swift
@@ -27,7 +27,7 @@ public struct SyntaxOptions: OptionSet {
   public static var modernComments: Self { Self(1 << 2) }
 
   /// ```
-  ///   'a{n...m}' == '/a{n,m}/
+  ///   'a{n...m}' == '/a{n,m}/'
   ///   'a{n..<m}' == '/a{n,m-1}/'
   ///   'a{n...}'  == '/a{n,}/'
   ///   'a{...m}'  == '/a{,m}/'
@@ -35,10 +35,11 @@ public struct SyntaxOptions: OptionSet {
   /// ```
   public static var modernRanges: Self { Self(1 << 3) }
 
+  /// `(name: .*)` == `(?<name>.*)`
+  ///  `(_: .*)` == `(?:.*)`
+  public static var modernCaptures: Self { Self(1 << 4) }
+
   /*
-    /// `(name: .*)` == `(?<name>.*)`
-    ///  `(_: .*)` == `(?:.*)`
-    public static var modernCaptures
 
     /// `<digit>*` == `[[:digit:]]*` == `\d*`
     public static var modernConsumers

--- a/Sources/Regex/SyntaxOptions.swift
+++ b/Sources/Regex/SyntaxOptions.swift
@@ -16,24 +16,32 @@ public struct SyntaxOptions: OptionSet {
   ///
   /// NOTE: Currently, this means we have raw quotes.
   /// Better would be to have real Swift string delimiter parsing logic.
-  public static var swiftyQuotes:          Self { Self(1 << 1) }
+  public static var modernQuotes:          Self { Self(1 << 1) }
 
   /// `a /* comment */ b` == `a(?#. comment )b`
-  public static var swiftyComments:        Self { Self(1 << 2) }
+  ///
+  /// NOTE: traditional comments are not nested. Currently, we are neither.
+  /// Traditional comments can't have `)`, not even escaped in them either, we
+  /// can. Traditional comments can have `*/` in them, we can't without
+  /// escaping. We don't currently do escaping.
+  public static var modernComments:        Self { Self(1 << 2) }
 
 /*
   /// `a{3..<10}` == `a{3,9}`
-  public static var swiftyRanges:        Self { Self(1 << 3) }
+  public static var modernRanges
 
-  /// `[[:digit:]]*` == `\d*` == `<digit>*`
- public static var consumers:            Self { Self(1 << 4) }
+  /// `(name: .*)` == `(?<name>.*)`
+  public static var modernCaptures
+
+ /// `<digit>*` == `[[:digit:]]*` == `\d*`
+ public static var modernConsumers
 
  */
 
   public static var traditional: Self { Self() }
 
   public static var modern: Self {
-    [.nonSemanticWhitespace, .swiftyQuotes, .swiftyComments]
+    [.nonSemanticWhitespace, .modernQuotes, .modernComments]
   }
 
   public var ignoreWhitespace: Bool {

--- a/Sources/Regex/SyntaxOptions.swift
+++ b/Sources/Regex/SyntaxOptions.swift
@@ -13,6 +13,9 @@ public struct SyntaxOptions: OptionSet {
   public static var nonSemanticWhitespace: Self { Self(1 << 0) }
 
   /// `a "." b` == `a\Q.\Eb`
+  ///
+  /// NOTE: Currently, this means we have raw quotes.
+  /// Better would be to have real Swift string delimiter parsing logic.
   public static var swiftyQuotes:          Self { Self(1 << 1) }
 
   /// `a /* comment */ b` == `a(?#. comment )b`

--- a/Sources/Regex/SyntaxOptions.swift
+++ b/Sources/Regex/SyntaxOptions.swift
@@ -9,28 +9,35 @@ public struct SyntaxOptions: OptionSet {
 
   public init() { self.init(0) }
 
-  /// `a \. b` == `a\.b`
+  /// `'a \. b' == '/a\.b/'`
   public static var nonSemanticWhitespace: Self { Self(1 << 0) }
 
-  /// `a "." b` == `a\Q.\Eb`
+  /// `'a "." b' == '/a\Q.\Eb/'`
   ///
   /// NOTE: Currently, this means we have raw quotes.
   /// Better would be to have real Swift string delimiter parsing logic.
-  public static var modernQuotes:          Self { Self(1 << 1) }
+  public static var modernQuotes: Self { Self(1 << 1) }
 
-  /// `a /* comment */ b` == `a(?#. comment )b`
+  /// `'a /* comment */ b' == '/a(?#. comment )b/'`
   ///
   /// NOTE: traditional comments are not nested. Currently, we are neither.
   /// Traditional comments can't have `)`, not even escaped in them either, we
   /// can. Traditional comments can have `*/` in them, we can't without
   /// escaping. We don't currently do escaping.
-  public static var modernComments:        Self { Self(1 << 2) }
+  public static var modernComments: Self { Self(1 << 2) }
 
-/*
-  /// `a{3..<10}` == `a{3,9}`
-  public static var modernRanges
+  /// ```
+  ///   'a{n...m}' == '/a{n,m}/
+  ///   'a{n..<m}' == '/a{n,m-1}/'
+  ///   'a{n...}'  == '/a{n,}/'
+  ///   'a{...m}'  == '/a{,m}/'
+  ///   'a{..<m}'  == '/a{,m-1}/'
+  /// ```
+  public static var modernRanges: Self { Self(1 << 3) }
 
+  /*
   /// `(name: .*)` == `(?<name>.*)`
+  ///  `(_: .*)` == `(?:.*)`
   public static var modernCaptures
 
  /// `<digit>*` == `[[:digit:]]*` == `\d*`
@@ -38,11 +45,9 @@ public struct SyntaxOptions: OptionSet {
 
  */
 
-  public static var traditional: Self { Self() }
+  public static var traditional: Self { Self(0) }
 
-  public static var modern: Self {
-    [.nonSemanticWhitespace, .modernQuotes, .modernComments]
-  }
+  public static var modern: Self { Self(~0) }
 
   public var ignoreWhitespace: Bool {
     contains(.nonSemanticWhitespace)

--- a/Sources/Regex/SyntaxOptions.swift
+++ b/Sources/Regex/SyntaxOptions.swift
@@ -36,14 +36,14 @@ public struct SyntaxOptions: OptionSet {
   public static var modernRanges: Self { Self(1 << 3) }
 
   /*
-  /// `(name: .*)` == `(?<name>.*)`
-  ///  `(_: .*)` == `(?:.*)`
-  public static var modernCaptures
+    /// `(name: .*)` == `(?<name>.*)`
+    ///  `(_: .*)` == `(?:.*)`
+    public static var modernCaptures
 
- /// `<digit>*` == `[[:digit:]]*` == `\d*`
- public static var modernConsumers
+    /// `<digit>*` == `[[:digit:]]*` == `\d*`
+    public static var modernConsumers
 
- */
+  */
 
   public static var traditional: Self { Self(0) }
 

--- a/Sources/Regex/Utility/ASTPrinting.swift
+++ b/Sources/Regex/Utility/ASTPrinting.swift
@@ -53,6 +53,7 @@ extension AST {
     case .characterClass(let cc): return ".characterClass(\(cc))"
     case .any: return ".any"
     case .empty: return "".halfWidthCornerQuoted
+    case .quote(let s): return s.halfWidthCornerQuoted
 
     case .trivia: return ""
     }

--- a/Sources/Regex/Utility/Peek.swift
+++ b/Sources/Regex/Utility/Peek.swift
@@ -17,11 +17,28 @@ extension _Peekable {
     defer { advance() }
     return peek().unsafelyUnwrapped
   }
+
+  mutating func advance(_ i: Int) {
+    for _ in 0..<i {
+      advance()
+    }
+  }
 }
 extension _Peekable where Output: Equatable {
   mutating func tryEat(_ c: Output) -> Bool {
     guard peek() == c else { return false }
     advance()
+    return true
+  }
+}
+extension _Peekable
+  where Self: Collection, Output == Element, Output: Equatable
+{
+  mutating func tryEat<C: Collection>(sequence c: C) -> Bool
+    where C.Element == Element
+  {
+    guard starts(with: c) else { return false }
+    advance(c.count)
     return true
   }
 }

--- a/Sources/Regex/Utility/Peek.swift
+++ b/Sources/Regex/Utility/Peek.swift
@@ -9,6 +9,12 @@ protocol _Peekable {
 }
 extension _Peekable where Self: Collection, Output == Element {
   func peek() -> Output? { self.first }
+
+  @discardableResult
+  mutating func eat(upTo: Index) -> SubSequence {
+    defer { while startIndex != upTo { eat() } }
+    return self[..<upTo]
+  }
 }
 extension _Peekable {
   @discardableResult

--- a/Tests/RegexTests/ParseTests.swift
+++ b/Tests/RegexTests/ParseTests.swift
@@ -120,9 +120,9 @@ extension RegexTests {
       #"a\Q .\Eb"#,
       "a", .startQuote, esc(" "), esc("."), .endQuote, "b")
     lexTest(
-      #"a\Q \Q \\.\Eb"#,
+      #"a\Q E\Q \\.\Eb"#,
       "a", .startQuote,
-      esc(" "), esc("\\"), esc("Q"), esc(" "),
+      esc(" "), esc("E"), esc("\\"), esc("Q"), esc(" "),
       esc("\\"), esc("\\"), esc("."),
       .endQuote, "b")
 
@@ -296,6 +296,17 @@ extension RegexTests {
       "--+", concat("-", .oneOrMore(.greedy, "-")))
     parseTest(
       "~~*", concat("~", .zeroOrMore(.greedy, "~")))
+
+    parseTest(
+      #"a\Q .\Eb"#,
+      concat("a", .quote(" ."), "b"))
+    parseTest(
+      #"a\Q \Q \\.\Eb"#,
+      concat(
+        "a",
+        .quote(#" \Q \\."#),
+        "b"))
+
 
     // TODO: failure tests
   }

--- a/Tests/RegexTests/ParseTests.swift
+++ b/Tests/RegexTests/ParseTests.swift
@@ -111,6 +111,21 @@ extension RegexTests {
       .leftSquareBracket, .rightSquareBracket,
       .setOperator(.doubleAmpersand), .rightSquareBracket,
       .rightSquareBracket, "&", "&")
+
+    // TODO: Lex unit testing is probably better formulated
+    // as parse tests. We might want a pull-based testing
+    // harness instead of running it for the sequence of tokens.
+
+    lexTest(
+      #"a\Q .\Eb"#,
+      "a", .startQuote, esc(" "), esc("."), .endQuote, "b")
+    lexTest(
+      #"a\Q \Q \\.\Eb"#,
+      "a", .startQuote,
+      esc(" "), esc("\\"), esc("Q"), esc(" "),
+      esc("\\"), esc("\\"), esc("."),
+      .endQuote, "b")
+
   }
 }
 

--- a/Tests/RegexTests/ParseTests.swift
+++ b/Tests/RegexTests/ParseTests.swift
@@ -312,6 +312,22 @@ extension RegexTests {
       #"a(?#. comment)b"#,
       concat("a", "b"))
 
+    parseTest(
+      #"a{1,2}"#,
+      .quantification(.range(.greedy, 1...2), "a"))
+    parseTest(
+      #"a{,2}"#,
+      .quantification(.upToN(.greedy, 2), "a"))
+    parseTest(
+      #"a{1,}"#,
+      .quantification(.nOrMore(.greedy, 1), "a"))
+    parseTest(
+      #"a{1}"#,
+      .quantification(.exactly(.greedy, 1), "a"))
+    parseTest(
+      #"a{1,2}?"#,
+      .quantification(.range(.reluctant, 1...2), "a"))
+
     // TODO: failure tests
   }
 

--- a/Tests/RegexTests/ParseTests.swift
+++ b/Tests/RegexTests/ParseTests.swift
@@ -328,6 +328,33 @@ extension RegexTests {
       #"a{1,2}?"#,
       .quantification(.range(.reluctant, 1...2), "a"))
 
+    // Named captures
+    parseTest(
+      #"a(?<label>b)c"#,
+      concat("a", .namedCapture("label", "b"), "c"))
+    parseTest(
+      #"a(?'label'b)c"#,
+      concat("a", .namedCapture("label", "b"), "c"))
+    parseTest(
+      #"a(?P<label>b)c"#,
+      concat("a", .namedCapture("label", "b"), "c"))
+    parseTest(
+      #"a(?P<label>b)c"#,
+      concat("a", .namedCapture("label", "b"), "c"))
+
+    // Other groups
+    parseTest(
+      #"a(?:b)c"#,
+      concat("a", .nonCapture("b"), "c"))
+    parseTest(
+      #"a(?|b)c"#,
+      concat("a", .nonCaptureReset("b"), "c"))
+    parseTest(
+      #"a(?>b)c"#,
+      concat("a", .atomicNonCapturing("b"), "c"))
+
+
+
     // TODO: failure tests
   }
 

--- a/Tests/RegexTests/ParseTests.swift
+++ b/Tests/RegexTests/ParseTests.swift
@@ -123,6 +123,13 @@ extension RegexTests {
       #"a\Q E\Q \\.\Eb"#,
       "a", .quote(#" E\Q \\."#), "b")
 
+    lexTest(
+      #"ab(?#. this is a comment)cd"#,
+      "a", "b", .comment(" this is a comment"), "c", "d")
+    lexTest(
+      #"ab(?#.not nested()cd"#,
+      "a", "b", .comment("not nested("), "c", "d")
+
   }
 }
 
@@ -299,11 +306,11 @@ extension RegexTests {
       concat("a", .quote(" ."), "b"))
     parseTest(
       #"a\Q \Q \\.\Eb"#,
-      concat(
-        "a",
-        .quote(#" \Q \\."#),
-        "b"))
+      concat("a", .quote(#" \Q \\."#), "b"))
 
+    parseTest(
+      #"a(?#. comment)b"#,
+      concat("a", "b"))
 
     // TODO: failure tests
   }

--- a/Tests/RegexTests/ParseTests.swift
+++ b/Tests/RegexTests/ParseTests.swift
@@ -118,13 +118,10 @@ extension RegexTests {
 
     lexTest(
       #"a\Q .\Eb"#,
-      "a", .startQuote, esc(" "), esc("."), .endQuote, "b")
+      "a", .quote(" ."), "b")
     lexTest(
       #"a\Q E\Q \\.\Eb"#,
-      "a", .startQuote,
-      esc(" "), esc("E"), esc("\\"), esc("Q"), esc(" "),
-      esc("\\"), esc("\\"), esc("."),
-      .endQuote, "b")
+      "a", .quote(#" E\Q \\."#), "b")
 
   }
 }

--- a/Tests/RegexTests/SyntaxOptionsTests.swift
+++ b/Tests/RegexTests/SyntaxOptionsTests.swift
@@ -19,4 +19,45 @@ extension RegexTests {
       #" \d+ \. \d+ \. \d+ \. \d+ "#,
       dotAST, syntax: .modern)
   }
+
+  func testSwiftyQuotes() {
+    func esc(_ c: Character) -> Token {
+      .character(c, isEscaped: true)
+    }
+
+    lexTest(
+      #"a\Q .\Eb"#,
+      "a", .startQuote, esc(" "), esc("."), .endQuote, "b",
+      syntax: .traditional)
+
+    // If we're quoted, whitespace is quoted too
+    lexTest(
+      #"a\Q .\Eb"#,
+      "a", .startQuote, esc(" "), esc("."), .endQuote, "b",
+      syntax: .nonSemanticWhitespace)
+
+    func concat(_ asts: AST...) -> AST { return .concatenation(asts) }
+    let quoteAST = concat(
+      "a", .quote(" ."), "b")
+    parseTest(
+      #"a\Q .\Eb"#,
+      quoteAST, syntax: .traditional)
+    parseTest(
+      #"a \Q .\E b"#,
+      quoteAST, syntax: .modern)
+    parseTest(
+      #"a" ."b"#,
+      quoteAST, syntax: .swiftyQuotes)
+    parseTest(
+      #"a " ." b"#,
+      quoteAST, syntax: .modern)
+
+    parseTest(
+      #" \d+ \. \d+ \. \d+ \. \d+ "#,
+      dotAST, syntax: .modern)
+    parseTest(
+      #" \d+ "." \d+ "." \d+ "." \d+ "#,
+      dotAST, syntax: .modern)
+  }
+
 }

--- a/Tests/RegexTests/SyntaxOptionsTests.swift
+++ b/Tests/RegexTests/SyntaxOptionsTests.swift
@@ -1,10 +1,16 @@
 @testable import Regex
 import XCTest
 
+private func esc(_ c: Character) -> Token {
+  .character(c, isEscaped: true)
+}
+
+
 private let dplus = AST.quantification(
   .oneOrMore(.greedy), .characterClass(.digit))
 private let dotAST = AST.concatenation([
   dplus, ".", dplus, ".", dplus, ".", dplus])
+
 
 extension RegexTests {
 
@@ -20,10 +26,7 @@ extension RegexTests {
       dotAST, syntax: .modern)
   }
 
-  func testSwiftyQuotes() {
-    func esc(_ c: Character) -> Token {
-      .character(c, isEscaped: true)
-    }
+  func testModernQuotes() {
 
     lexTest(
       #"a\Q .\Eb"#,
@@ -47,7 +50,7 @@ extension RegexTests {
       quoteAST, syntax: .modern)
     parseTest(
       #"a" ."b"#,
-      quoteAST, syntax: .swiftyQuotes)
+      quoteAST, syntax: .modernQuotes)
     parseTest(
       #"a " ." b"#,
       quoteAST, syntax: .modern)
@@ -60,4 +63,16 @@ extension RegexTests {
       dotAST, syntax: .modern)
   }
 
+  func testModernComments() {
+    lexTest(
+      #"(?#. network ) \d+ \. \d+"#,
+      .comment(" network "), esc("d"), .plus,
+      esc("."), esc("d"), .plus,
+      syntax: .nonSemanticWhitespace)
+    lexTest(
+      #"/* network */ \d+ \. \d+"#,
+      .comment(" network "), esc("d"), .plus,
+      esc("."), esc("d"), .plus,
+      syntax: .modern)
+  }
 }

--- a/Tests/RegexTests/SyntaxOptionsTests.swift
+++ b/Tests/RegexTests/SyntaxOptionsTests.swift
@@ -27,13 +27,13 @@ extension RegexTests {
 
     lexTest(
       #"a\Q .\Eb"#,
-      "a", .startQuote, esc(" "), esc("."), .endQuote, "b",
+      "a", .quote(" ."), "b",
       syntax: .traditional)
 
     // If we're quoted, whitespace is quoted too
     lexTest(
       #"a\Q .\Eb"#,
-      "a", .startQuote, esc(" "), esc("."), .endQuote, "b",
+      "a", .quote(" ."), "b",
       syntax: .nonSemanticWhitespace)
 
     func concat(_ asts: AST...) -> AST { return .concatenation(asts) }

--- a/Tests/RegexTests/SyntaxOptionsTests.swift
+++ b/Tests/RegexTests/SyntaxOptionsTests.swift
@@ -95,6 +95,18 @@ extension RegexTests {
       syntax: .modern)
   }
 
+  func testModernCaptures() {
+    parseTest(
+      #"a(?:b)c"#,
+      .concatenation(["a", .nonCapture("b"), "c"]))
+    parseTest(
+      #"a(_:b)c"#,
+      .concatenation(["a", .nonCapture("b"), "c"]),
+      syntax: .modernCaptures)
+
+    // TODO: `(name: .*)`
+  }
+
   func testModernComments() {
     lexTest(
       #"(?#. network ) \d+ \. \d+"#,

--- a/Tests/RegexTests/SyntaxOptionsTests.swift
+++ b/Tests/RegexTests/SyntaxOptionsTests.swift
@@ -61,6 +61,38 @@ extension RegexTests {
     parseTest(
       #" \d+ "." \d+ "." \d+ "." \d+ "#,
       dotAST, syntax: .modern)
+
+    parseTest(
+      #"a{1,2}"#,
+      .quantification(.range(.greedy, 1...2), "a"))
+    parseTest(
+      #"a{1...2}"#,
+      .quantification(.range(.greedy, 1...2), "a"),
+      syntax: .modernRanges)
+    parseTest(
+      #"a{1..<3}"#,
+      .quantification(.range(.greedy, 1...2), "a"),
+      syntax: .modernRanges)
+
+    parseTest(
+      #"a{,2}"#,
+      .quantification(.upToN(.greedy, 2), "a"))
+    parseTest(
+      #"a{...2}"#,
+      .quantification(.upToN(.greedy, 2), "a"),
+      syntax: .modern)
+    parseTest(
+      #"a{..<3}"#,
+      .quantification(.upToN(.greedy, 2), "a"),
+      syntax: .modern)
+
+    parseTest(
+      #"a{1,}"#,
+      .quantification(.nOrMore(.greedy, 1), "a"))
+    parseTest(
+      #"a{1...}"#,
+      .quantification(.nOrMore(.greedy, 1), "a"),
+      syntax: .modern)
   }
 
   func testModernComments() {


### PR DESCRIPTION
I went ahead and finished up groups and quantification with associated syntax options. I added in quotes and comments too.

This demonstrates some the brokenness of the lexer's current approach, beyond brokenness from custom character classes. It also shows some of the absurdity of trying to model with nested `enum`s.

I have this as a draft PR because it probably makes sense to fix the tokens and lexer instead of piling on hacks.