### PR TITLE
Some AST construction and DSL refactoring

### DIFF
--- a/Sources/_MatchingEngine/Regex/AST/AST.swift
+++ b/Sources/_MatchingEngine/Regex/AST/AST.swift
@@ -1,5 +1,5 @@
 /// A regex abstract syntax tree
-public enum AST: ASTValue, ASTAction {
+public enum AST: ASTValue/*, ASTAction*/ {
   public typealias Product = Self
 
   /// ... | ... | ...
@@ -10,10 +10,6 @@ public enum AST: ASTValue, ASTAction {
 
   /// (...)
   indirect case group(Group, AST)
-
-  /// Group with a registered transform
-  indirect case groupTransform(
-    Group, AST, transform: CaptureTransform)
 
   indirect case quantification(Quantifier, AST)
 
@@ -26,6 +22,11 @@ public enum AST: ASTValue, ASTAction {
   case customCharacterClass(CustomCharacterClass)
 
   case empty
+
+
+  // FIXME: Move off the regex literal AST
+  indirect case groupTransform(
+    Group, AST, transform: CaptureTransform)
 }
 
 extension AST {

--- a/Sources/_MatchingEngine/Regex/AST/ASTAction.swift
+++ b/Sources/_MatchingEngine/Regex/AST/ASTAction.swift
@@ -1,20 +1,23 @@
-public protocol ASTAction {
-  // TODO: associated types, or just make them produce AST nodes?
+// TODO: This might be interesting in the future, but for now
+// we make trees
 
-  // MARK: Group
-  static func capture(_ a: AST, _ sr: SourceRange?) -> AST
-
-  static func nonCapture(_ a: AST, _ sr: SourceRange?) -> AST
-
-  // MARK: Quantification
-
-  static func zeroOrMore(
-    _ kind: Quantifier.Kind, _ a: AST, _ r: SourceRange?
-  ) -> AST
-  static func oneOrMore(
-    _ kind: Quantifier.Kind, _ a: AST, _ r: SourceRange?
-  ) -> AST
-  static func zeroOrOne(
-    _ kind: Quantifier.Kind, _ a: AST, _ r: SourceRange?
-  ) -> AST
-}
+//public protocol ASTAction {
+//  // TODO: associated types, or just make them produce AST nodes?
+//
+//  // MARK: Group
+//  static func capture(_ a: AST, _ sr: SourceRange?) -> AST
+//
+//  static func nonCapture(_ a: AST, _ sr: SourceRange?) -> AST
+//
+//  // MARK: Quantification
+//
+//  static func zeroOrMore(
+//    _ kind: Quantifier.Kind, _ a: AST, _ r: SourceRange?
+//  ) -> AST
+//  static func oneOrMore(
+//    _ kind: Quantifier.Kind, _ a: AST, _ r: SourceRange?
+//  ) -> AST
+//  static func zeroOrOne(
+//    _ kind: Quantifier.Kind, _ a: AST, _ r: SourceRange?
+//  ) -> AST
+//}

--- a/Sources/_MatchingEngine/Regex/AST/ASTBuilder.swift
+++ b/Sources/_MatchingEngine/Regex/AST/ASTBuilder.swift
@@ -1,0 +1,156 @@
+/*
+
+These functions are temporary AST construction helpers. As
+the AST gets more and more source-location tracking, we'll
+want easier migration paths for our parser tests (which
+construct and compare location-less AST nodes) as well as the
+result builder DSL (which has a different notion of location).
+
+Without real namespaces and `using`, attempts at
+pseudo-namespaces tie the use site to being nested inside a
+type. So for now, these are global, but they will likely be
+namespaced in the future if/when clients are weaned off the
+AST.
+
+*/
+
+public let _fakeLoc = "".startIndex
+public let _fakeRange = _fakeLoc ..< _fakeLoc
+
+public func alt(_ asts: [AST]) -> AST {
+  .alternation(asts)
+}
+public func alt(_ asts: AST...) -> AST {
+  alt(asts)
+}
+
+public func concat(_ asts: [AST]) -> AST {
+  .concatenation(asts)
+}
+public func concat(_ asts: AST...) -> AST {
+  concat(asts)
+}
+
+public func group(
+  _ kind: Group.Kind, _ child: AST
+) -> AST {
+  .group(Group(kind, _fakeRange), child)
+}
+public func capture(
+  _ child: AST
+) -> AST {
+  group(.capture, child)
+}
+public func nonCapture(
+  _ child: AST
+) -> AST {
+  group(.nonCapture, child)
+}
+public func namedCapture(
+  _ name: String,
+  _ child: AST
+) -> AST {
+  group(.namedCapture(name), child)
+}
+public func nonCaptureReset(
+  _ child: AST
+) -> AST {
+  group(.nonCaptureReset, child)
+}
+public func atomicNonCapturing(
+  _ child: AST
+) -> AST {
+  group(.atomicNonCapturing, child)
+}
+public func lookahead(_ child: AST) -> AST {
+  group(.lookahead, child)
+}
+public func lookbehind(_ child: AST) -> AST {
+  group(.lookbehind, child)
+}
+public func negativeLookahead(_ child: AST) -> AST {
+  group(.negativeLookahead, child)
+}
+public func negativeLookbehind(_ child: AST) -> AST {
+  group(.negativeLookbehind, child)
+}
+
+public var any: AST { .atom(.any) }
+
+public func quant(
+  _ amount: Quantifier.Amount,
+  _ kind: Quantifier.Kind = .greedy,
+  _ child: AST
+) -> AST {
+  .quantification(Quantifier(amount, kind, _fakeRange), child)
+}
+public func zeroOrMore(
+  _ kind: Quantifier.Kind = .greedy,
+  _ child: AST
+) -> AST {
+  quant(.zeroOrMore, kind, child)
+}
+public func zeroOrOne(
+  _ kind: Quantifier.Kind = .greedy,
+  _ child: AST
+) -> AST {
+  quant(.zeroOrOne, kind, child)
+}
+public func oneOrMore(
+  _ kind: Quantifier.Kind = .greedy,
+  _ child: AST
+) -> AST {
+  quant(.oneOrMore, kind, child)
+}
+public func exactly(
+  _ kind: Quantifier.Kind = .greedy,
+  _ i: Int,
+  child: AST
+) -> AST {
+  quant(.exactly(i), kind, child)
+}
+public func nOrMore(
+  _ kind: Quantifier.Kind = .greedy,
+  _ i: Int,
+  child: AST
+) -> AST {
+  quant(.nOrMore(i), kind, child)
+}
+public func upToN(
+  _ kind: Quantifier.Kind = .greedy,
+  _ i: Int,
+  child: AST
+) -> AST {
+  quant(.upToN(i), kind, child)
+}
+public func quantRange(
+  _ kind: Quantifier.Kind = .greedy,
+  _ r: ClosedRange<Int>,
+  child: AST
+) -> AST {
+  quant(.range(r), kind, child)
+}
+
+public func charClass(
+  _ members: CustomCharacterClass.Member...,
+  inverted: Bool = false
+) -> AST {
+  let cc = CustomCharacterClass(
+    inverted ? .inverted : .normal, members
+  )
+  return .customCharacterClass(cc)
+}
+public func charClass(
+  _ members: CustomCharacterClass.Member...,
+  inverted: Bool = false
+) -> CustomCharacterClass.Member {
+  let cc = CustomCharacterClass(
+    inverted ? .inverted : .normal, members
+  )
+  return .custom(cc)
+}
+public func posixSet(
+  _ set: Unicode.POSIXCharacterSet, inverted: Bool = false
+) -> Atom {
+  return .named(.init(inverted: inverted, set: set))
+}

--- a/Sources/_MatchingEngine/Regex/AST/ASTEntity.swift
+++ b/Sources/_MatchingEngine/Regex/AST/ASTEntity.swift
@@ -10,7 +10,7 @@ public protocol ASTValue: _ASTPrintable, Hashable {
 ///
 /// Tracks source location information
 public protocol ASTEntity: ASTValue {
-  var sourceRange: SourceRange? { get }
+  var sourceRange: SourceRange { get }
 }
 
 public protocol ASTParentEntity: ASTEntity, _ASTPrintableNested {

--- a/Sources/_MatchingEngine/Regex/AST/Group.swift
+++ b/Sources/_MatchingEngine/Regex/AST/Group.swift
@@ -1,10 +1,10 @@
 public struct Group: ASTParentEntity {
   public let kind: Kind
 
-  public let sourceRange: SourceRange?
+  public let sourceRange: SourceRange
 
-  init(
-    _ kind: Kind, _ r: SourceRange?
+  public init(
+    _ kind: Kind, _ r: SourceRange
   ) {
     self.kind = kind
     self.sourceRange = r
@@ -45,40 +45,6 @@ extension Group {
     // NOTE: Comments appear to be groups, but are not parsed
     // the same. They parse more like quotes, so are not listed
     // here.
-  }
-}
-
-// MARK: - Convenience constructors
-
-extension Group {
-  public static func capture(_ sr: SourceRange? = nil) -> Group {
-    Group(.capture, sr)
-  }
-  public static func named(
-    _ s: String, _ sr: SourceRange? = nil
-  ) -> Group {
-    Group(.namedCapture(s), sr)
-  }
-  public static func nonCapture(_ sr: SourceRange? = nil) -> Group {
-    Group(.nonCapture, sr)
-  }
-  public static func nonCaptureReset(_ sr: SourceRange? = nil) -> Group {
-    Group(.nonCaptureReset, sr)
-  }
-  public static func atomicNonCapturing(_ sr: SourceRange? = nil) -> Group {
-    Group(.atomicNonCapturing, sr)
-  }
-  public static func lookahead(_ sr: SourceRange? = nil) -> Group {
-    Group(.lookahead, sr)
-  }
-  public static func lookbehind(inverted: Bool, _ sr: SourceRange? = nil) -> Group {
-    Group(.lookbehind, sr)
-  }
-  public static func negativeLookahead(inverted: Bool, _ sr: SourceRange? = nil) -> Group {
-    Group(.negativeLookahead, sr)
-  }
-  public static func negativeLookbehind(inverted: Bool, _ sr: SourceRange? = nil) -> Group {
-    Group(.negativeLookbehind, sr)
   }
 }
 
@@ -150,47 +116,4 @@ extension Group {
     res += ")"
     return res
   }
-}
-
-// MARK: - AST constructors
-
-// TODO: Consider refactoring ASTAction some, but it will have
-// to encode the structure of the AST, fundamentally...
-
-extension AST {
-  public static func capture(
-    _ a: AST, _ sr: SourceRange? = nil
-  ) -> AST {
-    .group(.capture(sr), a)
-  }
-  public static func namedCapture(
-    _ name: String, _ a: AST, _ sr: SourceRange? = nil
-  ) -> AST {
-    .group(.named(name, sr), a)
-  }
-  public static func nonCapture(
-    _ a: AST, _ sr: SourceRange? = nil
-  ) -> AST {
-    .group(.nonCapture(sr), a)
-  }
-  public static func nonCaptureReset(
-    _ a: AST, _ sr: SourceRange? = nil
-  ) -> AST {
-    .group(.nonCaptureReset(sr), a)
-  }
-  public static func atomicNonCapturing(
-    _ a: AST, _ sr: SourceRange? = nil
-  ) -> AST {
-    .group(.atomicNonCapturing(sr), a)
-  }
-//  public static func lookahead(
-//    inverted: Bool, _ a: AST, _ sr: SourceRange? = nil
-//  ) -> AST {
-//    .group(.lookahead(inverted: inverted, sr), a)
-//  }
-//  public static func lookbehind(
-//    inverted: Bool, _ a: AST, _ sr: SourceRange? = nil
-//  ) -> AST {
-//    .group(.lookbehind(inverted: inverted, sr), a)
-//  }
 }

--- a/Sources/_MatchingEngine/Regex/AST/Quantifier.swift
+++ b/Sources/_MatchingEngine/Regex/AST/Quantifier.swift
@@ -2,9 +2,9 @@ public struct Quantifier: ASTParentEntity {
   public let amount: Amount
   public let kind: Kind
 
-  public let sourceRange: SourceRange?
+  public let sourceRange: SourceRange
 
-  init(_ a: Amount, _ k: Kind, _ r: SourceRange?) {
+  init(_ a: Amount, _ k: Kind, _ r: SourceRange) {
     self.amount = a
     self.kind = k
     self.sourceRange = r
@@ -33,41 +33,42 @@ extension Quantifier {
  
 // MARK: - Convenience constructors
 
+// TODO: This should get dropped with AST overhaul
 extension Quantifier {
   public static func zeroOrMore(
-    _ k: Kind, _ sr: SourceRange? = nil
+    _ k: Kind
   ) -> Self {
-    Self(.zeroOrMore, k, sr)
+    Self(.zeroOrMore, k, _fakeRange)
   }
   public static func oneOrMore(
-    _ k: Kind, _ sr: SourceRange? = nil
+    _ k: Kind
   ) -> Self {
-    Self(.oneOrMore, k, sr)
+    Self(.oneOrMore, k, _fakeRange)
   }
   public static func zeroOrOne(
-    _ k: Kind, _ sr: SourceRange? = nil
+    _ k: Kind
   ) -> Self {
-    Self(.zeroOrOne, k, sr)
+    Self(.zeroOrOne, k, _fakeRange)
   }
   public static func exactly(
-    _ k: Kind, _ i: Int, _ sr: SourceRange? = nil
+    _ k: Kind, _ i: Int
   ) -> Self {
-    Self(.exactly(i), k, sr)
+    Self(.exactly(i), k, _fakeRange)
   }
   public static func nOrMore(
-    _ k: Kind, _ i: Int, _ sr: SourceRange? = nil
+    _ k: Kind, _ i: Int
   ) -> Self {
-    Self(.nOrMore(i), k, sr)
+    Self(.nOrMore(i), k, _fakeRange)
   }
   public static func upToN(
-    _ k: Kind, _ i: Int, _ sr: SourceRange? = nil
+    _ k: Kind, _ i: Int
   ) -> Self {
-    Self(.upToN(i), k, sr)
+    Self(.upToN(i), k, _fakeRange)
   }
   public static func range(
-    _ k: Kind, _ r: ClosedRange<Int>, _ sr: SourceRange? = nil
+    _ k: Kind, _ r: ClosedRange<Int>
   ) -> Self {
-    Self(.range(r), k, sr)
+    Self(.range(r), k, _fakeRange)
   }
 }
 
@@ -117,25 +118,5 @@ extension Quantifier: _ASTPrintable {
 
   public func _dumpNested(_ child: String) -> String {
     "\(amount._dump())_\(kind._dump())(\(child)"
-  }
-}
-
-// MARK: - AST constructors
-
-extension AST {
-  public static func zeroOrMore(
-    _ kind: Quantifier.Kind, _ a: AST, _ r: SourceRange? = nil
-  ) -> AST {
-    .quantification(.zeroOrMore(kind, r), a)
-  }
-  public static func oneOrMore(
-    _ kind: Quantifier.Kind, _ a: AST, _ r: SourceRange? = nil
-  ) -> AST {
-    .quantification(.oneOrMore(kind, r), a)
-  }
-  public static func zeroOrOne(
-    _ kind: Quantifier.Kind, _ a: AST, _ r: SourceRange? = nil
-  ) -> AST {
-    .quantification(.zeroOrOne(kind, r), a)
   }
 }

--- a/Sources/_MatchingEngine/Regex/Parse/LexicalAnalysis.swift
+++ b/Sources/_MatchingEngine/Regex/Parse/LexicalAnalysis.swift
@@ -176,7 +176,7 @@ extension Source {
         let amt = try src.expectRange()
         try src.expect("}")
         let kind = consumeKind()
-        return Quantifier(amt.value, kind, nil)
+        return Quantifier(amt.value, kind, _fakeRange)
       }
 
       return nil

--- a/Sources/_MatchingEngine/Regex/Parse/Parse.swift
+++ b/Sources/_MatchingEngine/Regex/Parse/Parse.swift
@@ -142,7 +142,8 @@ extension Parser {
     assert(!source.isEmpty)
 
     if let groupStart = try source.lexGroupStart()?.value {
-      let ast = AST.group(Group(groupStart, nil), try parse())
+      let ast = AST.group(
+        Group(groupStart, _fakeRange), try parse())
       try source.expect(")")
       return ast
     }

--- a/Sources/_StringProcessing/Legacy/LegacyCompile.swift
+++ b/Sources/_StringProcessing/Legacy/LegacyCompile.swift
@@ -35,22 +35,23 @@ func compile(
       instructions.append(.any)
       return
 
-    case .group(.nonCapture(), let child):
-      instructions.append(.beginGroup)
-      compileNode(child)
-      instructions.append(.endGroup)
-      return
+    case .group(let g, let child):
+      switch g.kind {
+      case .nonCapture:
+        instructions.append(.beginGroup)
+        compileNode(child)
+        instructions.append(.endGroup)
+        return
+      case .capture:
+        instructions.append(.beginCapture)
+        compileNode(child)
+        instructions.append(.endCapture())
+        return
+      default:
+        fatalError("Unsupported group \(g)")
+      }
 
-    case .group(.capture(), let child):
-      instructions.append(.beginCapture)
-      compileNode(child)
-      instructions.append(.endCapture())
-      return
-
-    case .group(let g, _):
-      fatalError("Unsupported group \(g)")
-
-    case .groupTransform(.capture(), let child, let transform):
+    case .groupTransform(let g, let child, let transform) where g.kind == .capture:
       instructions.append(.beginCapture)
       compileNode(child)
       instructions.append(.endCapture(transform: transform))

--- a/Sources/_StringProcessing/RegexDSL/Concatenation.swift
+++ b/Sources/_StringProcessing/RegexDSL/Concatenation.swift
@@ -1,11 +1,16 @@
 // BEGIN AUTO-GENERATED CONTENT
 
-
-public struct Concatenate2_TT<T0: RegexProtocol, T1: RegexProtocol>: RegexProtocol {
+import _MatchingEngine
+public struct Concatenate2_TT<
+  T0: RegexProtocol, T1: RegexProtocol
+>: RegexProtocol {
   public typealias Capture = (T0.Capture, T1.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast
+    ))
   }
 }
 
@@ -17,11 +22,16 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate2_TV<T0: RegexProtocol, T1: RegexProtocol>: RegexProtocol where T0.Capture: EmptyProtocol {
+public struct Concatenate2_TV<
+  T0: RegexProtocol, T1: RegexProtocol
+>: RegexProtocol where T0.Capture: EmptyProtocol {
   public typealias Capture = (T1.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast
+    ))
   }
 }
 
@@ -33,11 +43,16 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate2_VT<T0: RegexProtocol, T1: RegexProtocol>: RegexProtocol where T1.Capture: EmptyProtocol {
+public struct Concatenate2_VT<
+  T0: RegexProtocol, T1: RegexProtocol
+>: RegexProtocol where T1.Capture: EmptyProtocol {
   public typealias Capture = (T0.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast
+    ))
   }
 }
 
@@ -49,11 +64,16 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate2_VV<T0: RegexProtocol, T1: RegexProtocol>: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol {
+public struct Concatenate2_VV<
+  T0: RegexProtocol, T1: RegexProtocol
+>: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol {
   public typealias Capture = Empty
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast
+    ))
   }
 }
 
@@ -67,11 +87,17 @@ extension RegexBuilder {
 
 
 
-public struct Concatenate3_TTT<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol>: RegexProtocol {
+public struct Concatenate3_TTT<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol
+>: RegexProtocol {
   public typealias Capture = (T0.Capture, T1.Capture, T2.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast
+    ))
   }
 }
 
@@ -83,11 +109,17 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate3_TTV<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol>: RegexProtocol where T0.Capture: EmptyProtocol {
+public struct Concatenate3_TTV<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol
+>: RegexProtocol where T0.Capture: EmptyProtocol {
   public typealias Capture = (T1.Capture, T2.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast
+    ))
   }
 }
 
@@ -99,11 +131,17 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate3_TVT<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol>: RegexProtocol where T1.Capture: EmptyProtocol {
+public struct Concatenate3_TVT<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol
+>: RegexProtocol where T1.Capture: EmptyProtocol {
   public typealias Capture = (T0.Capture, T2.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast
+    ))
   }
 }
 
@@ -115,11 +153,17 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate3_TVV<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol>: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol {
+public struct Concatenate3_TVV<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol
+>: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol {
   public typealias Capture = (T2.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast
+    ))
   }
 }
 
@@ -131,11 +175,17 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate3_VTT<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol>: RegexProtocol where T2.Capture: EmptyProtocol {
+public struct Concatenate3_VTT<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol
+>: RegexProtocol where T2.Capture: EmptyProtocol {
   public typealias Capture = (T0.Capture, T1.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast
+    ))
   }
 }
 
@@ -147,11 +197,17 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate3_VTV<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol>: RegexProtocol where T0.Capture: EmptyProtocol, T2.Capture: EmptyProtocol {
+public struct Concatenate3_VTV<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol
+>: RegexProtocol where T0.Capture: EmptyProtocol, T2.Capture: EmptyProtocol {
   public typealias Capture = (T1.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast
+    ))
   }
 }
 
@@ -163,11 +219,17 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate3_VVT<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol>: RegexProtocol where T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol {
+public struct Concatenate3_VVT<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol
+>: RegexProtocol where T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol {
   public typealias Capture = (T0.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast
+    ))
   }
 }
 
@@ -179,11 +241,17 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate3_VVV<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol>: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol {
+public struct Concatenate3_VVV<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol
+>: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol {
   public typealias Capture = Empty
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast
+    ))
   }
 }
 
