### PR TITLE
Tests: remove `LinuxMain.swift`

### DIFF
--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1,6 +1,0 @@
-import XCTest
-@testable import _StringProcessingTests
-
-XCTMain([
-    testCase(regexTests.allTests),
-])


### PR DESCRIPTION
This precludes building tests on Windows.  The use of top-level
expressions requires `-parse-as-library`, which we cannot pass along.
Furthermore, at this point, it is of questionable value to add the entry
stub as SPM can generate this.  This change allows running the test
suite on Windows.

~~~
Test Suite 'All tests' started at 2021-12-15 13:23:44.241
Test Suite 'debug.xctest' started at 2021-12-15 13:23:44.257
Test Suite 'AllScalarsTests' started at 2021-12-15 13:23:44.257
Test Case 'AllScalarsTests.testCollectionConformance' started at 2021-12-15 13:23:44.257
Test Case 'AllScalarsTests.testCollectionConformance' passed (0.406 seconds)
Test Case 'AllScalarsTests.testIndexOf' started at 2021-12-15 13:23:44.663
Test Case 'AllScalarsTests.testIndexOf' passed (0.126 seconds)
Test Case 'AllScalarsTests.testProperties' started at 2021-12-15 13:23:44.789
Test Case 'AllScalarsTests.testProperties' passed (1.275 seconds)
Test Suite 'AllScalarsTests' passed at 2021-12-15 13:23:46.064
         Executed 3 tests, with 0 failures (0 unexpected) in 1.807 (1.807) seconds
Test Suite 'UtilTests' started at 2021-12-15 13:23:46.064
Test Case 'UtilTests.testTupleTypeConstruction' started at 2021-12-15 13:23:46.064
Test Case 'UtilTests.testTupleTypeConstruction' passed (0.0 seconds)
Test Case 'UtilTests.testTypeErasedTupleConstruction' started at 2021-12-15 13:23:46.064
Test Case 'UtilTests.testTypeErasedTupleConstruction' passed (0.0 seconds)
Test Suite 'UtilTests' passed at 2021-12-15 13:23:46.064
         Executed 2 tests, with 0 failures (0 unexpected) in 0.0 (0.0) seconds
Test Suite 'RegexConsumerTests' started at 2021-12-15 13:23:46.064
Test Case 'RegexConsumerTests.testAdHoc' started at 2021-12-15 13:23:46.064
Test Case 'RegexConsumerTests.testAdHoc' passed (0.006 seconds)
Test Case 'RegexConsumerTests.testRanges' started at 2021-12-15 13:23:46.070
Test Case 'RegexConsumerTests.testRanges' passed (0.01 seconds)
Test Case 'RegexConsumerTests.testReplace' started at 2021-12-15 13:23:46.080
Test Case 'RegexConsumerTests.testReplace' passed (0.0 seconds)
Test Case 'RegexConsumerTests.testSplit' started at 2021-12-15 13:23:46.080
Test Case 'RegexConsumerTests.testSplit' passed (0.0 seconds)
Test Suite 'RegexConsumerTests' passed at 2021-12-15 13:23:46.080
         Executed 4 tests, with 0 failures (0 unexpected) in 0.016 (0.016) seconds
Test Suite 'PTCaRetTests' started at 2021-12-15 13:23:46.080
Test Case 'PTCaRetTests.testAcquireRelease' started at 2021-12-15 13:23:46.080
Test Case 'PTCaRetTests.testAcquireRelease' passed (0.0 seconds)
Test Case 'PTCaRetTests.testComplex' started at 2021-12-15 13:23:46.080
Test Case 'PTCaRetTests.testComplex' passed (0.0 seconds)
Test Case 'PTCaRetTests.testDirectCall' started at 2021-12-15 13:23:46.080
Test Case 'PTCaRetTests.testDirectCall' passed (0.0 seconds)
Test Case 'PTCaRetTests.testHappensBefore' started at 2021-12-15 13:23:46.080
Test Case 'PTCaRetTests.testHappensBefore' passed (0.0 seconds)
Test Suite 'PTCaRetTests' passed at 2021-12-15 13:23:46.080
         Executed 4 tests, with 0 failures (0 unexpected) in 0.0 (0.0) seconds
