### PR TITLE
More terminal classification

### DIFF
--- a/Sources/Regex/Anchor.swift
+++ b/Sources/Regex/Anchor.swift
@@ -1,0 +1,18 @@
+/// An token that matches against a certain position in the subject.
+public enum Anchor: String, Hashable {
+  case lineStart = "^"
+  case lineEnd = "$"
+  case wordBoundary = "\\b"
+  case nonWordBoundary = "\\B"
+  case stringStart = "\\A"
+  case stringEndOrBeforeNewline = "\\Z"
+  case stringEnd = "\\z"
+  case startOfPreviousMatch = "\\G"
+  case resetMatch = "\\K"
+  case textSegmentBoundary = "\\y"
+  case textSegmentNonBoundary = "\\Y"
+}
+
+extension Anchor: CustomStringConvertible {
+  public var description: String { rawValue }
+}

--- a/Sources/Regex/CharacterClass.swift
+++ b/Sources/Regex/CharacterClass.swift
@@ -95,11 +95,13 @@ public struct CharacterClass: Hashable {
     return result
   }
 
-  /// Returns the character class with the isInverted property set to a given
-  /// value.
+  /// Returns an inverted character class if true is passed, otherwise the
+  /// same character class is returned.
   public func withInversion(_ invertion: Bool) -> Self {
     var copy = self
-    copy.isInverted = invertion
+    if invertion {
+      copy.isInverted.toggle()
+    }
     return copy
   }
 

--- a/Sources/Regex/CharacterClass.swift
+++ b/Sources/Regex/CharacterClass.swift
@@ -174,18 +174,6 @@ extension CharacterClass {
   ) -> CharacterClass {
     .init(cc: .custom(components), matchLevel: .graphemeCluster)
   }