@@ -197,11 +265,18 @@ extension RegexBuilder {
 
 
 
-public struct Concatenate4_TTTT<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol>: RegexProtocol {
+public struct Concatenate4_TTTT<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol
+>: RegexProtocol {
   public typealias Capture = (T0.Capture, T1.Capture, T2.Capture, T3.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast
+    ))
   }
 }
 
@@ -213,11 +288,18 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate4_TTTV<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol>: RegexProtocol where T0.Capture: EmptyProtocol {
+public struct Concatenate4_TTTV<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol
+>: RegexProtocol where T0.Capture: EmptyProtocol {
   public typealias Capture = (T1.Capture, T2.Capture, T3.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast
+    ))
   }
 }
 
@@ -229,11 +311,18 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate4_TTVT<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol>: RegexProtocol where T1.Capture: EmptyProtocol {
+public struct Concatenate4_TTVT<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol
+>: RegexProtocol where T1.Capture: EmptyProtocol {
   public typealias Capture = (T0.Capture, T2.Capture, T3.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast
+    ))
   }
 }
 
@@ -245,11 +334,18 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate4_TTVV<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol>: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol {
+public struct Concatenate4_TTVV<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol
+>: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol {
   public typealias Capture = (T2.Capture, T3.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast
+    ))
   }
 }
 
@@ -261,11 +357,18 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate4_TVTT<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol>: RegexProtocol where T2.Capture: EmptyProtocol {
+public struct Concatenate4_TVTT<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol
+>: RegexProtocol where T2.Capture: EmptyProtocol {
   public typealias Capture = (T0.Capture, T1.Capture, T3.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast
+    ))
   }
 }
 
@@ -277,11 +380,18 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate4_TVTV<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol>: RegexProtocol where T0.Capture: EmptyProtocol, T2.Capture: EmptyProtocol {
+public struct Concatenate4_TVTV<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol
+>: RegexProtocol where T0.Capture: EmptyProtocol, T2.Capture: EmptyProtocol {
   public typealias Capture = (T1.Capture, T3.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast
+    ))
   }
 }
 
@@ -293,11 +403,18 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate4_TVVT<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol>: RegexProtocol where T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol {
+public struct Concatenate4_TVVT<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol
+>: RegexProtocol where T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol {
   public typealias Capture = (T0.Capture, T3.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast
+    ))
   }
 }
 
@@ -309,11 +426,18 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate4_TVVV<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol>: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol {
+public struct Concatenate4_TVVV<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol
+>: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol {
   public typealias Capture = (T3.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast
+    ))
   }
 }
 
@@ -325,11 +449,18 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate4_VTTT<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol>: RegexProtocol where T3.Capture: EmptyProtocol {
+public struct Concatenate4_VTTT<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol
+>: RegexProtocol where T3.Capture: EmptyProtocol {
   public typealias Capture = (T0.Capture, T1.Capture, T2.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast
+    ))
   }
 }
 
@@ -341,11 +472,18 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate4_VTTV<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol>: RegexProtocol where T0.Capture: EmptyProtocol, T3.Capture: EmptyProtocol {
+public struct Concatenate4_VTTV<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol
+>: RegexProtocol where T0.Capture: EmptyProtocol, T3.Capture: EmptyProtocol {
   public typealias Capture = (T1.Capture, T2.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast
+    ))
   }
 }
 
@@ -357,11 +495,18 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate4_VTVT<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol>: RegexProtocol where T1.Capture: EmptyProtocol, T3.Capture: EmptyProtocol {
+public struct Concatenate4_VTVT<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol
+>: RegexProtocol where T1.Capture: EmptyProtocol, T3.Capture: EmptyProtocol {
   public typealias Capture = (T0.Capture, T2.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast
+    ))
   }
 }
 
@@ -373,11 +518,18 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate4_VTVV<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol>: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T3.Capture: EmptyProtocol {
+public struct Concatenate4_VTVV<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol
+>: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T3.Capture: EmptyProtocol {
   public typealias Capture = (T2.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast
+    ))
   }
 }
 
@@ -389,11 +541,18 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate4_VVTT<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol>: RegexProtocol where T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol {
+public struct Concatenate4_VVTT<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol
+>: RegexProtocol where T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol {
   public typealias Capture = (T0.Capture, T1.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast
+    ))
   }
 }
 
@@ -405,11 +564,18 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate4_VVTV<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol>: RegexProtocol where T0.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol {
+public struct Concatenate4_VVTV<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol
+>: RegexProtocol where T0.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol {
   public typealias Capture = (T1.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast
+    ))
   }
 }
 
@@ -421,11 +587,18 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate4_VVVT<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol>: RegexProtocol where T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol {
+public struct Concatenate4_VVVT<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol
+>: RegexProtocol where T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol {
   public typealias Capture = (T0.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast
+    ))
   }
 }
 
@@ -437,11 +610,18 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate4_VVVV<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol>: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol {
+public struct Concatenate4_VVVV<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol
+>: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol {
   public typealias Capture = Empty
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast
+    ))
   }
 }
 
@@ -455,11 +635,19 @@ extension RegexBuilder {
 
 
 
-public struct Concatenate5_TTTTT<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol>: RegexProtocol {
+public struct Concatenate5_TTTTT<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol
+>: RegexProtocol {
   public typealias Capture = (T0.Capture, T1.Capture, T2.Capture, T3.Capture, T4.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast
+    ))
   }
 }
 
@@ -471,11 +659,19 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate5_TTTTV<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol>: RegexProtocol where T0.Capture: EmptyProtocol {
+public struct Concatenate5_TTTTV<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol
+>: RegexProtocol where T0.Capture: EmptyProtocol {
   public typealias Capture = (T1.Capture, T2.Capture, T3.Capture, T4.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast
+    ))
   }
 }
 
@@ -487,11 +683,19 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate5_TTTVT<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol>: RegexProtocol where T1.Capture: EmptyProtocol {
+public struct Concatenate5_TTTVT<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol
+>: RegexProtocol where T1.Capture: EmptyProtocol {
   public typealias Capture = (T0.Capture, T2.Capture, T3.Capture, T4.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast
+    ))
   }
 }
 