Test Suite 'UnicodeTests' started at 2021-12-15 13:23:46.080
Test Case 'UnicodeTests.testUnsafeDecoding' started at 2021-12-15 13:23:46.080
Test Case 'UnicodeTests.testUnsafeDecoding' passed (0.0 seconds)
Test Suite 'UnicodeTests' passed at 2021-12-15 13:23:46.080
         Executed 1 test, with 0 failures (0 unexpected) in 0.0 (0.0) seconds
Test Suite 'ExercisesTests' started at 2021-12-15 13:23:46.080
Test Case 'ExercisesTests.testAll' started at 2021-12-15 13:23:46.080
Test Case 'ExercisesTests.testAll' passed (0.943 seconds)
Test Suite 'ExercisesTests' passed at 2021-12-15 13:23:47.023
         Executed 1 test, with 0 failures (0 unexpected) in 0.943 (0.943) seconds
Test Suite 'RegexTests' started at 2021-12-15 13:23:47.023
Test Case 'RegexTests.testRender' started at 2021-12-15 13:23:47.023
Test Case 'RegexTests.testRender' passed (0.004 seconds)
Test Case 'RegexTests.testUnit' started at 2021-12-15 13:23:47.027
Test Case 'RegexTests.testUnit' passed (0.0 seconds)
Test Case 'RegexTests.testLegacyCompile' started at 2021-12-15 13:23:47.027
Test Case 'RegexTests.testLegacyCompile' passed (0.0 seconds)
Test Case 'RegexTests.testLegacyMatchLevel' started at 2021-12-15 13:23:47.027
Test Case 'RegexTests.testLegacyMatchLevel' passed (0.0 seconds)
Test Case 'RegexTests.testLegacyPartialMatches' started at 2021-12-15 13:23:47.027
Test Case 'RegexTests.testLegacyPartialMatches' passed (0.0 seconds)
Test Case 'RegexTests.testLegacySubrangeMatches' started at 2021-12-15 13:23:47.027
Test Case 'RegexTests.testLegacySubrangeMatches' passed (0.0 seconds)
Test Case 'RegexTests.testLegacyVMs' started at 2021-12-15 13:23:47.027
Test Case 'RegexTests.testLegacyVMs' passed (0.037 seconds)
Test Case 'RegexTests.testCompilerInterface' started at 2021-12-15 13:23:47.064
Test Case 'RegexTests.testCompilerInterface' passed (0.008 seconds)
Test Case 'RegexTests.testLexicalAnalysis' started at 2021-12-15 13:23:47.072
Test Case 'RegexTests.testLexicalAnalysis' passed (0.0 seconds)
Test Case 'RegexTests.testMatch' started at 2021-12-15 13:23:47.072
Test Case 'RegexTests.testMatch' passed (0.0 seconds)
Test Case 'RegexTests.testParse' started at 2021-12-15 13:23:47.072
Test Case 'RegexTests.testParse' passed (0.02 seconds)
Test Case 'RegexTests.testParseErrors' started at 2021-12-15 13:23:47.092
Test Case 'RegexTests.testParseErrors' passed (0.0 seconds)
Test Case 'RegexTests.testModernCaptures' started at 2021-12-15 13:23:47.092
Test Case 'RegexTests.testModernCaptures' passed (0.001 seconds)
Test Case 'RegexTests.testModernComments' started at 2021-12-15 13:23:47.093
Test Case 'RegexTests.testModernComments' passed (0.0 seconds)
Test Case 'RegexTests.testModernQuotes' started at 2021-12-15 13:23:47.093
Test Case 'RegexTests.testModernQuotes' passed (0.001 seconds)
Test Case 'RegexTests.testModernRanges' started at 2021-12-15 13:23:47.094
Test Case 'RegexTests.testModernRanges' passed (0.0 seconds)
Test Case 'RegexTests.testSemanticWhitespace' started at 2021-12-15 13:23:47.094
Test Case 'RegexTests.testSemanticWhitespace' passed (0.001 seconds)
Test Suite 'RegexTests' passed at 2021-12-15 13:23:47.095
         Executed 17 tests, with 0 failures (0 unexpected) in 0.072 (0.072) seconds