-  
-  init?(_ ch: Character) {
-    switch ch {
-    case "s": self = .whitespace
-    case "d": self = .digit
-    case "w": self = .word
-    case "S", "D", "W":
-      self = Self(Character(ch.lowercased()))!.inverted
-
-    default: return nil
-    }
-  }
 }
 
 extension CharacterClass.CharacterSetComponent: CustomStringConvertible {

--- a/Sources/Regex/Parse/Parse.swift
+++ b/Sources/Regex/Parse/Parse.swift
@@ -108,17 +108,6 @@ extension Parser {
       // TODO: anything else here?
       return .character(c)
 
-    case .minus?, .colon?, .rightSquareBracket?:
-      // Outside of custom character classes, these are not considered to be
-      // metacharacters.
-
-      // TODO: we want a much cleaner separation here, perhaps
-      // lexer can present as normal characters
-      guard case .meta(let meta) = lexer.eat() else {
-        fatalError("Not a metachar?")
-      }
-      return .character(meta.rawValue)
-
     case .leftSquareBracket?:
       return .characterClass(try parseCustomCharacterClass())
 

--- a/Sources/Regex/Parse/Parse.swift
+++ b/Sources/Regex/Parse/Parse.swift
@@ -100,13 +100,13 @@ extension Parser {
 
     case .character(let c, isEscaped: true):
       lexer.eat()
-      if let cc = CharacterClass(c) {
-        // Other characters either match a character class...
-        return .characterClass(cc)
-      }
 
       // TODO: anything else here?
       return .character(c)
+
+    case .builtinCharClass(let cc):
+      lexer.eat()
+      return .characterClass(cc)
 
     case .leftSquareBracket?:
       return .characterClass(try parseCustomCharacterClass())
@@ -155,9 +155,8 @@ extension Parser {
     if lexer.peek() == .leftSquareBracket {
       return .characterClass(try parseCustomCharacterClass())
     }
-    // Escaped character class.
-    if case .character(let c, isEscaped: true) = lexer.peek(),
-       let cc = CharacterClass(c) {
+    // Builtin character class.
+    if case .builtinCharClass(let cc) = lexer.peek() {
       lexer.eat()
       return .characterClass(cc)
     }

--- a/Sources/Regex/Parse/Token.swift
+++ b/Sources/Regex/Parse/Token.swift
@@ -19,6 +19,7 @@ enum Token: Hashable {
   case setOperator(SetOperator)
   case character(Character, isEscaped: Bool)
   case unicodeScalar(UnicodeScalar)
+  case builtinCharClass(CharacterClass)
 
   case trivia // comments, ignored stuff, etc
 
@@ -86,6 +87,7 @@ extension Token: CustomStringConvertible {
     case .setOperator(let op): return op.description
     case .character(let c, _): return c.halfWidthCornerQuoted
     case .unicodeScalar(let u): return "U\(u.halfWidthCornerQuoted)"
+    case .builtinCharClass(let cc): return cc.description
     case .trivia: return ""
     }
   }

--- a/Sources/Regex/Parse/Token.swift
+++ b/Sources/Regex/Parse/Token.swift
@@ -94,25 +94,3 @@ extension Token: CustomStringConvertible {
 extension Character {
   var isEscape: Bool { return self == "\\" }
 }
-
-extension Lexer {
-  /// Classify a given terminal character
-  func classifyTerminal(
-    _ t: Character,
-    fromEscape escaped: Bool
-  ) -> Token {
-    assert(!t.isEscape || escaped)
-    if !escaped {
-      // TODO: figure out best way to organize options logic...
-      if syntax.ignoreWhitespace, t == " " {
-        return .trivia
-      }
-
-      if let mc = Token.MetaCharacter(rawValue: t) {
-        return .meta(mc)
-      }
-    }
-
-    return .character(t, isEscaped: escaped)
-  }
-}

--- a/Sources/Regex/Parse/Token.swift
+++ b/Sources/Regex/Parse/Token.swift
@@ -20,6 +20,7 @@ enum Token: Hashable {
   case character(Character, isEscaped: Bool)
   case unicodeScalar(UnicodeScalar)
   case builtinCharClass(CharacterClass)
+  case anchor(Anchor)
 
   case trivia // comments, ignored stuff, etc
 
@@ -42,9 +43,7 @@ extension Token {
     case rsquare = "]"
     case minus = "-"
     case caret = "^"
-    case dollar = "$"
   }
-
 
   enum SetOperator: String, Hashable {
     case doubleAmpersand = "&&"
@@ -88,6 +87,7 @@ extension Token: CustomStringConvertible {
     case .character(let c, _): return c.halfWidthCornerQuoted
     case .unicodeScalar(let u): return "U\(u.halfWidthCornerQuoted)"
     case .builtinCharClass(let cc): return cc.description
+    case .anchor(let anchor): return anchor.description
     case .trivia: return ""
     }
   }

--- a/Sources/Regex/Parse/Token.swift
+++ b/Sources/Regex/Parse/Token.swift
@@ -21,6 +21,7 @@ enum Token: Hashable {
   case unicodeScalar(UnicodeScalar)
   case builtinCharClass(CharacterClass)
   case anchor(Anchor)
+  case specialCharEscape(SpecialCharacterEscape)
 
   case trivia // comments, ignored stuff, etc
 
@@ -51,6 +52,15 @@ extension Token {
     case doubleTilda = "~~"
   }
 
+  enum SpecialCharacterEscape: String, Hashable {
+    case tab = "\\t"
+    case carriageReturn = "\\r"
+    case backspace = "\\b"
+    case formFeed = "\\f"
+    case bell = "\\a"
+    case escape = "\\e"
+  }
+
   // Note: We do each character individually, as post-fix modifiers bind
   // tighter than concatenation. "abc*" is "a" -> "b" -> "c*"
 }
@@ -79,6 +89,9 @@ extension Token.MetaCharacter: CustomStringConvertible {
 extension Token.SetOperator: CustomStringConvertible {
   var description: String { rawValue }
 }
+extension Token.SpecialCharacterEscape: CustomStringConvertible {
+  var description: String { rawValue }
+}
 extension Token: CustomStringConvertible {
   var description: String {
     switch self {
@@ -88,6 +101,7 @@ extension Token: CustomStringConvertible {
     case .unicodeScalar(let u): return "U\(u.halfWidthCornerQuoted)"
     case .builtinCharClass(let cc): return cc.description
     case .anchor(let anchor): return anchor.description
+    case .specialCharEscape(let special): return special.description
     case .trivia: return ""
     }
   }

--- a/Sources/Regex/Parse/TokenClassification.swift
+++ b/Sources/Regex/Parse/TokenClassification.swift
@@ -1,0 +1,47 @@
+extension Lexer {
+  private static func classifyAsMetaChar(
+    _ t: Character, inCustomCharClass: Bool
+  ) -> Token.MetaCharacter? {
+    guard let mc = Token.MetaCharacter(rawValue: t) else { return nil }
+
+    // Inside a custom character class, the only metacharacters are
+    // '[', ']', '^', '-', ':'.
+    switch mc {
+    case .lsquare:
+      // Metacharacters both inside and outside custom character classes.
+      break
+    case .rsquare, .minus, .colon, .caret:
+      // Only metacharacters inside a custom character class. Though colon is
+      // only needed for POSIX char classes, and caret for inverted char
+      // classes, they could be dropped if we produced a single token for a
+      // char class start.
+      if !inCustomCharClass { return nil }
+    default:
+      // By default, no other metacharacters exist in custom character
+      // classes.
+      if inCustomCharClass { return nil }
+    }
+    return mc
+  }
+
+  /// Classify a given terminal character
+  static func classifyTerminal(
+    _ t: Character,
+    fromEscape escaped: Bool,
+    inCustomCharClass: Bool,
+    syntax: SyntaxOptions
+  ) -> Token {
+    assert(!t.isEscape || escaped)
+    if !escaped {
+      // TODO: figure out best way to organize options logic...
+      if syntax.ignoreWhitespace, t == " " {
+        return .trivia
+      }
+      // A metacharacter such as '(', ']', '?'.
+      if let mc = classifyAsMetaChar(t, inCustomCharClass: inCustomCharClass) {
+        return .meta(mc)
+      }
+    }
+    return .character(t, isEscaped: escaped)
+  }
+}

--- a/Tests/RegexTests/ParseTests.swift
+++ b/Tests/RegexTests/ParseTests.swift
@@ -88,7 +88,7 @@ extension RegexTests {
       .rightSquareBracket)
     lexTest(
       "&&^-^-~~",
-      "&", "&", .caret, "-", .caret, "-", "~", "~")
+      "&", "&", .anchor(.lineStart), "-", .anchor(.lineStart), "-", "~", "~")
     lexTest(
       "[]]&&",
       .leftSquareBracket, .rightSquareBracket, "]", "&", "&")
@@ -109,6 +109,10 @@ extension RegexTests {
       .leftSquareBracket, .rightSquareBracket,
       .setOperator(.doubleAmpersand), .rightSquareBracket,
       .rightSquareBracket, "&", "&")
+
+    lexTest("$\\A\\B[\\A\\B$]", .anchor(.lineEnd), .anchor(.stringStart),
+            .anchor(.nonWordBoundary), .leftSquareBracket, esc("A"), esc("B"),
+            "$", .rightSquareBracket)
   }
 }
 

--- a/Tests/RegexTests/ParseTests.swift
+++ b/Tests/RegexTests/ParseTests.swift
@@ -72,7 +72,7 @@ extension RegexTests {
       "a|b?c", "a", .pipe, "b", .question, "c")
     lexTest(
       "(?:a|b)c",
-      .leftParen, .question, .colon, "a", .pipe, "b",
+      .leftParen, .question, ":", "a", .pipe, "b",
       .rightParen, "c")
     lexTest(
       "a\\u0065b\\u{65}c\\x65d",
@@ -88,15 +88,13 @@ extension RegexTests {
       .rightSquareBracket)
     lexTest(
       "&&^-^-~~",
-      "&", "&", .caret, .minus, .caret, .minus, "~", "~")
+      "&", "&", .caret, "-", .caret, "-", "~", "~")
     lexTest(
       "[]]&&",
-      .leftSquareBracket, .rightSquareBracket,
-      .rightSquareBracket, "&", "&")
+      .leftSquareBracket, .rightSquareBracket, "]", "&", "&")
     lexTest(
       "[]]&\\&",
-      .leftSquareBracket, .rightSquareBracket,
-      .rightSquareBracket, "&", esc("&"))
+      .leftSquareBracket, .rightSquareBracket, "]", "&", esc("&"))
 
     // Gramatically invalid (yet lexically valid)
     lexTest(


### PR DESCRIPTION
Add terminal classification for anchors, special escape characters, and meta characters, parameterized by whether or not we're in a custom character class.