@@ -503,11 +707,19 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate5_TTTVV<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol>: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol {
+public struct Concatenate5_TTTVV<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol
+>: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol {
   public typealias Capture = (T2.Capture, T3.Capture, T4.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast
+    ))
   }
 }
 
@@ -519,11 +731,19 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate5_TTVTT<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol>: RegexProtocol where T2.Capture: EmptyProtocol {
+public struct Concatenate5_TTVTT<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol
+>: RegexProtocol where T2.Capture: EmptyProtocol {
   public typealias Capture = (T0.Capture, T1.Capture, T3.Capture, T4.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast
+    ))
   }
 }
 
@@ -535,11 +755,19 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate5_TTVTV<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol>: RegexProtocol where T0.Capture: EmptyProtocol, T2.Capture: EmptyProtocol {
+public struct Concatenate5_TTVTV<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol
+>: RegexProtocol where T0.Capture: EmptyProtocol, T2.Capture: EmptyProtocol {
   public typealias Capture = (T1.Capture, T3.Capture, T4.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast
+    ))
   }
 }
 
@@ -551,11 +779,19 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate5_TTVVT<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol>: RegexProtocol where T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol {
+public struct Concatenate5_TTVVT<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol
+>: RegexProtocol where T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol {
   public typealias Capture = (T0.Capture, T3.Capture, T4.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast
+    ))
   }
 }
 
@@ -567,11 +803,19 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate5_TTVVV<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol>: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol {
+public struct Concatenate5_TTVVV<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol
+>: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol {
   public typealias Capture = (T3.Capture, T4.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast
+    ))
   }
 }
 
@@ -583,11 +827,19 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate5_TVTTT<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol>: RegexProtocol where T3.Capture: EmptyProtocol {
+public struct Concatenate5_TVTTT<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol
+>: RegexProtocol where T3.Capture: EmptyProtocol {
   public typealias Capture = (T0.Capture, T1.Capture, T2.Capture, T4.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast
+    ))
   }
 }
 
@@ -599,11 +851,19 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate5_TVTTV<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol>: RegexProtocol where T0.Capture: EmptyProtocol, T3.Capture: EmptyProtocol {
+public struct Concatenate5_TVTTV<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol
+>: RegexProtocol where T0.Capture: EmptyProtocol, T3.Capture: EmptyProtocol {
   public typealias Capture = (T1.Capture, T2.Capture, T4.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast
+    ))
   }
 }
 
@@ -615,11 +875,19 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate5_TVTVT<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol>: RegexProtocol where T1.Capture: EmptyProtocol, T3.Capture: EmptyProtocol {
+public struct Concatenate5_TVTVT<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol
+>: RegexProtocol where T1.Capture: EmptyProtocol, T3.Capture: EmptyProtocol {
   public typealias Capture = (T0.Capture, T2.Capture, T4.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast
+    ))
   }
 }
 
@@ -631,11 +899,19 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate5_TVTVV<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol>: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T3.Capture: EmptyProtocol {
+public struct Concatenate5_TVTVV<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol
+>: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T3.Capture: EmptyProtocol {
   public typealias Capture = (T2.Capture, T4.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast
+    ))
   }
 }
 
@@ -647,11 +923,19 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate5_TVVTT<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol>: RegexProtocol where T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol {
+public struct Concatenate5_TVVTT<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol
+>: RegexProtocol where T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol {
   public typealias Capture = (T0.Capture, T1.Capture, T4.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast
+    ))
   }
 }
 
@@ -663,11 +947,19 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate5_TVVTV<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol>: RegexProtocol where T0.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol {
+public struct Concatenate5_TVVTV<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol
+>: RegexProtocol where T0.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol {
   public typealias Capture = (T1.Capture, T4.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast
+    ))
   }
 }
 
@@ -679,11 +971,19 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate5_TVVVT<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol>: RegexProtocol where T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol {
+public struct Concatenate5_TVVVT<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol
+>: RegexProtocol where T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol {
   public typealias Capture = (T0.Capture, T4.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast
+    ))
   }
 }
 
@@ -695,11 +995,19 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate5_TVVVV<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol>: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol {
+public struct Concatenate5_TVVVV<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol
+>: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol {
   public typealias Capture = (T4.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast
+    ))
   }
 }
 
@@ -711,11 +1019,19 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate5_VTTTT<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol>: RegexProtocol where T4.Capture: EmptyProtocol {
+public struct Concatenate5_VTTTT<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol
+>: RegexProtocol where T4.Capture: EmptyProtocol {
   public typealias Capture = (T0.Capture, T1.Capture, T2.Capture, T3.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast
+    ))
   }
 }
 
@@ -727,11 +1043,19 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate5_VTTTV<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol>: RegexProtocol where T0.Capture: EmptyProtocol, T4.Capture: EmptyProtocol {
+public struct Concatenate5_VTTTV<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol
+>: RegexProtocol where T0.Capture: EmptyProtocol, T4.Capture: EmptyProtocol {
   public typealias Capture = (T1.Capture, T2.Capture, T3.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast
+    ))
   }
 }
 
@@ -743,11 +1067,19 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate5_VTTVT<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol>: RegexProtocol where T1.Capture: EmptyProtocol, T4.Capture: EmptyProtocol {
+public struct Concatenate5_VTTVT<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol
+>: RegexProtocol where T1.Capture: EmptyProtocol, T4.Capture: EmptyProtocol {
   public typealias Capture = (T0.Capture, T2.Capture, T3.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast
+    ))
   }
 }
 
@@ -759,11 +1091,19 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate5_VTTVV<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol>: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T4.Capture: EmptyProtocol {
+public struct Concatenate5_VTTVV<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol
+>: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T4.Capture: EmptyProtocol {
   public typealias Capture = (T2.Capture, T3.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast
+    ))
   }
 }
 
@@ -775,11 +1115,19 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate5_VTVTT<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol>: RegexProtocol where T2.Capture: EmptyProtocol, T4.Capture: EmptyProtocol {
+public struct Concatenate5_VTVTT<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol
+>: RegexProtocol where T2.Capture: EmptyProtocol, T4.Capture: EmptyProtocol {
   public typealias Capture = (T0.Capture, T1.Capture, T3.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast
+    ))
   }
 }
 
@@ -791,11 +1139,19 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate5_VTVTV<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol>: RegexProtocol where T0.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T4.Capture: EmptyProtocol {
+public struct Concatenate5_VTVTV<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol
+>: RegexProtocol where T0.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T4.Capture: EmptyProtocol {
   public typealias Capture = (T1.Capture, T3.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast
+    ))
   }
 }
 
@@ -807,11 +1163,19 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate5_VTVVT<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol>: RegexProtocol where T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T4.Capture: EmptyProtocol {
+public struct Concatenate5_VTVVT<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol
+>: RegexProtocol where T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T4.Capture: EmptyProtocol {
   public typealias Capture = (T0.Capture, T3.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast
+    ))
   }
 }
 
@@ -823,11 +1187,19 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate5_VTVVV<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol>: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T4.Capture: EmptyProtocol {
+public struct Concatenate5_VTVVV<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol
+>: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T4.Capture: EmptyProtocol {
   public typealias Capture = (T3.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast
+    ))
   }
 }
 
@@ -839,11 +1211,19 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate5_VVTTT<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol>: RegexProtocol where T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol {
+public struct Concatenate5_VVTTT<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol
+>: RegexProtocol where T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol {
   public typealias Capture = (T0.Capture, T1.Capture, T2.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast
+    ))
   }
 }
 
@@ -855,11 +1235,19 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate5_VVTTV<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol>: RegexProtocol where T0.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol {
+public struct Concatenate5_VVTTV<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol
+>: RegexProtocol where T0.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol {
   public typealias Capture = (T1.Capture, T2.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast
+    ))
   }
 }
 
@@ -871,11 +1259,19 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate5_VVTVT<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol>: RegexProtocol where T1.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol {
+public struct Concatenate5_VVTVT<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol
+>: RegexProtocol where T1.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol {
   public typealias Capture = (T0.Capture, T2.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast
+    ))
   }
 }
 
@@ -887,11 +1283,19 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate5_VVTVV<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol>: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol {
+public struct Concatenate5_VVTVV<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol
+>: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol {
   public typealias Capture = (T2.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast
+    ))
   }
 }
 
@@ -903,11 +1307,19 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate5_VVVTT<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol>: RegexProtocol where T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol {
+public struct Concatenate5_VVVTT<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol
+>: RegexProtocol where T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol {
   public typealias Capture = (T0.Capture, T1.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast
+    ))
   }
 }
 
@@ -919,11 +1331,19 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate5_VVVTV<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol>: RegexProtocol where T0.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol {
+public struct Concatenate5_VVVTV<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol
+>: RegexProtocol where T0.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol {
   public typealias Capture = (T1.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast
+    ))
   }
 }
 
@@ -935,11 +1355,19 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate5_VVVVT<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol>: RegexProtocol where T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol {
+public struct Concatenate5_VVVVT<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol
+>: RegexProtocol where T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol {
   public typealias Capture = (T0.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast
+    ))
   }
 }
 
@@ -951,11 +1379,19 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate5_VVVVV<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol>: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol {
+public struct Concatenate5_VVVVV<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol
+>: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol {
   public typealias Capture = Empty
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast
+    ))
   }
 }
 
@@ -969,11 +1405,20 @@ extension RegexBuilder {
 
 
 
-public struct Concatenate6_TTTTTT<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol>: RegexProtocol {
+public struct Concatenate6_TTTTTT<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol
+>: RegexProtocol {
   public typealias Capture = (T0.Capture, T1.Capture, T2.Capture, T3.Capture, T4.Capture, T5.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast
+    ))
   }
 }
 
@@ -985,11 +1430,20 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate6_TTTTTV<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol>: RegexProtocol where T0.Capture: EmptyProtocol {
+public struct Concatenate6_TTTTTV<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol
+>: RegexProtocol where T0.Capture: EmptyProtocol {
   public typealias Capture = (T1.Capture, T2.Capture, T3.Capture, T4.Capture, T5.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast
+    ))
   }
 }
 
@@ -1001,11 +1455,20 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate6_TTTTVT<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol>: RegexProtocol where T1.Capture: EmptyProtocol {
+public struct Concatenate6_TTTTVT<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol
+>: RegexProtocol where T1.Capture: EmptyProtocol {
   public typealias Capture = (T0.Capture, T2.Capture, T3.Capture, T4.Capture, T5.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast
+    ))
   }
 }
 
@@ -1017,11 +1480,20 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate6_TTTTVV<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol>: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol {
+public struct Concatenate6_TTTTVV<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol
+>: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol {
   public typealias Capture = (T2.Capture, T3.Capture, T4.Capture, T5.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast
+    ))
   }
 }
 
@@ -1033,11 +1505,20 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate6_TTTVTT<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol>: RegexProtocol where T2.Capture: EmptyProtocol {
+public struct Concatenate6_TTTVTT<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol
+>: RegexProtocol where T2.Capture: EmptyProtocol {
   public typealias Capture = (T0.Capture, T1.Capture, T3.Capture, T4.Capture, T5.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast
+    ))
   }
 }
 
@@ -1049,11 +1530,20 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate6_TTTVTV<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol>: RegexProtocol where T0.Capture: EmptyProtocol, T2.Capture: EmptyProtocol {
+public struct Concatenate6_TTTVTV<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol
+>: RegexProtocol where T0.Capture: EmptyProtocol, T2.Capture: EmptyProtocol {
   public typealias Capture = (T1.Capture, T3.Capture, T4.Capture, T5.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast
+    ))
   }
 }
 
@@ -1065,11 +1555,20 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate6_TTTVVT<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol>: RegexProtocol where T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol {
+public struct Concatenate6_TTTVVT<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol
+>: RegexProtocol where T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol {
   public typealias Capture = (T0.Capture, T3.Capture, T4.Capture, T5.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast
+    ))
   }
 }
 
@@ -1081,11 +1580,20 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate6_TTTVVV<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol>: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol {
+public struct Concatenate6_TTTVVV<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol
+>: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol {
   public typealias Capture = (T3.Capture, T4.Capture, T5.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast
+    ))
   }
 }
 
@@ -1097,11 +1605,20 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate6_TTVTTT<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol>: RegexProtocol where T3.Capture: EmptyProtocol {
+public struct Concatenate6_TTVTTT<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol
+>: RegexProtocol where T3.Capture: EmptyProtocol {
   public typealias Capture = (T0.Capture, T1.Capture, T2.Capture, T4.Capture, T5.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast
+    ))
   }
 }
 
@@ -1113,11 +1630,20 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate6_TTVTTV<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol>: RegexProtocol where T0.Capture: EmptyProtocol, T3.Capture: EmptyProtocol {
+public struct Concatenate6_TTVTTV<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol
+>: RegexProtocol where T0.Capture: EmptyProtocol, T3.Capture: EmptyProtocol {
   public typealias Capture = (T1.Capture, T2.Capture, T4.Capture, T5.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast
+    ))
   }
 }
 
@@ -1129,11 +1655,20 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate6_TTVTVT<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol>: RegexProtocol where T1.Capture: EmptyProtocol, T3.Capture: EmptyProtocol {
+public struct Concatenate6_TTVTVT<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol
+>: RegexProtocol where T1.Capture: EmptyProtocol, T3.Capture: EmptyProtocol {
   public typealias Capture = (T0.Capture, T2.Capture, T4.Capture, T5.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast
+    ))
   }
 }
 
