### PR TITLE
Quick compiler interface mockup

### DIFF
--- a/Sources/_MatchingEngine/Regex/Parse/Mocking.swift
+++ b/Sources/_MatchingEngine/Regex/Parse/Mocking.swift
@@ -36,3 +36,72 @@ struct SwiftLexer {
 }
 
 // TODO: mock up multi-line soon
+
+
+enum LexError: Error {
+  case endOfString
+  case invalidUTF8 // TODO: better range reporting
+  case notRegexLiteralStart
+}
+
+public func _lexRegex(
+  _ start: UnsafeRawPointer
+) throws -> (String, SyntaxOptions)? {
+  var current = start
+
+  func ascii(_ s: Unicode.Scalar) -> UInt8 {
+    assert(s.value <= 0x7F)
+    return UInt8(truncatingIfNeeded: s.value)
+  }
+  func load(offset: Int) -> UInt8 {
+    current.load(fromByteOffset: offset, as: UInt8.self)
+  }
+  func load() -> UInt8 { load(offset: 0) }
+  func advance() { current = current.successor() }
+  func eat() -> UInt8 {
+    defer { advance() }
+    return load()
+  }
+
+  guard eat() == ascii("'") else {
+    throw LexError.notRegexLiteralStart
+  }
+
+  let syntax: SyntaxOptions
+  let delimiter = eat()
+  switch delimiter {
+  case ascii("|"): syntax = .modern
+  case ascii("/"): syntax = .traditional
+  default: return nil
+  }
+
+  let contentsStart = current
+  let count: Int = try {
+    while true {
+      switch load() {
+      case 0: throw LexError.endOfString
+      case ascii("\\"):
+        // Skip next byte
+        advance()
+        advance()
+      case delimiter:
+        if load(offset: 1) == ascii("'") {
+          return current - contentsStart
+        }
+        advance()
+
+      default: advance()
+      }
+    }
+  }()
+
+  let contents = UnsafeRawBufferPointer(
+    start: contentsStart, count: count)
+  let s = String(decoding: contents, as: UTF8.self)
+
+  guard s.utf8.elementsEqual(contents) else {
+    throw LexError.invalidUTF8
+  }
+
+  return (s, syntax)
+}

--- a/Tests/RegexTests/LexTests.swift
+++ b/Tests/RegexTests/LexTests.swift
@@ -96,4 +96,32 @@ extension RegexTests {
     // TODO: want to dummy print out source ranges, etc, test that.
   }
 
+
+  func testCompilerInterface() {
+    let testCases: [(String, (String, SyntaxOptions)?)] = [
+      ("'/abc/'", ("abc", .traditional)),
+      ("'|abc|'", ("abc", .modern)),
+      ("'|ab\0c|'", nil),
+      ("'abc'", nil),
+      ("'/abc/def/'", ("abc/def", .traditional)),
+      ("'|abc|def|'", ("abc|def", .modern)),
+      ("'/abc\\/'def/'", ("abc\\/'def", .traditional)),
+      ("'|abc\\|'def|'", ("abc\\|'def", .modern)),
+      ("'/abc|'def/'", ("abc|'def", .traditional)),
+      ("'|abc/'def|'", ("abc/'def", .modern)),
+      ("'/abc|'def/", nil),
+      ("'|abc/'def'", nil),
+    ]
+
+    for (input, expected) in testCases {
+      input.withCString {
+        guard let out = try? _lexRegex(UnsafeRawPointer($0)) else {
+          XCTAssertNil(expected)
+          return
+        }
+        XCTAssertEqual(expected?.0, out.0)
+        XCTAssertEqual(expected?.1, out.1)
+      }
+    }
+  }
 }


### PR DESCRIPTION
Quick mockup of full lexing in the package, where the Swift compiler hands off a pointer to us and we proceed from there, instead of the compiler parsing the delimiter for us.