### PR TITLE
Add 'init(_regexString:)' for compiler integration.

### DIFF
--- a/Sources/_StringProcessing/RegexDSL/Core.swift
+++ b/Sources/_StringProcessing/RegexDSL/Core.swift
@@ -12,9 +12,11 @@ public protocol RegexProtocol {
 }
 
 /// A regular expression.
+@frozen
 public struct Regex<Capture>: RegexProtocol {
   /// A program representation that caches any lowered representation for
   /// execution.
+  @usableFromInline
   internal class Program {
     /// The underlying AST.
     let ast: AST
@@ -34,11 +36,18 @@ public struct Regex<Capture>: RegexProtocol {
     }
   }
 
+  @usableFromInline
   let program: Program
   var ast: AST { program.ast }
 
   init(ast: AST) {
     self.program = Program(ast: ast)
+  }
+
+  // Compiler interface. Do not change independently.
+  @usableFromInline
+  init(_regexString pattern: String) {
+    self.init(ast: try! parse(pattern, .traditional))
   }
 
   public init<Content: RegexProtocol>(


### PR DESCRIPTION
Add 'init(_regexString:)' for compiler integration.

Also make `Regex` frozen to avoid it being an address-only type. I think it's not likely going to need resilience, but we can also change later if needed.