@@ -1145,11 +1680,20 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate6_TTVTVV<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol>: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T3.Capture: EmptyProtocol {
+public struct Concatenate6_TTVTVV<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol
+>: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T3.Capture: EmptyProtocol {
   public typealias Capture = (T2.Capture, T4.Capture, T5.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast
+    ))
   }
 }
 
@@ -1161,11 +1705,20 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate6_TTVVTT<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol>: RegexProtocol where T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol {
+public struct Concatenate6_TTVVTT<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol
+>: RegexProtocol where T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol {
   public typealias Capture = (T0.Capture, T1.Capture, T4.Capture, T5.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast
+    ))
   }
 }
 
@@ -1177,11 +1730,20 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate6_TTVVTV<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol>: RegexProtocol where T0.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol {
+public struct Concatenate6_TTVVTV<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol
+>: RegexProtocol where T0.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol {
   public typealias Capture = (T1.Capture, T4.Capture, T5.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast
+    ))
   }
 }
 
@@ -1193,11 +1755,20 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate6_TTVVVT<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol>: RegexProtocol where T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol {
+public struct Concatenate6_TTVVVT<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol
+>: RegexProtocol where T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol {
   public typealias Capture = (T0.Capture, T4.Capture, T5.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast
+    ))
   }
 }
 
@@ -1209,11 +1780,20 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate6_TTVVVV<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol>: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol {
+public struct Concatenate6_TTVVVV<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol
+>: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol {
   public typealias Capture = (T4.Capture, T5.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast
+    ))
   }
 }
 
@@ -1225,11 +1805,20 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate6_TVTTTT<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol>: RegexProtocol where T4.Capture: EmptyProtocol {
+public struct Concatenate6_TVTTTT<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol
+>: RegexProtocol where T4.Capture: EmptyProtocol {
   public typealias Capture = (T0.Capture, T1.Capture, T2.Capture, T3.Capture, T5.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast
+    ))
   }
 }
 
@@ -1241,11 +1830,20 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate6_TVTTTV<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol>: RegexProtocol where T0.Capture: EmptyProtocol, T4.Capture: EmptyProtocol {
+public struct Concatenate6_TVTTTV<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol
+>: RegexProtocol where T0.Capture: EmptyProtocol, T4.Capture: EmptyProtocol {
   public typealias Capture = (T1.Capture, T2.Capture, T3.Capture, T5.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast
+    ))
   }
 }
 
@@ -1257,11 +1855,20 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate6_TVTTVT<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol>: RegexProtocol where T1.Capture: EmptyProtocol, T4.Capture: EmptyProtocol {
+public struct Concatenate6_TVTTVT<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol
+>: RegexProtocol where T1.Capture: EmptyProtocol, T4.Capture: EmptyProtocol {
   public typealias Capture = (T0.Capture, T2.Capture, T3.Capture, T5.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast
+    ))
   }
 }
 
@@ -1273,11 +1880,20 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate6_TVTTVV<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol>: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T4.Capture: EmptyProtocol {
+public struct Concatenate6_TVTTVV<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol
+>: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T4.Capture: EmptyProtocol {
   public typealias Capture = (T2.Capture, T3.Capture, T5.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast
+    ))
   }
 }
 
@@ -1289,11 +1905,20 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate6_TVTVTT<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol>: RegexProtocol where T2.Capture: EmptyProtocol, T4.Capture: EmptyProtocol {
+public struct Concatenate6_TVTVTT<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol
+>: RegexProtocol where T2.Capture: EmptyProtocol, T4.Capture: EmptyProtocol {
   public typealias Capture = (T0.Capture, T1.Capture, T3.Capture, T5.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast
+    ))
   }
 }
 
@@ -1305,11 +1930,20 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate6_TVTVTV<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol>: RegexProtocol where T0.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T4.Capture: EmptyProtocol {
+public struct Concatenate6_TVTVTV<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol
+>: RegexProtocol where T0.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T4.Capture: EmptyProtocol {
   public typealias Capture = (T1.Capture, T3.Capture, T5.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast
+    ))
   }
 }
 
@@ -1321,11 +1955,20 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate6_TVTVVT<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol>: RegexProtocol where T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T4.Capture: EmptyProtocol {
+public struct Concatenate6_TVTVVT<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol
+>: RegexProtocol where T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T4.Capture: EmptyProtocol {
   public typealias Capture = (T0.Capture, T3.Capture, T5.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast
+    ))
   }
 }
 
@@ -1337,11 +1980,20 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate6_TVTVVV<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol>: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T4.Capture: EmptyProtocol {
+public struct Concatenate6_TVTVVV<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol
+>: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T4.Capture: EmptyProtocol {
   public typealias Capture = (T3.Capture, T5.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast
+    ))
   }
 }
 
@@ -1353,11 +2005,20 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate6_TVVTTT<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol>: RegexProtocol where T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol {
+public struct Concatenate6_TVVTTT<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol
+>: RegexProtocol where T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol {
   public typealias Capture = (T0.Capture, T1.Capture, T2.Capture, T5.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast
+    ))
   }
 }
 
@@ -1369,11 +2030,20 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate6_TVVTTV<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol>: RegexProtocol where T0.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol {
+public struct Concatenate6_TVVTTV<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol
+>: RegexProtocol where T0.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol {
   public typealias Capture = (T1.Capture, T2.Capture, T5.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast
+    ))
   }
 }
 
@@ -1385,11 +2055,20 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate6_TVVTVT<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol>: RegexProtocol where T1.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol {
+public struct Concatenate6_TVVTVT<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol
+>: RegexProtocol where T1.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol {
   public typealias Capture = (T0.Capture, T2.Capture, T5.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast
+    ))
   }
 }
 
@@ -1401,11 +2080,20 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate6_TVVTVV<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol>: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol {
+public struct Concatenate6_TVVTVV<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol
+>: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol {
   public typealias Capture = (T2.Capture, T5.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast
+    ))
   }
 }
 
@@ -1417,11 +2105,20 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate6_TVVVTT<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol>: RegexProtocol where T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol {
+public struct Concatenate6_TVVVTT<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol
+>: RegexProtocol where T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol {
   public typealias Capture = (T0.Capture, T1.Capture, T5.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast
+    ))
   }
 }
 
@@ -1433,11 +2130,20 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate6_TVVVTV<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol>: RegexProtocol where T0.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol {
+public struct Concatenate6_TVVVTV<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol
+>: RegexProtocol where T0.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol {
   public typealias Capture = (T1.Capture, T5.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast
+    ))
   }
 }
 
@@ -1449,11 +2155,20 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate6_TVVVVT<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol>: RegexProtocol where T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol {
+public struct Concatenate6_TVVVVT<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol
+>: RegexProtocol where T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol {
   public typealias Capture = (T0.Capture, T5.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast
+    ))
   }
 }
 
@@ -1465,11 +2180,20 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate6_TVVVVV<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol>: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol {
+public struct Concatenate6_TVVVVV<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol
+>: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol {
   public typealias Capture = (T5.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast
+    ))
   }
 }
 
@@ -1481,11 +2205,20 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate6_VTTTTT<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol>: RegexProtocol where T5.Capture: EmptyProtocol {
+public struct Concatenate6_VTTTTT<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol
+>: RegexProtocol where T5.Capture: EmptyProtocol {
   public typealias Capture = (T0.Capture, T1.Capture, T2.Capture, T3.Capture, T4.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast
+    ))
   }
 }
 
@@ -1497,11 +2230,20 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate6_VTTTTV<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol>: RegexProtocol where T0.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
+public struct Concatenate6_VTTTTV<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol
+>: RegexProtocol where T0.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
   public typealias Capture = (T1.Capture, T2.Capture, T3.Capture, T4.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast
+    ))
   }
 }
 
@@ -1513,11 +2255,20 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate6_VTTTVT<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol>: RegexProtocol where T1.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
+public struct Concatenate6_VTTTVT<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol
+>: RegexProtocol where T1.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
   public typealias Capture = (T0.Capture, T2.Capture, T3.Capture, T4.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast
+    ))
   }
 }
 
@@ -1529,11 +2280,20 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate6_VTTTVV<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol>: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
+public struct Concatenate6_VTTTVV<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol
+>: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
   public typealias Capture = (T2.Capture, T3.Capture, T4.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast
+    ))
   }
 }
 
@@ -1545,11 +2305,20 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate6_VTTVTT<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol>: RegexProtocol where T2.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
+public struct Concatenate6_VTTVTT<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol
+>: RegexProtocol where T2.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
   public typealias Capture = (T0.Capture, T1.Capture, T3.Capture, T4.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast
+    ))
   }
 }
 
@@ -1561,11 +2330,20 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate6_VTTVTV<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol>: RegexProtocol where T0.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
+public struct Concatenate6_VTTVTV<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol
+>: RegexProtocol where T0.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
   public typealias Capture = (T1.Capture, T3.Capture, T4.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast
+    ))
   }
 }
 
@@ -1577,11 +2355,20 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate6_VTTVVT<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol>: RegexProtocol where T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
+public struct Concatenate6_VTTVVT<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol
+>: RegexProtocol where T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
   public typealias Capture = (T0.Capture, T3.Capture, T4.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast
+    ))
   }
 }
 
@@ -1593,11 +2380,20 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate6_VTTVVV<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol>: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
+public struct Concatenate6_VTTVVV<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol
+>: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
   public typealias Capture = (T3.Capture, T4.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast
+    ))
   }
 }
 
@@ -1609,11 +2405,20 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate6_VTVTTT<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol>: RegexProtocol where T3.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
+public struct Concatenate6_VTVTTT<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol
+>: RegexProtocol where T3.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
   public typealias Capture = (T0.Capture, T1.Capture, T2.Capture, T4.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast
+    ))
   }
 }
 
@@ -1625,11 +2430,20 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate6_VTVTTV<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol>: RegexProtocol where T0.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
+public struct Concatenate6_VTVTTV<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol
+>: RegexProtocol where T0.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
   public typealias Capture = (T1.Capture, T2.Capture, T4.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast
+    ))
   }
 }
 
@@ -1641,11 +2455,20 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate6_VTVTVT<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol>: RegexProtocol where T1.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
+public struct Concatenate6_VTVTVT<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol
+>: RegexProtocol where T1.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
   public typealias Capture = (T0.Capture, T2.Capture, T4.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast
+    ))
   }
 }
 
@@ -1657,11 +2480,20 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate6_VTVTVV<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol>: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
+public struct Concatenate6_VTVTVV<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol
+>: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
   public typealias Capture = (T2.Capture, T4.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast
+    ))
   }
 }
 
@@ -1673,11 +2505,20 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate6_VTVVTT<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol>: RegexProtocol where T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
+public struct Concatenate6_VTVVTT<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol
+>: RegexProtocol where T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
   public typealias Capture = (T0.Capture, T1.Capture, T4.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast
+    ))
   }
 }
 
@@ -1689,11 +2530,20 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate6_VTVVTV<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol>: RegexProtocol where T0.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
+public struct Concatenate6_VTVVTV<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol
+>: RegexProtocol where T0.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
   public typealias Capture = (T1.Capture, T4.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast
+    ))
   }
 }
 
@@ -1705,11 +2555,20 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate6_VTVVVT<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol>: RegexProtocol where T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
+public struct Concatenate6_VTVVVT<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol
+>: RegexProtocol where T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
   public typealias Capture = (T0.Capture, T4.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast
+    ))
   }
 }
 
@@ -1721,11 +2580,20 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate6_VTVVVV<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol>: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
+public struct Concatenate6_VTVVVV<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol
+>: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
   public typealias Capture = (T4.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast
+    ))
   }
 }
 
@@ -1737,11 +2605,20 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate6_VVTTTT<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol>: RegexProtocol where T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
+public struct Concatenate6_VVTTTT<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol
+>: RegexProtocol where T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
   public typealias Capture = (T0.Capture, T1.Capture, T2.Capture, T3.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast
+    ))
   }
 }
 
@@ -1753,11 +2630,20 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate6_VVTTTV<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol>: RegexProtocol where T0.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
+public struct Concatenate6_VVTTTV<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol
+>: RegexProtocol where T0.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
   public typealias Capture = (T1.Capture, T2.Capture, T3.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast
+    ))
   }
 }
 
@@ -1769,11 +2655,20 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate6_VVTTVT<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol>: RegexProtocol where T1.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
+public struct Concatenate6_VVTTVT<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol
+>: RegexProtocol where T1.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
   public typealias Capture = (T0.Capture, T2.Capture, T3.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast
+    ))
   }
 }
 
@@ -1785,11 +2680,20 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate6_VVTTVV<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol>: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
+public struct Concatenate6_VVTTVV<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol
+>: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
   public typealias Capture = (T2.Capture, T3.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast
+    ))
   }
 }
 
@@ -1801,11 +2705,20 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate6_VVTVTT<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol>: RegexProtocol where T2.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
+public struct Concatenate6_VVTVTT<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol
+>: RegexProtocol where T2.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
   public typealias Capture = (T0.Capture, T1.Capture, T3.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast
+    ))
   }
 }
 
@@ -1817,11 +2730,20 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate6_VVTVTV<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol>: RegexProtocol where T0.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
+public struct Concatenate6_VVTVTV<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol
+>: RegexProtocol where T0.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
   public typealias Capture = (T1.Capture, T3.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast
+    ))
   }
 }
 
