### PR TITLE
Expand builtin character class parsing

### DIFF
--- a/Sources/Regex/Parse/Lex.swift
+++ b/Sources/Regex/Parse/Lex.swift
@@ -189,13 +189,8 @@ extension Lexer {
                | 'x{' HexDigit{1, 8}
                | 'x' HexDigit{2}
                | 'U' HexDigit{8}
-    BuiltinCharClass -> '\d' | '\D' | '\s' | '\S' | '\w' | '\W'
     */
-    let c = source.eat()
-    if let cc = tryConsumeBuiltinCharacterClass(c) {
-      return .builtinCharClass(cc)
-    }
-    switch c {
+    switch source.eat() {
     case "u":
       return consumeUniScalar(
         allowBracketVariant: true, unbracketedNumDigits: 4)
@@ -270,22 +265,6 @@ extension Lexer {
       return .setOperator(.doubleTilda)
     case "&" where source.tryEat("&"):
       return .setOperator(.doubleAmpersand)
-    default:
-      return nil
-    }
-  }
-
-  private mutating func tryConsumeBuiltinCharacterClass(
-    _ c: Character
-  ) -> CharacterClass? {
-    // These are valid both inside and outside custom character classes.
-    switch c {
-    case "s": return .whitespace
-    case "d": return .digit
-    case "w": return .word
-    case "S", "D", "W":
-      let lower = Character(c.lowercased())
-      return tryConsumeBuiltinCharacterClass(lower)!.inverted
     default:
       return nil
     }

--- a/Sources/Regex/Parse/Parse.swift
+++ b/Sources/Regex/Parse/Parse.swift
@@ -111,10 +111,6 @@ extension Parser {
     case .leftSquareBracket?:
       return .characterClass(try parseCustomCharacterClass())
 
-    case .dot?:
-      lexer.eat()
-      return .characterClass(.any)
-
     // Correct terminations
 
     case .trivia?:

--- a/Sources/Regex/Parse/Token.swift
+++ b/Sources/Regex/Parse/Token.swift
@@ -59,6 +59,7 @@ extension Token {
     case formFeed = "\\f"
     case bell = "\\a"
     case escape = "\\e"
+    case newline = "\\n"
   }
 
   // Note: We do each character individually, as post-fix modifiers bind

--- a/Sources/Regex/Parse/Token.swift
+++ b/Sources/Regex/Parse/Token.swift
@@ -38,7 +38,6 @@ extension Token {
     case pipe = "|"
     case lparen = "("
     case rparen = ")"
-    case dot = "."
     case colon = ":"
     case lsquare = "["
     case rsquare = "]"
@@ -76,7 +75,6 @@ extension Token {
   static var rightParen: Self { .meta(.rparen) }
   static var star: Self { .meta(.star) }
   static var plus: Self { .meta(.plus) }
-  static var dot: Self { .meta(.dot) }
   static var colon: Self { .meta(.colon) }
   static var leftSquareBracket: Self { .meta(.lsquare) }
   static var rightSquareBracket: Self { .meta(.rsquare) }

--- a/Sources/Regex/Parse/TokenClassification.swift
+++ b/Sources/Regex/Parse/TokenClassification.swift
@@ -1,4 +1,11 @@
 extension Lexer {
+  /// Classify a 'special character escape'.
+  ///
+  /// If in a custom character class:
+  /// SpecialCharEscape -> '\t' | '\r' | '\b' | '\f' | '\a' | '\e'
+  ///
+  /// Otherwise
+  /// SpecialCharEscape -> '\t' | '\r' | '\f' | '\a' | '\e'
   private static func classifyAsSpecialCharEscape(
     _ t: Character, inCustomCharClass: Bool
   ) -> Token.SpecialCharacterEscape? {
@@ -20,6 +27,15 @@ extension Lexer {
       return nil
     }
   }
+
+  /// Classify an anchor character.
+  ///
+  /// If in a custom character class:
+  /// Anchor -> <none>
+  ///
+  /// Otherwise:
+  /// Anchor -> '^' | '$' | '\b' | '\B' | '\A' | '\Z' | '\z' | '\G' | '\K' |
+  ///           '\y' | '\Y'
   private static func classifyAsAnchor(
     _ t: Character, fromEscape escaped: Bool, inCustomCharClass: Bool
   ) -> Anchor? {
@@ -58,6 +74,15 @@ extension Lexer {
       return nil
     }
   }
+
+  /// Classify a meta-character.
+  ///
+  /// In a custom character class:
+  /// MetaChar -> '[' | ']' | '-' | '^'
+  ///
+  /// Otherwise:
+  /// MetaChar -> '[' | '*' | '?' | '|' | '(' | ')' | '.' | ':'
+  ///
   private static func classifyAsMetaChar(
     _ t: Character, inCustomCharClass: Bool
   ) -> Token.MetaCharacter? {
@@ -83,7 +108,13 @@ extension Lexer {
     return mc
   }
 
-  /// Classify a given terminal character
+  /// Classify a given terminal character.
+  ///
+  /// Terminal -> Anchor | MetaChar | SpecialCharEscape | Character
+  ///
+  /// If .ignoreWhitespace:
+  /// ' ' -> Trivia
+  ///
   static func classifyTerminal(
     _ t: Character,
     fromEscape escaped: Bool,

--- a/Sources/Regex/Parse/TokenClassification.swift
+++ b/Sources/Regex/Parse/TokenClassification.swift
@@ -2,10 +2,10 @@ extension Lexer {
   /// Classify a 'special character escape'.
   ///
   /// If in a custom character class:
-  /// SpecialCharEscape -> '\t' | '\r' | '\b' | '\f' | '\a' | '\e'
+  /// SpecialCharEscape -> '\t' | '\r' | '\b' | '\f' | '\a' | '\e' | '\n'
   ///
-  /// Otherwise
-  /// SpecialCharEscape -> '\t' | '\r' | '\f' | '\a' | '\e'
+  /// Otherwise:
+  /// SpecialCharEscape -> '\t' | '\r' | '\f' | '\a' | '\e' | '\n'
   private static func classifyAsSpecialCharEscape(
     _ t: Character, inCustomCharClass: Bool
   ) -> Token.SpecialCharacterEscape? {
@@ -23,6 +23,8 @@ extension Lexer {
       return .bell
     case "e":
       return .escape
+    case "n":
+      return .newline
     default:
       return nil
     }

--- a/Tests/RegexTests/ParseTests.swift
+++ b/Tests/RegexTests/ParseTests.swift
@@ -121,10 +121,11 @@ extension RegexTests {
             .anchor(.nonWordBoundary), .leftSquareBracket, esc("A"), esc("B"),
             "$", .rightSquareBracket)
 
-    let specialChars = [.tab, .carriageReturn, .formFeed, .bell, .escape]
-      .map(Token.specialCharEscape)
+    let specialChars = [
+      .tab, .carriageReturn, .formFeed, .bell, .escape, .newline
+    ].map(Token.specialCharEscape)
 
-    lexTest(#"\t\r\f\a\e[\t\r\f\a\e]"#,
+    lexTest(#"\t\r\f\a\e\n[\t\r\f\a\e\n]"#,
             specialChars + [.leftSquareBracket] + specialChars +
             [.rightSquareBracket])
 


### PR DESCRIPTION
Move classification of builtin character classes into TerminalClassification.swift, and handle more builtin character class kinds.