### PR TITLE
Fix compilation with Swift 5.5.

### DIFF
--- a/Sources/Algorithms/Consumers/RegexConsumer.swift
+++ b/Sources/Algorithms/Consumers/RegexConsumer.swift
@@ -13,7 +13,7 @@ public struct Regex {
 public struct RegexConsumer: CollectionConsumer {
   // NOTE: existential
   let vm: Executor
-  let referenceVM: VirtualMachine
+  let referenceVM: TortoiseVM
 
   public init(regex: Regex) {
     let ast = try! parse(regex.string, .traditional)


### PR DESCRIPTION
Not use `VirtualMachine` as an existential in `RegexConsumer` given that it's being initialized as a concrete `TortoiseVM` anyway.