@@ -1833,11 +2755,20 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate6_VVTVVT<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol>: RegexProtocol where T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
+public struct Concatenate6_VVTVVT<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol
+>: RegexProtocol where T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
   public typealias Capture = (T0.Capture, T3.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast
+    ))
   }
 }
 
@@ -1849,11 +2780,20 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate6_VVTVVV<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol>: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
+public struct Concatenate6_VVTVVV<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol
+>: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
   public typealias Capture = (T3.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast
+    ))
   }
 }
 
@@ -1865,11 +2805,20 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate6_VVVTTT<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol>: RegexProtocol where T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
+public struct Concatenate6_VVVTTT<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol
+>: RegexProtocol where T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
   public typealias Capture = (T0.Capture, T1.Capture, T2.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast
+    ))
   }
 }
 
@@ -1881,11 +2830,20 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate6_VVVTTV<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol>: RegexProtocol where T0.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
+public struct Concatenate6_VVVTTV<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol
+>: RegexProtocol where T0.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
   public typealias Capture = (T1.Capture, T2.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast
+    ))
   }
 }
 
@@ -1897,11 +2855,20 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate6_VVVTVT<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol>: RegexProtocol where T1.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
+public struct Concatenate6_VVVTVT<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol
+>: RegexProtocol where T1.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
   public typealias Capture = (T0.Capture, T2.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast
+    ))
   }
 }
 
@@ -1913,11 +2880,20 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate6_VVVTVV<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol>: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
+public struct Concatenate6_VVVTVV<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol
+>: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
   public typealias Capture = (T2.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast
+    ))
   }
 }
 
@@ -1929,11 +2905,20 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate6_VVVVTT<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol>: RegexProtocol where T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
+public struct Concatenate6_VVVVTT<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol
+>: RegexProtocol where T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
   public typealias Capture = (T0.Capture, T1.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast
+    ))
   }
 }
 
@@ -1945,11 +2930,20 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate6_VVVVTV<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol>: RegexProtocol where T0.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
+public struct Concatenate6_VVVVTV<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol
+>: RegexProtocol where T0.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
   public typealias Capture = (T1.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast
+    ))
   }
 }
 
@@ -1961,11 +2955,20 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate6_VVVVVT<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol>: RegexProtocol where T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
+public struct Concatenate6_VVVVVT<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol
+>: RegexProtocol where T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
   public typealias Capture = (T0.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast
+    ))
   }
 }
 
@@ -1977,11 +2980,20 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate6_VVVVVV<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol>: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
+public struct Concatenate6_VVVVVV<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol
+>: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
   public typealias Capture = Empty
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast
+    ))
   }
 }
 
@@ -1995,11 +3007,21 @@ extension RegexBuilder {
 
 
 
-public struct Concatenate7_TTTTTTT<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>: RegexProtocol {
+public struct Concatenate7_TTTTTTT<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
+>: RegexProtocol {
   public typealias Capture = (T0.Capture, T1.Capture, T2.Capture, T3.Capture, T4.Capture, T5.Capture, T6.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast, x6.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast,
+      x6.regex.ast
+    ))
   }
 }
 
@@ -2011,11 +3033,21 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate7_TTTTTTV<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>: RegexProtocol where T0.Capture: EmptyProtocol {
+public struct Concatenate7_TTTTTTV<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
+>: RegexProtocol where T0.Capture: EmptyProtocol {
   public typealias Capture = (T1.Capture, T2.Capture, T3.Capture, T4.Capture, T5.Capture, T6.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast, x6.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast,
+      x6.regex.ast
+    ))
   }
 }
 
@@ -2027,11 +3059,21 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate7_TTTTTVT<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>: RegexProtocol where T1.Capture: EmptyProtocol {
+public struct Concatenate7_TTTTTVT<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
+>: RegexProtocol where T1.Capture: EmptyProtocol {
   public typealias Capture = (T0.Capture, T2.Capture, T3.Capture, T4.Capture, T5.Capture, T6.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast, x6.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast,
+      x6.regex.ast
+    ))
   }
 }
 
@@ -2043,11 +3085,21 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate7_TTTTTVV<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol {
+public struct Concatenate7_TTTTTVV<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
+>: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol {
   public typealias Capture = (T2.Capture, T3.Capture, T4.Capture, T5.Capture, T6.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast, x6.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast,
+      x6.regex.ast
+    ))
   }
 }
 
@@ -2059,11 +3111,21 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate7_TTTTVTT<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>: RegexProtocol where T2.Capture: EmptyProtocol {
+public struct Concatenate7_TTTTVTT<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
+>: RegexProtocol where T2.Capture: EmptyProtocol {
   public typealias Capture = (T0.Capture, T1.Capture, T3.Capture, T4.Capture, T5.Capture, T6.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast, x6.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast,
+      x6.regex.ast
+    ))
   }
 }
 
@@ -2075,11 +3137,21 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate7_TTTTVTV<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>: RegexProtocol where T0.Capture: EmptyProtocol, T2.Capture: EmptyProtocol {
+public struct Concatenate7_TTTTVTV<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
+>: RegexProtocol where T0.Capture: EmptyProtocol, T2.Capture: EmptyProtocol {
   public typealias Capture = (T1.Capture, T3.Capture, T4.Capture, T5.Capture, T6.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast, x6.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast,
+      x6.regex.ast
+    ))
   }
 }
 
@@ -2091,11 +3163,21 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate7_TTTTVVT<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>: RegexProtocol where T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol {
+public struct Concatenate7_TTTTVVT<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
+>: RegexProtocol where T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol {
   public typealias Capture = (T0.Capture, T3.Capture, T4.Capture, T5.Capture, T6.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast, x6.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast,
+      x6.regex.ast
+    ))
   }
 }
 
@@ -2107,11 +3189,21 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate7_TTTTVVV<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol {
+public struct Concatenate7_TTTTVVV<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
+>: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol {
   public typealias Capture = (T3.Capture, T4.Capture, T5.Capture, T6.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast, x6.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast,
+      x6.regex.ast
+    ))
   }
 }
 
@@ -2123,11 +3215,21 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate7_TTTVTTT<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>: RegexProtocol where T3.Capture: EmptyProtocol {
+public struct Concatenate7_TTTVTTT<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
+>: RegexProtocol where T3.Capture: EmptyProtocol {
   public typealias Capture = (T0.Capture, T1.Capture, T2.Capture, T4.Capture, T5.Capture, T6.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast, x6.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast,
+      x6.regex.ast
+    ))
   }
 }
 
@@ -2139,11 +3241,21 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate7_TTTVTTV<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>: RegexProtocol where T0.Capture: EmptyProtocol, T3.Capture: EmptyProtocol {
+public struct Concatenate7_TTTVTTV<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
+>: RegexProtocol where T0.Capture: EmptyProtocol, T3.Capture: EmptyProtocol {
   public typealias Capture = (T1.Capture, T2.Capture, T4.Capture, T5.Capture, T6.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast, x6.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast,
+      x6.regex.ast
+    ))
   }
 }
 
@@ -2155,11 +3267,21 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate7_TTTVTVT<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>: RegexProtocol where T1.Capture: EmptyProtocol, T3.Capture: EmptyProtocol {
+public struct Concatenate7_TTTVTVT<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
+>: RegexProtocol where T1.Capture: EmptyProtocol, T3.Capture: EmptyProtocol {
   public typealias Capture = (T0.Capture, T2.Capture, T4.Capture, T5.Capture, T6.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast, x6.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast,
+      x6.regex.ast
+    ))
   }
 }
 
@@ -2171,11 +3293,21 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate7_TTTVTVV<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T3.Capture: EmptyProtocol {
+public struct Concatenate7_TTTVTVV<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
+>: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T3.Capture: EmptyProtocol {
   public typealias Capture = (T2.Capture, T4.Capture, T5.Capture, T6.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast, x6.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast,
+      x6.regex.ast
+    ))
   }
 }
 
@@ -2187,11 +3319,21 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate7_TTTVVTT<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>: RegexProtocol where T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol {
+public struct Concatenate7_TTTVVTT<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
+>: RegexProtocol where T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol {
   public typealias Capture = (T0.Capture, T1.Capture, T4.Capture, T5.Capture, T6.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast, x6.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast,
+      x6.regex.ast
+    ))
   }
 }
 
@@ -2203,11 +3345,21 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate7_TTTVVTV<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>: RegexProtocol where T0.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol {
+public struct Concatenate7_TTTVVTV<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
+>: RegexProtocol where T0.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol {
   public typealias Capture = (T1.Capture, T4.Capture, T5.Capture, T6.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast, x6.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast,
+      x6.regex.ast
+    ))
   }
 }
 
@@ -2219,11 +3371,21 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate7_TTTVVVT<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>: RegexProtocol where T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol {
+public struct Concatenate7_TTTVVVT<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
+>: RegexProtocol where T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol {
   public typealias Capture = (T0.Capture, T4.Capture, T5.Capture, T6.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast, x6.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast,
+      x6.regex.ast
+    ))
   }
 }
 
@@ -2235,11 +3397,21 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate7_TTTVVVV<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol {
+public struct Concatenate7_TTTVVVV<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
+>: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol {
   public typealias Capture = (T4.Capture, T5.Capture, T6.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast, x6.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast,
+      x6.regex.ast
+    ))
   }
 }
 
@@ -2251,11 +3423,21 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate7_TTVTTTT<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>: RegexProtocol where T4.Capture: EmptyProtocol {
+public struct Concatenate7_TTVTTTT<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
+>: RegexProtocol where T4.Capture: EmptyProtocol {
   public typealias Capture = (T0.Capture, T1.Capture, T2.Capture, T3.Capture, T5.Capture, T6.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast, x6.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast,
+      x6.regex.ast
+    ))
   }
 }
 
@@ -2267,11 +3449,21 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate7_TTVTTTV<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>: RegexProtocol where T0.Capture: EmptyProtocol, T4.Capture: EmptyProtocol {
+public struct Concatenate7_TTVTTTV<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
+>: RegexProtocol where T0.Capture: EmptyProtocol, T4.Capture: EmptyProtocol {
   public typealias Capture = (T1.Capture, T2.Capture, T3.Capture, T5.Capture, T6.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast, x6.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast,
+      x6.regex.ast
+    ))
   }
 }
 
@@ -2283,11 +3475,21 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate7_TTVTTVT<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>: RegexProtocol where T1.Capture: EmptyProtocol, T4.Capture: EmptyProtocol {
+public struct Concatenate7_TTVTTVT<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
+>: RegexProtocol where T1.Capture: EmptyProtocol, T4.Capture: EmptyProtocol {
   public typealias Capture = (T0.Capture, T2.Capture, T3.Capture, T5.Capture, T6.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast, x6.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast,
+      x6.regex.ast
+    ))
   }
 }
 
@@ -2299,11 +3501,21 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate7_TTVTTVV<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T4.Capture: EmptyProtocol {
+public struct Concatenate7_TTVTTVV<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
+>: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T4.Capture: EmptyProtocol {
   public typealias Capture = (T2.Capture, T3.Capture, T5.Capture, T6.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast, x6.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast,
+      x6.regex.ast
+    ))
   }
 }
 
@@ -2315,11 +3527,21 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate7_TTVTVTT<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>: RegexProtocol where T2.Capture: EmptyProtocol, T4.Capture: EmptyProtocol {
+public struct Concatenate7_TTVTVTT<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
+>: RegexProtocol where T2.Capture: EmptyProtocol, T4.Capture: EmptyProtocol {
   public typealias Capture = (T0.Capture, T1.Capture, T3.Capture, T5.Capture, T6.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast, x6.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast,
+      x6.regex.ast
+    ))
   }
 }
 
@@ -2331,11 +3553,21 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate7_TTVTVTV<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>: RegexProtocol where T0.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T4.Capture: EmptyProtocol {
+public struct Concatenate7_TTVTVTV<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
+>: RegexProtocol where T0.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T4.Capture: EmptyProtocol {
   public typealias Capture = (T1.Capture, T3.Capture, T5.Capture, T6.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast, x6.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast,
+      x6.regex.ast
+    ))
   }
 }
 
@@ -2347,11 +3579,21 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate7_TTVTVVT<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>: RegexProtocol where T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T4.Capture: EmptyProtocol {
+public struct Concatenate7_TTVTVVT<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
+>: RegexProtocol where T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T4.Capture: EmptyProtocol {
   public typealias Capture = (T0.Capture, T3.Capture, T5.Capture, T6.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast, x6.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast,
+      x6.regex.ast
+    ))
   }
 }
 
@@ -2363,11 +3605,21 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate7_TTVTVVV<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T4.Capture: EmptyProtocol {
+public struct Concatenate7_TTVTVVV<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
+>: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T4.Capture: EmptyProtocol {
   public typealias Capture = (T3.Capture, T5.Capture, T6.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast, x6.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast,
+      x6.regex.ast
+    ))
   }
 }
 
@@ -2379,11 +3631,21 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate7_TTVVTTT<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>: RegexProtocol where T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol {
+public struct Concatenate7_TTVVTTT<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
+>: RegexProtocol where T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol {
   public typealias Capture = (T0.Capture, T1.Capture, T2.Capture, T5.Capture, T6.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast, x6.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast,
+      x6.regex.ast
+    ))
   }
 }
 
@@ -2395,11 +3657,21 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate7_TTVVTTV<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>: RegexProtocol where T0.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol {
+public struct Concatenate7_TTVVTTV<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
+>: RegexProtocol where T0.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol {
   public typealias Capture = (T1.Capture, T2.Capture, T5.Capture, T6.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast, x6.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast,
+      x6.regex.ast
+    ))
   }
 }
 