Test Suite 'PEGStringTests' started at 2021-12-15 13:23:47.095
Test Case 'PEGStringTests.testCamelCase' started at 2021-12-15 13:23:47.095
Test Case 'PEGStringTests.testCamelCase' passed (0.0 seconds)
Test Case 'PEGStringTests.testCharacterClasses' started at 2021-12-15 13:23:47.095
Test Case 'PEGStringTests.testCharacterClasses' passed (0.006 seconds)
Test Case 'PEGStringTests.testComments' started at 2021-12-15 13:23:47.101
Test Case 'PEGStringTests.testComments' passed (0.005 seconds)
Test Case 'PEGStringTests.testEvenZeroesOnes' started at 2021-12-15 13:23:47.106
Test Case 'PEGStringTests.testEvenZeroesOnes' passed (0.002 seconds)
Test Case 'PEGStringTests.testHappensBefore' started at 2021-12-15 13:23:47.108
Test Case 'PEGStringTests.testHappensBefore' passed (0.0 seconds)
Test Suite 'PEGStringTests' passed at 2021-12-15 13:23:47.108
         Executed 5 tests, with 0 failures (0 unexpected) in 0.013 (0.013) seconds
Test Suite 'MatchingEngineTests' started at 2021-12-15 13:23:47.108
Test Case 'MatchingEngineTests.testAEaters' started at 2021-12-15 13:23:47.108
Test Case 'MatchingEngineTests.testAEaters' passed (0.003 seconds)
Test Suite 'MatchingEngineTests' passed at 2021-12-15 13:23:47.111
         Executed 1 test, with 0 failures (0 unexpected) in 0.003 (0.003) seconds
Test Suite 'RegexDSLTests' started at 2021-12-15 13:23:47.111
Test Case 'RegexDSLTests.testCharacterClasses' started at 2021-12-15 13:23:47.111
Test Case 'RegexDSLTests.testCharacterClasses' passed (0.0 seconds)
Test Case 'RegexDSLTests.testCombinators' started at 2021-12-15 13:23:47.111
Test Case 'RegexDSLTests.testCombinators' passed (0.0 seconds)
Test Case 'RegexDSLTests.testDynamicCaptures' started at 2021-12-15 13:23:47.111
Test Case 'RegexDSLTests.testDynamicCaptures' passed (0.001 seconds)
Test Case 'RegexDSLTests.testGraphemeBreakData' started at 2021-12-15 13:23:47.112
Test Case 'RegexDSLTests.testGraphemeBreakData' passed (0.001 seconds)
Test Case 'RegexDSLTests.testNestedCaptureTypes' started at 2021-12-15 13:23:47.113
Test Case 'RegexDSLTests.testNestedCaptureTypes' passed (0.0 seconds)
Test Case 'RegexDSLTests.testNestedGroups' started at 2021-12-15 13:23:47.113
Test Case 'RegexDSLTests.testNestedGroups' passed (0.001 seconds)
Test Case 'RegexDSLTests.testSimpleStrings' started at 2021-12-15 13:23:47.114
Test Case 'RegexDSLTests.testSimpleStrings' passed (0.0 seconds)
Test Case 'RegexDSLTests.testUnicodeScalarPostProcessing' started at 2021-12-15 13:23:47.114
Test Case 'RegexDSLTests.testUnicodeScalarPostProcessing' passed (0.001 seconds)
Test Suite 'RegexDSLTests' passed at 2021-12-15 13:23:47.115
         Executed 8 tests, with 0 failures (0 unexpected) in 0.004 (0.004) seconds
Test Suite 'debug.xctest' passed at 2021-12-15 13:23:47.115
         Executed 46 tests, with 0 failures (0 unexpected) in 2.858 (2.858) seconds
Test Suite 'All tests' passed at 2021-12-15 13:23:47.115
         Executed 46 tests, with 0 failures (0 unexpected) in 2.858 (2.858) seconds
~~~