### PR TITLE
Source plumbing, source rendering

### DIFF
--- a/Sources/_MatchingEngine/Regex/AST/AST.swift
+++ b/Sources/_MatchingEngine/Regex/AST/AST.swift
@@ -43,6 +43,10 @@ private struct ASTStorage {
 
 extension AST {
   // :-(
+  //
+  // Existential-based programming is highly prone to silent
+  // errors, but it does enable us to avoid having to switch
+  // over `self` _everywhere_ we want to do anything.
   var _associatedValue: _ASTNode {
     switch self {
     case let .alternation(v):          return v

--- a/Sources/_MatchingEngine/Regex/AST/ASTBuilder.swift
+++ b/Sources/_MatchingEngine/Regex/AST/ASTBuilder.swift
@@ -14,6 +14,10 @@ AST.
 
 */
 
+// TODO: Sink this file into _StringProcessing and make it all
+// internal. For now, this lets us incrementally add source
+// ranges...
+
 public let _fakeLoc = "".startIndex
 public let _fakeRange = _fakeLoc ..< _fakeLoc
 public func _fake<T: Hashable>(_ t: T) -> AST.Loc<T> {

--- a/Sources/_MatchingEngine/Regex/AST/ASTBuilder.swift
+++ b/Sources/_MatchingEngine/Regex/AST/ASTBuilder.swift
@@ -138,21 +138,23 @@ public func quantRange(
 }
 
 public func charClass(
-  _ members: CustomCharacterClass.Member...,
+  _ members: AST.CustomCharacterClass.Member...,
   inverted: Bool = false
 ) -> AST {
-  let cc = CustomCharacterClass(
-    inverted ? .inverted : .normal, members, _fakeRange
-  )
+  let cc = CustomCC(
+    _fake(inverted ? .inverted : .normal),
+    members,
+    _fakeRange)
   return .customCharacterClass(cc)
 }
 public func charClass(
-  _ members: CustomCharacterClass.Member...,
+  _ members: AST.CustomCharacterClass.Member...,
   inverted: Bool = false
-) -> CustomCharacterClass.Member {
-  let cc = CustomCharacterClass(
-    inverted ? .inverted : .normal, members, _fakeRange
-  )
+) -> AST.CustomCharacterClass.Member {
+  let cc = CustomCC(
+    _fake(inverted ? .inverted : .normal),
+    members,
+    _fakeRange)
   return .custom(cc)
 }
 public func posixSet(

--- a/Sources/_MatchingEngine/Regex/AST/ASTProtocols.swift
+++ b/Sources/_MatchingEngine/Regex/AST/ASTProtocols.swift
@@ -13,6 +13,10 @@
 protocol _ASTNode: _ASTPrintable {
   var sourceRange: SourceRange { get }
 }
+extension _ASTNode {
+  var startLoc: SourceLoc { sourceRange.lowerBound }
+  var endLoc: SourceLoc { sourceRange.upperBound }
+}
 
 protocol _ASTParent: _ASTNode {
   var children: [AST] { get }
@@ -110,6 +114,9 @@ extension AST {
     }
 
     for level in levels {
+      // TODO: Actually, I want to render into the bottom-most
+      // string that only has spaces over this range...
+
       var line = base
       for node in level {
         node._renderRange(in: input, into: &line)

--- a/Sources/_MatchingEngine/Regex/AST/Atom.swift
+++ b/Sources/_MatchingEngine/Regex/AST/Atom.swift
@@ -462,7 +462,7 @@ extension Atom {
 
 extension Atom {
   var sourceRange: SourceRange {
-    // TODO: Does this mean we need to make Atom a struct?
+    // FIXME: source location tracking
     _fakeRange
   }
 }

--- a/Sources/_MatchingEngine/Regex/AST/CustomCharClass.swift
+++ b/Sources/_MatchingEngine/Regex/AST/CustomCharClass.swift
@@ -1,56 +1,61 @@
 
-// TODO: source ranges? ASTValue? etc?
-public struct CustomCharacterClass: Hashable {
-  public var start: Start
-  public var members: [Member]
+extension AST {
+  public struct CustomCharacterClass: Hashable {
+    public var start: Loc<Start>
+    public var members: [Member]
 
-  public let sourceRange: SourceRange
+    public let sourceRange: SourceRange
 
+    public init(
+      _ start: Loc<Start>,
+      _ members: [Member],
+      _ sr: SourceRange
+    ) {
+      self.start = start
+      self.members = members
+      self.sourceRange = sr
+    }
 
-  public init(
-    _ start: Start,
-    _ members: [Member],
-    _ sr: SourceRange
-  ) {
-    self.start = start
-    self.members = members
-    self.sourceRange = sr
-  }
+    // FIXME: track source ranges
+    public enum Member: Hashable {
+      /// A nested custom character class `[[ab][cd]]`
+      case custom(CustomCharacterClass)
 
-  public enum Member: Hashable {
-    /// A nested custom character class `[[ab][cd]]`
-    case custom(CustomCharacterClass)
+      /// A character range `a-z`
+      case range(Atom, Atom)
 
-    /// A character range `a-z`
-    case range(Atom, Atom)
+      /// A single character or escape
+      case atom(Atom)
 
-    /// A single character or escape
-    case atom(Atom)
+      /// A binary operator applied to sets of members `abc&&def`
+      case setOperation([Member], SetOp, [Member])
+    }
+    public enum SetOp: String, Hashable {
+      case subtraction = "--"
+      case intersection = "&&"
+      case symmetricDifference = "~~"
+    }
+    public enum Start: Hashable {
+      /// `[`
+      case normal
 
-    /// A binary operator applied to sets of members `abc&&def`
-    case setOperation([Member], SetOp, [Member])
-  }
-  public enum SetOp: String, Hashable {
-    case subtraction = "--"
-    case intersection = "&&"
-    case symmetricDifference = "~~"
-  }
-  public enum Start: Hashable {
-    /// `[`
-    case normal
-
-    /// `[^`
-    case inverted
+      /// `[^`
+      case inverted
+    }
   }
 }
 
-extension CustomCharacterClass {
-  public var isInverted: Bool { start == .inverted }
+/// `AST.CustomCharacterClass.Start` is a mouthful
+internal typealias CustomCC = AST.CustomCharacterClass
+
+extension CustomCC {
+  public var isInverted: Bool { start.value == .inverted }
 }
 
-extension CustomCharacterClass: _ASTNode {
+extension CustomCC: _ASTNode {
   public var _dumpBase: String {
     // FIXME: print out members...
     "customCharacterClass"
   }
 }
+

--- a/Sources/_MatchingEngine/Regex/AST/CustomCharClass.swift
+++ b/Sources/_MatchingEngine/Regex/AST/CustomCharClass.swift
@@ -28,7 +28,7 @@ extension AST {
       case atom(Atom)
 
       /// A binary operator applied to sets of members `abc&&def`
-      case setOperation([Member], SetOp, [Member])
+      case setOperation([Member], Loc<SetOp>, [Member])
     }
     public enum SetOp: String, Hashable {
       case subtraction = "--"

--- a/Sources/_MatchingEngine/Regex/Parse/LexicalAnalysis.swift
+++ b/Sources/_MatchingEngine/Regex/Parse/LexicalAnalysis.swift
@@ -390,7 +390,7 @@ extension Source {
   }
 
   mutating func lexCustomCCStart(
-  ) throws -> Value<CustomCharacterClass.Start>? {
+  ) throws -> Value<CustomCC.Start>? {
     try recordLoc { src in
       // POSIX named sets are atoms.
       guard !src.starts(with: "[:") else { return nil }
@@ -406,7 +406,7 @@ extension Source {
   ///
   ///     CustomCCBinOp -> '--' | '~~' | '&&'
   ///
-  mutating func lexCustomCCBinOp() throws -> Value<CustomCharacterClass.SetOp>? {
+  mutating func lexCustomCCBinOp() throws -> Value<CustomCC.SetOp>? {
     try recordLoc { src in
       // TODO: Perhaps a syntax options check (!PCRE)
       // TODO: Better AST types here
@@ -417,7 +417,7 @@ extension Source {
   }
 
   // Check to see if we can lex a binary operator.
-  func peekCCBinOp() -> CustomCharacterClass.SetOp? {
+  func peekCCBinOp() -> CustomCC.SetOp? {
     if starts(with: "--") { return .subtraction }
     if starts(with: "~~") { return .symmetricDifference }
     if starts(with: "&&") { return .intersection }

--- a/Sources/_MatchingEngine/Regex/Parse/LexicalAnalysis.swift
+++ b/Sources/_MatchingEngine/Regex/Parse/LexicalAnalysis.swift
@@ -221,12 +221,16 @@ extension Source {
 
       switch (lowerOpt, closedRange, upperOpt) {
       case let (l?, nil, nil):
+        // FIXME: source location tracking
         return .exactly(_fake(l))
       case let (l?, true, nil):
+        // FIXME: source location tracking
         return .nOrMore(_fake(l))
       case let (nil, closed?, u?):
+        // FIXME: source location tracking
         return .upToN(_fake(closed ? u : u-1))
       case let (l?, closed?, u?):
+        // FIXME: source location tracking
         return .range(
           _fake(l) ... _fake(closed ? u : u-1))
       case let (nil, nil, u) where u != nil:
@@ -327,6 +331,7 @@ extension Source {
       while src.tryEat(" ") {
         didSomething = true
       }
+      // FIXME: source location tracking
       return didSomething ? AST.Trivia(_fakeRange) : nil
     }
   }

--- a/Sources/_MatchingEngine/Regex/Parse/Parse.swift
+++ b/Sources/_MatchingEngine/Regex/Parse/Parse.swift
@@ -86,6 +86,7 @@ extension Parser {
       // TODO: track pipe locations too...
       result.append(try parseConcatenation())
     }
+
     if result.count == 1 {
       return result[0]
     }
@@ -233,6 +234,8 @@ extension Parser {
   mutating func parseCCCMembers(
     into members: inout Array<CustomCC.Member>
   ) throws {
+    // FIXME: Track source locations
+
     // Parse members until we see the end of the custom char class or an
     // operator.
     while source.peek() != "]" && source.peekCCBinOp() == nil {

--- a/Sources/_MatchingEngine/Regex/Parse/Parse.swift
+++ b/Sources/_MatchingEngine/Regex/Parse/Parse.swift
@@ -64,6 +64,10 @@ extension Parser {
         (error detected in parser at \(function):\(line))
         """
   }
+
+  fileprivate func sr(_ start: SourceLoc) -> SourceRange {
+    start ..< source.currentLoc
+  }
 }
 
 extension Parser {
@@ -98,28 +102,30 @@ extension Parser {
       if source.isEmpty { break }
       if source.peek() == "|" || source.peek() == ")" { break }
 
+      let _start = source.currentLoc
+
       //     Trivia -> `lexComment` | `lexNonSemanticWhitespace`
       if let _ = try source.lexComment() {
         // TODO: remember comments
-        result.append(.trivia(.init(_fakeRange)))
+        result.append(.trivia(.init(sr(_start))))
         continue
       }
       if let _ = try source.lexNonSemanticWhitespace() {
         // TODO: Remember source range
-        result.append(.trivia(.init(_fakeRange)))
+        result.append(.trivia(.init(sr(_start))))
         continue
       }
 
       //     Quote      -> `lexQuote`
       if let quote = try source.lexQuote() {
-        result.append(.quote(.init(quote.value, _fakeRange)))
+        result.append(.quote(.init(quote.value, sr(_start))))
         continue
       }
       //     Quantification  -> QuantOperand Quantifier?
       if let operand = try parseQuantifierOperand() {
         if let (amt, kind) = try source.lexQuantifier() {
            result.append(.quantification(.init(
-            amt, kind, operand, _fakeRange)))
+            amt, kind, operand, sr(_start))))
         } else {
           result.append(operand)
         }
@@ -137,6 +143,7 @@ extension Parser {
     if result.count == 1 {
       return result[0]
     }
+
     return .concatenation(.init(result, _fakeRange))
   }
 
@@ -148,16 +155,18 @@ extension Parser {
   mutating func parseQuantifierOperand() throws -> AST? {
     assert(!source.isEmpty)
 
+    let _start = source.currentLoc
+
     if let kind = try source.lexGroupStart() {
       // TODO: more source locations
       let child = try parse()
-
-      let ast = AST.group(.init(kind, child, _fakeRange))
       try source.expect(")")
-      return ast
+
+      return .group(.init(kind, child, sr(_start)))
     }
-    if let cccStart = try source.lexCustomCCStart()?.value {
-      return .customCharacterClass(try parseCustomCharacterClass(cccStart))
+    if let cccStart = try source.lexCustomCCStart() {
+      return .customCharacterClass(
+        try parseCustomCharacterClass(cccStart))
     }
 
     if let atom = try source.lexAtom(
@@ -182,9 +191,9 @@ extension Parser {
   ///     Range           -> Atom `-` Atom
   ///
   mutating func parseCustomCharacterClass(
-    _ start: CustomCharacterClass.Start
-  ) throws -> CustomCharacterClass {
-    typealias Member = CustomCharacterClass.Member
+    _ start: Source.Value<CustomCC.Start>
+  ) throws -> CustomCC {
+    typealias Member = CustomCC.Member
     try source.expectNonEmpty()
 
     var members: Array<Member> = []
@@ -206,7 +215,10 @@ extension Parser {
       // If we're done, bail early
       let setOp = Member.setOperation(members, binOp, rhs)
       if source.tryEat("]") {
-        return CustomCharacterClass(start, [setOp], _fakeRange)
+        return CustomCC(
+          start,
+          [setOp],
+          start.sourceRange.lowerBound ..< source.currentLoc)
       }
 
       // Otherwise it's just another member to accumulate
@@ -216,18 +228,21 @@ extension Parser {
       throw ParseError.expectedCustomCharacterClassMembers
     }
     try source.expect("]")
-    return CustomCharacterClass(start, members, _fakeRange)
+    return CustomCC(
+      start,
+      members,
+      start.sourceRange.lowerBound ..< source.currentLoc)
   }
 
   mutating func parseCCCMembers(
-    into members: inout Array<CustomCharacterClass.Member>
+    into members: inout Array<CustomCC.Member>
   ) throws {
     // Parse members until we see the end of the custom char class or an
     // operator.
     while source.peek() != "]" && source.peekCCBinOp() == nil {
 
       // Nested custom character class.
-      if let cccStart = try source.lexCustomCCStart()?.value {
+      if let cccStart = try source.lexCustomCCStart() {
         members.append(.custom(try parseCustomCharacterClass(cccStart)))
         continue
       }

--- a/Sources/_MatchingEngine/Regex/Parse/SourceRange.swift
+++ b/Sources/_MatchingEngine/Regex/Parse/SourceRange.swift
@@ -104,4 +104,7 @@ extension SourceRange {
   ///
   /// Currently, the empty range at the start of any string is the "fake" range
   public var isFake: Bool { self == _fakeRange }
+
+  // Much of the time we actually want the inverse...
+  public var isReal: Bool { !isFake }
 }

--- a/Sources/_MatchingEngine/Utility/Misc.swift
+++ b/Sources/_MatchingEngine/Utility/Misc.swift
@@ -11,3 +11,35 @@ func unreachable(_ s: @autoclosure () -> String) -> Never {
 func unreachable() -> Never {
   fatalError("unreachable")
 }
+
+// From Algorithms...
+extension Array /* for enumerated */ {
+  /// Returns a collection of subsequences of this collection, chunked by the
+  /// given predicate.
+  ///
+  /// - Complexity: O(*n*), where *n* is the length of this collection.
+  public func chunked(
+    by belongInSameGroup: (Element, Element) throws -> Bool
+  ) rethrows -> [SubSequence] {
+    guard !isEmpty else { return [] }
+    var result: [SubSequence] = []
+
+    var start = startIndex
+    var current = self[start]
+
+    for (index, element) in enumerated().dropFirst() {
+      if try !belongInSameGroup(current, element) {
+        result.append(self[start..<index])
+        start = index
+      }
+      current = element
+    }
+
+    if start != endIndex {
+      result.append(self[start...])
+    }
+
+    return result
+  }
+}
+

--- a/Sources/_StringProcessing/CharacterClass.swift
+++ b/Sources/_StringProcessing/CharacterClass.swift
@@ -40,7 +40,7 @@ public struct CharacterClass: Hashable {
     case custom([CharacterSetComponent])
   }
 
-  public typealias SetOperator = CustomCharacterClass.SetOp
+  public typealias SetOperator = AST.CustomCharacterClass.SetOp
 
   /// A binary set operation that forms a character class component.
   public struct SetOperation: Hashable {
@@ -280,13 +280,13 @@ extension CharacterClass {
       return esc(.graphemeCluster)
 
     case .hexDigit:
-      let members: [CustomCharacterClass.Member] = [
+      let members: [AST.CustomCharacterClass.Member] = [
         .range(.char("a"), .char("f")),
         .range(.char("A"), .char("F")),
         .range(.char("0"), .char("9")),
       ]
-      let ccc = CustomCharacterClass(
-        inv ? .inverted : .normal,
+      let ccc = AST.CustomCharacterClass(
+        _fake(inv ? .inverted : .normal),
         members,
         _fakeRange)
 
@@ -373,7 +373,7 @@ extension Atom.EscapedBuiltin {
   }
 }
 
-extension CustomCharacterClass {
+extension AST.CustomCharacterClass {
   /// The model character class for this custom character class.
   var modelCharacterClass: CharacterClass {
     typealias Component = CharacterClass.CharacterSetComponent

--- a/Sources/_StringProcessing/CharacterClass.swift
+++ b/Sources/_StringProcessing/CharacterClass.swift
@@ -393,8 +393,11 @@ extension AST.CustomCharacterClass {
           // multiple components in each operand, we should fix that. For now,
           // just produce custom components.
           return .setOperation(
-            .init(lhs: .characterClass(.custom(getComponents(lhs))), op: op,
-                  rhs: .characterClass(.custom(getComponents(rhs))))
+            .init(
+              lhs: .characterClass(
+                .custom(getComponents(lhs))), op: op.value,
+              rhs: .characterClass(
+                .custom(getComponents(rhs))))
           )
 
         case .atom(let a) where a.literalCharacterValue != nil:

--- a/Tests/RegexTests/DiagnosticTests.swift
+++ b/Tests/RegexTests/DiagnosticTests.swift
@@ -45,17 +45,23 @@ extension RegexTests {
       let lines = try! parse(
         str, .traditional
       )._render(in: str)
-      guard lines.count == expected.count else {
+      func fail() {
         XCTFail("""
           expected:
             \(expected.joined(separator: "\n    "))
           saw:
             \(lines.joined(separator: "\n    "))
         """)
+      }
+      guard lines.count == expected.count else {
+        fail()
         return
       }
       for (e, l) in zip(expected, lines) {
-        XCTAssertEqual(e, l)
+        guard e.elementsEqual(l) else {
+          fail()
+          return
+        }
       }
     }
 
@@ -70,12 +76,12 @@ extension RegexTests {
 
     // FIXME: Groups do, however
     // FIXME: This isn't an ideal leaf rendering...
-    renderTest("a(b)c+(d(e))f(?:g)", [
-           /*  "^^^ ^^^^^^  ^--^^ ", */
-               " --^-^  --^       ",
-               "       ---^       ",
-               "      -----^ ----^", // should be  higher
-               "-----------------^"
+    renderTest("a(b)c+(d(e))f(?:gh)", [
+           /*  "^^^ ^^^^^^  ^--^^^ ", */
+               " --^-^  --^     -^ ",
+               "       ---^  -----^",
+               "      -----^       ",
+               "------------------^"
     ])
   }
 }

--- a/Tests/RegexTests/DiagnosticTests.swift
+++ b/Tests/RegexTests/DiagnosticTests.swift
@@ -15,6 +15,10 @@ extension RegexTests {
 
   func testRender() {
     // Test top-level source range tracking from an example
+    // "Flat" because it will extract immediate children of
+    // concatenations and alternations, but not recurse.
+    //
+    // Input should be a concatenation or alternation
     func flatTest(_ str: String, _ expected: [String]) {
       guard let ast = try? parse(str, .traditional) else {
         XCTFail("Fail to parse: \(str)")
@@ -33,25 +37,45 @@ extension RegexTests {
     flatTest("a(b)c+", [/*"a",*/ "(b)", "c+"])
     flatTest("a*?b(c(d))", ["a*?", /*"b",*/ "(c(d))"])
     flatTest("[abc]*?d", ["[abc]*?" /*, "d"*/])
+    flatTest("a(?:b)", [/* "a",*/ "(?:b)"])
+    flatTest("a|b|c|", [/* "a", "b", "c", */ ""])
+    flatTest("a|(b)|", [/* "a", */ "(b)", ""])
 
     func renderTest(_ str: String, _ expected: [String]) {
       let lines = try! parse(
         str, .traditional
       )._render(in: str)
-      XCTAssertEqual(expected, lines)
+      guard lines.count == expected.count else {
+        XCTFail("""
+          expected:
+            \(expected.joined(separator: "\n    "))
+          saw:
+            \(lines.joined(separator: "\n    "))
+        """)
+        return
+      }
+      for (e, l) in zip(expected, lines) {
+        XCTAssertEqual(e, l)
+      }
     }
 
     // AST constructors fake ranges, nothing to render
     XCTAssertEqual([], concat("a", "b")._render(in: "ab"))
 
     // FIXME: Atoms currently don't track locations
-    renderTest("ab", [])
+    renderTest("ab", [
+            /* "^^", */
+               "-^",
+    ])
 
     // FIXME: Groups do, however
-    renderTest("a(b)c+(d(e))f", [
-               " --^-^  --^  ",
-               "      -----^ ",
+    // FIXME: This isn't an ideal leaf rendering...
+    renderTest("a(b)c+(d(e))f(?:g)", [
+           /*  "^^^ ^^^^^^  ^--^^ ", */
+               " --^-^  --^       ",
+               "       ---^       ",
+               "      -----^ ----^", // should be  higher
+               "-----------------^"
     ])
   }
-
 }

--- a/Tests/RegexTests/DiagnosticTests.swift
+++ b/Tests/RegexTests/DiagnosticTests.swift
@@ -8,6 +8,50 @@ extension RegexTests {
   func testUnit() {
     XCTAssert(_fakeRange.isFake)
     XCTAssert(group(.capture, "a").sourceRange.isFake)
+
+    let ast = try! parse("(a)", .traditional)
+    XCTAssert(ast.sourceRange.isReal)
+  }
+
+  func testRender() {
+    // Test top-level source range tracking from an example
+    func flatTest(_ str: String, _ expected: [String]) {
+      guard let ast = try? parse(str, .traditional) else {
+        XCTFail("Fail to parse: \(str)")
+        return
+      }
+      let nodes = ast.children?.filter(\.sourceRange.isReal)
+      let tracked = nodes?.map {
+        String(str[$0.sourceRange])
+      }
+      XCTAssertEqual(expected, tracked)
+    }
+
+    // FIXME: We don't track atoms yet, but this at least
+    // checks for groups and quantifiers
+    flatTest("a(b)c", [/*"a",*/ "(b)" /*, "c" */])
+    flatTest("a(b)c+", [/*"a",*/ "(b)", "c+"])
+    flatTest("a*?b(c(d))", ["a*?", /*"b",*/ "(c(d))"])
+    flatTest("[abc]*?d", ["[abc]*?" /*, "d"*/])
+
+    func renderTest(_ str: String, _ expected: [String]) {
+      let lines = try! parse(
+        str, .traditional
+      )._render(in: str)
+      XCTAssertEqual(expected, lines)
+    }
+
+    // AST constructors fake ranges, nothing to render
+    XCTAssertEqual([], concat("a", "b")._render(in: "ab"))
+
+    // FIXME: Atoms currently don't track locations
+    renderTest("ab", [])
+
+    // FIXME: Groups do, however
+    renderTest("a(b)c+(d(e))f", [
+               " --^-^  --^  ",
+               "      -----^ ",
+    ])
   }
 
 }

--- a/Tests/RegexTests/DiagnosticTests.swift
+++ b/Tests/RegexTests/DiagnosticTests.swift
@@ -1,4 +1,4 @@
-import _MatchingEngine
+@testable import _MatchingEngine
 import _StringProcessing
 
 import XCTest

--- a/Tests/RegexTests/ParseTests.swift
+++ b/Tests/RegexTests/ParseTests.swift
@@ -105,8 +105,9 @@ extension RegexTests {
 
     parseTest("[a-z]", charClass(.range("a", "z")))
 
+    // FIXME: AST builder helpers for custom char class types
     parseTest("[a-d--a-c]", charClass(
-      .setOperation([.range("a", "d")], .subtraction, [.range("a", "c")])
+      .setOperation([.range("a", "d")], _fake(.subtraction), [.range("a", "c")])
     ))
 
     parseTest("[-]", charClass("-"))
@@ -156,26 +157,26 @@ extension RegexTests {
       oneOrMore(.greedy, charClass(
         .setOperation(
           ["a", charClass("b", "c"), "d", "e"],
-          .intersection,
+          _fake(.intersection),
           [charClass("b", "c", inverted: true), .atom(.escaped(.decimalDigit))]
         ))))
 
     parseTest(
       "[a&&b]",
       charClass(
-        .setOperation(["a"], .intersection, ["b"])))
+        .setOperation(["a"], _fake(.intersection), ["b"])))
 
     parseTest(
       "[abc--def]",
-      charClass(.setOperation(["a", "b", "c"], .subtraction, ["d", "e", "f"])))
+      charClass(.setOperation(["a", "b", "c"], _fake(.subtraction), ["d", "e", "f"])))
 
     // We left-associate for chained operators.
     parseTest(
       "[ab&&b~~cd]",
       charClass(
         .setOperation(
-          [.setOperation(["a", "b"], .intersection, ["b"])],
-          .symmetricDifference,
+          [.setOperation(["a", "b"], _fake(.intersection), ["b"])],
+          _fake(.symmetricDifference),
           ["c", "d"])))
 
     // Operators are only valid in custom character classes.

--- a/Tests/RegexTests/ParseTests.swift
+++ b/Tests/RegexTests/ParseTests.swift
@@ -15,7 +15,7 @@ extension Atom: ExpressibleByExtendedGraphemeClusterLiteral {
     self = .char(value)
   }
 }
-extension CustomCharacterClass.Member: ExpressibleByExtendedGraphemeClusterLiteral {
+extension AST.CustomCharacterClass.Member: ExpressibleByExtendedGraphemeClusterLiteral {
   public typealias ExtendedGraphemeClusterLiteralType = Character
   public init(extendedGraphemeClusterLiteral value: Character) {
     self = .atom(.char(value))

--- a/Tests/RegexTests/SyntaxOptionsTests.swift
+++ b/Tests/RegexTests/SyntaxOptionsTests.swift
@@ -102,5 +102,11 @@ extension RegexTests {
 //      .comment(" network "), esc("d"), .plus,
 //      esc("."), esc("d"), .plus,
 //      syntax: .modern)
+//
+//    // TODO: better trivia stuff
+//    parseTest(
+//      "(?#. comment)b",
+//      concat(trivia(), "b")
+//    )
   }
 }

--- a/Tests/RegexTests/SyntaxOptionsTests.swift
+++ b/Tests/RegexTests/SyntaxOptionsTests.swift
@@ -22,18 +22,6 @@ extension RegexTests {
   }
 
   func testModernQuotes() {
-//
-//    lexTest(
-//      #"a\Q .\Eb"#,
-//      "a", .quote(" ."), "b",
-//      syntax: .traditional)
-//
-//    // If we're quoted, whitespace is quoted too
-//    lexTest(
-//      #"a\Q .\Eb"#,
-//      "a", .quote(" ."), "b",
-//      syntax: .nonSemanticWhitespace)
-
     let quoteAST = concat(
       "a", quote(" ."), "b")
     parseTest(
@@ -55,7 +43,9 @@ extension RegexTests {
     parseTest(
       #" \d+ "." \d+ "." \d+ "." \d+ "#,
       dotAST, syntax: .modern)
+  }
 
+  func testModernRanges() {
     parseTest(
       #"a{1,2}"#,
       quantRange(.greedy, 1...2, "a"))


### PR DESCRIPTION
This is an on-going PR to plumb and track source ranges throughout the AST.

Includes a "renderer" that will pretty-ish-print out ranges of covered input.