@@ -2411,11 +3683,21 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate7_TTVVTVT<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>: RegexProtocol where T1.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol {
+public struct Concatenate7_TTVVTVT<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
+>: RegexProtocol where T1.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol {
   public typealias Capture = (T0.Capture, T2.Capture, T5.Capture, T6.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast, x6.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast,
+      x6.regex.ast
+    ))
   }
 }
 
@@ -2427,11 +3709,21 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate7_TTVVTVV<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol {
+public struct Concatenate7_TTVVTVV<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
+>: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol {
   public typealias Capture = (T2.Capture, T5.Capture, T6.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast, x6.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast,
+      x6.regex.ast
+    ))
   }
 }
 
@@ -2443,11 +3735,21 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate7_TTVVVTT<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>: RegexProtocol where T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol {
+public struct Concatenate7_TTVVVTT<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
+>: RegexProtocol where T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol {
   public typealias Capture = (T0.Capture, T1.Capture, T5.Capture, T6.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast, x6.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast,
+      x6.regex.ast
+    ))
   }
 }
 
@@ -2459,11 +3761,21 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate7_TTVVVTV<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>: RegexProtocol where T0.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol {
+public struct Concatenate7_TTVVVTV<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
+>: RegexProtocol where T0.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol {
   public typealias Capture = (T1.Capture, T5.Capture, T6.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast, x6.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast,
+      x6.regex.ast
+    ))
   }
 }
 
@@ -2475,11 +3787,21 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate7_TTVVVVT<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>: RegexProtocol where T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol {
+public struct Concatenate7_TTVVVVT<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
+>: RegexProtocol where T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol {
   public typealias Capture = (T0.Capture, T5.Capture, T6.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast, x6.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast,
+      x6.regex.ast
+    ))
   }
 }
 
@@ -2491,11 +3813,21 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate7_TTVVVVV<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol {
+public struct Concatenate7_TTVVVVV<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
+>: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol {
   public typealias Capture = (T5.Capture, T6.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast, x6.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast,
+      x6.regex.ast
+    ))
   }
 }
 
@@ -2507,11 +3839,21 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate7_TVTTTTT<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>: RegexProtocol where T5.Capture: EmptyProtocol {
+public struct Concatenate7_TVTTTTT<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
+>: RegexProtocol where T5.Capture: EmptyProtocol {
   public typealias Capture = (T0.Capture, T1.Capture, T2.Capture, T3.Capture, T4.Capture, T6.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast, x6.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast,
+      x6.regex.ast
+    ))
   }
 }
 
@@ -2523,11 +3865,21 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate7_TVTTTTV<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>: RegexProtocol where T0.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
+public struct Concatenate7_TVTTTTV<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
+>: RegexProtocol where T0.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
   public typealias Capture = (T1.Capture, T2.Capture, T3.Capture, T4.Capture, T6.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast, x6.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast,
+      x6.regex.ast
+    ))
   }
 }
 
@@ -2539,11 +3891,21 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate7_TVTTTVT<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>: RegexProtocol where T1.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
+public struct Concatenate7_TVTTTVT<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
+>: RegexProtocol where T1.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
   public typealias Capture = (T0.Capture, T2.Capture, T3.Capture, T4.Capture, T6.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast, x6.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast,
+      x6.regex.ast
+    ))
   }
 }
 
@@ -2555,11 +3917,21 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate7_TVTTTVV<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
+public struct Concatenate7_TVTTTVV<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
+>: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
   public typealias Capture = (T2.Capture, T3.Capture, T4.Capture, T6.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast, x6.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast,
+      x6.regex.ast
+    ))
   }
 }
 
@@ -2571,11 +3943,21 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate7_TVTTVTT<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>: RegexProtocol where T2.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
+public struct Concatenate7_TVTTVTT<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
+>: RegexProtocol where T2.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
   public typealias Capture = (T0.Capture, T1.Capture, T3.Capture, T4.Capture, T6.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast, x6.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast,
+      x6.regex.ast
+    ))
   }
 }
 
@@ -2587,11 +3969,21 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate7_TVTTVTV<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>: RegexProtocol where T0.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
+public struct Concatenate7_TVTTVTV<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
+>: RegexProtocol where T0.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
   public typealias Capture = (T1.Capture, T3.Capture, T4.Capture, T6.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast, x6.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast,
+      x6.regex.ast
+    ))
   }
 }
 
@@ -2603,11 +3995,21 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate7_TVTTVVT<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>: RegexProtocol where T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
+public struct Concatenate7_TVTTVVT<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
+>: RegexProtocol where T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
   public typealias Capture = (T0.Capture, T3.Capture, T4.Capture, T6.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast, x6.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast,
+      x6.regex.ast
+    ))
   }
 }
 
@@ -2619,11 +4021,21 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate7_TVTTVVV<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
+public struct Concatenate7_TVTTVVV<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
+>: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
   public typealias Capture = (T3.Capture, T4.Capture, T6.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast, x6.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast,
+      x6.regex.ast
+    ))
   }
 }
 
@@ -2635,11 +4047,21 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate7_TVTVTTT<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>: RegexProtocol where T3.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
+public struct Concatenate7_TVTVTTT<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
+>: RegexProtocol where T3.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
   public typealias Capture = (T0.Capture, T1.Capture, T2.Capture, T4.Capture, T6.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast, x6.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast,
+      x6.regex.ast
+    ))
   }
 }
 
@@ -2651,11 +4073,21 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate7_TVTVTTV<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>: RegexProtocol where T0.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
+public struct Concatenate7_TVTVTTV<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
+>: RegexProtocol where T0.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
   public typealias Capture = (T1.Capture, T2.Capture, T4.Capture, T6.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast, x6.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast,
+      x6.regex.ast
+    ))
   }
 }
 
@@ -2667,11 +4099,21 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate7_TVTVTVT<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>: RegexProtocol where T1.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
+public struct Concatenate7_TVTVTVT<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
+>: RegexProtocol where T1.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
   public typealias Capture = (T0.Capture, T2.Capture, T4.Capture, T6.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast, x6.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast,
+      x6.regex.ast
+    ))
   }
 }
 
@@ -2683,11 +4125,21 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate7_TVTVTVV<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
+public struct Concatenate7_TVTVTVV<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
+>: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
   public typealias Capture = (T2.Capture, T4.Capture, T6.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast, x6.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast,
+      x6.regex.ast
+    ))
   }
 }
 
@@ -2699,11 +4151,21 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate7_TVTVVTT<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>: RegexProtocol where T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
+public struct Concatenate7_TVTVVTT<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
+>: RegexProtocol where T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
   public typealias Capture = (T0.Capture, T1.Capture, T4.Capture, T6.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast, x6.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast,
+      x6.regex.ast
+    ))
   }
 }
 
@@ -2715,11 +4177,21 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate7_TVTVVTV<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>: RegexProtocol where T0.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
+public struct Concatenate7_TVTVVTV<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
+>: RegexProtocol where T0.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
   public typealias Capture = (T1.Capture, T4.Capture, T6.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast, x6.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast,
+      x6.regex.ast
+    ))
   }
 }
 
@@ -2731,11 +4203,21 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate7_TVTVVVT<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>: RegexProtocol where T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
+public struct Concatenate7_TVTVVVT<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
+>: RegexProtocol where T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
   public typealias Capture = (T0.Capture, T4.Capture, T6.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast, x6.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast,
+      x6.regex.ast
+    ))
   }
 }
 
@@ -2747,11 +4229,21 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate7_TVTVVVV<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
+public struct Concatenate7_TVTVVVV<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
+>: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
   public typealias Capture = (T4.Capture, T6.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast, x6.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast,
+      x6.regex.ast
+    ))
   }
 }
 
@@ -2763,11 +4255,21 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate7_TVVTTTT<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>: RegexProtocol where T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
+public struct Concatenate7_TVVTTTT<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
+>: RegexProtocol where T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
   public typealias Capture = (T0.Capture, T1.Capture, T2.Capture, T3.Capture, T6.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast, x6.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast,
+      x6.regex.ast
+    ))
   }
 }
 
@@ -2779,11 +4281,21 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate7_TVVTTTV<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>: RegexProtocol where T0.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
+public struct Concatenate7_TVVTTTV<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
+>: RegexProtocol where T0.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
   public typealias Capture = (T1.Capture, T2.Capture, T3.Capture, T6.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast, x6.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast,
+      x6.regex.ast
+    ))
   }
 }
 
@@ -2795,11 +4307,21 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate7_TVVTTVT<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>: RegexProtocol where T1.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
+public struct Concatenate7_TVVTTVT<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
+>: RegexProtocol where T1.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
   public typealias Capture = (T0.Capture, T2.Capture, T3.Capture, T6.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast, x6.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast,
+      x6.regex.ast
+    ))
   }
 }
 
@@ -2811,11 +4333,21 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate7_TVVTTVV<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
+public struct Concatenate7_TVVTTVV<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
+>: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
   public typealias Capture = (T2.Capture, T3.Capture, T6.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast, x6.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast,
+      x6.regex.ast
+    ))
   }
 }
 
@@ -2827,11 +4359,21 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate7_TVVTVTT<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>: RegexProtocol where T2.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
+public struct Concatenate7_TVVTVTT<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
+>: RegexProtocol where T2.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
   public typealias Capture = (T0.Capture, T1.Capture, T3.Capture, T6.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast, x6.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast,
+      x6.regex.ast
+    ))
   }
 }
 
@@ -2843,11 +4385,21 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate7_TVVTVTV<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>: RegexProtocol where T0.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
+public struct Concatenate7_TVVTVTV<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
+>: RegexProtocol where T0.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
   public typealias Capture = (T1.Capture, T3.Capture, T6.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast, x6.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast,
+      x6.regex.ast
+    ))
   }
 }
 
@@ -2859,11 +4411,21 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate7_TVVTVVT<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>: RegexProtocol where T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
+public struct Concatenate7_TVVTVVT<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
+>: RegexProtocol where T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
   public typealias Capture = (T0.Capture, T3.Capture, T6.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast, x6.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast,
+      x6.regex.ast
+    ))
   }
 }
 
@@ -2875,11 +4437,21 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate7_TVVTVVV<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
+public struct Concatenate7_TVVTVVV<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
+>: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
   public typealias Capture = (T3.Capture, T6.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast, x6.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast,
+      x6.regex.ast
+    ))
   }
 }
 
@@ -2891,11 +4463,21 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate7_TVVVTTT<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>: RegexProtocol where T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
+public struct Concatenate7_TVVVTTT<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
+>: RegexProtocol where T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
   public typealias Capture = (T0.Capture, T1.Capture, T2.Capture, T6.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast, x6.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast,
+      x6.regex.ast
+    ))
   }
 }
 
@@ -2907,11 +4489,21 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate7_TVVVTTV<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>: RegexProtocol where T0.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
+public struct Concatenate7_TVVVTTV<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
+>: RegexProtocol where T0.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
   public typealias Capture = (T1.Capture, T2.Capture, T6.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast, x6.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast,
+      x6.regex.ast
+    ))
   }
 }
 
@@ -2923,11 +4515,21 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate7_TVVVTVT<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>: RegexProtocol where T1.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
+public struct Concatenate7_TVVVTVT<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
+>: RegexProtocol where T1.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
   public typealias Capture = (T0.Capture, T2.Capture, T6.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast, x6.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast,
+      x6.regex.ast
+    ))
   }
 }
 
@@ -2939,11 +4541,21 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate7_TVVVTVV<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
+public struct Concatenate7_TVVVTVV<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
+>: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
   public typealias Capture = (T2.Capture, T6.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast, x6.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast,
+      x6.regex.ast
+    ))
   }
 }
 
@@ -2955,11 +4567,21 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate7_TVVVVTT<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>: RegexProtocol where T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
+public struct Concatenate7_TVVVVTT<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
+>: RegexProtocol where T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
   public typealias Capture = (T0.Capture, T1.Capture, T6.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast, x6.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast,
+      x6.regex.ast
+    ))
   }
 }
 
@@ -2971,11 +4593,21 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate7_TVVVVTV<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>: RegexProtocol where T0.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
+public struct Concatenate7_TVVVVTV<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
+>: RegexProtocol where T0.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
   public typealias Capture = (T1.Capture, T6.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast, x6.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast,
+      x6.regex.ast
+    ))
   }
 }
 
@@ -2987,11 +4619,21 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate7_TVVVVVT<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>: RegexProtocol where T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
+public struct Concatenate7_TVVVVVT<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
+>: RegexProtocol where T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
   public typealias Capture = (T0.Capture, T6.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast, x6.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast,
+      x6.regex.ast
+    ))
   }
 }
 
@@ -3003,11 +4645,21 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate7_TVVVVVV<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
+public struct Concatenate7_TVVVVVV<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
+>: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
   public typealias Capture = (T6.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast, x6.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast,
+      x6.regex.ast
+    ))
   }
 }
 
@@ -3019,11 +4671,21 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate7_VTTTTTT<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>: RegexProtocol where T6.Capture: EmptyProtocol {
+public struct Concatenate7_VTTTTTT<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
+>: RegexProtocol where T6.Capture: EmptyProtocol {
   public typealias Capture = (T0.Capture, T1.Capture, T2.Capture, T3.Capture, T4.Capture, T5.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast, x6.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast,
+      x6.regex.ast
+    ))
   }
 }
 
@@ -3035,11 +4697,21 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate7_VTTTTTV<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>: RegexProtocol where T0.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
+public struct Concatenate7_VTTTTTV<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
+>: RegexProtocol where T0.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
   public typealias Capture = (T1.Capture, T2.Capture, T3.Capture, T4.Capture, T5.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast, x6.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast,
+      x6.regex.ast
+    ))
   }
 }
 
