### PR TITLE
'Regex<Captures>' -> 'Regex<Match>'

### DIFF
--- a/Sources/Exercises/Participants/RegexParticipant.swift
+++ b/Sources/Exercises/Participants/RegexParticipant.swift
@@ -33,11 +33,11 @@ struct RegexLiteralParticipant: Participant {
 }
 
 private func extractFromCaptures(
-  lower: Substring, upper: Substring?, prop: Substring
+  _ match: Tuple4<Substring, Substring, Substring?, Substring>
 ) -> GraphemeBreakEntry? {
-  guard let lowerScalar = Unicode.Scalar(hex: lower),
-        let upperScalar = upper.map(Unicode.Scalar.init(hex:)) ?? lowerScalar,
-        let property = Unicode.GraphemeBreakProperty(prop)
+  guard let lowerScalar = Unicode.Scalar(hex: match.1),
+        let upperScalar = match.2.map(Unicode.Scalar.init(hex:)) ?? lowerScalar,
+        let property = Unicode.GraphemeBreakProperty(match.3)
   else {
     return nil
   }
@@ -48,8 +48,8 @@ private func extractFromCaptures(
 private func graphemeBreakPropertyData<RP: RegexProtocol>(
   forLine line: String,
   using regex: RP
-) -> GraphemeBreakEntry? where RP.Capture == (Substring, Substring?, Substring) {
-  line.match(regex).map(\.captures).flatMap(extractFromCaptures)
+) -> GraphemeBreakEntry? where RP.Match == Tuple4<Substring, Substring, Substring?, Substring> {
+  line.match(regex).map(\.match).flatMap(extractFromCaptures)
 }
 
 private func graphemeBreakPropertyData(
@@ -75,5 +75,5 @@ private func graphemeBreakPropertyDataLiteral(
   return graphemeBreakPropertyData(
     forLine: line,
     using: r(#"([0-9A-F]+)(?:\.\.([0-9A-F]+))?\s+;\s+(\w+).*"#,
-             capturing: (Substring, Substring?, Substring).self))
+             matching: Tuple4<Substring, Substring, Substring?, Substring>.self))
 }

--- a/Sources/_MatchingEngine/Utility/TypeConstruction.swift
+++ b/Sources/_MatchingEngine/Utility/TypeConstruction.swift
@@ -48,10 +48,9 @@ private func swift_getTupleTypeMetadata3(
   proposedWitnesses: UnsafeRawPointer?
 ) -> (value: Any.Type, state: Int)
 
-enum TypeConstruction {
-
+public enum TypeConstruction {
   /// Returns a tuple metatype of the given element types.
-  static func tupleType<
+  public static func tupleType<
     ElementTypes: BidirectionalCollection
   >(
     of elementTypes: __owned ElementTypes
@@ -104,7 +103,7 @@ enum TypeConstruction {
   }
 
   /// Creates a type-erased tuple with the given elements.
-  static func tuple<Elements: BidirectionalCollection>(
+  public static func tuple<Elements: BidirectionalCollection>(
     of elements: __owned Elements
   ) -> Any where Elements.Element == Any {
     // Open existential on the overall tuple type.
@@ -132,5 +131,19 @@ enum TypeConstruction {
     }
     let elementTypes = elements.map { type(of: $0) }
     return _openExistential(tupleType(of: elementTypes), do: create)
+  }
+
+  public static func arrayType(of childType: Any.Type) -> Any.Type {
+    func helper<T>(_: T.Type) -> Any.Type {
+      [T].self
+    }
+    return _openExistential(childType, do: helper)
+  }
+
+  public static func optionalType(of childType: Any.Type) -> Any.Type {
+    func helper<T>(_: T.Type) -> Any.Type {
+      T?.self
+    }
+    return _openExistential(childType, do: helper)
   }
 }

--- a/Sources/_StringProcessing/Legacy/HareVM.swift
+++ b/Sources/_StringProcessing/Legacy/HareVM.swift
@@ -192,12 +192,12 @@ struct HareVM: VirtualMachine {
         bunny.core.captureSome()
         bunny.hop()
 
-      case .captureNil:
-        bunny.core.captureNil()
+      case .captureNil(let childType):
+        bunny.core.captureNil(childType: childType)
         bunny.hop()
 
-      case .captureArray:
-        bunny.core.captureArray()
+      case .captureArray(let childType):
+        bunny.core.captureArray(childType: childType)
         bunny.hop()
       }
     }

--- a/Sources/_StringProcessing/Legacy/LegacyCompile.swift
+++ b/Sources/_StringProcessing/Legacy/LegacyCompile.swift
@@ -76,7 +76,6 @@ func compile(
       }
       return
 
-
     case .quantification(let quant):
       let child = quant.child
       switch (quant.amount.value, quant.kind.value) {
@@ -94,7 +93,7 @@ func compile(
         instructions.append(.goto(label: start.label!))
         instructions.append(done)
         if childHasCaptures {
-          instructions.append(.captureArray)
+          instructions.append(.captureArray(childType: child.captureStructure.type))
           instructions.append(.endGroup)
         }
         return
@@ -117,7 +116,7 @@ func compile(
         instructions.append(.goto(label: start.label!))
         instructions.append(done)
         if childHasCaptures {
-          instructions.append(.captureArray)
+          instructions.append(.captureArray(childType: child.captureStructure.type))
           instructions.append(.endGroup)
         }
         return
@@ -134,7 +133,7 @@ func compile(
             .captureSome,
             .goto(label: done.label!),
             nilCase,
-            .captureNil,
+            .captureNil(childType: child.captureStructure.type),
             done,
             .endGroup
           ]
@@ -161,7 +160,7 @@ func compile(
             .captureSome,
             .goto(label: done.label!),
             nilCase,
-            .captureNil,
+            .captureNil(childType: child.captureStructure.type),
             done,
             .endGroup
           ]
@@ -190,7 +189,7 @@ func compile(
         instructions.append(.goto(label: start.label!))
         instructions.append(done)
         if childHasCaptures {
-          instructions.append(.captureArray)
+          instructions.append(.captureArray(childType: child.captureStructure.type))
           instructions.append(.endGroup)
         }
         return
@@ -206,7 +205,7 @@ func compile(
         try compileNode(child)
         instructions.append(.split(disfavoring: start.label!))
         if childHasCaptures {
-          instructions.append(.captureArray)
+          instructions.append(.captureArray(childType: child.captureStructure.type))
           instructions.append(.endGroup)
         }
         return

--- a/Sources/_StringProcessing/Legacy/RECode.swift
+++ b/Sources/_StringProcessing/Legacy/RECode.swift
@@ -64,11 +64,11 @@ extension RECode {
     case captureSome
 
     /// Replace top-level captures with a single `Capture.optional(nil)`.
-    case captureNil
+    case captureNil(childType: AnyCaptureType)
 
     /// Form a `Capture.array(...)` from top-level captures, and use it to replace the top-level
     /// captures.
-    case captureArray
+    case captureArray(childType: AnyCaptureType)
 
     var isAccept: Bool {
       switch self {
@@ -119,6 +119,14 @@ extension RECode.Instruction {
 
   // Convenience constructors
   static func label(_ i: Int) -> Self { .label(LabelId(i)) }
+
+  static func captureNil(childType: Any.Type) -> Self {
+    .captureNil(childType: AnyCaptureType(childType))
+  }
+
+  static func captureArray(childType: Any.Type) -> Self {
+    .captureArray(childType: AnyCaptureType(childType))
+  }
 }
 
 public struct REOptions: OptionSet {

--- a/Sources/_StringProcessing/Legacy/TortoiseVM.swift
+++ b/Sources/_StringProcessing/Legacy/TortoiseVM.swift
@@ -108,11 +108,11 @@ extension TortoiseVM {
         case .captureSome:
           hatchling.core.captureSome()
           hatchling.plod()
-        case .captureNil:
-          hatchling.core.captureNil()
+        case .captureNil(let childType):
+          hatchling.core.captureNil(childType: childType)
           hatchling.plod()
-        case .captureArray:
-          hatchling.core.captureArray()
+        case .captureArray(let childType):
+          hatchling.core.captureArray(childType: childType)
           hatchling.plod()
 
         default:

--- a/Sources/_StringProcessing/Legacy/VirtualMachine.swift
+++ b/Sources/_StringProcessing/Legacy/VirtualMachine.swift
@@ -116,16 +116,16 @@ extension RECode {
       topLevelCaptures = top
     }
 
-    mutating func captureNil() {
-      topLevelCaptures = [.optional(nil)]
+    mutating func captureNil(childType: AnyCaptureType) {
+      topLevelCaptures = [.none(childType: childType)]
     }
 
     mutating func captureSome() {
-      topLevelCaptures = [.optional(.tupleOrAtom(topLevelCaptures))]
+      topLevelCaptures = [.some(.tupleOrAtom(topLevelCaptures))]
     }
 
-    mutating func captureArray() {
-      topLevelCaptures = [.array(topLevelCaptures)]
+    mutating func captureArray(childType: AnyCaptureType) {
+      topLevelCaptures = [.array(topLevelCaptures, childType: childType)]
     }
 
     func singleCapture() -> Capture {

--- a/Sources/_StringProcessing/RegexDSL/Builder.swift
+++ b/Sources/_StringProcessing/RegexDSL/Builder.swift
@@ -12,7 +12,9 @@ public enum RegexBuilder {
     component
   }
 
-  public static func buildLimitedAvailability<R: RegexProtocol>(_ component: R) -> Optionally<R> {
+  public static func buildLimitedAvailability<R: RegexProtocol>(
+    _ component: R
+  ) -> Optionally<R> {
     .init(component)
   }
 }

--- a/Sources/_StringProcessing/RegexDSL/Concatenation.swift
+++ b/Sources/_StringProcessing/RegexDSL/Concatenation.swift
@@ -1,21 +1,176 @@
 // BEGIN AUTO-GENERATED CONTENT
 
 import _MatchingEngine
+
+@frozen @dynamicMemberLookup
+public struct Tuple2<_0, _1> {
+  public typealias Tuple = (_0, _1)
+  public var tuple: Tuple
+  public subscript<T>(dynamicMember keyPath: WritableKeyPath<Tuple, T>) -> T {
+    get { tuple[keyPath: keyPath] }
+    _modify { yield &tuple[keyPath: keyPath] }
+  }
+}
+extension Tuple2: EmptyCaptureProtocol where _1: EmptyCaptureProtocol {}
+extension Tuple2: MatchProtocol {
+  public typealias Capture = _1
+  public init(_ tuple: Tuple) { self.tuple = tuple }
+  public init(_ _0: _0, _ _1: _1) {
+    self.init((_0, _1))
+  }
+}
+extension Tuple2: Equatable where _0: Equatable, _1: Equatable {
+  public static func == (lhs: Self, rhs: Self) -> Bool {
+    lhs.tuple.0 == rhs.tuple.0 && lhs.tuple.1 == rhs.tuple.1
+  }
+}
+@frozen @dynamicMemberLookup
+public struct Tuple3<_0, _1, _2> {
+  public typealias Tuple = (_0, _1, _2)
+  public var tuple: Tuple
+  public subscript<T>(dynamicMember keyPath: WritableKeyPath<Tuple, T>) -> T {
+    get { tuple[keyPath: keyPath] }
+    _modify { yield &tuple[keyPath: keyPath] }
+  }
+}
+extension Tuple3: EmptyCaptureProtocol where _1: EmptyCaptureProtocol, _2: EmptyCaptureProtocol {}
+extension Tuple3: MatchProtocol {
+  public typealias Capture = Tuple2<_1, _2>
+  public init(_ tuple: Tuple) { self.tuple = tuple }
+  public init(_ _0: _0, _ _1: _1, _ _2: _2) {
+    self.init((_0, _1, _2))
+  }
+}
+extension Tuple3: Equatable where _0: Equatable, _1: Equatable, _2: Equatable {
+  public static func == (lhs: Self, rhs: Self) -> Bool {
+    lhs.tuple.0 == rhs.tuple.0 && lhs.tuple.1 == rhs.tuple.1 && lhs.tuple.2 == rhs.tuple.2
+  }
+}
+@frozen @dynamicMemberLookup
+public struct Tuple4<_0, _1, _2, _3> {
+  public typealias Tuple = (_0, _1, _2, _3)
+  public var tuple: Tuple
+  public subscript<T>(dynamicMember keyPath: WritableKeyPath<Tuple, T>) -> T {
+    get { tuple[keyPath: keyPath] }
+    _modify { yield &tuple[keyPath: keyPath] }
+  }
+}
+extension Tuple4: EmptyCaptureProtocol where _1: EmptyCaptureProtocol, _2: EmptyCaptureProtocol, _3: EmptyCaptureProtocol {}
+extension Tuple4: MatchProtocol {
+  public typealias Capture = Tuple3<_1, _2, _3>
+  public init(_ tuple: Tuple) { self.tuple = tuple }
+  public init(_ _0: _0, _ _1: _1, _ _2: _2, _ _3: _3) {
+    self.init((_0, _1, _2, _3))
+  }
+}
+extension Tuple4: Equatable where _0: Equatable, _1: Equatable, _2: Equatable, _3: Equatable {
+  public static func == (lhs: Self, rhs: Self) -> Bool {
+    lhs.tuple.0 == rhs.tuple.0 && lhs.tuple.1 == rhs.tuple.1 && lhs.tuple.2 == rhs.tuple.2 && lhs.tuple.3 == rhs.tuple.3
+  }
+}
+@frozen @dynamicMemberLookup
+public struct Tuple5<_0, _1, _2, _3, _4> {
+  public typealias Tuple = (_0, _1, _2, _3, _4)
+  public var tuple: Tuple
+  public subscript<T>(dynamicMember keyPath: WritableKeyPath<Tuple, T>) -> T {
+    get { tuple[keyPath: keyPath] }
+    _modify { yield &tuple[keyPath: keyPath] }
+  }
+}
+extension Tuple5: EmptyCaptureProtocol where _1: EmptyCaptureProtocol, _2: EmptyCaptureProtocol, _3: EmptyCaptureProtocol, _4: EmptyCaptureProtocol {}
+extension Tuple5: MatchProtocol {
+  public typealias Capture = Tuple4<_1, _2, _3, _4>
+  public init(_ tuple: Tuple) { self.tuple = tuple }
+  public init(_ _0: _0, _ _1: _1, _ _2: _2, _ _3: _3, _ _4: _4) {
+    self.init((_0, _1, _2, _3, _4))
+  }
+}
+extension Tuple5: Equatable where _0: Equatable, _1: Equatable, _2: Equatable, _3: Equatable, _4: Equatable {
+  public static func == (lhs: Self, rhs: Self) -> Bool {
+    lhs.tuple.0 == rhs.tuple.0 && lhs.tuple.1 == rhs.tuple.1 && lhs.tuple.2 == rhs.tuple.2 && lhs.tuple.3 == rhs.tuple.3 && lhs.tuple.4 == rhs.tuple.4
+  }
+}
+@frozen @dynamicMemberLookup
+public struct Tuple6<_0, _1, _2, _3, _4, _5> {
+  public typealias Tuple = (_0, _1, _2, _3, _4, _5)
+  public var tuple: Tuple
+  public subscript<T>(dynamicMember keyPath: WritableKeyPath<Tuple, T>) -> T {
+    get { tuple[keyPath: keyPath] }
+    _modify { yield &tuple[keyPath: keyPath] }
+  }
+}
+extension Tuple6: EmptyCaptureProtocol where _1: EmptyCaptureProtocol, _2: EmptyCaptureProtocol, _3: EmptyCaptureProtocol, _4: EmptyCaptureProtocol, _5: EmptyCaptureProtocol {}
+extension Tuple6: MatchProtocol {
+  public typealias Capture = Tuple5<_1, _2, _3, _4, _5>
+  public init(_ tuple: Tuple) { self.tuple = tuple }
+  public init(_ _0: _0, _ _1: _1, _ _2: _2, _ _3: _3, _ _4: _4, _ _5: _5) {
+    self.init((_0, _1, _2, _3, _4, _5))
+  }
+}
+extension Tuple6: Equatable where _0: Equatable, _1: Equatable, _2: Equatable, _3: Equatable, _4: Equatable, _5: Equatable {
+  public static func == (lhs: Self, rhs: Self) -> Bool {
+    lhs.tuple.0 == rhs.tuple.0 && lhs.tuple.1 == rhs.tuple.1 && lhs.tuple.2 == rhs.tuple.2 && lhs.tuple.3 == rhs.tuple.3 && lhs.tuple.4 == rhs.tuple.4 && lhs.tuple.5 == rhs.tuple.5
+  }
+}
+@frozen @dynamicMemberLookup
+public struct Tuple7<_0, _1, _2, _3, _4, _5, _6> {
+  public typealias Tuple = (_0, _1, _2, _3, _4, _5, _6)
+  public var tuple: Tuple
+  public subscript<T>(dynamicMember keyPath: WritableKeyPath<Tuple, T>) -> T {
+    get { tuple[keyPath: keyPath] }
+    _modify { yield &tuple[keyPath: keyPath] }
+  }
+}
+extension Tuple7: EmptyCaptureProtocol where _1: EmptyCaptureProtocol, _2: EmptyCaptureProtocol, _3: EmptyCaptureProtocol, _4: EmptyCaptureProtocol, _5: EmptyCaptureProtocol, _6: EmptyCaptureProtocol {}
+extension Tuple7: MatchProtocol {
+  public typealias Capture = Tuple6<_1, _2, _3, _4, _5, _6>
+  public init(_ tuple: Tuple) { self.tuple = tuple }
+  public init(_ _0: _0, _ _1: _1, _ _2: _2, _ _3: _3, _ _4: _4, _ _5: _5, _ _6: _6) {
+    self.init((_0, _1, _2, _3, _4, _5, _6))
+  }
+}
+extension Tuple7: Equatable where _0: Equatable, _1: Equatable, _2: Equatable, _3: Equatable, _4: Equatable, _5: Equatable, _6: Equatable {
+  public static func == (lhs: Self, rhs: Self) -> Bool {
+    lhs.tuple.0 == rhs.tuple.0 && lhs.tuple.1 == rhs.tuple.1 && lhs.tuple.2 == rhs.tuple.2 && lhs.tuple.3 == rhs.tuple.3 && lhs.tuple.4 == rhs.tuple.4 && lhs.tuple.5 == rhs.tuple.5 && lhs.tuple.6 == rhs.tuple.6
+  }
+}
+@frozen @dynamicMemberLookup
+public struct Tuple8<_0, _1, _2, _3, _4, _5, _6, _7> {
+  public typealias Tuple = (_0, _1, _2, _3, _4, _5, _6, _7)
+  public var tuple: Tuple
+  public subscript<T>(dynamicMember keyPath: WritableKeyPath<Tuple, T>) -> T {
+    get { tuple[keyPath: keyPath] }
+    _modify { yield &tuple[keyPath: keyPath] }
+  }
+}
+extension Tuple8: EmptyCaptureProtocol where _1: EmptyCaptureProtocol, _2: EmptyCaptureProtocol, _3: EmptyCaptureProtocol, _4: EmptyCaptureProtocol, _5: EmptyCaptureProtocol, _6: EmptyCaptureProtocol, _7: EmptyCaptureProtocol {}
+extension Tuple8: MatchProtocol {
+  public typealias Capture = Tuple7<_1, _2, _3, _4, _5, _6, _7>
+  public init(_ tuple: Tuple) { self.tuple = tuple }
+  public init(_ _0: _0, _ _1: _1, _ _2: _2, _ _3: _3, _ _4: _4, _ _5: _5, _ _6: _6, _ _7: _7) {
+    self.init((_0, _1, _2, _3, _4, _5, _6, _7))
+  }
+}
+extension Tuple8: Equatable where _0: Equatable, _1: Equatable, _2: Equatable, _3: Equatable, _4: Equatable, _5: Equatable, _6: Equatable, _7: Equatable {
+  public static func == (lhs: Self, rhs: Self) -> Bool {
+    lhs.tuple.0 == rhs.tuple.0 && lhs.tuple.1 == rhs.tuple.1 && lhs.tuple.2 == rhs.tuple.2 && lhs.tuple.3 == rhs.tuple.3 && lhs.tuple.4 == rhs.tuple.4 && lhs.tuple.5 == rhs.tuple.5 && lhs.tuple.6 == rhs.tuple.6 && lhs.tuple.7 == rhs.tuple.7
+  }
+}
 public struct Concatenate2_TT<
   T0: RegexProtocol, T1: RegexProtocol
 >: RegexProtocol {
-  public typealias Capture = (T0.Capture, T1.Capture)
-  public let regex: Regex<Capture>
+  public typealias Match = Tuple3<Substring, T0.Match.Capture, T1.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1) {
     regex = .init(ast: concat(
-      x0.regex.ast,
+      x0.regex.ast, 
       x1.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol>(
     _ x0: T0, _ x1: T1
   ) -> Concatenate2_TT<T0, T1> {
     Concatenate2_TT(x0, x1)
@@ -24,19 +179,19 @@ extension RegexBuilder {
 
 public struct Concatenate2_TV<
   T0: RegexProtocol, T1: RegexProtocol
->: RegexProtocol where T0.Capture: EmptyProtocol {
-  public typealias Capture = (T1.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T0.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple2<Substring, T1.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1) {
     regex = .init(ast: concat(
-      x0.regex.ast,
+      x0.regex.ast, 
       x1.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol>(
     _ x0: T0, _ x1: T1
   ) -> Concatenate2_TV<T0, T1> {
     Concatenate2_TV(x0, x1)
@@ -45,19 +200,19 @@ extension RegexBuilder {
 
 public struct Concatenate2_VT<
   T0: RegexProtocol, T1: RegexProtocol
->: RegexProtocol where T1.Capture: EmptyProtocol {
-  public typealias Capture = (T0.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T1.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple2<Substring, T0.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1) {
     regex = .init(ast: concat(
-      x0.regex.ast,
+      x0.regex.ast, 
       x1.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol>(
     _ x0: T0, _ x1: T1
   ) -> Concatenate2_VT<T0, T1> {
     Concatenate2_VT(x0, x1)
@@ -66,19 +221,19 @@ extension RegexBuilder {
 
 public struct Concatenate2_VV<
   T0: RegexProtocol, T1: RegexProtocol
->: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol {
-  public typealias Capture = Empty
-  public let regex: Regex<Capture>
+>: RegexProtocol where T0.Match.Capture: EmptyCaptureProtocol, T1.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Substring
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1) {
     regex = .init(ast: concat(
-      x0.regex.ast,
+      x0.regex.ast, 
       x1.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol>(
     _ x0: T0, _ x1: T1
   ) -> Concatenate2_VV<T0, T1> {
     Concatenate2_VV(x0, x1)
@@ -90,19 +245,19 @@ extension RegexBuilder {
 public struct Concatenate3_TTT<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol
 >: RegexProtocol {
-  public typealias Capture = (T0.Capture, T1.Capture, T2.Capture)
-  public let regex: Regex<Capture>
+  public typealias Match = Tuple4<Substring, T0.Match.Capture, T1.Match.Capture, T2.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
       x2.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2
   ) -> Concatenate3_TTT<T0, T1, T2> {
     Concatenate3_TTT(x0, x1, x2)
@@ -111,20 +266,20 @@ extension RegexBuilder {
 
 public struct Concatenate3_TTV<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol
->: RegexProtocol where T0.Capture: EmptyProtocol {
-  public typealias Capture = (T1.Capture, T2.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T0.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple3<Substring, T1.Match.Capture, T2.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
       x2.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2
   ) -> Concatenate3_TTV<T0, T1, T2> {
     Concatenate3_TTV(x0, x1, x2)
@@ -133,20 +288,20 @@ extension RegexBuilder {
 
 public struct Concatenate3_TVT<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol
->: RegexProtocol where T1.Capture: EmptyProtocol {
-  public typealias Capture = (T0.Capture, T2.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T1.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple3<Substring, T0.Match.Capture, T2.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
       x2.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2
   ) -> Concatenate3_TVT<T0, T1, T2> {
     Concatenate3_TVT(x0, x1, x2)
@@ -155,20 +310,20 @@ extension RegexBuilder {
 
 public struct Concatenate3_TVV<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol
->: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol {
-  public typealias Capture = (T2.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T0.Match.Capture: EmptyCaptureProtocol, T1.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple2<Substring, T2.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
       x2.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2
   ) -> Concatenate3_TVV<T0, T1, T2> {
     Concatenate3_TVV(x0, x1, x2)
@@ -177,20 +332,20 @@ extension RegexBuilder {
 
 public struct Concatenate3_VTT<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol
->: RegexProtocol where T2.Capture: EmptyProtocol {
-  public typealias Capture = (T0.Capture, T1.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T2.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple3<Substring, T0.Match.Capture, T1.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
       x2.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2
   ) -> Concatenate3_VTT<T0, T1, T2> {
     Concatenate3_VTT(x0, x1, x2)
@@ -199,20 +354,20 @@ extension RegexBuilder {
 
 public struct Concatenate3_VTV<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol
->: RegexProtocol where T0.Capture: EmptyProtocol, T2.Capture: EmptyProtocol {
-  public typealias Capture = (T1.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T0.Match.Capture: EmptyCaptureProtocol, T2.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple2<Substring, T1.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
       x2.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2
   ) -> Concatenate3_VTV<T0, T1, T2> {
     Concatenate3_VTV(x0, x1, x2)
@@ -221,20 +376,20 @@ extension RegexBuilder {
 
 public struct Concatenate3_VVT<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol
->: RegexProtocol where T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol {
-  public typealias Capture = (T0.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T1.Match.Capture: EmptyCaptureProtocol, T2.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple2<Substring, T0.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
       x2.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2
   ) -> Concatenate3_VVT<T0, T1, T2> {
     Concatenate3_VVT(x0, x1, x2)
@@ -243,20 +398,20 @@ extension RegexBuilder {
 
 public struct Concatenate3_VVV<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol
->: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol {
-  public typealias Capture = Empty
-  public let regex: Regex<Capture>
+>: RegexProtocol where T0.Match.Capture: EmptyCaptureProtocol, T1.Match.Capture: EmptyCaptureProtocol, T2.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Substring
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
       x2.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2
   ) -> Concatenate3_VVV<T0, T1, T2> {
     Concatenate3_VVV(x0, x1, x2)
@@ -268,20 +423,20 @@ extension RegexBuilder {
 public struct Concatenate4_TTTT<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol
 >: RegexProtocol {
-  public typealias Capture = (T0.Capture, T1.Capture, T2.Capture, T3.Capture)
-  public let regex: Regex<Capture>
+  public typealias Match = Tuple5<Substring, T0.Match.Capture, T1.Match.Capture, T2.Match.Capture, T3.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
       x3.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3
   ) -> Concatenate4_TTTT<T0, T1, T2, T3> {
     Concatenate4_TTTT(x0, x1, x2, x3)
@@ -290,21 +445,21 @@ extension RegexBuilder {
 
 public struct Concatenate4_TTTV<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol
->: RegexProtocol where T0.Capture: EmptyProtocol {
-  public typealias Capture = (T1.Capture, T2.Capture, T3.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T0.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple4<Substring, T1.Match.Capture, T2.Match.Capture, T3.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
       x3.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3
   ) -> Concatenate4_TTTV<T0, T1, T2, T3> {
     Concatenate4_TTTV(x0, x1, x2, x3)
@@ -313,21 +468,21 @@ extension RegexBuilder {
 
 public struct Concatenate4_TTVT<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol
->: RegexProtocol where T1.Capture: EmptyProtocol {
-  public typealias Capture = (T0.Capture, T2.Capture, T3.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T1.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple4<Substring, T0.Match.Capture, T2.Match.Capture, T3.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
       x3.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3
   ) -> Concatenate4_TTVT<T0, T1, T2, T3> {
     Concatenate4_TTVT(x0, x1, x2, x3)
@@ -336,21 +491,21 @@ extension RegexBuilder {
 
 public struct Concatenate4_TTVV<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol
->: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol {
-  public typealias Capture = (T2.Capture, T3.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T0.Match.Capture: EmptyCaptureProtocol, T1.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple3<Substring, T2.Match.Capture, T3.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
       x3.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3
   ) -> Concatenate4_TTVV<T0, T1, T2, T3> {
     Concatenate4_TTVV(x0, x1, x2, x3)
@@ -359,21 +514,21 @@ extension RegexBuilder {
 
 public struct Concatenate4_TVTT<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol
->: RegexProtocol where T2.Capture: EmptyProtocol {
-  public typealias Capture = (T0.Capture, T1.Capture, T3.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T2.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple4<Substring, T0.Match.Capture, T1.Match.Capture, T3.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
       x3.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3
   ) -> Concatenate4_TVTT<T0, T1, T2, T3> {
     Concatenate4_TVTT(x0, x1, x2, x3)
@@ -382,21 +537,21 @@ extension RegexBuilder {
 
 public struct Concatenate4_TVTV<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol
->: RegexProtocol where T0.Capture: EmptyProtocol, T2.Capture: EmptyProtocol {
-  public typealias Capture = (T1.Capture, T3.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T0.Match.Capture: EmptyCaptureProtocol, T2.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple3<Substring, T1.Match.Capture, T3.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
       x3.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3
   ) -> Concatenate4_TVTV<T0, T1, T2, T3> {
     Concatenate4_TVTV(x0, x1, x2, x3)
@@ -405,21 +560,21 @@ extension RegexBuilder {
 
 public struct Concatenate4_TVVT<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol
->: RegexProtocol where T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol {
-  public typealias Capture = (T0.Capture, T3.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T1.Match.Capture: EmptyCaptureProtocol, T2.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple3<Substring, T0.Match.Capture, T3.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
       x3.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3
   ) -> Concatenate4_TVVT<T0, T1, T2, T3> {
     Concatenate4_TVVT(x0, x1, x2, x3)
@@ -428,21 +583,21 @@ extension RegexBuilder {
 
 public struct Concatenate4_TVVV<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol
->: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol {
-  public typealias Capture = (T3.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T0.Match.Capture: EmptyCaptureProtocol, T1.Match.Capture: EmptyCaptureProtocol, T2.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple2<Substring, T3.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
       x3.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3
   ) -> Concatenate4_TVVV<T0, T1, T2, T3> {
     Concatenate4_TVVV(x0, x1, x2, x3)
@@ -451,21 +606,21 @@ extension RegexBuilder {
 
 public struct Concatenate4_VTTT<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol
->: RegexProtocol where T3.Capture: EmptyProtocol {
-  public typealias Capture = (T0.Capture, T1.Capture, T2.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T3.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple4<Substring, T0.Match.Capture, T1.Match.Capture, T2.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
       x3.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3
   ) -> Concatenate4_VTTT<T0, T1, T2, T3> {
     Concatenate4_VTTT(x0, x1, x2, x3)
@@ -474,21 +629,21 @@ extension RegexBuilder {
 
 public struct Concatenate4_VTTV<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol
->: RegexProtocol where T0.Capture: EmptyProtocol, T3.Capture: EmptyProtocol {
-  public typealias Capture = (T1.Capture, T2.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T0.Match.Capture: EmptyCaptureProtocol, T3.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple3<Substring, T1.Match.Capture, T2.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
       x3.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3
   ) -> Concatenate4_VTTV<T0, T1, T2, T3> {
     Concatenate4_VTTV(x0, x1, x2, x3)
@@ -497,21 +652,21 @@ extension RegexBuilder {
 
 public struct Concatenate4_VTVT<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol
->: RegexProtocol where T1.Capture: EmptyProtocol, T3.Capture: EmptyProtocol {
-  public typealias Capture = (T0.Capture, T2.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T1.Match.Capture: EmptyCaptureProtocol, T3.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple3<Substring, T0.Match.Capture, T2.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
       x3.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3
   ) -> Concatenate4_VTVT<T0, T1, T2, T3> {
     Concatenate4_VTVT(x0, x1, x2, x3)
@@ -520,21 +675,21 @@ extension RegexBuilder {
 
 public struct Concatenate4_VTVV<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol
->: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T3.Capture: EmptyProtocol {
-  public typealias Capture = (T2.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T0.Match.Capture: EmptyCaptureProtocol, T1.Match.Capture: EmptyCaptureProtocol, T3.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple2<Substring, T2.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
       x3.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3
   ) -> Concatenate4_VTVV<T0, T1, T2, T3> {
     Concatenate4_VTVV(x0, x1, x2, x3)
@@ -543,21 +698,21 @@ extension RegexBuilder {
 
 public struct Concatenate4_VVTT<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol
->: RegexProtocol where T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol {
-  public typealias Capture = (T0.Capture, T1.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T2.Match.Capture: EmptyCaptureProtocol, T3.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple3<Substring, T0.Match.Capture, T1.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
       x3.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3
   ) -> Concatenate4_VVTT<T0, T1, T2, T3> {
     Concatenate4_VVTT(x0, x1, x2, x3)
@@ -566,21 +721,21 @@ extension RegexBuilder {
 
 public struct Concatenate4_VVTV<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol
->: RegexProtocol where T0.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol {
-  public typealias Capture = (T1.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T0.Match.Capture: EmptyCaptureProtocol, T2.Match.Capture: EmptyCaptureProtocol, T3.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple2<Substring, T1.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
       x3.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3
   ) -> Concatenate4_VVTV<T0, T1, T2, T3> {
     Concatenate4_VVTV(x0, x1, x2, x3)
@@ -589,21 +744,21 @@ extension RegexBuilder {
 
 public struct Concatenate4_VVVT<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol
->: RegexProtocol where T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol {
-  public typealias Capture = (T0.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T1.Match.Capture: EmptyCaptureProtocol, T2.Match.Capture: EmptyCaptureProtocol, T3.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple2<Substring, T0.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
       x3.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3
   ) -> Concatenate4_VVVT<T0, T1, T2, T3> {
     Concatenate4_VVVT(x0, x1, x2, x3)
@@ -612,21 +767,21 @@ extension RegexBuilder {
 
 public struct Concatenate4_VVVV<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol
->: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol {
-  public typealias Capture = Empty
-  public let regex: Regex<Capture>
+>: RegexProtocol where T0.Match.Capture: EmptyCaptureProtocol, T1.Match.Capture: EmptyCaptureProtocol, T2.Match.Capture: EmptyCaptureProtocol, T3.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Substring
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
       x3.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3
   ) -> Concatenate4_VVVV<T0, T1, T2, T3> {
     Concatenate4_VVVV(x0, x1, x2, x3)
@@ -638,21 +793,21 @@ extension RegexBuilder {
 public struct Concatenate5_TTTTT<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol
 >: RegexProtocol {
-  public typealias Capture = (T0.Capture, T1.Capture, T2.Capture, T3.Capture, T4.Capture)
-  public let regex: Regex<Capture>
+  public typealias Match = Tuple6<Substring, T0.Match.Capture, T1.Match.Capture, T2.Match.Capture, T3.Match.Capture, T4.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
       x4.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4
   ) -> Concatenate5_TTTTT<T0, T1, T2, T3, T4> {
     Concatenate5_TTTTT(x0, x1, x2, x3, x4)
@@ -661,22 +816,22 @@ extension RegexBuilder {
 
 public struct Concatenate5_TTTTV<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol
->: RegexProtocol where T0.Capture: EmptyProtocol {
-  public typealias Capture = (T1.Capture, T2.Capture, T3.Capture, T4.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T0.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple5<Substring, T1.Match.Capture, T2.Match.Capture, T3.Match.Capture, T4.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
       x4.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4
   ) -> Concatenate5_TTTTV<T0, T1, T2, T3, T4> {
     Concatenate5_TTTTV(x0, x1, x2, x3, x4)
@@ -685,22 +840,22 @@ extension RegexBuilder {
 
 public struct Concatenate5_TTTVT<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol
->: RegexProtocol where T1.Capture: EmptyProtocol {
-  public typealias Capture = (T0.Capture, T2.Capture, T3.Capture, T4.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T1.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple5<Substring, T0.Match.Capture, T2.Match.Capture, T3.Match.Capture, T4.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
       x4.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4
   ) -> Concatenate5_TTTVT<T0, T1, T2, T3, T4> {
     Concatenate5_TTTVT(x0, x1, x2, x3, x4)
@@ -709,22 +864,22 @@ extension RegexBuilder {
 
 public struct Concatenate5_TTTVV<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol
->: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol {
-  public typealias Capture = (T2.Capture, T3.Capture, T4.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T0.Match.Capture: EmptyCaptureProtocol, T1.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple4<Substring, T2.Match.Capture, T3.Match.Capture, T4.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
       x4.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4
   ) -> Concatenate5_TTTVV<T0, T1, T2, T3, T4> {
     Concatenate5_TTTVV(x0, x1, x2, x3, x4)
@@ -733,22 +888,22 @@ extension RegexBuilder {
 
 public struct Concatenate5_TTVTT<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol
->: RegexProtocol where T2.Capture: EmptyProtocol {
-  public typealias Capture = (T0.Capture, T1.Capture, T3.Capture, T4.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T2.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple5<Substring, T0.Match.Capture, T1.Match.Capture, T3.Match.Capture, T4.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
       x4.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4
   ) -> Concatenate5_TTVTT<T0, T1, T2, T3, T4> {
     Concatenate5_TTVTT(x0, x1, x2, x3, x4)
@@ -757,22 +912,22 @@ extension RegexBuilder {
 
 public struct Concatenate5_TTVTV<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol
->: RegexProtocol where T0.Capture: EmptyProtocol, T2.Capture: EmptyProtocol {
-  public typealias Capture = (T1.Capture, T3.Capture, T4.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T0.Match.Capture: EmptyCaptureProtocol, T2.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple4<Substring, T1.Match.Capture, T3.Match.Capture, T4.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
       x4.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4
   ) -> Concatenate5_TTVTV<T0, T1, T2, T3, T4> {
     Concatenate5_TTVTV(x0, x1, x2, x3, x4)
@@ -781,22 +936,22 @@ extension RegexBuilder {
 
 public struct Concatenate5_TTVVT<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol
->: RegexProtocol where T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol {
-  public typealias Capture = (T0.Capture, T3.Capture, T4.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T1.Match.Capture: EmptyCaptureProtocol, T2.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple4<Substring, T0.Match.Capture, T3.Match.Capture, T4.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
       x4.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4
   ) -> Concatenate5_TTVVT<T0, T1, T2, T3, T4> {
     Concatenate5_TTVVT(x0, x1, x2, x3, x4)
@@ -805,22 +960,22 @@ extension RegexBuilder {
 
 public struct Concatenate5_TTVVV<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol
->: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol {
-  public typealias Capture = (T3.Capture, T4.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T0.Match.Capture: EmptyCaptureProtocol, T1.Match.Capture: EmptyCaptureProtocol, T2.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple3<Substring, T3.Match.Capture, T4.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
       x4.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4
   ) -> Concatenate5_TTVVV<T0, T1, T2, T3, T4> {
     Concatenate5_TTVVV(x0, x1, x2, x3, x4)
@@ -829,22 +984,22 @@ extension RegexBuilder {
 
 public struct Concatenate5_TVTTT<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol
->: RegexProtocol where T3.Capture: EmptyProtocol {
-  public typealias Capture = (T0.Capture, T1.Capture, T2.Capture, T4.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T3.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple5<Substring, T0.Match.Capture, T1.Match.Capture, T2.Match.Capture, T4.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
       x4.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4
   ) -> Concatenate5_TVTTT<T0, T1, T2, T3, T4> {
     Concatenate5_TVTTT(x0, x1, x2, x3, x4)
@@ -853,22 +1008,22 @@ extension RegexBuilder {
 
 public struct Concatenate5_TVTTV<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol
->: RegexProtocol where T0.Capture: EmptyProtocol, T3.Capture: EmptyProtocol {
-  public typealias Capture = (T1.Capture, T2.Capture, T4.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T0.Match.Capture: EmptyCaptureProtocol, T3.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple4<Substring, T1.Match.Capture, T2.Match.Capture, T4.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
       x4.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4
   ) -> Concatenate5_TVTTV<T0, T1, T2, T3, T4> {
     Concatenate5_TVTTV(x0, x1, x2, x3, x4)
@@ -877,22 +1032,22 @@ extension RegexBuilder {
 
 public struct Concatenate5_TVTVT<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol
->: RegexProtocol where T1.Capture: EmptyProtocol, T3.Capture: EmptyProtocol {
-  public typealias Capture = (T0.Capture, T2.Capture, T4.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T1.Match.Capture: EmptyCaptureProtocol, T3.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple4<Substring, T0.Match.Capture, T2.Match.Capture, T4.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
       x4.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4
   ) -> Concatenate5_TVTVT<T0, T1, T2, T3, T4> {
     Concatenate5_TVTVT(x0, x1, x2, x3, x4)
@@ -901,22 +1056,22 @@ extension RegexBuilder {
 
 public struct Concatenate5_TVTVV<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol
->: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T3.Capture: EmptyProtocol {
-  public typealias Capture = (T2.Capture, T4.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T0.Match.Capture: EmptyCaptureProtocol, T1.Match.Capture: EmptyCaptureProtocol, T3.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple3<Substring, T2.Match.Capture, T4.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
       x4.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4
   ) -> Concatenate5_TVTVV<T0, T1, T2, T3, T4> {
     Concatenate5_TVTVV(x0, x1, x2, x3, x4)
@@ -925,22 +1080,22 @@ extension RegexBuilder {
 
 public struct Concatenate5_TVVTT<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol
->: RegexProtocol where T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol {
-  public typealias Capture = (T0.Capture, T1.Capture, T4.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T2.Match.Capture: EmptyCaptureProtocol, T3.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple4<Substring, T0.Match.Capture, T1.Match.Capture, T4.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
       x4.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4
   ) -> Concatenate5_TVVTT<T0, T1, T2, T3, T4> {
     Concatenate5_TVVTT(x0, x1, x2, x3, x4)
@@ -949,22 +1104,22 @@ extension RegexBuilder {
 
 public struct Concatenate5_TVVTV<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol
->: RegexProtocol where T0.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol {
-  public typealias Capture = (T1.Capture, T4.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T0.Match.Capture: EmptyCaptureProtocol, T2.Match.Capture: EmptyCaptureProtocol, T3.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple3<Substring, T1.Match.Capture, T4.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
       x4.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4
   ) -> Concatenate5_TVVTV<T0, T1, T2, T3, T4> {
     Concatenate5_TVVTV(x0, x1, x2, x3, x4)
@@ -973,22 +1128,22 @@ extension RegexBuilder {
 
 public struct Concatenate5_TVVVT<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol
->: RegexProtocol where T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol {
-  public typealias Capture = (T0.Capture, T4.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T1.Match.Capture: EmptyCaptureProtocol, T2.Match.Capture: EmptyCaptureProtocol, T3.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple3<Substring, T0.Match.Capture, T4.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
       x4.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4
   ) -> Concatenate5_TVVVT<T0, T1, T2, T3, T4> {
     Concatenate5_TVVVT(x0, x1, x2, x3, x4)
@@ -997,22 +1152,22 @@ extension RegexBuilder {
 
 public struct Concatenate5_TVVVV<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol
->: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol {
-  public typealias Capture = (T4.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T0.Match.Capture: EmptyCaptureProtocol, T1.Match.Capture: EmptyCaptureProtocol, T2.Match.Capture: EmptyCaptureProtocol, T3.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple2<Substring, T4.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
       x4.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4
   ) -> Concatenate5_TVVVV<T0, T1, T2, T3, T4> {
     Concatenate5_TVVVV(x0, x1, x2, x3, x4)
@@ -1021,22 +1176,22 @@ extension RegexBuilder {
 
 public struct Concatenate5_VTTTT<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol
->: RegexProtocol where T4.Capture: EmptyProtocol {
-  public typealias Capture = (T0.Capture, T1.Capture, T2.Capture, T3.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T4.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple5<Substring, T0.Match.Capture, T1.Match.Capture, T2.Match.Capture, T3.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
       x4.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4
   ) -> Concatenate5_VTTTT<T0, T1, T2, T3, T4> {
     Concatenate5_VTTTT(x0, x1, x2, x3, x4)
@@ -1045,22 +1200,22 @@ extension RegexBuilder {
 
 public struct Concatenate5_VTTTV<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol
->: RegexProtocol where T0.Capture: EmptyProtocol, T4.Capture: EmptyProtocol {
-  public typealias Capture = (T1.Capture, T2.Capture, T3.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T0.Match.Capture: EmptyCaptureProtocol, T4.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple4<Substring, T1.Match.Capture, T2.Match.Capture, T3.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
       x4.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4
   ) -> Concatenate5_VTTTV<T0, T1, T2, T3, T4> {
     Concatenate5_VTTTV(x0, x1, x2, x3, x4)
@@ -1069,22 +1224,22 @@ extension RegexBuilder {
 
 public struct Concatenate5_VTTVT<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol
->: RegexProtocol where T1.Capture: EmptyProtocol, T4.Capture: EmptyProtocol {
-  public typealias Capture = (T0.Capture, T2.Capture, T3.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T1.Match.Capture: EmptyCaptureProtocol, T4.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple4<Substring, T0.Match.Capture, T2.Match.Capture, T3.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
       x4.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4
   ) -> Concatenate5_VTTVT<T0, T1, T2, T3, T4> {
     Concatenate5_VTTVT(x0, x1, x2, x3, x4)
@@ -1093,22 +1248,22 @@ extension RegexBuilder {
 
 public struct Concatenate5_VTTVV<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol
->: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T4.Capture: EmptyProtocol {
-  public typealias Capture = (T2.Capture, T3.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T0.Match.Capture: EmptyCaptureProtocol, T1.Match.Capture: EmptyCaptureProtocol, T4.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple3<Substring, T2.Match.Capture, T3.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
       x4.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4
   ) -> Concatenate5_VTTVV<T0, T1, T2, T3, T4> {
     Concatenate5_VTTVV(x0, x1, x2, x3, x4)
@@ -1117,22 +1272,22 @@ extension RegexBuilder {
 
 public struct Concatenate5_VTVTT<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol
->: RegexProtocol where T2.Capture: EmptyProtocol, T4.Capture: EmptyProtocol {
-  public typealias Capture = (T0.Capture, T1.Capture, T3.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T2.Match.Capture: EmptyCaptureProtocol, T4.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple4<Substring, T0.Match.Capture, T1.Match.Capture, T3.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
       x4.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4
   ) -> Concatenate5_VTVTT<T0, T1, T2, T3, T4> {
     Concatenate5_VTVTT(x0, x1, x2, x3, x4)
@@ -1141,22 +1296,22 @@ extension RegexBuilder {
 
 public struct Concatenate5_VTVTV<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol
->: RegexProtocol where T0.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T4.Capture: EmptyProtocol {
-  public typealias Capture = (T1.Capture, T3.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T0.Match.Capture: EmptyCaptureProtocol, T2.Match.Capture: EmptyCaptureProtocol, T4.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple3<Substring, T1.Match.Capture, T3.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
       x4.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4
   ) -> Concatenate5_VTVTV<T0, T1, T2, T3, T4> {
     Concatenate5_VTVTV(x0, x1, x2, x3, x4)
@@ -1165,22 +1320,22 @@ extension RegexBuilder {
 
 public struct Concatenate5_VTVVT<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol
->: RegexProtocol where T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T4.Capture: EmptyProtocol {
-  public typealias Capture = (T0.Capture, T3.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T1.Match.Capture: EmptyCaptureProtocol, T2.Match.Capture: EmptyCaptureProtocol, T4.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple3<Substring, T0.Match.Capture, T3.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
       x4.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4
   ) -> Concatenate5_VTVVT<T0, T1, T2, T3, T4> {
     Concatenate5_VTVVT(x0, x1, x2, x3, x4)
@@ -1189,22 +1344,22 @@ extension RegexBuilder {
 
 public struct Concatenate5_VTVVV<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol
->: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T4.Capture: EmptyProtocol {
-  public typealias Capture = (T3.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T0.Match.Capture: EmptyCaptureProtocol, T1.Match.Capture: EmptyCaptureProtocol, T2.Match.Capture: EmptyCaptureProtocol, T4.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple2<Substring, T3.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
       x4.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4
   ) -> Concatenate5_VTVVV<T0, T1, T2, T3, T4> {
     Concatenate5_VTVVV(x0, x1, x2, x3, x4)
@@ -1213,22 +1368,22 @@ extension RegexBuilder {
 
 public struct Concatenate5_VVTTT<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol
->: RegexProtocol where T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol {
-  public typealias Capture = (T0.Capture, T1.Capture, T2.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T3.Match.Capture: EmptyCaptureProtocol, T4.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple4<Substring, T0.Match.Capture, T1.Match.Capture, T2.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
       x4.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4
   ) -> Concatenate5_VVTTT<T0, T1, T2, T3, T4> {
     Concatenate5_VVTTT(x0, x1, x2, x3, x4)
@@ -1237,22 +1392,22 @@ extension RegexBuilder {
 
 public struct Concatenate5_VVTTV<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol
->: RegexProtocol where T0.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol {
-  public typealias Capture = (T1.Capture, T2.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T0.Match.Capture: EmptyCaptureProtocol, T3.Match.Capture: EmptyCaptureProtocol, T4.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple3<Substring, T1.Match.Capture, T2.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
       x4.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4
   ) -> Concatenate5_VVTTV<T0, T1, T2, T3, T4> {
     Concatenate5_VVTTV(x0, x1, x2, x3, x4)
@@ -1261,22 +1416,22 @@ extension RegexBuilder {
 
 public struct Concatenate5_VVTVT<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol
->: RegexProtocol where T1.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol {
-  public typealias Capture = (T0.Capture, T2.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T1.Match.Capture: EmptyCaptureProtocol, T3.Match.Capture: EmptyCaptureProtocol, T4.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple3<Substring, T0.Match.Capture, T2.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
       x4.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4
   ) -> Concatenate5_VVTVT<T0, T1, T2, T3, T4> {
     Concatenate5_VVTVT(x0, x1, x2, x3, x4)
@@ -1285,22 +1440,22 @@ extension RegexBuilder {
 
 public struct Concatenate5_VVTVV<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol
->: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol {
-  public typealias Capture = (T2.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T0.Match.Capture: EmptyCaptureProtocol, T1.Match.Capture: EmptyCaptureProtocol, T3.Match.Capture: EmptyCaptureProtocol, T4.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple2<Substring, T2.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
       x4.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4
   ) -> Concatenate5_VVTVV<T0, T1, T2, T3, T4> {
     Concatenate5_VVTVV(x0, x1, x2, x3, x4)
@@ -1309,22 +1464,22 @@ extension RegexBuilder {
 
 public struct Concatenate5_VVVTT<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol
->: RegexProtocol where T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol {
-  public typealias Capture = (T0.Capture, T1.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T2.Match.Capture: EmptyCaptureProtocol, T3.Match.Capture: EmptyCaptureProtocol, T4.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple3<Substring, T0.Match.Capture, T1.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
       x4.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4
   ) -> Concatenate5_VVVTT<T0, T1, T2, T3, T4> {
     Concatenate5_VVVTT(x0, x1, x2, x3, x4)
@@ -1333,22 +1488,22 @@ extension RegexBuilder {
 
 public struct Concatenate5_VVVTV<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol
->: RegexProtocol where T0.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol {
-  public typealias Capture = (T1.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T0.Match.Capture: EmptyCaptureProtocol, T2.Match.Capture: EmptyCaptureProtocol, T3.Match.Capture: EmptyCaptureProtocol, T4.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple2<Substring, T1.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
       x4.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4
   ) -> Concatenate5_VVVTV<T0, T1, T2, T3, T4> {
     Concatenate5_VVVTV(x0, x1, x2, x3, x4)
@@ -1357,22 +1512,22 @@ extension RegexBuilder {
 
 public struct Concatenate5_VVVVT<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol
->: RegexProtocol where T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol {
-  public typealias Capture = (T0.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T1.Match.Capture: EmptyCaptureProtocol, T2.Match.Capture: EmptyCaptureProtocol, T3.Match.Capture: EmptyCaptureProtocol, T4.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple2<Substring, T0.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
       x4.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4
   ) -> Concatenate5_VVVVT<T0, T1, T2, T3, T4> {
     Concatenate5_VVVVT(x0, x1, x2, x3, x4)
@@ -1381,22 +1536,22 @@ extension RegexBuilder {
 
 public struct Concatenate5_VVVVV<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol
->: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol {
-  public typealias Capture = Empty
-  public let regex: Regex<Capture>
+>: RegexProtocol where T0.Match.Capture: EmptyCaptureProtocol, T1.Match.Capture: EmptyCaptureProtocol, T2.Match.Capture: EmptyCaptureProtocol, T3.Match.Capture: EmptyCaptureProtocol, T4.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Substring
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
       x4.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4
   ) -> Concatenate5_VVVVV<T0, T1, T2, T3, T4> {
     Concatenate5_VVVVV(x0, x1, x2, x3, x4)
@@ -1408,22 +1563,22 @@ extension RegexBuilder {
 public struct Concatenate6_TTTTTT<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol
 >: RegexProtocol {
-  public typealias Capture = (T0.Capture, T1.Capture, T2.Capture, T3.Capture, T4.Capture, T5.Capture)
-  public let regex: Regex<Capture>
+  public typealias Match = Tuple7<Substring, T0.Match.Capture, T1.Match.Capture, T2.Match.Capture, T3.Match.Capture, T4.Match.Capture, T5.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
       x5.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5
   ) -> Concatenate6_TTTTTT<T0, T1, T2, T3, T4, T5> {
     Concatenate6_TTTTTT(x0, x1, x2, x3, x4, x5)
@@ -1432,23 +1587,23 @@ extension RegexBuilder {
 
 public struct Concatenate6_TTTTTV<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol
->: RegexProtocol where T0.Capture: EmptyProtocol {
-  public typealias Capture = (T1.Capture, T2.Capture, T3.Capture, T4.Capture, T5.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T0.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple6<Substring, T1.Match.Capture, T2.Match.Capture, T3.Match.Capture, T4.Match.Capture, T5.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
       x5.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5
   ) -> Concatenate6_TTTTTV<T0, T1, T2, T3, T4, T5> {
     Concatenate6_TTTTTV(x0, x1, x2, x3, x4, x5)
@@ -1457,23 +1612,23 @@ extension RegexBuilder {
 
 public struct Concatenate6_TTTTVT<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol
->: RegexProtocol where T1.Capture: EmptyProtocol {
-  public typealias Capture = (T0.Capture, T2.Capture, T3.Capture, T4.Capture, T5.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T1.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple6<Substring, T0.Match.Capture, T2.Match.Capture, T3.Match.Capture, T4.Match.Capture, T5.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
       x5.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5
   ) -> Concatenate6_TTTTVT<T0, T1, T2, T3, T4, T5> {
     Concatenate6_TTTTVT(x0, x1, x2, x3, x4, x5)
@@ -1482,23 +1637,23 @@ extension RegexBuilder {
 
 public struct Concatenate6_TTTTVV<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol
->: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol {
-  public typealias Capture = (T2.Capture, T3.Capture, T4.Capture, T5.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T0.Match.Capture: EmptyCaptureProtocol, T1.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple5<Substring, T2.Match.Capture, T3.Match.Capture, T4.Match.Capture, T5.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
       x5.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5
   ) -> Concatenate6_TTTTVV<T0, T1, T2, T3, T4, T5> {
     Concatenate6_TTTTVV(x0, x1, x2, x3, x4, x5)
@@ -1507,23 +1662,23 @@ extension RegexBuilder {
 
 public struct Concatenate6_TTTVTT<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol
->: RegexProtocol where T2.Capture: EmptyProtocol {
-  public typealias Capture = (T0.Capture, T1.Capture, T3.Capture, T4.Capture, T5.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T2.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple6<Substring, T0.Match.Capture, T1.Match.Capture, T3.Match.Capture, T4.Match.Capture, T5.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
       x5.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5
   ) -> Concatenate6_TTTVTT<T0, T1, T2, T3, T4, T5> {
     Concatenate6_TTTVTT(x0, x1, x2, x3, x4, x5)
@@ -1532,23 +1687,23 @@ extension RegexBuilder {
 
 public struct Concatenate6_TTTVTV<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol
->: RegexProtocol where T0.Capture: EmptyProtocol, T2.Capture: EmptyProtocol {
-  public typealias Capture = (T1.Capture, T3.Capture, T4.Capture, T5.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T0.Match.Capture: EmptyCaptureProtocol, T2.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple5<Substring, T1.Match.Capture, T3.Match.Capture, T4.Match.Capture, T5.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
       x5.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5
   ) -> Concatenate6_TTTVTV<T0, T1, T2, T3, T4, T5> {
     Concatenate6_TTTVTV(x0, x1, x2, x3, x4, x5)
@@ -1557,23 +1712,23 @@ extension RegexBuilder {
 
 public struct Concatenate6_TTTVVT<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol
->: RegexProtocol where T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol {
-  public typealias Capture = (T0.Capture, T3.Capture, T4.Capture, T5.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T1.Match.Capture: EmptyCaptureProtocol, T2.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple5<Substring, T0.Match.Capture, T3.Match.Capture, T4.Match.Capture, T5.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
       x5.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5
   ) -> Concatenate6_TTTVVT<T0, T1, T2, T3, T4, T5> {
     Concatenate6_TTTVVT(x0, x1, x2, x3, x4, x5)
@@ -1582,23 +1737,23 @@ extension RegexBuilder {
 
 public struct Concatenate6_TTTVVV<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol
->: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol {
-  public typealias Capture = (T3.Capture, T4.Capture, T5.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T0.Match.Capture: EmptyCaptureProtocol, T1.Match.Capture: EmptyCaptureProtocol, T2.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple4<Substring, T3.Match.Capture, T4.Match.Capture, T5.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
       x5.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5
   ) -> Concatenate6_TTTVVV<T0, T1, T2, T3, T4, T5> {
     Concatenate6_TTTVVV(x0, x1, x2, x3, x4, x5)
@@ -1607,23 +1762,23 @@ extension RegexBuilder {
 
 public struct Concatenate6_TTVTTT<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol
->: RegexProtocol where T3.Capture: EmptyProtocol {
-  public typealias Capture = (T0.Capture, T1.Capture, T2.Capture, T4.Capture, T5.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T3.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple6<Substring, T0.Match.Capture, T1.Match.Capture, T2.Match.Capture, T4.Match.Capture, T5.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
       x5.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5
   ) -> Concatenate6_TTVTTT<T0, T1, T2, T3, T4, T5> {
     Concatenate6_TTVTTT(x0, x1, x2, x3, x4, x5)
@@ -1632,23 +1787,23 @@ extension RegexBuilder {
 
 public struct Concatenate6_TTVTTV<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol
->: RegexProtocol where T0.Capture: EmptyProtocol, T3.Capture: EmptyProtocol {
-  public typealias Capture = (T1.Capture, T2.Capture, T4.Capture, T5.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T0.Match.Capture: EmptyCaptureProtocol, T3.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple5<Substring, T1.Match.Capture, T2.Match.Capture, T4.Match.Capture, T5.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
       x5.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5
   ) -> Concatenate6_TTVTTV<T0, T1, T2, T3, T4, T5> {
     Concatenate6_TTVTTV(x0, x1, x2, x3, x4, x5)
@@ -1657,23 +1812,23 @@ extension RegexBuilder {
 
 public struct Concatenate6_TTVTVT<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol
->: RegexProtocol where T1.Capture: EmptyProtocol, T3.Capture: EmptyProtocol {
-  public typealias Capture = (T0.Capture, T2.Capture, T4.Capture, T5.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T1.Match.Capture: EmptyCaptureProtocol, T3.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple5<Substring, T0.Match.Capture, T2.Match.Capture, T4.Match.Capture, T5.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
       x5.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5
   ) -> Concatenate6_TTVTVT<T0, T1, T2, T3, T4, T5> {
     Concatenate6_TTVTVT(x0, x1, x2, x3, x4, x5)
@@ -1682,23 +1837,23 @@ extension RegexBuilder {
 
 public struct Concatenate6_TTVTVV<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol
->: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T3.Capture: EmptyProtocol {
-  public typealias Capture = (T2.Capture, T4.Capture, T5.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T0.Match.Capture: EmptyCaptureProtocol, T1.Match.Capture: EmptyCaptureProtocol, T3.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple4<Substring, T2.Match.Capture, T4.Match.Capture, T5.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
       x5.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5
   ) -> Concatenate6_TTVTVV<T0, T1, T2, T3, T4, T5> {
     Concatenate6_TTVTVV(x0, x1, x2, x3, x4, x5)
@@ -1707,23 +1862,23 @@ extension RegexBuilder {
 
 public struct Concatenate6_TTVVTT<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol
->: RegexProtocol where T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol {
-  public typealias Capture = (T0.Capture, T1.Capture, T4.Capture, T5.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T2.Match.Capture: EmptyCaptureProtocol, T3.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple5<Substring, T0.Match.Capture, T1.Match.Capture, T4.Match.Capture, T5.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
       x5.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5
   ) -> Concatenate6_TTVVTT<T0, T1, T2, T3, T4, T5> {
     Concatenate6_TTVVTT(x0, x1, x2, x3, x4, x5)
@@ -1732,23 +1887,23 @@ extension RegexBuilder {
 
 public struct Concatenate6_TTVVTV<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol
->: RegexProtocol where T0.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol {
-  public typealias Capture = (T1.Capture, T4.Capture, T5.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T0.Match.Capture: EmptyCaptureProtocol, T2.Match.Capture: EmptyCaptureProtocol, T3.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple4<Substring, T1.Match.Capture, T4.Match.Capture, T5.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
       x5.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5
   ) -> Concatenate6_TTVVTV<T0, T1, T2, T3, T4, T5> {
     Concatenate6_TTVVTV(x0, x1, x2, x3, x4, x5)
@@ -1757,23 +1912,23 @@ extension RegexBuilder {
 
 public struct Concatenate6_TTVVVT<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol
->: RegexProtocol where T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol {
-  public typealias Capture = (T0.Capture, T4.Capture, T5.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T1.Match.Capture: EmptyCaptureProtocol, T2.Match.Capture: EmptyCaptureProtocol, T3.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple4<Substring, T0.Match.Capture, T4.Match.Capture, T5.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
       x5.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5
   ) -> Concatenate6_TTVVVT<T0, T1, T2, T3, T4, T5> {
     Concatenate6_TTVVVT(x0, x1, x2, x3, x4, x5)
@@ -1782,23 +1937,23 @@ extension RegexBuilder {
 
 public struct Concatenate6_TTVVVV<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol
->: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol {
-  public typealias Capture = (T4.Capture, T5.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T0.Match.Capture: EmptyCaptureProtocol, T1.Match.Capture: EmptyCaptureProtocol, T2.Match.Capture: EmptyCaptureProtocol, T3.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple3<Substring, T4.Match.Capture, T5.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
       x5.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5
   ) -> Concatenate6_TTVVVV<T0, T1, T2, T3, T4, T5> {
     Concatenate6_TTVVVV(x0, x1, x2, x3, x4, x5)
@@ -1807,23 +1962,23 @@ extension RegexBuilder {
 
 public struct Concatenate6_TVTTTT<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol
->: RegexProtocol where T4.Capture: EmptyProtocol {
-  public typealias Capture = (T0.Capture, T1.Capture, T2.Capture, T3.Capture, T5.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T4.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple6<Substring, T0.Match.Capture, T1.Match.Capture, T2.Match.Capture, T3.Match.Capture, T5.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
       x5.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5
   ) -> Concatenate6_TVTTTT<T0, T1, T2, T3, T4, T5> {
     Concatenate6_TVTTTT(x0, x1, x2, x3, x4, x5)
@@ -1832,23 +1987,23 @@ extension RegexBuilder {
 
 public struct Concatenate6_TVTTTV<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol
->: RegexProtocol where T0.Capture: EmptyProtocol, T4.Capture: EmptyProtocol {
-  public typealias Capture = (T1.Capture, T2.Capture, T3.Capture, T5.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T0.Match.Capture: EmptyCaptureProtocol, T4.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple5<Substring, T1.Match.Capture, T2.Match.Capture, T3.Match.Capture, T5.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
       x5.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5
   ) -> Concatenate6_TVTTTV<T0, T1, T2, T3, T4, T5> {
     Concatenate6_TVTTTV(x0, x1, x2, x3, x4, x5)
@@ -1857,23 +2012,23 @@ extension RegexBuilder {
 
 public struct Concatenate6_TVTTVT<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol
->: RegexProtocol where T1.Capture: EmptyProtocol, T4.Capture: EmptyProtocol {
-  public typealias Capture = (T0.Capture, T2.Capture, T3.Capture, T5.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T1.Match.Capture: EmptyCaptureProtocol, T4.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple5<Substring, T0.Match.Capture, T2.Match.Capture, T3.Match.Capture, T5.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
       x5.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5
   ) -> Concatenate6_TVTTVT<T0, T1, T2, T3, T4, T5> {
     Concatenate6_TVTTVT(x0, x1, x2, x3, x4, x5)
@@ -1882,23 +2037,23 @@ extension RegexBuilder {
 
 public struct Concatenate6_TVTTVV<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol
->: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T4.Capture: EmptyProtocol {
-  public typealias Capture = (T2.Capture, T3.Capture, T5.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T0.Match.Capture: EmptyCaptureProtocol, T1.Match.Capture: EmptyCaptureProtocol, T4.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple4<Substring, T2.Match.Capture, T3.Match.Capture, T5.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
       x5.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5
   ) -> Concatenate6_TVTTVV<T0, T1, T2, T3, T4, T5> {
     Concatenate6_TVTTVV(x0, x1, x2, x3, x4, x5)
@@ -1907,23 +2062,23 @@ extension RegexBuilder {
 
 public struct Concatenate6_TVTVTT<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol
->: RegexProtocol where T2.Capture: EmptyProtocol, T4.Capture: EmptyProtocol {
-  public typealias Capture = (T0.Capture, T1.Capture, T3.Capture, T5.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T2.Match.Capture: EmptyCaptureProtocol, T4.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple5<Substring, T0.Match.Capture, T1.Match.Capture, T3.Match.Capture, T5.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
       x5.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5
   ) -> Concatenate6_TVTVTT<T0, T1, T2, T3, T4, T5> {
     Concatenate6_TVTVTT(x0, x1, x2, x3, x4, x5)
@@ -1932,23 +2087,23 @@ extension RegexBuilder {
 
 public struct Concatenate6_TVTVTV<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol
->: RegexProtocol where T0.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T4.Capture: EmptyProtocol {
-  public typealias Capture = (T1.Capture, T3.Capture, T5.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T0.Match.Capture: EmptyCaptureProtocol, T2.Match.Capture: EmptyCaptureProtocol, T4.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple4<Substring, T1.Match.Capture, T3.Match.Capture, T5.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
       x5.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5
   ) -> Concatenate6_TVTVTV<T0, T1, T2, T3, T4, T5> {
     Concatenate6_TVTVTV(x0, x1, x2, x3, x4, x5)
@@ -1957,23 +2112,23 @@ extension RegexBuilder {
 
 public struct Concatenate6_TVTVVT<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol
->: RegexProtocol where T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T4.Capture: EmptyProtocol {
-  public typealias Capture = (T0.Capture, T3.Capture, T5.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T1.Match.Capture: EmptyCaptureProtocol, T2.Match.Capture: EmptyCaptureProtocol, T4.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple4<Substring, T0.Match.Capture, T3.Match.Capture, T5.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
       x5.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5
   ) -> Concatenate6_TVTVVT<T0, T1, T2, T3, T4, T5> {
     Concatenate6_TVTVVT(x0, x1, x2, x3, x4, x5)
@@ -1982,23 +2137,23 @@ extension RegexBuilder {
 
 public struct Concatenate6_TVTVVV<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol
->: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T4.Capture: EmptyProtocol {
-  public typealias Capture = (T3.Capture, T5.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T0.Match.Capture: EmptyCaptureProtocol, T1.Match.Capture: EmptyCaptureProtocol, T2.Match.Capture: EmptyCaptureProtocol, T4.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple3<Substring, T3.Match.Capture, T5.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
       x5.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5
   ) -> Concatenate6_TVTVVV<T0, T1, T2, T3, T4, T5> {
     Concatenate6_TVTVVV(x0, x1, x2, x3, x4, x5)
@@ -2007,23 +2162,23 @@ extension RegexBuilder {
 
 public struct Concatenate6_TVVTTT<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol
->: RegexProtocol where T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol {
-  public typealias Capture = (T0.Capture, T1.Capture, T2.Capture, T5.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T3.Match.Capture: EmptyCaptureProtocol, T4.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple5<Substring, T0.Match.Capture, T1.Match.Capture, T2.Match.Capture, T5.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
       x5.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5
   ) -> Concatenate6_TVVTTT<T0, T1, T2, T3, T4, T5> {
     Concatenate6_TVVTTT(x0, x1, x2, x3, x4, x5)
@@ -2032,23 +2187,23 @@ extension RegexBuilder {
 
 public struct Concatenate6_TVVTTV<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol
->: RegexProtocol where T0.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol {
-  public typealias Capture = (T1.Capture, T2.Capture, T5.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T0.Match.Capture: EmptyCaptureProtocol, T3.Match.Capture: EmptyCaptureProtocol, T4.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple4<Substring, T1.Match.Capture, T2.Match.Capture, T5.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
       x5.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5
   ) -> Concatenate6_TVVTTV<T0, T1, T2, T3, T4, T5> {
     Concatenate6_TVVTTV(x0, x1, x2, x3, x4, x5)
@@ -2057,23 +2212,23 @@ extension RegexBuilder {
 
 public struct Concatenate6_TVVTVT<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol
->: RegexProtocol where T1.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol {
-  public typealias Capture = (T0.Capture, T2.Capture, T5.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T1.Match.Capture: EmptyCaptureProtocol, T3.Match.Capture: EmptyCaptureProtocol, T4.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple4<Substring, T0.Match.Capture, T2.Match.Capture, T5.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
       x5.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5
   ) -> Concatenate6_TVVTVT<T0, T1, T2, T3, T4, T5> {
     Concatenate6_TVVTVT(x0, x1, x2, x3, x4, x5)
@@ -2082,23 +2237,23 @@ extension RegexBuilder {
 
 public struct Concatenate6_TVVTVV<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol
->: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol {
-  public typealias Capture = (T2.Capture, T5.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T0.Match.Capture: EmptyCaptureProtocol, T1.Match.Capture: EmptyCaptureProtocol, T3.Match.Capture: EmptyCaptureProtocol, T4.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple3<Substring, T2.Match.Capture, T5.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
       x5.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5
   ) -> Concatenate6_TVVTVV<T0, T1, T2, T3, T4, T5> {
     Concatenate6_TVVTVV(x0, x1, x2, x3, x4, x5)
@@ -2107,23 +2262,23 @@ extension RegexBuilder {
 
 public struct Concatenate6_TVVVTT<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol
->: RegexProtocol where T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol {
-  public typealias Capture = (T0.Capture, T1.Capture, T5.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T2.Match.Capture: EmptyCaptureProtocol, T3.Match.Capture: EmptyCaptureProtocol, T4.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple4<Substring, T0.Match.Capture, T1.Match.Capture, T5.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
       x5.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5
   ) -> Concatenate6_TVVVTT<T0, T1, T2, T3, T4, T5> {
     Concatenate6_TVVVTT(x0, x1, x2, x3, x4, x5)
@@ -2132,23 +2287,23 @@ extension RegexBuilder {
 
 public struct Concatenate6_TVVVTV<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol
->: RegexProtocol where T0.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol {
-  public typealias Capture = (T1.Capture, T5.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T0.Match.Capture: EmptyCaptureProtocol, T2.Match.Capture: EmptyCaptureProtocol, T3.Match.Capture: EmptyCaptureProtocol, T4.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple3<Substring, T1.Match.Capture, T5.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
       x5.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5
   ) -> Concatenate6_TVVVTV<T0, T1, T2, T3, T4, T5> {
     Concatenate6_TVVVTV(x0, x1, x2, x3, x4, x5)
@@ -2157,23 +2312,23 @@ extension RegexBuilder {
 
 public struct Concatenate6_TVVVVT<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol
->: RegexProtocol where T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol {
-  public typealias Capture = (T0.Capture, T5.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T1.Match.Capture: EmptyCaptureProtocol, T2.Match.Capture: EmptyCaptureProtocol, T3.Match.Capture: EmptyCaptureProtocol, T4.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple3<Substring, T0.Match.Capture, T5.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
       x5.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5
   ) -> Concatenate6_TVVVVT<T0, T1, T2, T3, T4, T5> {
     Concatenate6_TVVVVT(x0, x1, x2, x3, x4, x5)
@@ -2182,23 +2337,23 @@ extension RegexBuilder {
 
 public struct Concatenate6_TVVVVV<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol
->: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol {
-  public typealias Capture = (T5.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T0.Match.Capture: EmptyCaptureProtocol, T1.Match.Capture: EmptyCaptureProtocol, T2.Match.Capture: EmptyCaptureProtocol, T3.Match.Capture: EmptyCaptureProtocol, T4.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple2<Substring, T5.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
       x5.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5
   ) -> Concatenate6_TVVVVV<T0, T1, T2, T3, T4, T5> {
     Concatenate6_TVVVVV(x0, x1, x2, x3, x4, x5)
@@ -2207,23 +2362,23 @@ extension RegexBuilder {
 
 public struct Concatenate6_VTTTTT<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol
->: RegexProtocol where T5.Capture: EmptyProtocol {
-  public typealias Capture = (T0.Capture, T1.Capture, T2.Capture, T3.Capture, T4.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T5.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple6<Substring, T0.Match.Capture, T1.Match.Capture, T2.Match.Capture, T3.Match.Capture, T4.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
       x5.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5
   ) -> Concatenate6_VTTTTT<T0, T1, T2, T3, T4, T5> {
     Concatenate6_VTTTTT(x0, x1, x2, x3, x4, x5)
@@ -2232,23 +2387,23 @@ extension RegexBuilder {
 
 public struct Concatenate6_VTTTTV<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol
->: RegexProtocol where T0.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
-  public typealias Capture = (T1.Capture, T2.Capture, T3.Capture, T4.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T0.Match.Capture: EmptyCaptureProtocol, T5.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple5<Substring, T1.Match.Capture, T2.Match.Capture, T3.Match.Capture, T4.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
       x5.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5
   ) -> Concatenate6_VTTTTV<T0, T1, T2, T3, T4, T5> {
     Concatenate6_VTTTTV(x0, x1, x2, x3, x4, x5)
@@ -2257,23 +2412,23 @@ extension RegexBuilder {
 
 public struct Concatenate6_VTTTVT<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol
->: RegexProtocol where T1.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
-  public typealias Capture = (T0.Capture, T2.Capture, T3.Capture, T4.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T1.Match.Capture: EmptyCaptureProtocol, T5.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple5<Substring, T0.Match.Capture, T2.Match.Capture, T3.Match.Capture, T4.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
       x5.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5
   ) -> Concatenate6_VTTTVT<T0, T1, T2, T3, T4, T5> {
     Concatenate6_VTTTVT(x0, x1, x2, x3, x4, x5)
@@ -2282,23 +2437,23 @@ extension RegexBuilder {
 
 public struct Concatenate6_VTTTVV<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol
->: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
-  public typealias Capture = (T2.Capture, T3.Capture, T4.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T0.Match.Capture: EmptyCaptureProtocol, T1.Match.Capture: EmptyCaptureProtocol, T5.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple4<Substring, T2.Match.Capture, T3.Match.Capture, T4.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
       x5.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5
   ) -> Concatenate6_VTTTVV<T0, T1, T2, T3, T4, T5> {
     Concatenate6_VTTTVV(x0, x1, x2, x3, x4, x5)
@@ -2307,23 +2462,23 @@ extension RegexBuilder {
 
 public struct Concatenate6_VTTVTT<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol
->: RegexProtocol where T2.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
-  public typealias Capture = (T0.Capture, T1.Capture, T3.Capture, T4.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T2.Match.Capture: EmptyCaptureProtocol, T5.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple5<Substring, T0.Match.Capture, T1.Match.Capture, T3.Match.Capture, T4.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
       x5.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5
   ) -> Concatenate6_VTTVTT<T0, T1, T2, T3, T4, T5> {
     Concatenate6_VTTVTT(x0, x1, x2, x3, x4, x5)
@@ -2332,23 +2487,23 @@ extension RegexBuilder {
 
 public struct Concatenate6_VTTVTV<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol
->: RegexProtocol where T0.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
-  public typealias Capture = (T1.Capture, T3.Capture, T4.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T0.Match.Capture: EmptyCaptureProtocol, T2.Match.Capture: EmptyCaptureProtocol, T5.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple4<Substring, T1.Match.Capture, T3.Match.Capture, T4.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
       x5.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5
   ) -> Concatenate6_VTTVTV<T0, T1, T2, T3, T4, T5> {
     Concatenate6_VTTVTV(x0, x1, x2, x3, x4, x5)
@@ -2357,23 +2512,23 @@ extension RegexBuilder {
 
 public struct Concatenate6_VTTVVT<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol
->: RegexProtocol where T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
-  public typealias Capture = (T0.Capture, T3.Capture, T4.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T1.Match.Capture: EmptyCaptureProtocol, T2.Match.Capture: EmptyCaptureProtocol, T5.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple4<Substring, T0.Match.Capture, T3.Match.Capture, T4.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
       x5.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5
   ) -> Concatenate6_VTTVVT<T0, T1, T2, T3, T4, T5> {
     Concatenate6_VTTVVT(x0, x1, x2, x3, x4, x5)
@@ -2382,23 +2537,23 @@ extension RegexBuilder {
 
 public struct Concatenate6_VTTVVV<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol
->: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
-  public typealias Capture = (T3.Capture, T4.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T0.Match.Capture: EmptyCaptureProtocol, T1.Match.Capture: EmptyCaptureProtocol, T2.Match.Capture: EmptyCaptureProtocol, T5.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple3<Substring, T3.Match.Capture, T4.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
       x5.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5
   ) -> Concatenate6_VTTVVV<T0, T1, T2, T3, T4, T5> {
     Concatenate6_VTTVVV(x0, x1, x2, x3, x4, x5)
@@ -2407,23 +2562,23 @@ extension RegexBuilder {
 
 public struct Concatenate6_VTVTTT<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol
->: RegexProtocol where T3.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
-  public typealias Capture = (T0.Capture, T1.Capture, T2.Capture, T4.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T3.Match.Capture: EmptyCaptureProtocol, T5.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple5<Substring, T0.Match.Capture, T1.Match.Capture, T2.Match.Capture, T4.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
       x5.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5
   ) -> Concatenate6_VTVTTT<T0, T1, T2, T3, T4, T5> {
     Concatenate6_VTVTTT(x0, x1, x2, x3, x4, x5)
@@ -2432,23 +2587,23 @@ extension RegexBuilder {
 
 public struct Concatenate6_VTVTTV<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol
->: RegexProtocol where T0.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
-  public typealias Capture = (T1.Capture, T2.Capture, T4.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T0.Match.Capture: EmptyCaptureProtocol, T3.Match.Capture: EmptyCaptureProtocol, T5.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple4<Substring, T1.Match.Capture, T2.Match.Capture, T4.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
       x5.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5
   ) -> Concatenate6_VTVTTV<T0, T1, T2, T3, T4, T5> {
     Concatenate6_VTVTTV(x0, x1, x2, x3, x4, x5)
@@ -2457,23 +2612,23 @@ extension RegexBuilder {
 
 public struct Concatenate6_VTVTVT<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol
->: RegexProtocol where T1.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
-  public typealias Capture = (T0.Capture, T2.Capture, T4.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T1.Match.Capture: EmptyCaptureProtocol, T3.Match.Capture: EmptyCaptureProtocol, T5.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple4<Substring, T0.Match.Capture, T2.Match.Capture, T4.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
       x5.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5
   ) -> Concatenate6_VTVTVT<T0, T1, T2, T3, T4, T5> {
     Concatenate6_VTVTVT(x0, x1, x2, x3, x4, x5)
@@ -2482,23 +2637,23 @@ extension RegexBuilder {
 
 public struct Concatenate6_VTVTVV<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol
->: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
-  public typealias Capture = (T2.Capture, T4.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T0.Match.Capture: EmptyCaptureProtocol, T1.Match.Capture: EmptyCaptureProtocol, T3.Match.Capture: EmptyCaptureProtocol, T5.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple3<Substring, T2.Match.Capture, T4.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
       x5.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5
   ) -> Concatenate6_VTVTVV<T0, T1, T2, T3, T4, T5> {
     Concatenate6_VTVTVV(x0, x1, x2, x3, x4, x5)
@@ -2507,23 +2662,23 @@ extension RegexBuilder {
 
 public struct Concatenate6_VTVVTT<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol
->: RegexProtocol where T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
-  public typealias Capture = (T0.Capture, T1.Capture, T4.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T2.Match.Capture: EmptyCaptureProtocol, T3.Match.Capture: EmptyCaptureProtocol, T5.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple4<Substring, T0.Match.Capture, T1.Match.Capture, T4.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
       x5.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5
   ) -> Concatenate6_VTVVTT<T0, T1, T2, T3, T4, T5> {
     Concatenate6_VTVVTT(x0, x1, x2, x3, x4, x5)
@@ -2532,23 +2687,23 @@ extension RegexBuilder {
 
 public struct Concatenate6_VTVVTV<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol
->: RegexProtocol where T0.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
-  public typealias Capture = (T1.Capture, T4.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T0.Match.Capture: EmptyCaptureProtocol, T2.Match.Capture: EmptyCaptureProtocol, T3.Match.Capture: EmptyCaptureProtocol, T5.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple3<Substring, T1.Match.Capture, T4.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
       x5.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5
   ) -> Concatenate6_VTVVTV<T0, T1, T2, T3, T4, T5> {
     Concatenate6_VTVVTV(x0, x1, x2, x3, x4, x5)
@@ -2557,23 +2712,23 @@ extension RegexBuilder {
 
 public struct Concatenate6_VTVVVT<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol
->: RegexProtocol where T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
-  public typealias Capture = (T0.Capture, T4.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T1.Match.Capture: EmptyCaptureProtocol, T2.Match.Capture: EmptyCaptureProtocol, T3.Match.Capture: EmptyCaptureProtocol, T5.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple3<Substring, T0.Match.Capture, T4.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
       x5.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5
   ) -> Concatenate6_VTVVVT<T0, T1, T2, T3, T4, T5> {
     Concatenate6_VTVVVT(x0, x1, x2, x3, x4, x5)
@@ -2582,23 +2737,23 @@ extension RegexBuilder {
 
 public struct Concatenate6_VTVVVV<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol
->: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
-  public typealias Capture = (T4.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T0.Match.Capture: EmptyCaptureProtocol, T1.Match.Capture: EmptyCaptureProtocol, T2.Match.Capture: EmptyCaptureProtocol, T3.Match.Capture: EmptyCaptureProtocol, T5.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple2<Substring, T4.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
       x5.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5
   ) -> Concatenate6_VTVVVV<T0, T1, T2, T3, T4, T5> {
     Concatenate6_VTVVVV(x0, x1, x2, x3, x4, x5)
@@ -2607,23 +2762,23 @@ extension RegexBuilder {
 
 public struct Concatenate6_VVTTTT<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol
->: RegexProtocol where T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
-  public typealias Capture = (T0.Capture, T1.Capture, T2.Capture, T3.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T4.Match.Capture: EmptyCaptureProtocol, T5.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple5<Substring, T0.Match.Capture, T1.Match.Capture, T2.Match.Capture, T3.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
       x5.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5
   ) -> Concatenate6_VVTTTT<T0, T1, T2, T3, T4, T5> {
     Concatenate6_VVTTTT(x0, x1, x2, x3, x4, x5)
@@ -2632,23 +2787,23 @@ extension RegexBuilder {
 
 public struct Concatenate6_VVTTTV<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol
->: RegexProtocol where T0.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
-  public typealias Capture = (T1.Capture, T2.Capture, T3.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T0.Match.Capture: EmptyCaptureProtocol, T4.Match.Capture: EmptyCaptureProtocol, T5.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple4<Substring, T1.Match.Capture, T2.Match.Capture, T3.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
       x5.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5
   ) -> Concatenate6_VVTTTV<T0, T1, T2, T3, T4, T5> {
     Concatenate6_VVTTTV(x0, x1, x2, x3, x4, x5)
@@ -2657,23 +2812,23 @@ extension RegexBuilder {
 
 public struct Concatenate6_VVTTVT<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol
->: RegexProtocol where T1.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
-  public typealias Capture = (T0.Capture, T2.Capture, T3.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T1.Match.Capture: EmptyCaptureProtocol, T4.Match.Capture: EmptyCaptureProtocol, T5.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple4<Substring, T0.Match.Capture, T2.Match.Capture, T3.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
       x5.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5
   ) -> Concatenate6_VVTTVT<T0, T1, T2, T3, T4, T5> {
     Concatenate6_VVTTVT(x0, x1, x2, x3, x4, x5)
@@ -2682,23 +2837,23 @@ extension RegexBuilder {
 
 public struct Concatenate6_VVTTVV<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol
->: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
-  public typealias Capture = (T2.Capture, T3.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T0.Match.Capture: EmptyCaptureProtocol, T1.Match.Capture: EmptyCaptureProtocol, T4.Match.Capture: EmptyCaptureProtocol, T5.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple3<Substring, T2.Match.Capture, T3.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
       x5.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5
   ) -> Concatenate6_VVTTVV<T0, T1, T2, T3, T4, T5> {
     Concatenate6_VVTTVV(x0, x1, x2, x3, x4, x5)
@@ -2707,23 +2862,23 @@ extension RegexBuilder {
 
 public struct Concatenate6_VVTVTT<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol
->: RegexProtocol where T2.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
-  public typealias Capture = (T0.Capture, T1.Capture, T3.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T2.Match.Capture: EmptyCaptureProtocol, T4.Match.Capture: EmptyCaptureProtocol, T5.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple4<Substring, T0.Match.Capture, T1.Match.Capture, T3.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
       x5.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5
   ) -> Concatenate6_VVTVTT<T0, T1, T2, T3, T4, T5> {
     Concatenate6_VVTVTT(x0, x1, x2, x3, x4, x5)
@@ -2732,23 +2887,23 @@ extension RegexBuilder {
 
 public struct Concatenate6_VVTVTV<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol
->: RegexProtocol where T0.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
-  public typealias Capture = (T1.Capture, T3.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T0.Match.Capture: EmptyCaptureProtocol, T2.Match.Capture: EmptyCaptureProtocol, T4.Match.Capture: EmptyCaptureProtocol, T5.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple3<Substring, T1.Match.Capture, T3.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
       x5.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5
   ) -> Concatenate6_VVTVTV<T0, T1, T2, T3, T4, T5> {
     Concatenate6_VVTVTV(x0, x1, x2, x3, x4, x5)
@@ -2757,23 +2912,23 @@ extension RegexBuilder {
 
 public struct Concatenate6_VVTVVT<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol
->: RegexProtocol where T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
-  public typealias Capture = (T0.Capture, T3.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T1.Match.Capture: EmptyCaptureProtocol, T2.Match.Capture: EmptyCaptureProtocol, T4.Match.Capture: EmptyCaptureProtocol, T5.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple3<Substring, T0.Match.Capture, T3.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
       x5.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5
   ) -> Concatenate6_VVTVVT<T0, T1, T2, T3, T4, T5> {
     Concatenate6_VVTVVT(x0, x1, x2, x3, x4, x5)
@@ -2782,23 +2937,23 @@ extension RegexBuilder {
 
 public struct Concatenate6_VVTVVV<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol
->: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
-  public typealias Capture = (T3.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T0.Match.Capture: EmptyCaptureProtocol, T1.Match.Capture: EmptyCaptureProtocol, T2.Match.Capture: EmptyCaptureProtocol, T4.Match.Capture: EmptyCaptureProtocol, T5.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple2<Substring, T3.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
       x5.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5
   ) -> Concatenate6_VVTVVV<T0, T1, T2, T3, T4, T5> {
     Concatenate6_VVTVVV(x0, x1, x2, x3, x4, x5)
@@ -2807,23 +2962,23 @@ extension RegexBuilder {
 
 public struct Concatenate6_VVVTTT<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol
->: RegexProtocol where T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
-  public typealias Capture = (T0.Capture, T1.Capture, T2.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T3.Match.Capture: EmptyCaptureProtocol, T4.Match.Capture: EmptyCaptureProtocol, T5.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple4<Substring, T0.Match.Capture, T1.Match.Capture, T2.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
       x5.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5
   ) -> Concatenate6_VVVTTT<T0, T1, T2, T3, T4, T5> {
     Concatenate6_VVVTTT(x0, x1, x2, x3, x4, x5)
@@ -2832,23 +2987,23 @@ extension RegexBuilder {
 
 public struct Concatenate6_VVVTTV<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol
->: RegexProtocol where T0.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
-  public typealias Capture = (T1.Capture, T2.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T0.Match.Capture: EmptyCaptureProtocol, T3.Match.Capture: EmptyCaptureProtocol, T4.Match.Capture: EmptyCaptureProtocol, T5.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple3<Substring, T1.Match.Capture, T2.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
       x5.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5
   ) -> Concatenate6_VVVTTV<T0, T1, T2, T3, T4, T5> {
     Concatenate6_VVVTTV(x0, x1, x2, x3, x4, x5)
@@ -2857,23 +3012,23 @@ extension RegexBuilder {
 
 public struct Concatenate6_VVVTVT<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol
->: RegexProtocol where T1.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
-  public typealias Capture = (T0.Capture, T2.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T1.Match.Capture: EmptyCaptureProtocol, T3.Match.Capture: EmptyCaptureProtocol, T4.Match.Capture: EmptyCaptureProtocol, T5.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple3<Substring, T0.Match.Capture, T2.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
       x5.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5
   ) -> Concatenate6_VVVTVT<T0, T1, T2, T3, T4, T5> {
     Concatenate6_VVVTVT(x0, x1, x2, x3, x4, x5)
@@ -2882,23 +3037,23 @@ extension RegexBuilder {
 
 public struct Concatenate6_VVVTVV<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol
->: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
-  public typealias Capture = (T2.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T0.Match.Capture: EmptyCaptureProtocol, T1.Match.Capture: EmptyCaptureProtocol, T3.Match.Capture: EmptyCaptureProtocol, T4.Match.Capture: EmptyCaptureProtocol, T5.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple2<Substring, T2.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
       x5.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5
   ) -> Concatenate6_VVVTVV<T0, T1, T2, T3, T4, T5> {
     Concatenate6_VVVTVV(x0, x1, x2, x3, x4, x5)
@@ -2907,23 +3062,23 @@ extension RegexBuilder {
 
 public struct Concatenate6_VVVVTT<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol
->: RegexProtocol where T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
-  public typealias Capture = (T0.Capture, T1.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T2.Match.Capture: EmptyCaptureProtocol, T3.Match.Capture: EmptyCaptureProtocol, T4.Match.Capture: EmptyCaptureProtocol, T5.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple3<Substring, T0.Match.Capture, T1.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
       x5.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5
   ) -> Concatenate6_VVVVTT<T0, T1, T2, T3, T4, T5> {
     Concatenate6_VVVVTT(x0, x1, x2, x3, x4, x5)
@@ -2932,23 +3087,23 @@ extension RegexBuilder {
 
 public struct Concatenate6_VVVVTV<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol
->: RegexProtocol where T0.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
-  public typealias Capture = (T1.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T0.Match.Capture: EmptyCaptureProtocol, T2.Match.Capture: EmptyCaptureProtocol, T3.Match.Capture: EmptyCaptureProtocol, T4.Match.Capture: EmptyCaptureProtocol, T5.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple2<Substring, T1.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
       x5.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5
   ) -> Concatenate6_VVVVTV<T0, T1, T2, T3, T4, T5> {
     Concatenate6_VVVVTV(x0, x1, x2, x3, x4, x5)
@@ -2957,23 +3112,23 @@ extension RegexBuilder {
 
 public struct Concatenate6_VVVVVT<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol
->: RegexProtocol where T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
-  public typealias Capture = (T0.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T1.Match.Capture: EmptyCaptureProtocol, T2.Match.Capture: EmptyCaptureProtocol, T3.Match.Capture: EmptyCaptureProtocol, T4.Match.Capture: EmptyCaptureProtocol, T5.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple2<Substring, T0.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
       x5.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5
   ) -> Concatenate6_VVVVVT<T0, T1, T2, T3, T4, T5> {
     Concatenate6_VVVVVT(x0, x1, x2, x3, x4, x5)
@@ -2982,23 +3137,23 @@ extension RegexBuilder {
 
 public struct Concatenate6_VVVVVV<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol
->: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
-  public typealias Capture = Empty
-  public let regex: Regex<Capture>
+>: RegexProtocol where T0.Match.Capture: EmptyCaptureProtocol, T1.Match.Capture: EmptyCaptureProtocol, T2.Match.Capture: EmptyCaptureProtocol, T3.Match.Capture: EmptyCaptureProtocol, T4.Match.Capture: EmptyCaptureProtocol, T5.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Substring
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
       x5.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5
   ) -> Concatenate6_VVVVVV<T0, T1, T2, T3, T4, T5> {
     Concatenate6_VVVVVV(x0, x1, x2, x3, x4, x5)
@@ -3010,23 +3165,23 @@ extension RegexBuilder {
 public struct Concatenate7_TTTTTTT<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
 >: RegexProtocol {
-  public typealias Capture = (T0.Capture, T1.Capture, T2.Capture, T3.Capture, T4.Capture, T5.Capture, T6.Capture)
-  public let regex: Regex<Capture>
+  public typealias Match = Tuple8<Substring, T0.Match.Capture, T1.Match.Capture, T2.Match.Capture, T3.Match.Capture, T4.Match.Capture, T5.Match.Capture, T6.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
-      x5.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
+      x5.regex.ast, 
       x6.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5, T6>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6
   ) -> Concatenate7_TTTTTTT<T0, T1, T2, T3, T4, T5, T6> {
     Concatenate7_TTTTTTT(x0, x1, x2, x3, x4, x5, x6)
@@ -3035,24 +3190,24 @@ extension RegexBuilder {
 
 public struct Concatenate7_TTTTTTV<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
->: RegexProtocol where T0.Capture: EmptyProtocol {
-  public typealias Capture = (T1.Capture, T2.Capture, T3.Capture, T4.Capture, T5.Capture, T6.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T0.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple7<Substring, T1.Match.Capture, T2.Match.Capture, T3.Match.Capture, T4.Match.Capture, T5.Match.Capture, T6.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
-      x5.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
+      x5.regex.ast, 
       x6.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5, T6>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6
   ) -> Concatenate7_TTTTTTV<T0, T1, T2, T3, T4, T5, T6> {
     Concatenate7_TTTTTTV(x0, x1, x2, x3, x4, x5, x6)
@@ -3061,24 +3216,24 @@ extension RegexBuilder {
 
 public struct Concatenate7_TTTTTVT<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
->: RegexProtocol where T1.Capture: EmptyProtocol {
-  public typealias Capture = (T0.Capture, T2.Capture, T3.Capture, T4.Capture, T5.Capture, T6.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T1.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple7<Substring, T0.Match.Capture, T2.Match.Capture, T3.Match.Capture, T4.Match.Capture, T5.Match.Capture, T6.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
-      x5.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
+      x5.regex.ast, 
       x6.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5, T6>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6
   ) -> Concatenate7_TTTTTVT<T0, T1, T2, T3, T4, T5, T6> {
     Concatenate7_TTTTTVT(x0, x1, x2, x3, x4, x5, x6)
@@ -3087,24 +3242,24 @@ extension RegexBuilder {
 
 public struct Concatenate7_TTTTTVV<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
->: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol {
-  public typealias Capture = (T2.Capture, T3.Capture, T4.Capture, T5.Capture, T6.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T0.Match.Capture: EmptyCaptureProtocol, T1.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple6<Substring, T2.Match.Capture, T3.Match.Capture, T4.Match.Capture, T5.Match.Capture, T6.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
-      x5.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
+      x5.regex.ast, 
       x6.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5, T6>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6
   ) -> Concatenate7_TTTTTVV<T0, T1, T2, T3, T4, T5, T6> {
     Concatenate7_TTTTTVV(x0, x1, x2, x3, x4, x5, x6)
@@ -3113,24 +3268,24 @@ extension RegexBuilder {
 
 public struct Concatenate7_TTTTVTT<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
->: RegexProtocol where T2.Capture: EmptyProtocol {
-  public typealias Capture = (T0.Capture, T1.Capture, T3.Capture, T4.Capture, T5.Capture, T6.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T2.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple7<Substring, T0.Match.Capture, T1.Match.Capture, T3.Match.Capture, T4.Match.Capture, T5.Match.Capture, T6.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
-      x5.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
+      x5.regex.ast, 
       x6.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5, T6>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6
   ) -> Concatenate7_TTTTVTT<T0, T1, T2, T3, T4, T5, T6> {
     Concatenate7_TTTTVTT(x0, x1, x2, x3, x4, x5, x6)
@@ -3139,24 +3294,24 @@ extension RegexBuilder {
 
 public struct Concatenate7_TTTTVTV<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
->: RegexProtocol where T0.Capture: EmptyProtocol, T2.Capture: EmptyProtocol {
-  public typealias Capture = (T1.Capture, T3.Capture, T4.Capture, T5.Capture, T6.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T0.Match.Capture: EmptyCaptureProtocol, T2.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple6<Substring, T1.Match.Capture, T3.Match.Capture, T4.Match.Capture, T5.Match.Capture, T6.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
-      x5.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
+      x5.regex.ast, 
       x6.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5, T6>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6
   ) -> Concatenate7_TTTTVTV<T0, T1, T2, T3, T4, T5, T6> {
     Concatenate7_TTTTVTV(x0, x1, x2, x3, x4, x5, x6)
@@ -3165,24 +3320,24 @@ extension RegexBuilder {
 
 public struct Concatenate7_TTTTVVT<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
->: RegexProtocol where T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol {
-  public typealias Capture = (T0.Capture, T3.Capture, T4.Capture, T5.Capture, T6.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T1.Match.Capture: EmptyCaptureProtocol, T2.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple6<Substring, T0.Match.Capture, T3.Match.Capture, T4.Match.Capture, T5.Match.Capture, T6.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
-      x5.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
+      x5.regex.ast, 
       x6.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5, T6>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6
   ) -> Concatenate7_TTTTVVT<T0, T1, T2, T3, T4, T5, T6> {
     Concatenate7_TTTTVVT(x0, x1, x2, x3, x4, x5, x6)
@@ -3191,24 +3346,24 @@ extension RegexBuilder {
 
 public struct Concatenate7_TTTTVVV<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
->: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol {
-  public typealias Capture = (T3.Capture, T4.Capture, T5.Capture, T6.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T0.Match.Capture: EmptyCaptureProtocol, T1.Match.Capture: EmptyCaptureProtocol, T2.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple5<Substring, T3.Match.Capture, T4.Match.Capture, T5.Match.Capture, T6.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
-      x5.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
+      x5.regex.ast, 
       x6.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5, T6>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6
   ) -> Concatenate7_TTTTVVV<T0, T1, T2, T3, T4, T5, T6> {
     Concatenate7_TTTTVVV(x0, x1, x2, x3, x4, x5, x6)
@@ -3217,24 +3372,24 @@ extension RegexBuilder {
 
 public struct Concatenate7_TTTVTTT<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
->: RegexProtocol where T3.Capture: EmptyProtocol {
-  public typealias Capture = (T0.Capture, T1.Capture, T2.Capture, T4.Capture, T5.Capture, T6.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T3.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple7<Substring, T0.Match.Capture, T1.Match.Capture, T2.Match.Capture, T4.Match.Capture, T5.Match.Capture, T6.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
-      x5.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
+      x5.regex.ast, 
       x6.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5, T6>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6
   ) -> Concatenate7_TTTVTTT<T0, T1, T2, T3, T4, T5, T6> {
     Concatenate7_TTTVTTT(x0, x1, x2, x3, x4, x5, x6)
@@ -3243,24 +3398,24 @@ extension RegexBuilder {
 
 public struct Concatenate7_TTTVTTV<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
->: RegexProtocol where T0.Capture: EmptyProtocol, T3.Capture: EmptyProtocol {
-  public typealias Capture = (T1.Capture, T2.Capture, T4.Capture, T5.Capture, T6.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T0.Match.Capture: EmptyCaptureProtocol, T3.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple6<Substring, T1.Match.Capture, T2.Match.Capture, T4.Match.Capture, T5.Match.Capture, T6.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
-      x5.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
+      x5.regex.ast, 
       x6.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5, T6>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6
   ) -> Concatenate7_TTTVTTV<T0, T1, T2, T3, T4, T5, T6> {
     Concatenate7_TTTVTTV(x0, x1, x2, x3, x4, x5, x6)
@@ -3269,24 +3424,24 @@ extension RegexBuilder {
 
 public struct Concatenate7_TTTVTVT<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
->: RegexProtocol where T1.Capture: EmptyProtocol, T3.Capture: EmptyProtocol {
-  public typealias Capture = (T0.Capture, T2.Capture, T4.Capture, T5.Capture, T6.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T1.Match.Capture: EmptyCaptureProtocol, T3.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple6<Substring, T0.Match.Capture, T2.Match.Capture, T4.Match.Capture, T5.Match.Capture, T6.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
-      x5.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
+      x5.regex.ast, 
       x6.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5, T6>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6
   ) -> Concatenate7_TTTVTVT<T0, T1, T2, T3, T4, T5, T6> {
     Concatenate7_TTTVTVT(x0, x1, x2, x3, x4, x5, x6)
@@ -3295,24 +3450,24 @@ extension RegexBuilder {
 
 public struct Concatenate7_TTTVTVV<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
->: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T3.Capture: EmptyProtocol {
-  public typealias Capture = (T2.Capture, T4.Capture, T5.Capture, T6.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T0.Match.Capture: EmptyCaptureProtocol, T1.Match.Capture: EmptyCaptureProtocol, T3.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple5<Substring, T2.Match.Capture, T4.Match.Capture, T5.Match.Capture, T6.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
-      x5.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
+      x5.regex.ast, 
       x6.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5, T6>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6
   ) -> Concatenate7_TTTVTVV<T0, T1, T2, T3, T4, T5, T6> {
     Concatenate7_TTTVTVV(x0, x1, x2, x3, x4, x5, x6)
@@ -3321,24 +3476,24 @@ extension RegexBuilder {
 
 public struct Concatenate7_TTTVVTT<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
->: RegexProtocol where T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol {
-  public typealias Capture = (T0.Capture, T1.Capture, T4.Capture, T5.Capture, T6.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T2.Match.Capture: EmptyCaptureProtocol, T3.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple6<Substring, T0.Match.Capture, T1.Match.Capture, T4.Match.Capture, T5.Match.Capture, T6.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
-      x5.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
+      x5.regex.ast, 
       x6.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5, T6>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6
   ) -> Concatenate7_TTTVVTT<T0, T1, T2, T3, T4, T5, T6> {
     Concatenate7_TTTVVTT(x0, x1, x2, x3, x4, x5, x6)
@@ -3347,24 +3502,24 @@ extension RegexBuilder {
 
 public struct Concatenate7_TTTVVTV<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
->: RegexProtocol where T0.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol {
-  public typealias Capture = (T1.Capture, T4.Capture, T5.Capture, T6.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T0.Match.Capture: EmptyCaptureProtocol, T2.Match.Capture: EmptyCaptureProtocol, T3.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple5<Substring, T1.Match.Capture, T4.Match.Capture, T5.Match.Capture, T6.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
-      x5.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
+      x5.regex.ast, 
       x6.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5, T6>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6
   ) -> Concatenate7_TTTVVTV<T0, T1, T2, T3, T4, T5, T6> {
     Concatenate7_TTTVVTV(x0, x1, x2, x3, x4, x5, x6)
@@ -3373,24 +3528,24 @@ extension RegexBuilder {
 
 public struct Concatenate7_TTTVVVT<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
->: RegexProtocol where T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol {
-  public typealias Capture = (T0.Capture, T4.Capture, T5.Capture, T6.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T1.Match.Capture: EmptyCaptureProtocol, T2.Match.Capture: EmptyCaptureProtocol, T3.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple5<Substring, T0.Match.Capture, T4.Match.Capture, T5.Match.Capture, T6.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
-      x5.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
+      x5.regex.ast, 
       x6.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5, T6>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6
   ) -> Concatenate7_TTTVVVT<T0, T1, T2, T3, T4, T5, T6> {
     Concatenate7_TTTVVVT(x0, x1, x2, x3, x4, x5, x6)
@@ -3399,24 +3554,24 @@ extension RegexBuilder {
 
 public struct Concatenate7_TTTVVVV<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
->: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol {
-  public typealias Capture = (T4.Capture, T5.Capture, T6.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T0.Match.Capture: EmptyCaptureProtocol, T1.Match.Capture: EmptyCaptureProtocol, T2.Match.Capture: EmptyCaptureProtocol, T3.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple4<Substring, T4.Match.Capture, T5.Match.Capture, T6.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
-      x5.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
+      x5.regex.ast, 
       x6.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5, T6>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6
   ) -> Concatenate7_TTTVVVV<T0, T1, T2, T3, T4, T5, T6> {
     Concatenate7_TTTVVVV(x0, x1, x2, x3, x4, x5, x6)
@@ -3425,24 +3580,24 @@ extension RegexBuilder {
 
 public struct Concatenate7_TTVTTTT<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
->: RegexProtocol where T4.Capture: EmptyProtocol {
-  public typealias Capture = (T0.Capture, T1.Capture, T2.Capture, T3.Capture, T5.Capture, T6.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T4.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple7<Substring, T0.Match.Capture, T1.Match.Capture, T2.Match.Capture, T3.Match.Capture, T5.Match.Capture, T6.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
-      x5.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
+      x5.regex.ast, 
       x6.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5, T6>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6
   ) -> Concatenate7_TTVTTTT<T0, T1, T2, T3, T4, T5, T6> {
     Concatenate7_TTVTTTT(x0, x1, x2, x3, x4, x5, x6)
@@ -3451,24 +3606,24 @@ extension RegexBuilder {
 
 public struct Concatenate7_TTVTTTV<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
->: RegexProtocol where T0.Capture: EmptyProtocol, T4.Capture: EmptyProtocol {
-  public typealias Capture = (T1.Capture, T2.Capture, T3.Capture, T5.Capture, T6.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T0.Match.Capture: EmptyCaptureProtocol, T4.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple6<Substring, T1.Match.Capture, T2.Match.Capture, T3.Match.Capture, T5.Match.Capture, T6.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
-      x5.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
+      x5.regex.ast, 
       x6.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5, T6>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6
   ) -> Concatenate7_TTVTTTV<T0, T1, T2, T3, T4, T5, T6> {
     Concatenate7_TTVTTTV(x0, x1, x2, x3, x4, x5, x6)
@@ -3477,24 +3632,24 @@ extension RegexBuilder {
 
 public struct Concatenate7_TTVTTVT<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
->: RegexProtocol where T1.Capture: EmptyProtocol, T4.Capture: EmptyProtocol {
-  public typealias Capture = (T0.Capture, T2.Capture, T3.Capture, T5.Capture, T6.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T1.Match.Capture: EmptyCaptureProtocol, T4.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple6<Substring, T0.Match.Capture, T2.Match.Capture, T3.Match.Capture, T5.Match.Capture, T6.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
-      x5.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
+      x5.regex.ast, 
       x6.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5, T6>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6
   ) -> Concatenate7_TTVTTVT<T0, T1, T2, T3, T4, T5, T6> {
     Concatenate7_TTVTTVT(x0, x1, x2, x3, x4, x5, x6)
@@ -3503,24 +3658,24 @@ extension RegexBuilder {
 
 public struct Concatenate7_TTVTTVV<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
->: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T4.Capture: EmptyProtocol {
-  public typealias Capture = (T2.Capture, T3.Capture, T5.Capture, T6.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T0.Match.Capture: EmptyCaptureProtocol, T1.Match.Capture: EmptyCaptureProtocol, T4.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple5<Substring, T2.Match.Capture, T3.Match.Capture, T5.Match.Capture, T6.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
-      x5.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
+      x5.regex.ast, 
       x6.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5, T6>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6
   ) -> Concatenate7_TTVTTVV<T0, T1, T2, T3, T4, T5, T6> {
     Concatenate7_TTVTTVV(x0, x1, x2, x3, x4, x5, x6)
@@ -3529,24 +3684,24 @@ extension RegexBuilder {
 
 public struct Concatenate7_TTVTVTT<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
->: RegexProtocol where T2.Capture: EmptyProtocol, T4.Capture: EmptyProtocol {
-  public typealias Capture = (T0.Capture, T1.Capture, T3.Capture, T5.Capture, T6.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T2.Match.Capture: EmptyCaptureProtocol, T4.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple6<Substring, T0.Match.Capture, T1.Match.Capture, T3.Match.Capture, T5.Match.Capture, T6.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
-      x5.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
+      x5.regex.ast, 
       x6.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5, T6>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6
   ) -> Concatenate7_TTVTVTT<T0, T1, T2, T3, T4, T5, T6> {
     Concatenate7_TTVTVTT(x0, x1, x2, x3, x4, x5, x6)
@@ -3555,24 +3710,24 @@ extension RegexBuilder {
 
 public struct Concatenate7_TTVTVTV<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
->: RegexProtocol where T0.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T4.Capture: EmptyProtocol {
-  public typealias Capture = (T1.Capture, T3.Capture, T5.Capture, T6.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T0.Match.Capture: EmptyCaptureProtocol, T2.Match.Capture: EmptyCaptureProtocol, T4.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple5<Substring, T1.Match.Capture, T3.Match.Capture, T5.Match.Capture, T6.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
-      x5.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
+      x5.regex.ast, 
       x6.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5, T6>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6
   ) -> Concatenate7_TTVTVTV<T0, T1, T2, T3, T4, T5, T6> {
     Concatenate7_TTVTVTV(x0, x1, x2, x3, x4, x5, x6)
@@ -3581,24 +3736,24 @@ extension RegexBuilder {
 
 public struct Concatenate7_TTVTVVT<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
->: RegexProtocol where T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T4.Capture: EmptyProtocol {
-  public typealias Capture = (T0.Capture, T3.Capture, T5.Capture, T6.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T1.Match.Capture: EmptyCaptureProtocol, T2.Match.Capture: EmptyCaptureProtocol, T4.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple5<Substring, T0.Match.Capture, T3.Match.Capture, T5.Match.Capture, T6.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
-      x5.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
+      x5.regex.ast, 
       x6.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5, T6>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6
   ) -> Concatenate7_TTVTVVT<T0, T1, T2, T3, T4, T5, T6> {
     Concatenate7_TTVTVVT(x0, x1, x2, x3, x4, x5, x6)
@@ -3607,24 +3762,24 @@ extension RegexBuilder {
 
 public struct Concatenate7_TTVTVVV<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
->: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T4.Capture: EmptyProtocol {
-  public typealias Capture = (T3.Capture, T5.Capture, T6.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T0.Match.Capture: EmptyCaptureProtocol, T1.Match.Capture: EmptyCaptureProtocol, T2.Match.Capture: EmptyCaptureProtocol, T4.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple4<Substring, T3.Match.Capture, T5.Match.Capture, T6.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
-      x5.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
+      x5.regex.ast, 
       x6.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5, T6>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6
   ) -> Concatenate7_TTVTVVV<T0, T1, T2, T3, T4, T5, T6> {
     Concatenate7_TTVTVVV(x0, x1, x2, x3, x4, x5, x6)
@@ -3633,24 +3788,24 @@ extension RegexBuilder {
 
 public struct Concatenate7_TTVVTTT<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
->: RegexProtocol where T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol {
-  public typealias Capture = (T0.Capture, T1.Capture, T2.Capture, T5.Capture, T6.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T3.Match.Capture: EmptyCaptureProtocol, T4.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple6<Substring, T0.Match.Capture, T1.Match.Capture, T2.Match.Capture, T5.Match.Capture, T6.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
-      x5.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
+      x5.regex.ast, 
       x6.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5, T6>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6
   ) -> Concatenate7_TTVVTTT<T0, T1, T2, T3, T4, T5, T6> {
     Concatenate7_TTVVTTT(x0, x1, x2, x3, x4, x5, x6)
@@ -3659,24 +3814,24 @@ extension RegexBuilder {
 
 public struct Concatenate7_TTVVTTV<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
->: RegexProtocol where T0.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol {
-  public typealias Capture = (T1.Capture, T2.Capture, T5.Capture, T6.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T0.Match.Capture: EmptyCaptureProtocol, T3.Match.Capture: EmptyCaptureProtocol, T4.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple5<Substring, T1.Match.Capture, T2.Match.Capture, T5.Match.Capture, T6.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
-      x5.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
+      x5.regex.ast, 
       x6.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5, T6>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6
   ) -> Concatenate7_TTVVTTV<T0, T1, T2, T3, T4, T5, T6> {
     Concatenate7_TTVVTTV(x0, x1, x2, x3, x4, x5, x6)
@@ -3685,24 +3840,24 @@ extension RegexBuilder {
 
 public struct Concatenate7_TTVVTVT<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
->: RegexProtocol where T1.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol {
-  public typealias Capture = (T0.Capture, T2.Capture, T5.Capture, T6.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T1.Match.Capture: EmptyCaptureProtocol, T3.Match.Capture: EmptyCaptureProtocol, T4.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple5<Substring, T0.Match.Capture, T2.Match.Capture, T5.Match.Capture, T6.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
-      x5.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
+      x5.regex.ast, 
       x6.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5, T6>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6
   ) -> Concatenate7_TTVVTVT<T0, T1, T2, T3, T4, T5, T6> {
     Concatenate7_TTVVTVT(x0, x1, x2, x3, x4, x5, x6)
@@ -3711,24 +3866,24 @@ extension RegexBuilder {
 
 public struct Concatenate7_TTVVTVV<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
->: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol {
-  public typealias Capture = (T2.Capture, T5.Capture, T6.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T0.Match.Capture: EmptyCaptureProtocol, T1.Match.Capture: EmptyCaptureProtocol, T3.Match.Capture: EmptyCaptureProtocol, T4.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple4<Substring, T2.Match.Capture, T5.Match.Capture, T6.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
-      x5.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
+      x5.regex.ast, 
       x6.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5, T6>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6
   ) -> Concatenate7_TTVVTVV<T0, T1, T2, T3, T4, T5, T6> {
     Concatenate7_TTVVTVV(x0, x1, x2, x3, x4, x5, x6)
@@ -3737,24 +3892,24 @@ extension RegexBuilder {
 
 public struct Concatenate7_TTVVVTT<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
->: RegexProtocol where T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol {
-  public typealias Capture = (T0.Capture, T1.Capture, T5.Capture, T6.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T2.Match.Capture: EmptyCaptureProtocol, T3.Match.Capture: EmptyCaptureProtocol, T4.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple5<Substring, T0.Match.Capture, T1.Match.Capture, T5.Match.Capture, T6.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
-      x5.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
+      x5.regex.ast, 
       x6.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5, T6>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6
   ) -> Concatenate7_TTVVVTT<T0, T1, T2, T3, T4, T5, T6> {
     Concatenate7_TTVVVTT(x0, x1, x2, x3, x4, x5, x6)
@@ -3763,24 +3918,24 @@ extension RegexBuilder {
 
 public struct Concatenate7_TTVVVTV<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
->: RegexProtocol where T0.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol {
-  public typealias Capture = (T1.Capture, T5.Capture, T6.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T0.Match.Capture: EmptyCaptureProtocol, T2.Match.Capture: EmptyCaptureProtocol, T3.Match.Capture: EmptyCaptureProtocol, T4.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple4<Substring, T1.Match.Capture, T5.Match.Capture, T6.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
-      x5.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
+      x5.regex.ast, 
       x6.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5, T6>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6
   ) -> Concatenate7_TTVVVTV<T0, T1, T2, T3, T4, T5, T6> {
     Concatenate7_TTVVVTV(x0, x1, x2, x3, x4, x5, x6)
@@ -3789,24 +3944,24 @@ extension RegexBuilder {
 
 public struct Concatenate7_TTVVVVT<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
->: RegexProtocol where T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol {
-  public typealias Capture = (T0.Capture, T5.Capture, T6.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T1.Match.Capture: EmptyCaptureProtocol, T2.Match.Capture: EmptyCaptureProtocol, T3.Match.Capture: EmptyCaptureProtocol, T4.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple4<Substring, T0.Match.Capture, T5.Match.Capture, T6.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
-      x5.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
+      x5.regex.ast, 
       x6.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5, T6>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6
   ) -> Concatenate7_TTVVVVT<T0, T1, T2, T3, T4, T5, T6> {
     Concatenate7_TTVVVVT(x0, x1, x2, x3, x4, x5, x6)
@@ -3815,24 +3970,24 @@ extension RegexBuilder {
 
 public struct Concatenate7_TTVVVVV<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
->: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol {
-  public typealias Capture = (T5.Capture, T6.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T0.Match.Capture: EmptyCaptureProtocol, T1.Match.Capture: EmptyCaptureProtocol, T2.Match.Capture: EmptyCaptureProtocol, T3.Match.Capture: EmptyCaptureProtocol, T4.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple3<Substring, T5.Match.Capture, T6.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
-      x5.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
+      x5.regex.ast, 
       x6.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5, T6>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6
   ) -> Concatenate7_TTVVVVV<T0, T1, T2, T3, T4, T5, T6> {
     Concatenate7_TTVVVVV(x0, x1, x2, x3, x4, x5, x6)
@@ -3841,24 +3996,24 @@ extension RegexBuilder {
 
 public struct Concatenate7_TVTTTTT<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
->: RegexProtocol where T5.Capture: EmptyProtocol {
-  public typealias Capture = (T0.Capture, T1.Capture, T2.Capture, T3.Capture, T4.Capture, T6.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T5.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple7<Substring, T0.Match.Capture, T1.Match.Capture, T2.Match.Capture, T3.Match.Capture, T4.Match.Capture, T6.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
-      x5.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
+      x5.regex.ast, 
       x6.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5, T6>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6
   ) -> Concatenate7_TVTTTTT<T0, T1, T2, T3, T4, T5, T6> {
     Concatenate7_TVTTTTT(x0, x1, x2, x3, x4, x5, x6)
@@ -3867,24 +4022,24 @@ extension RegexBuilder {
 
 public struct Concatenate7_TVTTTTV<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
->: RegexProtocol where T0.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
-  public typealias Capture = (T1.Capture, T2.Capture, T3.Capture, T4.Capture, T6.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T0.Match.Capture: EmptyCaptureProtocol, T5.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple6<Substring, T1.Match.Capture, T2.Match.Capture, T3.Match.Capture, T4.Match.Capture, T6.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
-      x5.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
+      x5.regex.ast, 
       x6.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5, T6>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6
   ) -> Concatenate7_TVTTTTV<T0, T1, T2, T3, T4, T5, T6> {
     Concatenate7_TVTTTTV(x0, x1, x2, x3, x4, x5, x6)
@@ -3893,24 +4048,24 @@ extension RegexBuilder {
 
 public struct Concatenate7_TVTTTVT<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
->: RegexProtocol where T1.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
-  public typealias Capture = (T0.Capture, T2.Capture, T3.Capture, T4.Capture, T6.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T1.Match.Capture: EmptyCaptureProtocol, T5.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple6<Substring, T0.Match.Capture, T2.Match.Capture, T3.Match.Capture, T4.Match.Capture, T6.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
-      x5.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
+      x5.regex.ast, 
       x6.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5, T6>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6
   ) -> Concatenate7_TVTTTVT<T0, T1, T2, T3, T4, T5, T6> {
     Concatenate7_TVTTTVT(x0, x1, x2, x3, x4, x5, x6)
@@ -3919,24 +4074,24 @@ extension RegexBuilder {
 
 public struct Concatenate7_TVTTTVV<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
->: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
-  public typealias Capture = (T2.Capture, T3.Capture, T4.Capture, T6.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T0.Match.Capture: EmptyCaptureProtocol, T1.Match.Capture: EmptyCaptureProtocol, T5.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple5<Substring, T2.Match.Capture, T3.Match.Capture, T4.Match.Capture, T6.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
-      x5.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
+      x5.regex.ast, 
       x6.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5, T6>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6
   ) -> Concatenate7_TVTTTVV<T0, T1, T2, T3, T4, T5, T6> {
     Concatenate7_TVTTTVV(x0, x1, x2, x3, x4, x5, x6)
@@ -3945,24 +4100,24 @@ extension RegexBuilder {
 
 public struct Concatenate7_TVTTVTT<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
->: RegexProtocol where T2.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
-  public typealias Capture = (T0.Capture, T1.Capture, T3.Capture, T4.Capture, T6.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T2.Match.Capture: EmptyCaptureProtocol, T5.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple6<Substring, T0.Match.Capture, T1.Match.Capture, T3.Match.Capture, T4.Match.Capture, T6.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
-      x5.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
+      x5.regex.ast, 
       x6.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5, T6>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6
   ) -> Concatenate7_TVTTVTT<T0, T1, T2, T3, T4, T5, T6> {
     Concatenate7_TVTTVTT(x0, x1, x2, x3, x4, x5, x6)
@@ -3971,24 +4126,24 @@ extension RegexBuilder {
 
 public struct Concatenate7_TVTTVTV<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
->: RegexProtocol where T0.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
-  public typealias Capture = (T1.Capture, T3.Capture, T4.Capture, T6.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T0.Match.Capture: EmptyCaptureProtocol, T2.Match.Capture: EmptyCaptureProtocol, T5.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple5<Substring, T1.Match.Capture, T3.Match.Capture, T4.Match.Capture, T6.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
-      x5.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
+      x5.regex.ast, 
       x6.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5, T6>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6
   ) -> Concatenate7_TVTTVTV<T0, T1, T2, T3, T4, T5, T6> {
     Concatenate7_TVTTVTV(x0, x1, x2, x3, x4, x5, x6)
@@ -3997,24 +4152,24 @@ extension RegexBuilder {
 
 public struct Concatenate7_TVTTVVT<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
->: RegexProtocol where T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
-  public typealias Capture = (T0.Capture, T3.Capture, T4.Capture, T6.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T1.Match.Capture: EmptyCaptureProtocol, T2.Match.Capture: EmptyCaptureProtocol, T5.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple5<Substring, T0.Match.Capture, T3.Match.Capture, T4.Match.Capture, T6.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
-      x5.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
+      x5.regex.ast, 
       x6.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5, T6>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6
   ) -> Concatenate7_TVTTVVT<T0, T1, T2, T3, T4, T5, T6> {
     Concatenate7_TVTTVVT(x0, x1, x2, x3, x4, x5, x6)
@@ -4023,24 +4178,24 @@ extension RegexBuilder {
 
 public struct Concatenate7_TVTTVVV<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
->: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
-  public typealias Capture = (T3.Capture, T4.Capture, T6.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T0.Match.Capture: EmptyCaptureProtocol, T1.Match.Capture: EmptyCaptureProtocol, T2.Match.Capture: EmptyCaptureProtocol, T5.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple4<Substring, T3.Match.Capture, T4.Match.Capture, T6.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
-      x5.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
+      x5.regex.ast, 
       x6.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5, T6>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6
   ) -> Concatenate7_TVTTVVV<T0, T1, T2, T3, T4, T5, T6> {
     Concatenate7_TVTTVVV(x0, x1, x2, x3, x4, x5, x6)
@@ -4049,24 +4204,24 @@ extension RegexBuilder {
 
 public struct Concatenate7_TVTVTTT<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
->: RegexProtocol where T3.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
-  public typealias Capture = (T0.Capture, T1.Capture, T2.Capture, T4.Capture, T6.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T3.Match.Capture: EmptyCaptureProtocol, T5.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple6<Substring, T0.Match.Capture, T1.Match.Capture, T2.Match.Capture, T4.Match.Capture, T6.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
-      x5.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
+      x5.regex.ast, 
       x6.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5, T6>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6
   ) -> Concatenate7_TVTVTTT<T0, T1, T2, T3, T4, T5, T6> {
     Concatenate7_TVTVTTT(x0, x1, x2, x3, x4, x5, x6)
@@ -4075,24 +4230,24 @@ extension RegexBuilder {
 
 public struct Concatenate7_TVTVTTV<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
->: RegexProtocol where T0.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
-  public typealias Capture = (T1.Capture, T2.Capture, T4.Capture, T6.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T0.Match.Capture: EmptyCaptureProtocol, T3.Match.Capture: EmptyCaptureProtocol, T5.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple5<Substring, T1.Match.Capture, T2.Match.Capture, T4.Match.Capture, T6.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
-      x5.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
+      x5.regex.ast, 
       x6.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5, T6>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6
   ) -> Concatenate7_TVTVTTV<T0, T1, T2, T3, T4, T5, T6> {
     Concatenate7_TVTVTTV(x0, x1, x2, x3, x4, x5, x6)
@@ -4101,24 +4256,24 @@ extension RegexBuilder {
 
 public struct Concatenate7_TVTVTVT<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
->: RegexProtocol where T1.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
-  public typealias Capture = (T0.Capture, T2.Capture, T4.Capture, T6.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T1.Match.Capture: EmptyCaptureProtocol, T3.Match.Capture: EmptyCaptureProtocol, T5.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple5<Substring, T0.Match.Capture, T2.Match.Capture, T4.Match.Capture, T6.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
-      x5.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
+      x5.regex.ast, 
       x6.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5, T6>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6
   ) -> Concatenate7_TVTVTVT<T0, T1, T2, T3, T4, T5, T6> {
     Concatenate7_TVTVTVT(x0, x1, x2, x3, x4, x5, x6)
@@ -4127,24 +4282,24 @@ extension RegexBuilder {
 
 public struct Concatenate7_TVTVTVV<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
->: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
-  public typealias Capture = (T2.Capture, T4.Capture, T6.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T0.Match.Capture: EmptyCaptureProtocol, T1.Match.Capture: EmptyCaptureProtocol, T3.Match.Capture: EmptyCaptureProtocol, T5.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple4<Substring, T2.Match.Capture, T4.Match.Capture, T6.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
-      x5.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
+      x5.regex.ast, 
       x6.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5, T6>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6
   ) -> Concatenate7_TVTVTVV<T0, T1, T2, T3, T4, T5, T6> {
     Concatenate7_TVTVTVV(x0, x1, x2, x3, x4, x5, x6)
@@ -4153,24 +4308,24 @@ extension RegexBuilder {
 
 public struct Concatenate7_TVTVVTT<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
->: RegexProtocol where T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
-  public typealias Capture = (T0.Capture, T1.Capture, T4.Capture, T6.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T2.Match.Capture: EmptyCaptureProtocol, T3.Match.Capture: EmptyCaptureProtocol, T5.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple5<Substring, T0.Match.Capture, T1.Match.Capture, T4.Match.Capture, T6.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
-      x5.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
+      x5.regex.ast, 
       x6.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5, T6>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6
   ) -> Concatenate7_TVTVVTT<T0, T1, T2, T3, T4, T5, T6> {
     Concatenate7_TVTVVTT(x0, x1, x2, x3, x4, x5, x6)
@@ -4179,24 +4334,24 @@ extension RegexBuilder {
 
 public struct Concatenate7_TVTVVTV<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
->: RegexProtocol where T0.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
-  public typealias Capture = (T1.Capture, T4.Capture, T6.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T0.Match.Capture: EmptyCaptureProtocol, T2.Match.Capture: EmptyCaptureProtocol, T3.Match.Capture: EmptyCaptureProtocol, T5.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple4<Substring, T1.Match.Capture, T4.Match.Capture, T6.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
-      x5.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
+      x5.regex.ast, 
       x6.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5, T6>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6
   ) -> Concatenate7_TVTVVTV<T0, T1, T2, T3, T4, T5, T6> {
     Concatenate7_TVTVVTV(x0, x1, x2, x3, x4, x5, x6)
@@ -4205,24 +4360,24 @@ extension RegexBuilder {
 
 public struct Concatenate7_TVTVVVT<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
->: RegexProtocol where T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
-  public typealias Capture = (T0.Capture, T4.Capture, T6.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T1.Match.Capture: EmptyCaptureProtocol, T2.Match.Capture: EmptyCaptureProtocol, T3.Match.Capture: EmptyCaptureProtocol, T5.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple4<Substring, T0.Match.Capture, T4.Match.Capture, T6.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
-      x5.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
+      x5.regex.ast, 
       x6.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5, T6>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6
   ) -> Concatenate7_TVTVVVT<T0, T1, T2, T3, T4, T5, T6> {
     Concatenate7_TVTVVVT(x0, x1, x2, x3, x4, x5, x6)
@@ -4231,24 +4386,24 @@ extension RegexBuilder {
 
 public struct Concatenate7_TVTVVVV<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
->: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
-  public typealias Capture = (T4.Capture, T6.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T0.Match.Capture: EmptyCaptureProtocol, T1.Match.Capture: EmptyCaptureProtocol, T2.Match.Capture: EmptyCaptureProtocol, T3.Match.Capture: EmptyCaptureProtocol, T5.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple3<Substring, T4.Match.Capture, T6.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
-      x5.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
+      x5.regex.ast, 
       x6.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5, T6>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6
   ) -> Concatenate7_TVTVVVV<T0, T1, T2, T3, T4, T5, T6> {
     Concatenate7_TVTVVVV(x0, x1, x2, x3, x4, x5, x6)
@@ -4257,24 +4412,24 @@ extension RegexBuilder {
 
 public struct Concatenate7_TVVTTTT<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
->: RegexProtocol where T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
-  public typealias Capture = (T0.Capture, T1.Capture, T2.Capture, T3.Capture, T6.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T4.Match.Capture: EmptyCaptureProtocol, T5.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple6<Substring, T0.Match.Capture, T1.Match.Capture, T2.Match.Capture, T3.Match.Capture, T6.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
-      x5.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
+      x5.regex.ast, 
       x6.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5, T6>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6
   ) -> Concatenate7_TVVTTTT<T0, T1, T2, T3, T4, T5, T6> {
     Concatenate7_TVVTTTT(x0, x1, x2, x3, x4, x5, x6)
@@ -4283,24 +4438,24 @@ extension RegexBuilder {
 
 public struct Concatenate7_TVVTTTV<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
->: RegexProtocol where T0.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
-  public typealias Capture = (T1.Capture, T2.Capture, T3.Capture, T6.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T0.Match.Capture: EmptyCaptureProtocol, T4.Match.Capture: EmptyCaptureProtocol, T5.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple5<Substring, T1.Match.Capture, T2.Match.Capture, T3.Match.Capture, T6.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
-      x5.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
+      x5.regex.ast, 
       x6.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5, T6>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6
   ) -> Concatenate7_TVVTTTV<T0, T1, T2, T3, T4, T5, T6> {
     Concatenate7_TVVTTTV(x0, x1, x2, x3, x4, x5, x6)
@@ -4309,24 +4464,24 @@ extension RegexBuilder {
 
 public struct Concatenate7_TVVTTVT<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
->: RegexProtocol where T1.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
-  public typealias Capture = (T0.Capture, T2.Capture, T3.Capture, T6.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T1.Match.Capture: EmptyCaptureProtocol, T4.Match.Capture: EmptyCaptureProtocol, T5.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple5<Substring, T0.Match.Capture, T2.Match.Capture, T3.Match.Capture, T6.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
-      x5.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
+      x5.regex.ast, 
       x6.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5, T6>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6
   ) -> Concatenate7_TVVTTVT<T0, T1, T2, T3, T4, T5, T6> {
     Concatenate7_TVVTTVT(x0, x1, x2, x3, x4, x5, x6)
@@ -4335,24 +4490,24 @@ extension RegexBuilder {
 
 public struct Concatenate7_TVVTTVV<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
->: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
-  public typealias Capture = (T2.Capture, T3.Capture, T6.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T0.Match.Capture: EmptyCaptureProtocol, T1.Match.Capture: EmptyCaptureProtocol, T4.Match.Capture: EmptyCaptureProtocol, T5.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple4<Substring, T2.Match.Capture, T3.Match.Capture, T6.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
-      x5.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
+      x5.regex.ast, 
       x6.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5, T6>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6
   ) -> Concatenate7_TVVTTVV<T0, T1, T2, T3, T4, T5, T6> {
     Concatenate7_TVVTTVV(x0, x1, x2, x3, x4, x5, x6)
@@ -4361,24 +4516,24 @@ extension RegexBuilder {
 
 public struct Concatenate7_TVVTVTT<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
->: RegexProtocol where T2.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
-  public typealias Capture = (T0.Capture, T1.Capture, T3.Capture, T6.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T2.Match.Capture: EmptyCaptureProtocol, T4.Match.Capture: EmptyCaptureProtocol, T5.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple5<Substring, T0.Match.Capture, T1.Match.Capture, T3.Match.Capture, T6.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
-      x5.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
+      x5.regex.ast, 
       x6.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5, T6>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6
   ) -> Concatenate7_TVVTVTT<T0, T1, T2, T3, T4, T5, T6> {
     Concatenate7_TVVTVTT(x0, x1, x2, x3, x4, x5, x6)
@@ -4387,24 +4542,24 @@ extension RegexBuilder {
 
 public struct Concatenate7_TVVTVTV<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
->: RegexProtocol where T0.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
-  public typealias Capture = (T1.Capture, T3.Capture, T6.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T0.Match.Capture: EmptyCaptureProtocol, T2.Match.Capture: EmptyCaptureProtocol, T4.Match.Capture: EmptyCaptureProtocol, T5.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple4<Substring, T1.Match.Capture, T3.Match.Capture, T6.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
-      x5.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
+      x5.regex.ast, 
       x6.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5, T6>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6
   ) -> Concatenate7_TVVTVTV<T0, T1, T2, T3, T4, T5, T6> {
     Concatenate7_TVVTVTV(x0, x1, x2, x3, x4, x5, x6)
@@ -4413,24 +4568,24 @@ extension RegexBuilder {
 
 public struct Concatenate7_TVVTVVT<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
->: RegexProtocol where T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
-  public typealias Capture = (T0.Capture, T3.Capture, T6.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T1.Match.Capture: EmptyCaptureProtocol, T2.Match.Capture: EmptyCaptureProtocol, T4.Match.Capture: EmptyCaptureProtocol, T5.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple4<Substring, T0.Match.Capture, T3.Match.Capture, T6.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
-      x5.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
+      x5.regex.ast, 
       x6.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5, T6>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6
   ) -> Concatenate7_TVVTVVT<T0, T1, T2, T3, T4, T5, T6> {
     Concatenate7_TVVTVVT(x0, x1, x2, x3, x4, x5, x6)
@@ -4439,24 +4594,24 @@ extension RegexBuilder {
 
 public struct Concatenate7_TVVTVVV<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
->: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
-  public typealias Capture = (T3.Capture, T6.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T0.Match.Capture: EmptyCaptureProtocol, T1.Match.Capture: EmptyCaptureProtocol, T2.Match.Capture: EmptyCaptureProtocol, T4.Match.Capture: EmptyCaptureProtocol, T5.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple3<Substring, T3.Match.Capture, T6.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
-      x5.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
+      x5.regex.ast, 
       x6.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5, T6>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6
   ) -> Concatenate7_TVVTVVV<T0, T1, T2, T3, T4, T5, T6> {
     Concatenate7_TVVTVVV(x0, x1, x2, x3, x4, x5, x6)
@@ -4465,24 +4620,24 @@ extension RegexBuilder {
 
 public struct Concatenate7_TVVVTTT<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
->: RegexProtocol where T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
-  public typealias Capture = (T0.Capture, T1.Capture, T2.Capture, T6.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T3.Match.Capture: EmptyCaptureProtocol, T4.Match.Capture: EmptyCaptureProtocol, T5.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple5<Substring, T0.Match.Capture, T1.Match.Capture, T2.Match.Capture, T6.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
-      x5.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
+      x5.regex.ast, 
       x6.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5, T6>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6
   ) -> Concatenate7_TVVVTTT<T0, T1, T2, T3, T4, T5, T6> {
     Concatenate7_TVVVTTT(x0, x1, x2, x3, x4, x5, x6)
@@ -4491,24 +4646,24 @@ extension RegexBuilder {
 
 public struct Concatenate7_TVVVTTV<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
->: RegexProtocol where T0.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
-  public typealias Capture = (T1.Capture, T2.Capture, T6.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T0.Match.Capture: EmptyCaptureProtocol, T3.Match.Capture: EmptyCaptureProtocol, T4.Match.Capture: EmptyCaptureProtocol, T5.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple4<Substring, T1.Match.Capture, T2.Match.Capture, T6.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
-      x5.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
+      x5.regex.ast, 
       x6.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5, T6>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6
   ) -> Concatenate7_TVVVTTV<T0, T1, T2, T3, T4, T5, T6> {
     Concatenate7_TVVVTTV(x0, x1, x2, x3, x4, x5, x6)
@@ -4517,24 +4672,24 @@ extension RegexBuilder {
 
 public struct Concatenate7_TVVVTVT<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
->: RegexProtocol where T1.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
-  public typealias Capture = (T0.Capture, T2.Capture, T6.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T1.Match.Capture: EmptyCaptureProtocol, T3.Match.Capture: EmptyCaptureProtocol, T4.Match.Capture: EmptyCaptureProtocol, T5.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple4<Substring, T0.Match.Capture, T2.Match.Capture, T6.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
-      x5.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
+      x5.regex.ast, 
       x6.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5, T6>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6
   ) -> Concatenate7_TVVVTVT<T0, T1, T2, T3, T4, T5, T6> {
     Concatenate7_TVVVTVT(x0, x1, x2, x3, x4, x5, x6)
@@ -4543,24 +4698,24 @@ extension RegexBuilder {
 
 public struct Concatenate7_TVVVTVV<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
->: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
-  public typealias Capture = (T2.Capture, T6.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T0.Match.Capture: EmptyCaptureProtocol, T1.Match.Capture: EmptyCaptureProtocol, T3.Match.Capture: EmptyCaptureProtocol, T4.Match.Capture: EmptyCaptureProtocol, T5.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple3<Substring, T2.Match.Capture, T6.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
-      x5.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
+      x5.regex.ast, 
       x6.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5, T6>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6
   ) -> Concatenate7_TVVVTVV<T0, T1, T2, T3, T4, T5, T6> {
     Concatenate7_TVVVTVV(x0, x1, x2, x3, x4, x5, x6)
@@ -4569,24 +4724,24 @@ extension RegexBuilder {
 
 public struct Concatenate7_TVVVVTT<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
->: RegexProtocol where T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
-  public typealias Capture = (T0.Capture, T1.Capture, T6.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T2.Match.Capture: EmptyCaptureProtocol, T3.Match.Capture: EmptyCaptureProtocol, T4.Match.Capture: EmptyCaptureProtocol, T5.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple4<Substring, T0.Match.Capture, T1.Match.Capture, T6.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
-      x5.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
+      x5.regex.ast, 
       x6.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5, T6>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6
   ) -> Concatenate7_TVVVVTT<T0, T1, T2, T3, T4, T5, T6> {
     Concatenate7_TVVVVTT(x0, x1, x2, x3, x4, x5, x6)
@@ -4595,24 +4750,24 @@ extension RegexBuilder {
 
 public struct Concatenate7_TVVVVTV<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
->: RegexProtocol where T0.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
-  public typealias Capture = (T1.Capture, T6.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T0.Match.Capture: EmptyCaptureProtocol, T2.Match.Capture: EmptyCaptureProtocol, T3.Match.Capture: EmptyCaptureProtocol, T4.Match.Capture: EmptyCaptureProtocol, T5.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple3<Substring, T1.Match.Capture, T6.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
-      x5.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
+      x5.regex.ast, 
       x6.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5, T6>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6
   ) -> Concatenate7_TVVVVTV<T0, T1, T2, T3, T4, T5, T6> {
     Concatenate7_TVVVVTV(x0, x1, x2, x3, x4, x5, x6)
@@ -4621,24 +4776,24 @@ extension RegexBuilder {
 
 public struct Concatenate7_TVVVVVT<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
->: RegexProtocol where T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
-  public typealias Capture = (T0.Capture, T6.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T1.Match.Capture: EmptyCaptureProtocol, T2.Match.Capture: EmptyCaptureProtocol, T3.Match.Capture: EmptyCaptureProtocol, T4.Match.Capture: EmptyCaptureProtocol, T5.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple3<Substring, T0.Match.Capture, T6.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
-      x5.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
+      x5.regex.ast, 
       x6.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5, T6>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6
   ) -> Concatenate7_TVVVVVT<T0, T1, T2, T3, T4, T5, T6> {
     Concatenate7_TVVVVVT(x0, x1, x2, x3, x4, x5, x6)
@@ -4647,24 +4802,24 @@ extension RegexBuilder {
 
 public struct Concatenate7_TVVVVVV<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
->: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol {
-  public typealias Capture = (T6.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T0.Match.Capture: EmptyCaptureProtocol, T1.Match.Capture: EmptyCaptureProtocol, T2.Match.Capture: EmptyCaptureProtocol, T3.Match.Capture: EmptyCaptureProtocol, T4.Match.Capture: EmptyCaptureProtocol, T5.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple2<Substring, T6.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
-      x5.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
+      x5.regex.ast, 
       x6.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5, T6>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6
   ) -> Concatenate7_TVVVVVV<T0, T1, T2, T3, T4, T5, T6> {
     Concatenate7_TVVVVVV(x0, x1, x2, x3, x4, x5, x6)
@@ -4673,24 +4828,24 @@ extension RegexBuilder {
 
 public struct Concatenate7_VTTTTTT<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
->: RegexProtocol where T6.Capture: EmptyProtocol {
-  public typealias Capture = (T0.Capture, T1.Capture, T2.Capture, T3.Capture, T4.Capture, T5.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T6.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple7<Substring, T0.Match.Capture, T1.Match.Capture, T2.Match.Capture, T3.Match.Capture, T4.Match.Capture, T5.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
-      x5.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
+      x5.regex.ast, 
       x6.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5, T6>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6
   ) -> Concatenate7_VTTTTTT<T0, T1, T2, T3, T4, T5, T6> {
     Concatenate7_VTTTTTT(x0, x1, x2, x3, x4, x5, x6)
@@ -4699,24 +4854,24 @@ extension RegexBuilder {
 
 public struct Concatenate7_VTTTTTV<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
->: RegexProtocol where T0.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
-  public typealias Capture = (T1.Capture, T2.Capture, T3.Capture, T4.Capture, T5.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T0.Match.Capture: EmptyCaptureProtocol, T6.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple6<Substring, T1.Match.Capture, T2.Match.Capture, T3.Match.Capture, T4.Match.Capture, T5.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
-      x5.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
+      x5.regex.ast, 
       x6.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5, T6>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6
   ) -> Concatenate7_VTTTTTV<T0, T1, T2, T3, T4, T5, T6> {
     Concatenate7_VTTTTTV(x0, x1, x2, x3, x4, x5, x6)
@@ -4725,24 +4880,24 @@ extension RegexBuilder {
 
 public struct Concatenate7_VTTTTVT<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
->: RegexProtocol where T1.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
-  public typealias Capture = (T0.Capture, T2.Capture, T3.Capture, T4.Capture, T5.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T1.Match.Capture: EmptyCaptureProtocol, T6.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple6<Substring, T0.Match.Capture, T2.Match.Capture, T3.Match.Capture, T4.Match.Capture, T5.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
-      x5.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
+      x5.regex.ast, 
       x6.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5, T6>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6
   ) -> Concatenate7_VTTTTVT<T0, T1, T2, T3, T4, T5, T6> {
     Concatenate7_VTTTTVT(x0, x1, x2, x3, x4, x5, x6)
@@ -4751,24 +4906,24 @@ extension RegexBuilder {
 
 public struct Concatenate7_VTTTTVV<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
->: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
-  public typealias Capture = (T2.Capture, T3.Capture, T4.Capture, T5.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T0.Match.Capture: EmptyCaptureProtocol, T1.Match.Capture: EmptyCaptureProtocol, T6.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple5<Substring, T2.Match.Capture, T3.Match.Capture, T4.Match.Capture, T5.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
-      x5.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
+      x5.regex.ast, 
       x6.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5, T6>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6
   ) -> Concatenate7_VTTTTVV<T0, T1, T2, T3, T4, T5, T6> {
     Concatenate7_VTTTTVV(x0, x1, x2, x3, x4, x5, x6)
@@ -4777,24 +4932,24 @@ extension RegexBuilder {
 
 public struct Concatenate7_VTTTVTT<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
->: RegexProtocol where T2.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
-  public typealias Capture = (T0.Capture, T1.Capture, T3.Capture, T4.Capture, T5.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T2.Match.Capture: EmptyCaptureProtocol, T6.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple6<Substring, T0.Match.Capture, T1.Match.Capture, T3.Match.Capture, T4.Match.Capture, T5.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
-      x5.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
+      x5.regex.ast, 
       x6.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5, T6>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6
   ) -> Concatenate7_VTTTVTT<T0, T1, T2, T3, T4, T5, T6> {
     Concatenate7_VTTTVTT(x0, x1, x2, x3, x4, x5, x6)
@@ -4803,24 +4958,24 @@ extension RegexBuilder {
 
 public struct Concatenate7_VTTTVTV<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
->: RegexProtocol where T0.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
-  public typealias Capture = (T1.Capture, T3.Capture, T4.Capture, T5.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T0.Match.Capture: EmptyCaptureProtocol, T2.Match.Capture: EmptyCaptureProtocol, T6.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple5<Substring, T1.Match.Capture, T3.Match.Capture, T4.Match.Capture, T5.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
-      x5.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
+      x5.regex.ast, 
       x6.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5, T6>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6
   ) -> Concatenate7_VTTTVTV<T0, T1, T2, T3, T4, T5, T6> {
     Concatenate7_VTTTVTV(x0, x1, x2, x3, x4, x5, x6)
@@ -4829,24 +4984,24 @@ extension RegexBuilder {
 
 public struct Concatenate7_VTTTVVT<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
->: RegexProtocol where T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
-  public typealias Capture = (T0.Capture, T3.Capture, T4.Capture, T5.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T1.Match.Capture: EmptyCaptureProtocol, T2.Match.Capture: EmptyCaptureProtocol, T6.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple5<Substring, T0.Match.Capture, T3.Match.Capture, T4.Match.Capture, T5.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
-      x5.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
+      x5.regex.ast, 
       x6.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5, T6>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6
   ) -> Concatenate7_VTTTVVT<T0, T1, T2, T3, T4, T5, T6> {
     Concatenate7_VTTTVVT(x0, x1, x2, x3, x4, x5, x6)
@@ -4855,24 +5010,24 @@ extension RegexBuilder {
 
 public struct Concatenate7_VTTTVVV<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
->: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
-  public typealias Capture = (T3.Capture, T4.Capture, T5.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T0.Match.Capture: EmptyCaptureProtocol, T1.Match.Capture: EmptyCaptureProtocol, T2.Match.Capture: EmptyCaptureProtocol, T6.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple4<Substring, T3.Match.Capture, T4.Match.Capture, T5.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
-      x5.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
+      x5.regex.ast, 
       x6.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5, T6>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6
   ) -> Concatenate7_VTTTVVV<T0, T1, T2, T3, T4, T5, T6> {
     Concatenate7_VTTTVVV(x0, x1, x2, x3, x4, x5, x6)
@@ -4881,24 +5036,24 @@ extension RegexBuilder {
 
 public struct Concatenate7_VTTVTTT<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
->: RegexProtocol where T3.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
-  public typealias Capture = (T0.Capture, T1.Capture, T2.Capture, T4.Capture, T5.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T3.Match.Capture: EmptyCaptureProtocol, T6.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple6<Substring, T0.Match.Capture, T1.Match.Capture, T2.Match.Capture, T4.Match.Capture, T5.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
-      x5.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
+      x5.regex.ast, 
       x6.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5, T6>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6
   ) -> Concatenate7_VTTVTTT<T0, T1, T2, T3, T4, T5, T6> {
     Concatenate7_VTTVTTT(x0, x1, x2, x3, x4, x5, x6)
@@ -4907,24 +5062,24 @@ extension RegexBuilder {
 
 public struct Concatenate7_VTTVTTV<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
->: RegexProtocol where T0.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
-  public typealias Capture = (T1.Capture, T2.Capture, T4.Capture, T5.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T0.Match.Capture: EmptyCaptureProtocol, T3.Match.Capture: EmptyCaptureProtocol, T6.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple5<Substring, T1.Match.Capture, T2.Match.Capture, T4.Match.Capture, T5.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
-      x5.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
+      x5.regex.ast, 
       x6.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5, T6>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6
   ) -> Concatenate7_VTTVTTV<T0, T1, T2, T3, T4, T5, T6> {
     Concatenate7_VTTVTTV(x0, x1, x2, x3, x4, x5, x6)
@@ -4933,24 +5088,24 @@ extension RegexBuilder {
 
 public struct Concatenate7_VTTVTVT<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
->: RegexProtocol where T1.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
-  public typealias Capture = (T0.Capture, T2.Capture, T4.Capture, T5.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T1.Match.Capture: EmptyCaptureProtocol, T3.Match.Capture: EmptyCaptureProtocol, T6.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple5<Substring, T0.Match.Capture, T2.Match.Capture, T4.Match.Capture, T5.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
-      x5.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
+      x5.regex.ast, 
       x6.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5, T6>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6
   ) -> Concatenate7_VTTVTVT<T0, T1, T2, T3, T4, T5, T6> {
     Concatenate7_VTTVTVT(x0, x1, x2, x3, x4, x5, x6)
@@ -4959,24 +5114,24 @@ extension RegexBuilder {
 
 public struct Concatenate7_VTTVTVV<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
->: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
-  public typealias Capture = (T2.Capture, T4.Capture, T5.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T0.Match.Capture: EmptyCaptureProtocol, T1.Match.Capture: EmptyCaptureProtocol, T3.Match.Capture: EmptyCaptureProtocol, T6.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple4<Substring, T2.Match.Capture, T4.Match.Capture, T5.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
-      x5.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
+      x5.regex.ast, 
       x6.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5, T6>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6
   ) -> Concatenate7_VTTVTVV<T0, T1, T2, T3, T4, T5, T6> {
     Concatenate7_VTTVTVV(x0, x1, x2, x3, x4, x5, x6)
@@ -4985,24 +5140,24 @@ extension RegexBuilder {
 
 public struct Concatenate7_VTTVVTT<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
->: RegexProtocol where T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
-  public typealias Capture = (T0.Capture, T1.Capture, T4.Capture, T5.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T2.Match.Capture: EmptyCaptureProtocol, T3.Match.Capture: EmptyCaptureProtocol, T6.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple5<Substring, T0.Match.Capture, T1.Match.Capture, T4.Match.Capture, T5.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
-      x5.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
+      x5.regex.ast, 
       x6.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5, T6>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6
   ) -> Concatenate7_VTTVVTT<T0, T1, T2, T3, T4, T5, T6> {
     Concatenate7_VTTVVTT(x0, x1, x2, x3, x4, x5, x6)
@@ -5011,24 +5166,24 @@ extension RegexBuilder {
 
 public struct Concatenate7_VTTVVTV<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
->: RegexProtocol where T0.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
-  public typealias Capture = (T1.Capture, T4.Capture, T5.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T0.Match.Capture: EmptyCaptureProtocol, T2.Match.Capture: EmptyCaptureProtocol, T3.Match.Capture: EmptyCaptureProtocol, T6.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple4<Substring, T1.Match.Capture, T4.Match.Capture, T5.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
-      x5.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
+      x5.regex.ast, 
       x6.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5, T6>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6
   ) -> Concatenate7_VTTVVTV<T0, T1, T2, T3, T4, T5, T6> {
     Concatenate7_VTTVVTV(x0, x1, x2, x3, x4, x5, x6)
@@ -5037,24 +5192,24 @@ extension RegexBuilder {
 
 public struct Concatenate7_VTTVVVT<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
->: RegexProtocol where T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
-  public typealias Capture = (T0.Capture, T4.Capture, T5.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T1.Match.Capture: EmptyCaptureProtocol, T2.Match.Capture: EmptyCaptureProtocol, T3.Match.Capture: EmptyCaptureProtocol, T6.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple4<Substring, T0.Match.Capture, T4.Match.Capture, T5.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
-      x5.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
+      x5.regex.ast, 
       x6.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5, T6>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6
   ) -> Concatenate7_VTTVVVT<T0, T1, T2, T3, T4, T5, T6> {
     Concatenate7_VTTVVVT(x0, x1, x2, x3, x4, x5, x6)
@@ -5063,24 +5218,24 @@ extension RegexBuilder {
 
 public struct Concatenate7_VTTVVVV<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
->: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
-  public typealias Capture = (T4.Capture, T5.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T0.Match.Capture: EmptyCaptureProtocol, T1.Match.Capture: EmptyCaptureProtocol, T2.Match.Capture: EmptyCaptureProtocol, T3.Match.Capture: EmptyCaptureProtocol, T6.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple3<Substring, T4.Match.Capture, T5.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
-      x5.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
+      x5.regex.ast, 
       x6.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5, T6>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6
   ) -> Concatenate7_VTTVVVV<T0, T1, T2, T3, T4, T5, T6> {
     Concatenate7_VTTVVVV(x0, x1, x2, x3, x4, x5, x6)
@@ -5089,24 +5244,24 @@ extension RegexBuilder {
 
 public struct Concatenate7_VTVTTTT<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
->: RegexProtocol where T4.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
-  public typealias Capture = (T0.Capture, T1.Capture, T2.Capture, T3.Capture, T5.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T4.Match.Capture: EmptyCaptureProtocol, T6.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple6<Substring, T0.Match.Capture, T1.Match.Capture, T2.Match.Capture, T3.Match.Capture, T5.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
-      x5.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
+      x5.regex.ast, 
       x6.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5, T6>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6
   ) -> Concatenate7_VTVTTTT<T0, T1, T2, T3, T4, T5, T6> {
     Concatenate7_VTVTTTT(x0, x1, x2, x3, x4, x5, x6)
@@ -5115,24 +5270,24 @@ extension RegexBuilder {
 
 public struct Concatenate7_VTVTTTV<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
->: RegexProtocol where T0.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
-  public typealias Capture = (T1.Capture, T2.Capture, T3.Capture, T5.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T0.Match.Capture: EmptyCaptureProtocol, T4.Match.Capture: EmptyCaptureProtocol, T6.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple5<Substring, T1.Match.Capture, T2.Match.Capture, T3.Match.Capture, T5.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
-      x5.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
+      x5.regex.ast, 
       x6.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5, T6>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6
   ) -> Concatenate7_VTVTTTV<T0, T1, T2, T3, T4, T5, T6> {
     Concatenate7_VTVTTTV(x0, x1, x2, x3, x4, x5, x6)
@@ -5141,24 +5296,24 @@ extension RegexBuilder {
 
 public struct Concatenate7_VTVTTVT<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
->: RegexProtocol where T1.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
-  public typealias Capture = (T0.Capture, T2.Capture, T3.Capture, T5.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T1.Match.Capture: EmptyCaptureProtocol, T4.Match.Capture: EmptyCaptureProtocol, T6.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple5<Substring, T0.Match.Capture, T2.Match.Capture, T3.Match.Capture, T5.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
-      x5.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
+      x5.regex.ast, 
       x6.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5, T6>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6
   ) -> Concatenate7_VTVTTVT<T0, T1, T2, T3, T4, T5, T6> {
     Concatenate7_VTVTTVT(x0, x1, x2, x3, x4, x5, x6)
@@ -5167,24 +5322,24 @@ extension RegexBuilder {
 
 public struct Concatenate7_VTVTTVV<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
->: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
-  public typealias Capture = (T2.Capture, T3.Capture, T5.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T0.Match.Capture: EmptyCaptureProtocol, T1.Match.Capture: EmptyCaptureProtocol, T4.Match.Capture: EmptyCaptureProtocol, T6.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple4<Substring, T2.Match.Capture, T3.Match.Capture, T5.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
-      x5.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
+      x5.regex.ast, 
       x6.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5, T6>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6
   ) -> Concatenate7_VTVTTVV<T0, T1, T2, T3, T4, T5, T6> {
     Concatenate7_VTVTTVV(x0, x1, x2, x3, x4, x5, x6)
@@ -5193,24 +5348,24 @@ extension RegexBuilder {
 
 public struct Concatenate7_VTVTVTT<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
->: RegexProtocol where T2.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
-  public typealias Capture = (T0.Capture, T1.Capture, T3.Capture, T5.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T2.Match.Capture: EmptyCaptureProtocol, T4.Match.Capture: EmptyCaptureProtocol, T6.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple5<Substring, T0.Match.Capture, T1.Match.Capture, T3.Match.Capture, T5.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
-      x5.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
+      x5.regex.ast, 
       x6.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5, T6>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6
   ) -> Concatenate7_VTVTVTT<T0, T1, T2, T3, T4, T5, T6> {
     Concatenate7_VTVTVTT(x0, x1, x2, x3, x4, x5, x6)
@@ -5219,24 +5374,24 @@ extension RegexBuilder {
 
 public struct Concatenate7_VTVTVTV<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
->: RegexProtocol where T0.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
-  public typealias Capture = (T1.Capture, T3.Capture, T5.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T0.Match.Capture: EmptyCaptureProtocol, T2.Match.Capture: EmptyCaptureProtocol, T4.Match.Capture: EmptyCaptureProtocol, T6.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple4<Substring, T1.Match.Capture, T3.Match.Capture, T5.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
-      x5.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
+      x5.regex.ast, 
       x6.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5, T6>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6
   ) -> Concatenate7_VTVTVTV<T0, T1, T2, T3, T4, T5, T6> {
     Concatenate7_VTVTVTV(x0, x1, x2, x3, x4, x5, x6)
@@ -5245,24 +5400,24 @@ extension RegexBuilder {
 
 public struct Concatenate7_VTVTVVT<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
->: RegexProtocol where T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
-  public typealias Capture = (T0.Capture, T3.Capture, T5.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T1.Match.Capture: EmptyCaptureProtocol, T2.Match.Capture: EmptyCaptureProtocol, T4.Match.Capture: EmptyCaptureProtocol, T6.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple4<Substring, T0.Match.Capture, T3.Match.Capture, T5.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
-      x5.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
+      x5.regex.ast, 
       x6.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5, T6>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6
   ) -> Concatenate7_VTVTVVT<T0, T1, T2, T3, T4, T5, T6> {
     Concatenate7_VTVTVVT(x0, x1, x2, x3, x4, x5, x6)
@@ -5271,24 +5426,24 @@ extension RegexBuilder {
 
 public struct Concatenate7_VTVTVVV<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
->: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
-  public typealias Capture = (T3.Capture, T5.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T0.Match.Capture: EmptyCaptureProtocol, T1.Match.Capture: EmptyCaptureProtocol, T2.Match.Capture: EmptyCaptureProtocol, T4.Match.Capture: EmptyCaptureProtocol, T6.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple3<Substring, T3.Match.Capture, T5.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
-      x5.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
+      x5.regex.ast, 
       x6.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5, T6>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6
   ) -> Concatenate7_VTVTVVV<T0, T1, T2, T3, T4, T5, T6> {
     Concatenate7_VTVTVVV(x0, x1, x2, x3, x4, x5, x6)
@@ -5297,24 +5452,24 @@ extension RegexBuilder {
 
 public struct Concatenate7_VTVVTTT<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
->: RegexProtocol where T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
-  public typealias Capture = (T0.Capture, T1.Capture, T2.Capture, T5.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T3.Match.Capture: EmptyCaptureProtocol, T4.Match.Capture: EmptyCaptureProtocol, T6.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple5<Substring, T0.Match.Capture, T1.Match.Capture, T2.Match.Capture, T5.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
-      x5.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
+      x5.regex.ast, 
       x6.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5, T6>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6
   ) -> Concatenate7_VTVVTTT<T0, T1, T2, T3, T4, T5, T6> {
     Concatenate7_VTVVTTT(x0, x1, x2, x3, x4, x5, x6)
@@ -5323,24 +5478,24 @@ extension RegexBuilder {
 
 public struct Concatenate7_VTVVTTV<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
->: RegexProtocol where T0.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
-  public typealias Capture = (T1.Capture, T2.Capture, T5.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T0.Match.Capture: EmptyCaptureProtocol, T3.Match.Capture: EmptyCaptureProtocol, T4.Match.Capture: EmptyCaptureProtocol, T6.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple4<Substring, T1.Match.Capture, T2.Match.Capture, T5.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
-      x5.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
+      x5.regex.ast, 
       x6.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5, T6>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6
   ) -> Concatenate7_VTVVTTV<T0, T1, T2, T3, T4, T5, T6> {
     Concatenate7_VTVVTTV(x0, x1, x2, x3, x4, x5, x6)
@@ -5349,24 +5504,24 @@ extension RegexBuilder {
 
 public struct Concatenate7_VTVVTVT<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
->: RegexProtocol where T1.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
-  public typealias Capture = (T0.Capture, T2.Capture, T5.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T1.Match.Capture: EmptyCaptureProtocol, T3.Match.Capture: EmptyCaptureProtocol, T4.Match.Capture: EmptyCaptureProtocol, T6.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple4<Substring, T0.Match.Capture, T2.Match.Capture, T5.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
-      x5.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
+      x5.regex.ast, 
       x6.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5, T6>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6
   ) -> Concatenate7_VTVVTVT<T0, T1, T2, T3, T4, T5, T6> {
     Concatenate7_VTVVTVT(x0, x1, x2, x3, x4, x5, x6)
@@ -5375,24 +5530,24 @@ extension RegexBuilder {
 
 public struct Concatenate7_VTVVTVV<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
->: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
-  public typealias Capture = (T2.Capture, T5.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T0.Match.Capture: EmptyCaptureProtocol, T1.Match.Capture: EmptyCaptureProtocol, T3.Match.Capture: EmptyCaptureProtocol, T4.Match.Capture: EmptyCaptureProtocol, T6.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple3<Substring, T2.Match.Capture, T5.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
-      x5.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
+      x5.regex.ast, 
       x6.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5, T6>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6
   ) -> Concatenate7_VTVVTVV<T0, T1, T2, T3, T4, T5, T6> {
     Concatenate7_VTVVTVV(x0, x1, x2, x3, x4, x5, x6)
@@ -5401,24 +5556,24 @@ extension RegexBuilder {
 
 public struct Concatenate7_VTVVVTT<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
->: RegexProtocol where T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
-  public typealias Capture = (T0.Capture, T1.Capture, T5.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T2.Match.Capture: EmptyCaptureProtocol, T3.Match.Capture: EmptyCaptureProtocol, T4.Match.Capture: EmptyCaptureProtocol, T6.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple4<Substring, T0.Match.Capture, T1.Match.Capture, T5.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
-      x5.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
+      x5.regex.ast, 
       x6.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5, T6>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6
   ) -> Concatenate7_VTVVVTT<T0, T1, T2, T3, T4, T5, T6> {
     Concatenate7_VTVVVTT(x0, x1, x2, x3, x4, x5, x6)
@@ -5427,24 +5582,24 @@ extension RegexBuilder {
 
 public struct Concatenate7_VTVVVTV<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
->: RegexProtocol where T0.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
-  public typealias Capture = (T1.Capture, T5.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T0.Match.Capture: EmptyCaptureProtocol, T2.Match.Capture: EmptyCaptureProtocol, T3.Match.Capture: EmptyCaptureProtocol, T4.Match.Capture: EmptyCaptureProtocol, T6.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple3<Substring, T1.Match.Capture, T5.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
-      x5.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
+      x5.regex.ast, 
       x6.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5, T6>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6
   ) -> Concatenate7_VTVVVTV<T0, T1, T2, T3, T4, T5, T6> {
     Concatenate7_VTVVVTV(x0, x1, x2, x3, x4, x5, x6)
@@ -5453,24 +5608,24 @@ extension RegexBuilder {
 
 public struct Concatenate7_VTVVVVT<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
->: RegexProtocol where T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
-  public typealias Capture = (T0.Capture, T5.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T1.Match.Capture: EmptyCaptureProtocol, T2.Match.Capture: EmptyCaptureProtocol, T3.Match.Capture: EmptyCaptureProtocol, T4.Match.Capture: EmptyCaptureProtocol, T6.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple3<Substring, T0.Match.Capture, T5.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
-      x5.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
+      x5.regex.ast, 
       x6.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5, T6>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6
   ) -> Concatenate7_VTVVVVT<T0, T1, T2, T3, T4, T5, T6> {
     Concatenate7_VTVVVVT(x0, x1, x2, x3, x4, x5, x6)
@@ -5479,24 +5634,24 @@ extension RegexBuilder {
 
 public struct Concatenate7_VTVVVVV<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
->: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
-  public typealias Capture = (T5.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T0.Match.Capture: EmptyCaptureProtocol, T1.Match.Capture: EmptyCaptureProtocol, T2.Match.Capture: EmptyCaptureProtocol, T3.Match.Capture: EmptyCaptureProtocol, T4.Match.Capture: EmptyCaptureProtocol, T6.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple2<Substring, T5.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
-      x5.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
+      x5.regex.ast, 
       x6.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5, T6>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6
   ) -> Concatenate7_VTVVVVV<T0, T1, T2, T3, T4, T5, T6> {
     Concatenate7_VTVVVVV(x0, x1, x2, x3, x4, x5, x6)
@@ -5505,24 +5660,24 @@ extension RegexBuilder {
 
 public struct Concatenate7_VVTTTTT<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
->: RegexProtocol where T5.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
-  public typealias Capture = (T0.Capture, T1.Capture, T2.Capture, T3.Capture, T4.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T5.Match.Capture: EmptyCaptureProtocol, T6.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple6<Substring, T0.Match.Capture, T1.Match.Capture, T2.Match.Capture, T3.Match.Capture, T4.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
-      x5.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
+      x5.regex.ast, 
       x6.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5, T6>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6
   ) -> Concatenate7_VVTTTTT<T0, T1, T2, T3, T4, T5, T6> {
     Concatenate7_VVTTTTT(x0, x1, x2, x3, x4, x5, x6)
@@ -5531,24 +5686,24 @@ extension RegexBuilder {
 
 public struct Concatenate7_VVTTTTV<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
->: RegexProtocol where T0.Capture: EmptyProtocol, T5.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
-  public typealias Capture = (T1.Capture, T2.Capture, T3.Capture, T4.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T0.Match.Capture: EmptyCaptureProtocol, T5.Match.Capture: EmptyCaptureProtocol, T6.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple5<Substring, T1.Match.Capture, T2.Match.Capture, T3.Match.Capture, T4.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
-      x5.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
+      x5.regex.ast, 
       x6.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5, T6>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6
   ) -> Concatenate7_VVTTTTV<T0, T1, T2, T3, T4, T5, T6> {
     Concatenate7_VVTTTTV(x0, x1, x2, x3, x4, x5, x6)
@@ -5557,24 +5712,24 @@ extension RegexBuilder {
 
 public struct Concatenate7_VVTTTVT<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
->: RegexProtocol where T1.Capture: EmptyProtocol, T5.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
-  public typealias Capture = (T0.Capture, T2.Capture, T3.Capture, T4.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T1.Match.Capture: EmptyCaptureProtocol, T5.Match.Capture: EmptyCaptureProtocol, T6.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple5<Substring, T0.Match.Capture, T2.Match.Capture, T3.Match.Capture, T4.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
-      x5.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
+      x5.regex.ast, 
       x6.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5, T6>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6
   ) -> Concatenate7_VVTTTVT<T0, T1, T2, T3, T4, T5, T6> {
     Concatenate7_VVTTTVT(x0, x1, x2, x3, x4, x5, x6)
@@ -5583,24 +5738,24 @@ extension RegexBuilder {
 
 public struct Concatenate7_VVTTTVV<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
->: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T5.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
-  public typealias Capture = (T2.Capture, T3.Capture, T4.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T0.Match.Capture: EmptyCaptureProtocol, T1.Match.Capture: EmptyCaptureProtocol, T5.Match.Capture: EmptyCaptureProtocol, T6.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple4<Substring, T2.Match.Capture, T3.Match.Capture, T4.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
-      x5.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
+      x5.regex.ast, 
       x6.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5, T6>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6
   ) -> Concatenate7_VVTTTVV<T0, T1, T2, T3, T4, T5, T6> {
     Concatenate7_VVTTTVV(x0, x1, x2, x3, x4, x5, x6)
@@ -5609,24 +5764,24 @@ extension RegexBuilder {
 
 public struct Concatenate7_VVTTVTT<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
->: RegexProtocol where T2.Capture: EmptyProtocol, T5.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
-  public typealias Capture = (T0.Capture, T1.Capture, T3.Capture, T4.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T2.Match.Capture: EmptyCaptureProtocol, T5.Match.Capture: EmptyCaptureProtocol, T6.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple5<Substring, T0.Match.Capture, T1.Match.Capture, T3.Match.Capture, T4.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
-      x5.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
+      x5.regex.ast, 
       x6.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5, T6>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6
   ) -> Concatenate7_VVTTVTT<T0, T1, T2, T3, T4, T5, T6> {
     Concatenate7_VVTTVTT(x0, x1, x2, x3, x4, x5, x6)
@@ -5635,24 +5790,24 @@ extension RegexBuilder {
 
 public struct Concatenate7_VVTTVTV<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
->: RegexProtocol where T0.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T5.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
-  public typealias Capture = (T1.Capture, T3.Capture, T4.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T0.Match.Capture: EmptyCaptureProtocol, T2.Match.Capture: EmptyCaptureProtocol, T5.Match.Capture: EmptyCaptureProtocol, T6.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple4<Substring, T1.Match.Capture, T3.Match.Capture, T4.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
-      x5.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
+      x5.regex.ast, 
       x6.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5, T6>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6
   ) -> Concatenate7_VVTTVTV<T0, T1, T2, T3, T4, T5, T6> {
     Concatenate7_VVTTVTV(x0, x1, x2, x3, x4, x5, x6)
@@ -5661,24 +5816,24 @@ extension RegexBuilder {
 
 public struct Concatenate7_VVTTVVT<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
->: RegexProtocol where T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T5.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
-  public typealias Capture = (T0.Capture, T3.Capture, T4.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T1.Match.Capture: EmptyCaptureProtocol, T2.Match.Capture: EmptyCaptureProtocol, T5.Match.Capture: EmptyCaptureProtocol, T6.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple4<Substring, T0.Match.Capture, T3.Match.Capture, T4.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
-      x5.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
+      x5.regex.ast, 
       x6.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5, T6>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6
   ) -> Concatenate7_VVTTVVT<T0, T1, T2, T3, T4, T5, T6> {
     Concatenate7_VVTTVVT(x0, x1, x2, x3, x4, x5, x6)
@@ -5687,24 +5842,24 @@ extension RegexBuilder {
 
 public struct Concatenate7_VVTTVVV<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
->: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T5.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
-  public typealias Capture = (T3.Capture, T4.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T0.Match.Capture: EmptyCaptureProtocol, T1.Match.Capture: EmptyCaptureProtocol, T2.Match.Capture: EmptyCaptureProtocol, T5.Match.Capture: EmptyCaptureProtocol, T6.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple3<Substring, T3.Match.Capture, T4.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
-      x5.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
+      x5.regex.ast, 
       x6.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5, T6>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6
   ) -> Concatenate7_VVTTVVV<T0, T1, T2, T3, T4, T5, T6> {
     Concatenate7_VVTTVVV(x0, x1, x2, x3, x4, x5, x6)
@@ -5713,24 +5868,24 @@ extension RegexBuilder {
 
 public struct Concatenate7_VVTVTTT<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
->: RegexProtocol where T3.Capture: EmptyProtocol, T5.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
-  public typealias Capture = (T0.Capture, T1.Capture, T2.Capture, T4.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T3.Match.Capture: EmptyCaptureProtocol, T5.Match.Capture: EmptyCaptureProtocol, T6.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple5<Substring, T0.Match.Capture, T1.Match.Capture, T2.Match.Capture, T4.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
-      x5.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
+      x5.regex.ast, 
       x6.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5, T6>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6
   ) -> Concatenate7_VVTVTTT<T0, T1, T2, T3, T4, T5, T6> {
     Concatenate7_VVTVTTT(x0, x1, x2, x3, x4, x5, x6)
@@ -5739,24 +5894,24 @@ extension RegexBuilder {
 
 public struct Concatenate7_VVTVTTV<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
->: RegexProtocol where T0.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T5.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
-  public typealias Capture = (T1.Capture, T2.Capture, T4.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T0.Match.Capture: EmptyCaptureProtocol, T3.Match.Capture: EmptyCaptureProtocol, T5.Match.Capture: EmptyCaptureProtocol, T6.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple4<Substring, T1.Match.Capture, T2.Match.Capture, T4.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
-      x5.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
+      x5.regex.ast, 
       x6.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5, T6>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6
   ) -> Concatenate7_VVTVTTV<T0, T1, T2, T3, T4, T5, T6> {
     Concatenate7_VVTVTTV(x0, x1, x2, x3, x4, x5, x6)
@@ -5765,24 +5920,24 @@ extension RegexBuilder {
 
 public struct Concatenate7_VVTVTVT<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
->: RegexProtocol where T1.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T5.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
-  public typealias Capture = (T0.Capture, T2.Capture, T4.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T1.Match.Capture: EmptyCaptureProtocol, T3.Match.Capture: EmptyCaptureProtocol, T5.Match.Capture: EmptyCaptureProtocol, T6.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple4<Substring, T0.Match.Capture, T2.Match.Capture, T4.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
-      x5.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
+      x5.regex.ast, 
       x6.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5, T6>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6
   ) -> Concatenate7_VVTVTVT<T0, T1, T2, T3, T4, T5, T6> {
     Concatenate7_VVTVTVT(x0, x1, x2, x3, x4, x5, x6)
@@ -5791,24 +5946,24 @@ extension RegexBuilder {
 
 public struct Concatenate7_VVTVTVV<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
->: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T5.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
-  public typealias Capture = (T2.Capture, T4.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T0.Match.Capture: EmptyCaptureProtocol, T1.Match.Capture: EmptyCaptureProtocol, T3.Match.Capture: EmptyCaptureProtocol, T5.Match.Capture: EmptyCaptureProtocol, T6.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple3<Substring, T2.Match.Capture, T4.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
-      x5.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
+      x5.regex.ast, 
       x6.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5, T6>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6
   ) -> Concatenate7_VVTVTVV<T0, T1, T2, T3, T4, T5, T6> {
     Concatenate7_VVTVTVV(x0, x1, x2, x3, x4, x5, x6)
@@ -5817,24 +5972,24 @@ extension RegexBuilder {
 
 public struct Concatenate7_VVTVVTT<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
->: RegexProtocol where T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T5.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
-  public typealias Capture = (T0.Capture, T1.Capture, T4.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T2.Match.Capture: EmptyCaptureProtocol, T3.Match.Capture: EmptyCaptureProtocol, T5.Match.Capture: EmptyCaptureProtocol, T6.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple4<Substring, T0.Match.Capture, T1.Match.Capture, T4.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
-      x5.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
+      x5.regex.ast, 
       x6.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5, T6>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6
   ) -> Concatenate7_VVTVVTT<T0, T1, T2, T3, T4, T5, T6> {
     Concatenate7_VVTVVTT(x0, x1, x2, x3, x4, x5, x6)
@@ -5843,24 +5998,24 @@ extension RegexBuilder {
 
 public struct Concatenate7_VVTVVTV<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
->: RegexProtocol where T0.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T5.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
-  public typealias Capture = (T1.Capture, T4.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T0.Match.Capture: EmptyCaptureProtocol, T2.Match.Capture: EmptyCaptureProtocol, T3.Match.Capture: EmptyCaptureProtocol, T5.Match.Capture: EmptyCaptureProtocol, T6.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple3<Substring, T1.Match.Capture, T4.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
-      x5.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
+      x5.regex.ast, 
       x6.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5, T6>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6
   ) -> Concatenate7_VVTVVTV<T0, T1, T2, T3, T4, T5, T6> {
     Concatenate7_VVTVVTV(x0, x1, x2, x3, x4, x5, x6)
@@ -5869,24 +6024,24 @@ extension RegexBuilder {
 
 public struct Concatenate7_VVTVVVT<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
->: RegexProtocol where T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T5.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
-  public typealias Capture = (T0.Capture, T4.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T1.Match.Capture: EmptyCaptureProtocol, T2.Match.Capture: EmptyCaptureProtocol, T3.Match.Capture: EmptyCaptureProtocol, T5.Match.Capture: EmptyCaptureProtocol, T6.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple3<Substring, T0.Match.Capture, T4.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
-      x5.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
+      x5.regex.ast, 
       x6.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5, T6>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6
   ) -> Concatenate7_VVTVVVT<T0, T1, T2, T3, T4, T5, T6> {
     Concatenate7_VVTVVVT(x0, x1, x2, x3, x4, x5, x6)
@@ -5895,24 +6050,24 @@ extension RegexBuilder {
 
 public struct Concatenate7_VVTVVVV<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
->: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T5.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
-  public typealias Capture = (T4.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T0.Match.Capture: EmptyCaptureProtocol, T1.Match.Capture: EmptyCaptureProtocol, T2.Match.Capture: EmptyCaptureProtocol, T3.Match.Capture: EmptyCaptureProtocol, T5.Match.Capture: EmptyCaptureProtocol, T6.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple2<Substring, T4.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
-      x5.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
+      x5.regex.ast, 
       x6.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5, T6>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6
   ) -> Concatenate7_VVTVVVV<T0, T1, T2, T3, T4, T5, T6> {
     Concatenate7_VVTVVVV(x0, x1, x2, x3, x4, x5, x6)
@@ -5921,24 +6076,24 @@ extension RegexBuilder {
 
 public struct Concatenate7_VVVTTTT<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
->: RegexProtocol where T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
-  public typealias Capture = (T0.Capture, T1.Capture, T2.Capture, T3.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T4.Match.Capture: EmptyCaptureProtocol, T5.Match.Capture: EmptyCaptureProtocol, T6.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple5<Substring, T0.Match.Capture, T1.Match.Capture, T2.Match.Capture, T3.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
-      x5.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
+      x5.regex.ast, 
       x6.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5, T6>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6
   ) -> Concatenate7_VVVTTTT<T0, T1, T2, T3, T4, T5, T6> {
     Concatenate7_VVVTTTT(x0, x1, x2, x3, x4, x5, x6)
@@ -5947,24 +6102,24 @@ extension RegexBuilder {
 
 public struct Concatenate7_VVVTTTV<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
->: RegexProtocol where T0.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
-  public typealias Capture = (T1.Capture, T2.Capture, T3.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T0.Match.Capture: EmptyCaptureProtocol, T4.Match.Capture: EmptyCaptureProtocol, T5.Match.Capture: EmptyCaptureProtocol, T6.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple4<Substring, T1.Match.Capture, T2.Match.Capture, T3.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
-      x5.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
+      x5.regex.ast, 
       x6.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5, T6>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6
   ) -> Concatenate7_VVVTTTV<T0, T1, T2, T3, T4, T5, T6> {
     Concatenate7_VVVTTTV(x0, x1, x2, x3, x4, x5, x6)
@@ -5973,24 +6128,24 @@ extension RegexBuilder {
 
 public struct Concatenate7_VVVTTVT<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
->: RegexProtocol where T1.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
-  public typealias Capture = (T0.Capture, T2.Capture, T3.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T1.Match.Capture: EmptyCaptureProtocol, T4.Match.Capture: EmptyCaptureProtocol, T5.Match.Capture: EmptyCaptureProtocol, T6.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple4<Substring, T0.Match.Capture, T2.Match.Capture, T3.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
-      x5.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
+      x5.regex.ast, 
       x6.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5, T6>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6
   ) -> Concatenate7_VVVTTVT<T0, T1, T2, T3, T4, T5, T6> {
     Concatenate7_VVVTTVT(x0, x1, x2, x3, x4, x5, x6)
@@ -5999,24 +6154,24 @@ extension RegexBuilder {
 
 public struct Concatenate7_VVVTTVV<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
->: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
-  public typealias Capture = (T2.Capture, T3.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T0.Match.Capture: EmptyCaptureProtocol, T1.Match.Capture: EmptyCaptureProtocol, T4.Match.Capture: EmptyCaptureProtocol, T5.Match.Capture: EmptyCaptureProtocol, T6.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple3<Substring, T2.Match.Capture, T3.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
-      x5.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
+      x5.regex.ast, 
       x6.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5, T6>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6
   ) -> Concatenate7_VVVTTVV<T0, T1, T2, T3, T4, T5, T6> {
     Concatenate7_VVVTTVV(x0, x1, x2, x3, x4, x5, x6)
@@ -6025,24 +6180,24 @@ extension RegexBuilder {
 
 public struct Concatenate7_VVVTVTT<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
->: RegexProtocol where T2.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
-  public typealias Capture = (T0.Capture, T1.Capture, T3.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T2.Match.Capture: EmptyCaptureProtocol, T4.Match.Capture: EmptyCaptureProtocol, T5.Match.Capture: EmptyCaptureProtocol, T6.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple4<Substring, T0.Match.Capture, T1.Match.Capture, T3.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
-      x5.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
+      x5.regex.ast, 
       x6.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5, T6>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6
   ) -> Concatenate7_VVVTVTT<T0, T1, T2, T3, T4, T5, T6> {
     Concatenate7_VVVTVTT(x0, x1, x2, x3, x4, x5, x6)
@@ -6051,24 +6206,24 @@ extension RegexBuilder {
 
 public struct Concatenate7_VVVTVTV<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
->: RegexProtocol where T0.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
-  public typealias Capture = (T1.Capture, T3.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T0.Match.Capture: EmptyCaptureProtocol, T2.Match.Capture: EmptyCaptureProtocol, T4.Match.Capture: EmptyCaptureProtocol, T5.Match.Capture: EmptyCaptureProtocol, T6.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple3<Substring, T1.Match.Capture, T3.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
-      x5.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
+      x5.regex.ast, 
       x6.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5, T6>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6
   ) -> Concatenate7_VVVTVTV<T0, T1, T2, T3, T4, T5, T6> {
     Concatenate7_VVVTVTV(x0, x1, x2, x3, x4, x5, x6)
@@ -6077,24 +6232,24 @@ extension RegexBuilder {
 
 public struct Concatenate7_VVVTVVT<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
->: RegexProtocol where T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
-  public typealias Capture = (T0.Capture, T3.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T1.Match.Capture: EmptyCaptureProtocol, T2.Match.Capture: EmptyCaptureProtocol, T4.Match.Capture: EmptyCaptureProtocol, T5.Match.Capture: EmptyCaptureProtocol, T6.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple3<Substring, T0.Match.Capture, T3.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
-      x5.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
+      x5.regex.ast, 
       x6.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5, T6>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6
   ) -> Concatenate7_VVVTVVT<T0, T1, T2, T3, T4, T5, T6> {
     Concatenate7_VVVTVVT(x0, x1, x2, x3, x4, x5, x6)
@@ -6103,24 +6258,24 @@ extension RegexBuilder {
 
 public struct Concatenate7_VVVTVVV<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
->: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
-  public typealias Capture = (T3.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T0.Match.Capture: EmptyCaptureProtocol, T1.Match.Capture: EmptyCaptureProtocol, T2.Match.Capture: EmptyCaptureProtocol, T4.Match.Capture: EmptyCaptureProtocol, T5.Match.Capture: EmptyCaptureProtocol, T6.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple2<Substring, T3.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
-      x5.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
+      x5.regex.ast, 
       x6.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5, T6>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6
   ) -> Concatenate7_VVVTVVV<T0, T1, T2, T3, T4, T5, T6> {
     Concatenate7_VVVTVVV(x0, x1, x2, x3, x4, x5, x6)
@@ -6129,24 +6284,24 @@ extension RegexBuilder {
 
 public struct Concatenate7_VVVVTTT<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
->: RegexProtocol where T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
-  public typealias Capture = (T0.Capture, T1.Capture, T2.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T3.Match.Capture: EmptyCaptureProtocol, T4.Match.Capture: EmptyCaptureProtocol, T5.Match.Capture: EmptyCaptureProtocol, T6.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple4<Substring, T0.Match.Capture, T1.Match.Capture, T2.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
-      x5.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
+      x5.regex.ast, 
       x6.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5, T6>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6
   ) -> Concatenate7_VVVVTTT<T0, T1, T2, T3, T4, T5, T6> {
     Concatenate7_VVVVTTT(x0, x1, x2, x3, x4, x5, x6)
@@ -6155,24 +6310,24 @@ extension RegexBuilder {
 
 public struct Concatenate7_VVVVTTV<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
->: RegexProtocol where T0.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
-  public typealias Capture = (T1.Capture, T2.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T0.Match.Capture: EmptyCaptureProtocol, T3.Match.Capture: EmptyCaptureProtocol, T4.Match.Capture: EmptyCaptureProtocol, T5.Match.Capture: EmptyCaptureProtocol, T6.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple3<Substring, T1.Match.Capture, T2.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
-      x5.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
+      x5.regex.ast, 
       x6.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5, T6>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6
   ) -> Concatenate7_VVVVTTV<T0, T1, T2, T3, T4, T5, T6> {
     Concatenate7_VVVVTTV(x0, x1, x2, x3, x4, x5, x6)
@@ -6181,24 +6336,24 @@ extension RegexBuilder {
 
 public struct Concatenate7_VVVVTVT<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
->: RegexProtocol where T1.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
-  public typealias Capture = (T0.Capture, T2.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T1.Match.Capture: EmptyCaptureProtocol, T3.Match.Capture: EmptyCaptureProtocol, T4.Match.Capture: EmptyCaptureProtocol, T5.Match.Capture: EmptyCaptureProtocol, T6.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple3<Substring, T0.Match.Capture, T2.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
-      x5.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
+      x5.regex.ast, 
       x6.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5, T6>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6
   ) -> Concatenate7_VVVVTVT<T0, T1, T2, T3, T4, T5, T6> {
     Concatenate7_VVVVTVT(x0, x1, x2, x3, x4, x5, x6)
@@ -6207,24 +6362,24 @@ extension RegexBuilder {
 
 public struct Concatenate7_VVVVTVV<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
->: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
-  public typealias Capture = (T2.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T0.Match.Capture: EmptyCaptureProtocol, T1.Match.Capture: EmptyCaptureProtocol, T3.Match.Capture: EmptyCaptureProtocol, T4.Match.Capture: EmptyCaptureProtocol, T5.Match.Capture: EmptyCaptureProtocol, T6.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple2<Substring, T2.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
-      x5.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
+      x5.regex.ast, 
       x6.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5, T6>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6
   ) -> Concatenate7_VVVVTVV<T0, T1, T2, T3, T4, T5, T6> {
     Concatenate7_VVVVTVV(x0, x1, x2, x3, x4, x5, x6)
@@ -6233,24 +6388,24 @@ extension RegexBuilder {
 
 public struct Concatenate7_VVVVVTT<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
->: RegexProtocol where T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
-  public typealias Capture = (T0.Capture, T1.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T2.Match.Capture: EmptyCaptureProtocol, T3.Match.Capture: EmptyCaptureProtocol, T4.Match.Capture: EmptyCaptureProtocol, T5.Match.Capture: EmptyCaptureProtocol, T6.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple3<Substring, T0.Match.Capture, T1.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
-      x5.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
+      x5.regex.ast, 
       x6.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5, T6>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6
   ) -> Concatenate7_VVVVVTT<T0, T1, T2, T3, T4, T5, T6> {
     Concatenate7_VVVVVTT(x0, x1, x2, x3, x4, x5, x6)
@@ -6259,24 +6414,24 @@ extension RegexBuilder {
 
 public struct Concatenate7_VVVVVTV<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
->: RegexProtocol where T0.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
-  public typealias Capture = (T1.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T0.Match.Capture: EmptyCaptureProtocol, T2.Match.Capture: EmptyCaptureProtocol, T3.Match.Capture: EmptyCaptureProtocol, T4.Match.Capture: EmptyCaptureProtocol, T5.Match.Capture: EmptyCaptureProtocol, T6.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple2<Substring, T1.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
-      x5.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
+      x5.regex.ast, 
       x6.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5, T6>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6
   ) -> Concatenate7_VVVVVTV<T0, T1, T2, T3, T4, T5, T6> {
     Concatenate7_VVVVVTV(x0, x1, x2, x3, x4, x5, x6)
@@ -6285,24 +6440,24 @@ extension RegexBuilder {
 
 public struct Concatenate7_VVVVVVT<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
->: RegexProtocol where T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
-  public typealias Capture = (T0.Capture)
-  public let regex: Regex<Capture>
+>: RegexProtocol where T1.Match.Capture: EmptyCaptureProtocol, T2.Match.Capture: EmptyCaptureProtocol, T3.Match.Capture: EmptyCaptureProtocol, T4.Match.Capture: EmptyCaptureProtocol, T5.Match.Capture: EmptyCaptureProtocol, T6.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Tuple2<Substring, T0.Match.Capture>
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
-      x5.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
+      x5.regex.ast, 
       x6.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5, T6>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6
   ) -> Concatenate7_VVVVVVT<T0, T1, T2, T3, T4, T5, T6> {
     Concatenate7_VVVVVVT(x0, x1, x2, x3, x4, x5, x6)
@@ -6311,24 +6466,24 @@ extension RegexBuilder {
 
 public struct Concatenate7_VVVVVVV<
   T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol
->: RegexProtocol where T0.Capture: EmptyProtocol, T1.Capture: EmptyProtocol, T2.Capture: EmptyProtocol, T3.Capture: EmptyProtocol, T4.Capture: EmptyProtocol, T5.Capture: EmptyProtocol, T6.Capture: EmptyProtocol {
-  public typealias Capture = Empty
-  public let regex: Regex<Capture>
+>: RegexProtocol where T0.Match.Capture: EmptyCaptureProtocol, T1.Match.Capture: EmptyCaptureProtocol, T2.Match.Capture: EmptyCaptureProtocol, T3.Match.Capture: EmptyCaptureProtocol, T4.Match.Capture: EmptyCaptureProtocol, T5.Match.Capture: EmptyCaptureProtocol, T6.Match.Capture: EmptyCaptureProtocol {
+  public typealias Match = Substring
+  public let regex: Regex<Match>
   init(_ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6) {
     regex = .init(ast: concat(
-      x0.regex.ast,
-      x1.regex.ast,
-      x2.regex.ast,
-      x3.regex.ast,
-      x4.regex.ast,
-      x5.regex.ast,
+      x0.regex.ast, 
+      x1.regex.ast, 
+      x2.regex.ast, 
+      x3.regex.ast, 
+      x4.regex.ast, 
+      x5.regex.ast, 
       x6.regex.ast
     ))
   }
 }
 
 extension RegexBuilder {
-  public static func buildBlock<T0, T1, T2, T3, T4, T5, T6>(
+  public static func buildBlock<T0: RegexProtocol, T1: RegexProtocol, T2: RegexProtocol, T3: RegexProtocol, T4: RegexProtocol, T5: RegexProtocol, T6: RegexProtocol>(
     _ x0: T0, _ x1: T1, _ x2: T2, _ x3: T3, _ x4: T4, _ x5: T5, _ x6: T6
   ) -> Concatenate7_VVVVVVV<T0, T1, T2, T3, T4, T5, T6> {
     Concatenate7_VVVVVVV(x0, x1, x2, x3, x4, x5, x6)

--- a/Sources/_StringProcessing/RegexDSL/DSLCapture.swift
+++ b/Sources/_StringProcessing/RegexDSL/DSLCapture.swift
@@ -1,74 +1,49 @@
-extension RegexProtocol where Capture: EmptyProtocol {
-  public func capture() -> CapturingGroup<Substring> {
-    .init(self)
-  }
-
-  public func capture<NewCapture>(
-    _ transform: @escaping (Substring) -> NewCapture
-  ) -> CapturingGroup<NewCapture> {
-    .init(self, transform: transform)
-  }
-}
-
 extension RegexProtocol {
-  // Note: We use `@_disfavoredOverload` to prevent tuple captures from choosing this overload.
-  @_disfavoredOverload
-  public func capture() -> CapturingGroup<(Substring, Capture)> {
+  public func capture() -> CapturingGroup<Tuple2<Substring, Substring>> where Match.Capture: EmptyCaptureProtocol {
     .init(self)
   }
 
-  // Note: We use `@_disfavoredOverload` to prevent tuple captures from choosing this overload.
-  @_disfavoredOverload
   public func capture<NewCapture>(
     _ transform: @escaping (Substring) -> NewCapture
-  ) -> CapturingGroup<(Substring, Capture)> {
+  ) -> CapturingGroup<Tuple2<Substring, NewCapture>> where Match.Capture: EmptyCaptureProtocol {
     .init(self, transform: transform)
   }
 
-  public func capture<C0, C1>() -> CapturingGroup<(Substring, C0, C1)> where Capture == (C0, C1) {
+  public func capture<C0>() -> CapturingGroup<Tuple3<Substring, Substring, C0>>
+  where Match.Capture == C0 {
+    .init(self)
+  }
+
+  public func capture<NewCapture, C0>(
+    _ transform: @escaping (Substring) -> NewCapture
+  ) -> CapturingGroup<Tuple3<Substring, NewCapture, C0>> where Match.Capture == C0 {
+    .init(self, transform: transform)
+  }
+
+  public func capture<C0, C1>() -> CapturingGroup<Tuple4<Substring, Substring, C0, C1>> where Match.Capture == Tuple2<C0, C1> {
     .init(self)
   }
 
   public func capture<NewCapture, C0, C1>(
     _ transform: @escaping (Substring) -> NewCapture
-  ) -> CapturingGroup<(Substring, C0, C1)> where Capture == (C0, C1) {
+  ) -> CapturingGroup<Tuple4<Substring, NewCapture, C0, C1>> where Match.Capture == Tuple2<C0, C1> {
     .init(self, transform: transform)
   }
 
-  public func capture<C0, C1, C2>() -> CapturingGroup<(Substring, C0, C1, C2)>
-  where Capture == (C0, C1, C2) {
+  public func capture<C0, C1, C2>() -> CapturingGroup<Tuple5<Substring, Substring, C0, C1, C2>>
+  where Match.Capture == Tuple3<C0, C1, C2> {
     .init(self)
   }
 
   public func capture<NewCapture, C0, C1, C2>(
     _ transform: @escaping (Substring) -> NewCapture
-  ) -> CapturingGroup<(Substring, C0, C1, C2)> where Capture == (C0, C1, C2) {
+  ) -> CapturingGroup<Tuple5<Substring, NewCapture, C0, C1, C2>> where Match.Capture == Tuple3<C0, C1, C2> {
     .init(self, transform: transform)
-  }
-
-  public func capture<C0, C1, C2, C3>() -> CapturingGroup<(Substring, C0, C1, C2, C3)>
-  where Capture == (C0, C1, C2, C3) {
-    .init(self)
-  }
-
-  public func capture<C0, C1, C2, C3, C4>() -> CapturingGroup<(Substring, C0, C1, C2, C3, C4)>
-  where Capture == (C0, C1, C2, C3, C4) {
-    .init(self)
-  }
-
-  public func capture<C0, C1, C2, C3, C4, C5>() -> CapturingGroup<(Substring, C0, C1, C2, C3, C4, C5)>
-  where Capture == (C0, C1, C2, C3, C4, C5) {
-    .init(self)
-  }
-
-  public func capture<C0, C1, C2, C3, C4, C5, C6>() -> CapturingGroup<(Substring, C0, C1, C2, C3, C4, C5, C6)>
-  where Capture == (C0, C1, C2, C3, C4, C5, C6) {
-    .init(self)
   }
 }
 
 /* Or using parameterized extensions and variadic generics.
-extension<T...> RegexProtocol where Capture == (T...) {
+extension<T...> RegexProtocol where Match == (T...) {
   public func capture() -> CapturingGroup<(Substring, T...)> {
     .init(self)
   }

--- a/Sources/_StringProcessing/RegexDSL/DynamicCaptures.swift
+++ b/Sources/_StringProcessing/RegexDSL/DynamicCaptures.swift
@@ -1,8 +1,8 @@
 import _MatchingEngine
 
-extension Regex where Capture == DynamicCaptures {
-  public init(_ string: String) throws {
-    self.init(ast: try parse(string, .traditional))
+extension Regex where Match == Tuple2<Substring, DynamicCaptures> {
+  public init(_ pattern: String) throws {
+    self.init(ast: try parse(pattern, .traditional))
   }
 }
 
@@ -22,11 +22,12 @@ public enum DynamicCaptures: Equatable {
       self = .substring(atom as! Substring)
     case .tuple(let components):
       self = .tuple(components.map(Self.init))
-    case .optional(let component):
-      self = .optional(component.map(Self.init))
-    case .array(let components):
+    case .some(let component):
+      self = .optional(Self(component))
+    case .none:
+      self = .optional(nil)
+    case .array(let components, _):
       self = .array(components.map(Self.init))
     }
   }
 }
-

--- a/Tests/MatchingEngineTests/UtilTests.swift
+++ b/Tests/MatchingEngineTests/UtilTests.swift
@@ -1,5 +1,5 @@
 import XCTest
-@testable import _StringProcessing
+@testable import _MatchingEngine
 
 class UtilTests: XCTestCase {
   func testTupleTypeConstruction() {

--- a/Tests/RegexTests/LegacyTests.swift
+++ b/Tests/RegexTests/LegacyTests.swift
@@ -237,7 +237,7 @@ extension RegexTests {
              .captureSome,
              goto(label: 1),
              label(0),
-             .captureNil,
+             .captureNil(childType: Substring.self),
              label(1),
              .endGroup,
              "d",
@@ -261,7 +261,7 @@ extension RegexTests {
              .endCapture(),
              .goto(label: 0),
              .label(1),
-             .captureArray,
+             .captureArray(childType: Substring.self),
              .endGroup,
              .endGroup,
              labels: [3, 14, 11, 9],
@@ -273,7 +273,7 @@ extension RegexTests {
              label(2), split(disfavoring: 3), "a", goto(label: 2),
              label(3), .endCapture(), goto(label: 0),
              label(1),
-             .captureArray,
+             .captureArray(childType: Substring.self),
              .endGroup,
              labels: [1, 11, 4, 8], splits: [2, 5]))
     performTest(

--- a/Tests/RegexTests/RegexDSLTests.swift
+++ b/Tests/RegexTests/RegexDSLTests.swift
@@ -9,10 +9,10 @@ class RegexDSLTests: XCTestCase {
       "1".capture { Int($0)! } // Int
     }
     // Assert the inferred capture type.
-    let _: (Substring, Int).Type = type(of: regex).Capture.self
+    let _: Tuple3<Substring, Substring, Int>.Type = type(of: regex).Match.self
     let maybeMatch = "ab1".match(regex)
     let match = try XCTUnwrap(maybeMatch)
-    XCTAssertTrue(match.captures == ("b", 1))
+    XCTAssertTrue(match.match == Tuple3("ab1", "b", 1))
   }
 
   func testCharacterClasses() throws {
@@ -22,29 +22,29 @@ class RegexDSLTests: XCTestCase {
       "c".capture() // Substring
     }
     // Assert the inferred capture type.
-    let _: (Substring, Substring).Type = type(of: regex).Capture.self
+    let _: Tuple3<Substring, Substring, Substring>.Type = type(of: regex).Match.self
     let maybeMatch = "a c".match(regex)
     let match = try XCTUnwrap(maybeMatch)
-    XCTAssertTrue(match.captures == (" ", "c"))
+    XCTAssertTrue(match.match == Tuple3("a c", " ", "c"))
   }
 
   func testCombinators() throws {
     let regex = Regex {
       "a".+
-      OneOrMore(Character("b")).capture() // [Character]
-      Repeat("c").capture() // [Substring]
-      CharacterClass.hexDigit.capture().* // [Character]
+      OneOrMore(Character("b")).capture() // Substring
+      Repeat("c").capture() // Substring
+      CharacterClass.hexDigit.capture().* // [Substring]
       "e".?
       ("t" | "k").capture() // Substring
     }
     // Assert the inferred capture type.
-    let _: (Substring, Substring, [Substring], Substring).Type
-      = type(of: regex).Capture.self
+    let _: Tuple5<Substring, Substring, Substring, [Substring], Substring>.Type
+      = type(of: regex).Match.self
     let maybeMatch = "aaaabccccdddk".match(regex)
     let match = try XCTUnwrap(maybeMatch)
     XCTAssertTrue(
-      match.captures
-        == ("b", "cccc", ["d", "d", "d"], "k"))
+      match.match
+        == Tuple5("aaaabccccdddk", "b", "cccc", ["d", "d", "d"], "k"))
   }
 
   func testNestedGroups() throws {
@@ -58,15 +58,20 @@ class RegexDSLTests: XCTestCase {
       }
     }
     // Assert the inferred capture type.
-    let _: [(Substring, Substring, [Substring])].Type = type(of: regex).Capture.self
+    let _: Tuple2<Substring, [Tuple3<Substring, Substring, [Substring]>]>.Type
+      = type(of: regex).Match.self
     let maybeMatch = "aaaabccccddd".match(regex)
     let match = try XCTUnwrap(maybeMatch)
-    XCTAssertEqual(match.captures.count, 1)
+    XCTAssertEqual(match.match.1.count, 1)
+    XCTAssertEqual(match.match.0, "aaaabccccddd")
     XCTAssertTrue(
-      match.captures[0]
-        == ("b", "cccc", ["d", "d", "d"]))
+      match.match.1[0]
+        == Tuple3("b", "cccc", ["d", "d", "d"]))
   }
 
+  // Note: Types of nested captures should be flat, but are currently nested
+  // due to the lack of variadic generics. Without it, we cannot effectively
+  // express type constraints to concatenate splatted tuples.
   func testNestedCaptureTypes() throws {
     let regex1 = Regex {
       "a".+
@@ -75,7 +80,8 @@ class RegexDSLTests: XCTestCase {
         "e".?
       }.capture()
     }
-    let _: (Substring, Substring).Type = type(of: regex1).Capture.self
+    let _: Tuple2<Substring, Tuple2<Substring, Substring>>.Type
+      = type(of: regex1).Match.self
     let regex2 = Regex {
       "a".+
       Regex {
@@ -83,7 +89,8 @@ class RegexDSLTests: XCTestCase {
         "e".?
       }.capture()
     }
-    let _: (Substring, [Int]).Type = type(of: regex2).Capture.self
+    let _: Tuple2<Substring, Tuple2<Substring, [Int]>>.Type
+      = type(of: regex2).Match.self
     let regex3 = Regex {
       "a".+
       Regex {
@@ -92,7 +99,8 @@ class RegexDSLTests: XCTestCase {
         "e".?
       }.capture()
     }
-    let _: (Substring, Int, [Double]).Type = type(of: regex3).Capture.self
+    let _: Tuple2<Substring, Tuple3<Substring, Int, [Double]>>.Type
+      = type(of: regex3).Match.self
     let regex4 = Regex {
       "a".+
       OneOrMore {
@@ -102,7 +110,10 @@ class RegexDSLTests: XCTestCase {
         "e".?
       }.capture()
     }
-    let _: (Substring, [(Substring, Substring, [Substring])]).Type = type(of: regex4).Capture.self
+    let _: Tuple2<
+      Substring, Tuple2<
+        Substring, [Tuple3<Substring, Substring, [Substring]>]>>.Type
+      = type(of: regex4).Match.self
   }
 
   func testUnicodeScalarPostProcessing() throws {
@@ -139,12 +150,13 @@ class RegexDSLTests: XCTestCase {
     }
 
     // Assert the inferred capture type.
-    let _: Substring.Type = type(of: unicodeData).Capture.self
+    let _: Tuple2<Substring, Substring>.Type = type(of: unicodeData).Match.self
 
     let unicodeLine =
       "1BCA0..1BCA3  ; Control # Cf   [4] SHORTHAND FORMAT LETTER OVERLAP..SHORTHAND FORMAT UP STEP"
     let match = try XCTUnwrap(unicodeLine.match(unicodeData))
-    XCTAssertEqual(match.captures, "Control")
+    XCTAssertEqual(match.0, Substring(unicodeLine))
+    XCTAssertEqual(match.1, "Control")
   }
 
   func testGraphemeBreakData() throws {
@@ -164,21 +176,24 @@ class RegexDSLTests: XCTestCase {
       Repeat(CharacterClass.any)
     }
     // Assert the inferred capture type.
-    typealias Capture = (Substring, Substring?, Substring)
-    let _: Capture.Type = type(of: regex).Capture.self
+    typealias ExpectedMatch = Tuple4<
+      Substring, Substring, Substring?, Substring
+    >
+    let _: ExpectedMatch.Type = type(of: regex).Match.self
     func run<R: RegexProtocol>(
       _ regex: R
-    ) throws where R.Capture == Capture {
+    ) throws where R.Match == ExpectedMatch {
       let maybeMatchResult = line.match(regex)
       let matchResult = try XCTUnwrap(maybeMatchResult)
-      let (lower, upper, propertyString) = matchResult.captures
+      let (wholeMatch, lower, upper, propertyString) = matchResult.match.tuple
+      XCTAssertEqual(wholeMatch, Substring(line))
       XCTAssertEqual(lower, "A6F0")
       XCTAssertEqual(upper, "A6F1")
       XCTAssertEqual(propertyString, "Extend")
     }
     let regexLiteral = try MockRegexLiteral(
-        #"([0-9A-F]+)(?:\.\.([0-9A-F]+))?\s+;\s+(\w+).*"#,
-        capturing: (Substring, Substring?, Substring).self)
+      #"([0-9A-F]+)(?:\.\.([0-9A-F]+))?\s+;\s+(\w+).*"#,
+      matching: Tuple4<Substring, Substring, Substring?, Substring>.self)
     try run(regex)
     try run(regexLiteral)
   }
@@ -187,22 +202,23 @@ class RegexDSLTests: XCTestCase {
     do {
       let regex = try Regex("aabcc.")
       let line = "aabccd"
-      let captures = try XCTUnwrap(line.match(regex)?.captures)
+      let captures = try XCTUnwrap(line.match(regex)?.1)
       XCTAssertEqual(captures, .empty)
     }
     do {
-      let regex = try Regex(#"([0-9A-F]+)(?:\.\.([0-9A-F]+))?\s+;\s+(\w+).*"#)
+      let regex = try Regex(
+        #"([0-9A-F]+)(?:\.\.([0-9A-F]+))?\s+;\s+(\w+).*"#)
       let line = """
         A6F0..A6F1    ; Extend # Mn   [2] BAMUM COMBINING MARK KOQNDON..BAMUM \
         COMBINING MARK TUKWENTIS
         """
-      let captures = try XCTUnwrap(line.match(regex)?.captures)
+      let captures = try XCTUnwrap(line.match(regex)?.1)
       XCTAssertEqual(
-          captures,
-          .tuple([
-            .substring("A6F0"),
-            .optional(.substring("A6F1")),
-            .substring("Extend")]))
+        captures,
+        .tuple([
+          .substring("A6F0"),
+          .optional(.substring("A6F1")),
+          .substring("Extend")]))
     }
   }
 }


### PR DESCRIPTION
Changes `Regex` and result builder prototype to use `Match` as the generic parameter to make it consistent with the [Strongly Typed Regex Captures](https://forums.swift.org/t/pitch-strongly-typed-regex-captures/53391) pitch.

Introduces `Tuple<n>` structs in order to be able to express constraints on capture types (i.e. `Match` dropped first) while being able to filter out empty captures in concatenation. `Tuple<n>` is also needed to implement a prototype of the [proposed matching semantics](#64).

```swift
@frozen @dynamicMemberLookup
public struct Tuple{n}<_0, _1, ...> {
  public typealias Tuple = (_0, _1, ...)
  public var tuple: Tuple
  public init(_ tuple: Tuple)
  public init(_ _0: _0, _ _1: _1, ...)
  public subscript<T>(dynamicMember keyPath: WritableKeyPath<Tuple, T>) -> T { get _modify }
}
```

As coercion into `Tuple<n>` can no longer use runtime magic like native tuples do, we incorporate child capture type information into RECode's `captureNil` and `captureArray` instructions so that we will always get a concrete type when forming a nil or an empty array capture. The resulting existential tuple capture can then be opened and bitcast to a `Tuple<n>`.