@@ -3051,11 +4723,21 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate7_VTTTTVT<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>: RegexProtocol where T1.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
+public struct Concatenate7_VTTTTVT<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
+>: RegexProtocol where T1.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
   public typealias Capture = (T0.Capture, T2.Capture, T3.Capture, T4.Capture, T5.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast, x6.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast,
+      x6.regex.ast
+    ))
   }
 }
 
@@ -3067,11 +4749,21 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate7_VTTTTVV<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
+public struct Concatenate7_VTTTTVV<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
+>: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
   public typealias Capture = (T2.Capture, T3.Capture, T4.Capture, T5.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast, x6.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast,
+      x6.regex.ast
+    ))
   }
 }
 
@@ -3083,11 +4775,21 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate7_VTTTVTT<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>: RegexProtocol where T2.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
+public struct Concatenate7_VTTTVTT<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
+>: RegexProtocol where T2.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
   public typealias Capture = (T0.Capture, T1.Capture, T3.Capture, T4.Capture, T5.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast, x6.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast,
+      x6.regex.ast
+    ))
   }
 }
 
@@ -3099,11 +4801,21 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate7_VTTTVTV<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>: RegexProtocol where T0.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
+public struct Concatenate7_VTTTVTV<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
+>: RegexProtocol where T0.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
   public typealias Capture = (T1.Capture, T3.Capture, T4.Capture, T5.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast, x6.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast,
+      x6.regex.ast
+    ))
   }
 }
 
@@ -3115,11 +4827,21 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate7_VTTTVVT<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>: RegexProtocol where T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
+public struct Concatenate7_VTTTVVT<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
+>: RegexProtocol where T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
   public typealias Capture = (T0.Capture, T3.Capture, T4.Capture, T5.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast, x6.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast,
+      x6.regex.ast
+    ))
   }
 }
 
@@ -3131,11 +4853,21 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate7_VTTTVVV<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
+public struct Concatenate7_VTTTVVV<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
+>: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
   public typealias Capture = (T3.Capture, T4.Capture, T5.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast, x6.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast,
+      x6.regex.ast
+    ))
   }
 }
 
@@ -3147,11 +4879,21 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate7_VTTVTTT<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>: RegexProtocol where T3.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
+public struct Concatenate7_VTTVTTT<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
+>: RegexProtocol where T3.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
   public typealias Capture = (T0.Capture, T1.Capture, T2.Capture, T4.Capture, T5.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast, x6.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast,
+      x6.regex.ast
+    ))
   }
 }
 
@@ -3163,11 +4905,21 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate7_VTTVTTV<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>: RegexProtocol where T0.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
+public struct Concatenate7_VTTVTTV<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
+>: RegexProtocol where T0.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
   public typealias Capture = (T1.Capture, T2.Capture, T4.Capture, T5.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast, x6.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast,
+      x6.regex.ast
+    ))
   }
 }
 
@@ -3179,11 +4931,21 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate7_VTTVTVT<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>: RegexProtocol where T1.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
+public struct Concatenate7_VTTVTVT<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
+>: RegexProtocol where T1.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
   public typealias Capture = (T0.Capture, T2.Capture, T4.Capture, T5.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast, x6.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast,
+      x6.regex.ast
+    ))
   }
 }
 
@@ -3195,11 +4957,21 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate7_VTTVTVV<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
+public struct Concatenate7_VTTVTVV<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
+>: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
   public typealias Capture = (T2.Capture, T4.Capture, T5.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast, x6.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast,
+      x6.regex.ast
+    ))
   }
 }
 
@@ -3211,11 +4983,21 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate7_VTTVVTT<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>: RegexProtocol where T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
+public struct Concatenate7_VTTVVTT<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
+>: RegexProtocol where T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
   public typealias Capture = (T0.Capture, T1.Capture, T4.Capture, T5.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast, x6.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast,
+      x6.regex.ast
+    ))
   }
 }
 
@@ -3227,11 +5009,21 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate7_VTTVVTV<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>: RegexProtocol where T0.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
+public struct Concatenate7_VTTVVTV<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
+>: RegexProtocol where T0.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
   public typealias Capture = (T1.Capture, T4.Capture, T5.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast, x6.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast,
+      x6.regex.ast
+    ))
   }
 }
 
@@ -3243,11 +5035,21 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate7_VTTVVVT<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>: RegexProtocol where T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
+public struct Concatenate7_VTTVVVT<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
+>: RegexProtocol where T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
   public typealias Capture = (T0.Capture, T4.Capture, T5.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast, x6.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast,
+      x6.regex.ast
+    ))
   }
 }
 
@@ -3259,11 +5061,21 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate7_VTTVVVV<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
+public struct Concatenate7_VTTVVVV<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
+>: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
   public typealias Capture = (T4.Capture, T5.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast, x6.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast,
+      x6.regex.ast
+    ))
   }
 }
 
@@ -3275,11 +5087,21 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate7_VTVTTTT<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>: RegexProtocol where T4.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
+public struct Concatenate7_VTVTTTT<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
+>: RegexProtocol where T4.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
   public typealias Capture = (T0.Capture, T1.Capture, T2.Capture, T3.Capture, T5.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast, x6.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast,
+      x6.regex.ast
+    ))
   }
 }
 
@@ -3291,11 +5113,21 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate7_VTVTTTV<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>: RegexProtocol where T0.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
+public struct Concatenate7_VTVTTTV<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
+>: RegexProtocol where T0.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
   public typealias Capture = (T1.Capture, T2.Capture, T3.Capture, T5.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast, x6.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast,
+      x6.regex.ast
+    ))
   }
 }
 
@@ -3307,11 +5139,21 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate7_VTVTTVT<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>: RegexProtocol where T1.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
+public struct Concatenate7_VTVTTVT<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
+>: RegexProtocol where T1.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
   public typealias Capture = (T0.Capture, T2.Capture, T3.Capture, T5.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast, x6.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast,
+      x6.regex.ast
+    ))
   }
 }
 
@@ -3323,11 +5165,21 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate7_VTVTTVV<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
+public struct Concatenate7_VTVTTVV<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
+>: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
   public typealias Capture = (T2.Capture, T3.Capture, T5.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast, x6.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast,
+      x6.regex.ast
+    ))
   }
 }
 
@@ -3339,11 +5191,21 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate7_VTVTVTT<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>: RegexProtocol where T2.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
+public struct Concatenate7_VTVTVTT<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
+>: RegexProtocol where T2.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
   public typealias Capture = (T0.Capture, T1.Capture, T3.Capture, T5.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast, x6.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast,
+      x6.regex.ast
+    ))
   }
 }
 
@@ -3355,11 +5217,21 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate7_VTVTVTV<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>: RegexProtocol where T0.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
+public struct Concatenate7_VTVTVTV<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
+>: RegexProtocol where T0.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
   public typealias Capture = (T1.Capture, T3.Capture, T5.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast, x6.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast,
+      x6.regex.ast
+    ))
   }
 }
 
@@ -3371,11 +5243,21 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate7_VTVTVVT<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>: RegexProtocol where T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
+public struct Concatenate7_VTVTVVT<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
+>: RegexProtocol where T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
   public typealias Capture = (T0.Capture, T3.Capture, T5.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast, x6.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast,
+      x6.regex.ast
+    ))
   }
 }
 
@@ -3387,11 +5269,21 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate7_VTVTVVV<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
+public struct Concatenate7_VTVTVVV<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
+>: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
   public typealias Capture = (T3.Capture, T5.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast, x6.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast,
+      x6.regex.ast
+    ))
   }
 }
 
@@ -3403,11 +5295,21 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate7_VTVVTTT<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>: RegexProtocol where T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
+public struct Concatenate7_VTVVTTT<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
+>: RegexProtocol where T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
   public typealias Capture = (T0.Capture, T1.Capture, T2.Capture, T5.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast, x6.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast,
+      x6.regex.ast
+    ))
   }
 }
 
@@ -3419,11 +5321,21 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate7_VTVVTTV<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>: RegexProtocol where T0.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
+public struct Concatenate7_VTVVTTV<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
+>: RegexProtocol where T0.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
   public typealias Capture = (T1.Capture, T2.Capture, T5.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast, x6.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast,
+      x6.regex.ast
+    ))
   }
 }
 
@@ -3435,11 +5347,21 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate7_VTVVTVT<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>: RegexProtocol where T1.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
+public struct Concatenate7_VTVVTVT<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
+>: RegexProtocol where T1.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
   public typealias Capture = (T0.Capture, T2.Capture, T5.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast, x6.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast,
+      x6.regex.ast
+    ))
   }
 }
 
@@ -3451,11 +5373,21 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate7_VTVVTVV<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
+public struct Concatenate7_VTVVTVV<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
+>: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
   public typealias Capture = (T2.Capture, T5.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast, x6.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast,
+      x6.regex.ast
+    ))
   }
 }
 
@@ -3467,11 +5399,21 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate7_VTVVVTT<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>: RegexProtocol where T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
+public struct Concatenate7_VTVVVTT<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
+>: RegexProtocol where T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
   public typealias Capture = (T0.Capture, T1.Capture, T5.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast, x6.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast,
+      x6.regex.ast
+    ))
   }
 }
 
@@ -3483,11 +5425,21 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate7_VTVVVTV<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>: RegexProtocol where T0.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
+public struct Concatenate7_VTVVVTV<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
+>: RegexProtocol where T0.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
   public typealias Capture = (T1.Capture, T5.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast, x6.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast,
+      x6.regex.ast
+    ))
   }
 }
 
@@ -3499,11 +5451,21 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate7_VTVVVVT<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>: RegexProtocol where T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
+public struct Concatenate7_VTVVVVT<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
+>: RegexProtocol where T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
   public typealias Capture = (T0.Capture, T5.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast, x6.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast,
+      x6.regex.ast
+    ))
   }
 }
 
@@ -3515,11 +5477,21 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate7_VTVVVVV<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
+public struct Concatenate7_VTVVVVV<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
+>: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
   public typealias Capture = (T5.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast, x6.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast,
+      x6.regex.ast
+    ))
   }
 }
 
@@ -3531,11 +5503,21 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate7_VVTTTTT<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>: RegexProtocol where T5.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
+public struct Concatenate7_VVTTTTT<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
+>: RegexProtocol where T5.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
   public typealias Capture = (T0.Capture, T1.Capture, T2.Capture, T3.Capture, T4.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast, x6.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast,
+      x6.regex.ast
+    ))
   }
 }
 
@@ -3547,11 +5529,21 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate7_VVTTTTV<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>: RegexProtocol where T0.Capture: EmptyProtocol, T5.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
+public struct Concatenate7_VVTTTTV<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
+>: RegexProtocol where T0.Capture: EmptyProtocol, T5.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
   public typealias Capture = (T1.Capture, T2.Capture, T3.Capture, T4.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast, x6.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast,
+      x6.regex.ast
+    ))
   }
 }
 
@@ -3563,11 +5555,21 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate7_VVTTTVT<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>: RegexProtocol where T1.Capture: EmptyProtocol, T5.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
+public struct Concatenate7_VVTTTVT<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
+>: RegexProtocol where T1.Capture: EmptyProtocol, T5.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
   public typealias Capture = (T0.Capture, T2.Capture, T3.Capture, T4.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast, x6.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast,
+      x6.regex.ast
+    ))
   }
 }
 
@@ -3579,11 +5581,21 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate7_VVTTTVV<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T5.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
+public struct Concatenate7_VVTTTVV<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
+>: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T5.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
   public typealias Capture = (T2.Capture, T3.Capture, T4.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast, x6.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast,
+      x6.regex.ast
+    ))
   }
 }
 
@@ -3595,11 +5607,21 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate7_VVTTVTT<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>: RegexProtocol where T2.Capture: EmptyProtocol, T5.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
+public struct Concatenate7_VVTTVTT<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
+>: RegexProtocol where T2.Capture: EmptyProtocol, T5.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
   public typealias Capture = (T0.Capture, T1.Capture, T3.Capture, T4.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast, x6.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast,
+      x6.regex.ast
+    ))
   }
 }
 
@@ -3611,11 +5633,21 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate7_VVTTVTV<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>: RegexProtocol where T0.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T5.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
+public struct Concatenate7_VVTTVTV<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
+>: RegexProtocol where T0.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T5.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
   public typealias Capture = (T1.Capture, T3.Capture, T4.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast, x6.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast,
+      x6.regex.ast
+    ))
   }
 }
 
@@ -3627,11 +5659,21 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate7_VVTTVVT<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>: RegexProtocol where T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T5.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
+public struct Concatenate7_VVTTVVT<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
+>: RegexProtocol where T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T5.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
   public typealias Capture = (T0.Capture, T3.Capture, T4.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast, x6.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast,
+      x6.regex.ast
+    ))
   }
 }
 
@@ -3643,11 +5685,21 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate7_VVTTVVV<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T5.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
+public struct Concatenate7_VVTTVVV<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
+>: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T5.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
   public typealias Capture = (T3.Capture, T4.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast, x6.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast,
+      x6.regex.ast
+    ))
   }
 }
 
@@ -3659,11 +5711,21 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate7_VVTVTTT<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>: RegexProtocol where T3.Capture: EmptyProtocol, T5.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
+public struct Concatenate7_VVTVTTT<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
+>: RegexProtocol where T3.Capture: EmptyProtocol, T5.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
   public typealias Capture = (T0.Capture, T1.Capture, T2.Capture, T4.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast, x6.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast,
+      x6.regex.ast
+    ))
   }
 }
 
@@ -3675,11 +5737,21 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate7_VVTVTTV<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>: RegexProtocol where T0.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T5.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
+public struct Concatenate7_VVTVTTV<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
+>: RegexProtocol where T0.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T5.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
   public typealias Capture = (T1.Capture, T2.Capture, T4.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast, x6.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast,
+      x6.regex.ast
+    ))
   }
 }
 
@@ -3691,11 +5763,21 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate7_VVTVTVT<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>: RegexProtocol where T1.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T5.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
+public struct Concatenate7_VVTVTVT<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
+>: RegexProtocol where T1.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T5.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
   public typealias Capture = (T0.Capture, T2.Capture, T4.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast, x6.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast,
+      x6.regex.ast
+    ))
   }
 }
 
@@ -3707,11 +5789,21 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate7_VVTVTVV<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T5.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
+public struct Concatenate7_VVTVTVV<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
+>: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T5.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
   public typealias Capture = (T2.Capture, T4.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast, x6.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast,
+      x6.regex.ast
+    ))
   }
 }
 
@@ -3723,11 +5815,21 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate7_VVTVVTT<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>: RegexProtocol where T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T5.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
+public struct Concatenate7_VVTVVTT<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
+>: RegexProtocol where T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T5.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
   public typealias Capture = (T0.Capture, T1.Capture, T4.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast, x6.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast,
+      x6.regex.ast
+    ))
   }
 }
 
@@ -3739,11 +5841,21 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate7_VVTVVTV<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>: RegexProtocol where T0.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T5.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
+public struct Concatenate7_VVTVVTV<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
+>: RegexProtocol where T0.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T5.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
   public typealias Capture = (T1.Capture, T4.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast, x6.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast,
+      x6.regex.ast
+    ))
   }
 }
 
@@ -3755,11 +5867,21 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate7_VVTVVVT<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>: RegexProtocol where T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T5.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
+public struct Concatenate7_VVTVVVT<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
+>: RegexProtocol where T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T5.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
   public typealias Capture = (T0.Capture, T4.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast, x6.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast,
+      x6.regex.ast
+    ))
   }
 }
 
@@ -3771,11 +5893,21 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate7_VVTVVVV<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T5.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
+public struct Concatenate7_VVTVVVV<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
+>: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T5.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
   public typealias Capture = (T4.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast, x6.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast,
+      x6.regex.ast
+    ))
   }
 }
 
@@ -3787,11 +5919,21 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate7_VVVTTTT<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>: RegexProtocol where T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
+public struct Concatenate7_VVVTTTT<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
+>: RegexProtocol where T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
   public typealias Capture = (T0.Capture, T1.Capture, T2.Capture, T3.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast, x6.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast,
+      x6.regex.ast
+    ))
   }
 }
 
@@ -3803,11 +5945,21 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate7_VVVTTTV<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>: RegexProtocol where T0.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
+public struct Concatenate7_VVVTTTV<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
+>: RegexProtocol where T0.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
   public typealias Capture = (T1.Capture, T2.Capture, T3.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast, x6.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast,
+      x6.regex.ast
+    ))
   }
 }
 
@@ -3819,11 +5971,21 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate7_VVVTTVT<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>: RegexProtocol where T1.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
+public struct Concatenate7_VVVTTVT<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
+>: RegexProtocol where T1.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
   public typealias Capture = (T0.Capture, T2.Capture, T3.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast, x6.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast,
+      x6.regex.ast
+    ))
   }
 }
 
@@ -3835,11 +5997,21 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate7_VVVTTVV<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
+public struct Concatenate7_VVVTTVV<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
+>: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
   public typealias Capture = (T2.Capture, T3.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast, x6.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast,
+      x6.regex.ast
+    ))
   }
 }
 
@@ -3851,11 +6023,21 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate7_VVVTVTT<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>: RegexProtocol where T2.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
+public struct Concatenate7_VVVTVTT<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
+>: RegexProtocol where T2.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
   public typealias Capture = (T0.Capture, T1.Capture, T3.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast, x6.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast,
+      x6.regex.ast
+    ))
   }
 }
 
@@ -3867,11 +6049,21 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate7_VVVTVTV<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>: RegexProtocol where T0.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
+public struct Concatenate7_VVVTVTV<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
+>: RegexProtocol where T0.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
   public typealias Capture = (T1.Capture, T3.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast, x6.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast,
+      x6.regex.ast
+    ))
   }
 }
 
@@ -3883,11 +6075,21 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate7_VVVTVVT<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>: RegexProtocol where T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
+public struct Concatenate7_VVVTVVT<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
+>: RegexProtocol where T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
   public typealias Capture = (T0.Capture, T3.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast, x6.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast,
+      x6.regex.ast
+    ))
   }
 }
 
@@ -3899,11 +6101,21 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate7_VVVTVVV<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
+public struct Concatenate7_VVVTVVV<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
+>: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
   public typealias Capture = (T3.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast, x6.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast,
+      x6.regex.ast
+    ))
   }
 }
 
@@ -3915,11 +6127,21 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate7_VVVVTTT<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>: RegexProtocol where T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
+public struct Concatenate7_VVVVTTT<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
+>: RegexProtocol where T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
   public typealias Capture = (T0.Capture, T1.Capture, T2.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast, x6.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast,
+      x6.regex.ast
+    ))
   }
 }
 
@@ -3931,11 +6153,21 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate7_VVVVTTV<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>: RegexProtocol where T0.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
+public struct Concatenate7_VVVVTTV<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
+>: RegexProtocol where T0.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
   public typealias Capture = (T1.Capture, T2.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast, x6.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast,
+      x6.regex.ast
+    ))
   }
 }
 
@@ -3947,11 +6179,21 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate7_VVVVTVT<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>: RegexProtocol where T1.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
+public struct Concatenate7_VVVVTVT<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
+>: RegexProtocol where T1.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
   public typealias Capture = (T0.Capture, T2.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast, x6.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast,
+      x6.regex.ast
+    ))
   }
 }
 
@@ -3963,11 +6205,21 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate7_VVVVTVV<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
+public struct Concatenate7_VVVVTVV<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
+>: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
   public typealias Capture = (T2.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast, x6.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast,
+      x6.regex.ast
+    ))
   }
 }
 
@@ -3979,11 +6231,21 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate7_VVVVVTT<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>: RegexProtocol where T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
+public struct Concatenate7_VVVVVTT<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
+>: RegexProtocol where T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
   public typealias Capture = (T0.Capture, T1.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast, x6.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast,
+      x6.regex.ast
+    ))
   }
 }
 
@@ -3995,11 +6257,21 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate7_VVVVVTV<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>: RegexProtocol where T0.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
+public struct Concatenate7_VVVVVTV<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
+>: RegexProtocol where T0.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
   public typealias Capture = (T1.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast, x6.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast,
+      x6.regex.ast
+    ))
   }
 }
 
@@ -4011,11 +6283,21 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate7_VVVVVVT<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>: RegexProtocol where T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
+public struct Concatenate7_VVVVVVT<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
+>: RegexProtocol where T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
   public typealias Capture = (T0.Capture)
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast, x6.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast,
+      x6.regex.ast
+    ))
   }
 }
 
@@ -4027,11 +6309,21 @@ extension RegexBuilder {
   }
 }
 
-public struct Concatenate7_VVVVVVV<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
+public struct Concatenate7_VVVVVVV<
+  T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
+>: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
   public typealias Capture = Empty
   public let regex: Regex<Capture>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
-    regex = .init(ast: .concatenation([x0.regex.ast, x1.regex.ast, x2.regex.ast, x3.regex.ast, x4.regex.ast, x5.regex.ast, x6.regex.ast]))
+    regex = .init(ast: concat(
+      x0.regex.ast,
+      x1.regex.ast,
+      x2.regex.ast,
+      x3.regex.ast,
+      x4.regex.ast,
+      x5.regex.ast,
+      x6.regex.ast
+    ))
   }
 }
 

--- a/Sources/_StringProcessing/RegexDSL/Core.swift
+++ b/Sources/_StringProcessing/RegexDSL/Core.swift
@@ -1,7 +1,5 @@
 import _MatchingEngine
 
-fileprivate typealias DefaultEngine = TortoiseVM
-
 public struct RegexMatch<CapturedValue> {
   public let range: Range<String.Index>
   public let captures: CapturedValue
@@ -12,11 +10,6 @@ public protocol RegexProtocol {
   associatedtype Capture
   var regex: Regex<Capture> { get }
 }
-
-public protocol EmptyProtocol {}
-public struct Empty: EmptyProtocol {}
-extension Array: EmptyProtocol where Element: EmptyProtocol {}
-extension Optional: EmptyProtocol where Wrapped: EmptyProtocol {}
 
 /// A regular expression.
 public struct Regex<Capture>: RegexProtocol {
@@ -119,3 +112,11 @@ public func r<C>(
 ) -> MockRegexLiteral<C> {
   try! MockRegexLiteral(s, capturing: capturing)
 }
+
+fileprivate typealias DefaultEngine = TortoiseVM
+
+public protocol EmptyProtocol {}
+public struct Empty: EmptyProtocol {}
+extension Array: EmptyProtocol where Element: EmptyProtocol {}
+extension Optional: EmptyProtocol where Wrapped: EmptyProtocol {}
+

--- a/Sources/_StringProcessing/RegexDSL/DSLCapture.swift
+++ b/Sources/_StringProcessing/RegexDSL/DSLCapture.swift
@@ -1,0 +1,82 @@
+extension RegexProtocol where Capture: EmptyProtocol {
+  public func capture() -> CapturingGroup<Substring> {
+    .init(self)
+  }
+
+  public func capture<NewCapture>(
+    _ transform: @escaping (Substring) -> NewCapture
+  ) -> CapturingGroup<NewCapture> {
+    .init(self, transform: transform)
+  }
+}
+
+extension RegexProtocol {
+  // Note: We use `@_disfavoredOverload` to prevent tuple captures from choosing this overload.
+  @_disfavoredOverload
+  public func capture() -> CapturingGroup<(Substring, Capture)> {
+    .init(self)
+  }
+
+  // Note: We use `@_disfavoredOverload` to prevent tuple captures from choosing this overload.
+  @_disfavoredOverload
+  public func capture<NewCapture>(
+    _ transform: @escaping (Substring) -> NewCapture
+  ) -> CapturingGroup<(Substring, Capture)> {
+    .init(self, transform: transform)
+  }
+
+  public func capture<C0, C1>() -> CapturingGroup<(Substring, C0, C1)> where Capture == (C0, C1) {
+    .init(self)
+  }
+
+  public func capture<NewCapture, C0, C1>(
+    _ transform: @escaping (Substring) -> NewCapture
+  ) -> CapturingGroup<(Substring, C0, C1)> where Capture == (C0, C1) {
+    .init(self, transform: transform)
+  }
+
+  public func capture<C0, C1, C2>() -> CapturingGroup<(Substring, C0, C1, C2)>
+  where Capture == (C0, C1, C2) {
+    .init(self)
+  }
+
+  public func capture<NewCapture, C0, C1, C2>(
+    _ transform: @escaping (Substring) -> NewCapture
+  ) -> CapturingGroup<(Substring, C0, C1, C2)> where Capture == (C0, C1, C2) {
+    .init(self, transform: transform)
+  }
+
+  public func capture<C0, C1, C2, C3>() -> CapturingGroup<(Substring, C0, C1, C2, C3)>
+  where Capture == (C0, C1, C2, C3) {
+    .init(self)
+  }
+
+  public func capture<C0, C1, C2, C3, C4>() -> CapturingGroup<(Substring, C0, C1, C2, C3, C4)>
+  where Capture == (C0, C1, C2, C3, C4) {
+    .init(self)
+  }
+
+  public func capture<C0, C1, C2, C3, C4, C5>() -> CapturingGroup<(Substring, C0, C1, C2, C3, C4, C5)>
+  where Capture == (C0, C1, C2, C3, C4, C5) {
+    .init(self)
+  }
+
+  public func capture<C0, C1, C2, C3, C4, C5, C6>() -> CapturingGroup<(Substring, C0, C1, C2, C3, C4, C5, C6)>
+  where Capture == (C0, C1, C2, C3, C4, C5, C6) {
+    .init(self)
+  }
+}
+
+/* Or using parameterized extensions and variadic generics.
+extension<T...> RegexProtocol where Capture == (T...) {
+  public func capture() -> CapturingGroup<(Substring, T...)> {
+    .init(self)
+  }
+
+  public func capture<NewCapture>(
+    _ transform: @escaping (Substring) -> NewCapture
+  ) -> CapturingGroup<(NewCapture, T...)> {
+    .init(self, transform: transform)
+  }
+}
+*/

--- a/Tests/RegexTests/SyntaxOptionsTests.swift
+++ b/Tests/RegexTests/SyntaxOptionsTests.swift
@@ -92,10 +92,10 @@ extension RegexTests {
   func testModernCaptures() {
     parseTest(
       #"a(?:b)c"#,
-      .concatenation(["a", .nonCapture("b"), "c"]))
+      .concatenation(["a", nonCapture("b"), "c"]))
     parseTest(
       #"a(_:b)c"#,
-      .concatenation(["a", .nonCapture("b"), "c"]),
+      .concatenation(["a", nonCapture("b"), "c"]),
       syntax: .modernCaptures)
 
     // TODO: `(name: .*)`


### PR DESCRIPTION
- Add in `PatternTree`, which holds a formula over an algebra of patterns
- Minor refactorings

Doing the [AST overhaul](https://github.com/apple/swift-experimental-string-processing/pull/57) involves _heavily_ modifying the DSL code, and I realize much of this overhaul can be refactored out and developed in parallel / incrementally. Trying to do it all at once is proving troublesome.

This does some cosmetic changes and starts us down the path towards a pattern algebra. It still falls back to regex AST. I also didn't bother to rename anything fundamental (like `Pattern` vs `Regex`). This is meant to be the minimal changes that help unblock AST reworking.

Next step will be to get `groupTransform` cleanly off the AST and into PatternTree. Compilation should compile a pattern tree. I don't know how or if we want to do a lot of nesting here...