### PR TITLE
AST Atom and custom char class consumers

### DIFF
--- a/Sources/Algorithms/Consumers/RegexConsumer.swift
+++ b/Sources/Algorithms/Consumers/RegexConsumer.swift
@@ -5,7 +5,7 @@ import _StringProcessing
 public struct Regex {
   let string: String
   let options: REOptions
-  
+
   public init(_ string: String, options: REOptions = .none) {
     self.string = string
     self.options = options
@@ -13,8 +13,8 @@ public struct Regex {
 }
 
 public struct RegexConsumer: CollectionConsumer {
-  // NOTE: existential
-  let vm: Executor
+  // TODO: consider let, for now lets us toggle tracing
+  var vm: Executor
 
   public init(_ regex: Regex) {
     self.vm = _compileRegex(regex.string)

--- a/Sources/Algorithms/Consumers/RegexConsumer.swift
+++ b/Sources/Algorithms/Consumers/RegexConsumer.swift
@@ -17,7 +17,7 @@ public struct RegexConsumer: CollectionConsumer {
   var vm: Executor
 
   public init(_ regex: Regex) {
-    self.vm = _compileRegex(regex.string)
+    self.vm = try! _compileRegex(regex.string)
   }
 
   public func consume(

--- a/Sources/_StringProcessing/Compiler.swift
+++ b/Sources/_StringProcessing/Compiler.swift
@@ -21,13 +21,13 @@ class Compiler {
     self.options = options
   }
 
-  __consuming func emit() -> RegexProgram {
-    emit(ast)
+  __consuming func emit() throws -> RegexProgram {
+    try emit(ast)
     builder.buildAccept()
     return RegexProgram(program: builder.assemble())
   }
 
-  func emit(_ node: AST) {
+  func emit(_ node: AST) throws {
 
     switch node {
     // Any: .
@@ -60,43 +60,43 @@ class Compiler {
       for component in alt.children.dropLast() {
         let next = builder.makeAddress()
         builder.buildSave(next)
-        emit(component)
+        try emit(component)
         builder.buildBranch(to: done)
         builder.label(next)
       }
-      emit(alt.children.last!)
+      try emit(alt.children.last!)
       builder.label(done)
 
     // FIXME: Wait, how does this work?
     case .groupTransform(let g, _):
-      emit(g.child)
+      try emit(g.child)
 
 
     case .concatenation(let concat):
-      concat.children.forEach(emit)
+      try concat.children.forEach(emit)
 
     case .trivia, .empty:
       break
 
     // FIXME: This can't be right...
     case .group(let g):
-      emit(g.child)
+      try emit(g.child)
 
     case .quantification(let quant):
-      emitQuantification(quant)
+      try emitQuantification(quant)
 
     // For now, we model sets and atoms as consumers.
     // This lets us rapidly expand support, and we can better
     // design the actual instruction set with real examples
-    case _ where node.generateConsumer(matchLevel) != nil:
-      builder.buildConsume(by: node.generateConsumer(matchLevel)!)
+    case _ where try node.generateConsumer(matchLevel) != nil:
+      try builder.buildConsume(by: node.generateConsumer(matchLevel)!)
 
     case .quote, .customCharacterClass, .atom:
-      fatalError("FIXME")
+      throw unsupported(node._dumpBase)
     }
   }
 
-  func emitQuantification(_ quant: AST.Quantification) {
+  func emitQuantification(_ quant: AST.Quantification) throws {
     let child = quant.child
     switch (quant.amount.value, quant.kind.value) {
     // Lazy zero or more: *?
@@ -115,7 +115,7 @@ class Compiler {
       builder.buildSave(element)
       builder.buildBranch(to: after)
       builder.label(element)
-      emit(child)
+      try emit(child)
       builder.buildBranch(to: start)
       builder.label(after)
 
@@ -128,7 +128,7 @@ class Compiler {
       let element = builder.makeAddress()
       let after = builder.makeAddress()
       builder.label(element)
-      emit(child)
+      try emit(child)
       builder.buildSave(element)
       builder.label(after)
 
@@ -144,7 +144,7 @@ class Compiler {
       builder.buildSave(element)
       builder.buildBranch(to: after)
       builder.label(element)
-      emit(child)
+      try emit(child)
       builder.label(after)
 
     // Zero or more: *
@@ -158,7 +158,7 @@ class Compiler {
       let start = builder.makeAddress()
       builder.label(start)
       builder.buildSave(end)
-      emit(child)
+      try emit(child)
       builder.buildBranch(to: start)
       builder.label(end)
 
@@ -172,7 +172,7 @@ class Compiler {
       let element = builder.makeAddress()
       let end = builder.makeAddress()
       builder.label(element)
-      emit(child)
+      try emit(child)
       builder.buildSave(end)
       builder.buildBranch(to: element)
       builder.label(end)
@@ -184,7 +184,7 @@ class Compiler {
     case (.zeroOrOne, .greedy):
       let end = builder.makeAddress()
       builder.buildSave(end)
-      emit(child)
+      try emit(child)
       builder.label(end)
 
     // Exactly: {n}
@@ -195,7 +195,7 @@ class Compiler {
     case (.exactly(let n), _):
       // FIXME: This works, but better to emit a loop
       for _ in 0..<n.value {
-        emit(child)
+        try emit(child)
       }
 
       case (.nOrMore, _),
@@ -209,9 +209,9 @@ class Compiler {
 
 public func _compileRegex(
   _ regex: String, _ syntax: SyntaxOptions = .traditional
-) -> Executor {
-  let ast = try! parse(regex, .traditional)
-  let program = Compiler(ast: ast).emit()
+) throws -> Executor {
+  let ast = try parse(regex, .traditional)
+  let program = try Compiler(ast: ast).emit()
   return Executor(program: program)
 }
 

--- a/Sources/_StringProcessing/Compiler.swift
+++ b/Sources/_StringProcessing/Compiler.swift
@@ -187,11 +187,21 @@ class Compiler {
       emit(child)
       builder.label(end)
 
-    case (.exactly, _),
-         (.nOrMore, _),
-         (.upToN, _),
-         (.range, _),
-         (_, .possessive):
+    // Exactly: {n}
+    //
+    //
+    //
+    //
+    case (.exactly(let n), _):
+      // FIXME: This works, but better to emit a loop
+      for _ in 0..<n.value {
+        emit(child)
+      }
+
+      case (.nOrMore, _),
+      (.upToN, _),
+      (.range, _),
+      (_, .possessive):
       fatalError("Not yet supported")
     }
   }

--- a/Sources/_StringProcessing/ConsumerInterface.swift
+++ b/Sources/_StringProcessing/ConsumerInterface.swift
@@ -354,25 +354,41 @@ extension Unicode.BinaryProperty {
     case .diacratic: // spelling?
       return consumeScalarProp(\.isDiacritic)
     case .emojiModifierBase:
-      break // availability
+      if #available(macOS 10.12.2, *) {
+        return consumeScalarProp(\.isEmojiModifierBase)
+      } else {
+        throw unsupported("isEmojiModifierBase on old OSes")
+      }
     case .emojiComponent:
       break
     case .emojiModifier:
-      break // availability
+      if #available(macOS 10.12.2, *) {
+        return consumeScalarProp(\.isEmojiModifier)
+      } else {
+        throw unsupported("isEmojiModifier on old OSes")
+      }
     case .emoji:
-      break // availability
+      if #available(macOS 10.12.2, *) {
+        return consumeScalarProp(\.isEmoji)
+      } else {
+        throw unsupported("isEmoji on old OSes")
+      }
     case .emojiPresentation:
-      break // availability
+      if #available(macOS 10.12.2, *) {
+        return consumeScalarProp(\.isEmojiPresentation)
+      } else {
+        throw unsupported("isEmojiPresentation on old OSes")
+      }
     case .extender:
       return consumeScalarProp(\.isExtender)
     case .extendedPictographic:
-      break
+      break // NOTE: Stdlib has this data internally
     case .fullCompositionExclusion:
       return consumeScalarProp(\.isFullCompositionExclusion)
     case .graphemeBase:
       return consumeScalarProp(\.isGraphemeBase)
     case .graphemeExtended:
-      break
+      return consumeScalarProp(\.isGraphemeExtend)
     case .graphemeLink:
       break
     case .hexDigit:
@@ -426,7 +442,9 @@ extension Unicode.BinaryProperty {
     case .radical:
       return consumeScalarProp(\.isRadical)
     case .regionalIndicator:
-      break
+      return consumeScalar { s in
+        (0x1F1E6...0x1F1FF).contains(s.value)
+      }
     case .softDotted:
       return consumeScalarProp(\.isSoftDotted)
     case .sentenceTerminal:
@@ -445,14 +463,9 @@ extension Unicode.BinaryProperty {
       return consumeScalarProp(\.isXIDContinue)
     case .xidStart:
       return consumeScalarProp(\.isXIDStart)
-    case .expandsOnNFC:
-      break
-    case .expandsOnNFD:
-      break
-    case .expandsOnNFKC:
-      break
-    case .expandsOnNFKD:
-      break
+    case .expandsOnNFC, .expandsOnNFD, .expandsOnNFKD,
+        .expandsOnNFKC:
+      throw unsupported("Unicode-deprecated: \(self)")
     }
 
     throw unsupported("TODO: map prop \(self)")

--- a/Sources/_StringProcessing/ConsumerInterface.swift
+++ b/Sources/_StringProcessing/ConsumerInterface.swift
@@ -595,8 +595,5 @@ extension Unicode.ExtendedGeneralCategory {
     case .spaceSeparator:
       return consumeScalarGC(.spaceSeparator)
     }
-
-
   }
-
 }

--- a/Sources/_StringProcessing/ConsumerInterface.swift
+++ b/Sources/_StringProcessing/ConsumerInterface.swift
@@ -223,14 +223,6 @@ extension AST.Atom.CharacterProperty {
   func generateConsumer(
     _ opts: CharacterClass.MatchLevel
   ) -> Program<String>.ConsumeFunction {
-    // TODO: Wean ourselves off of this type...
-    if let cc = self.characterClass?.withMatchLevel(opts) {
-      return { input, bounds in
-        // FIXME: should we worry about out of bounds?
-        cc.matches(in: input, at: bounds.lowerBound)
-      }
-    }
-
     // Handle inversion for us, albeit not efficiently
     func invert(
       _ p: @escaping Program<String>.ConsumeFunction

--- a/Sources/_StringProcessing/ConsumerInterface.swift
+++ b/Sources/_StringProcessing/ConsumerInterface.swift
@@ -1,0 +1,468 @@
+import _MatchingEngine
+
+extension AST {
+  /// Attempt to generate a consumer from this AST node
+  ///
+  /// A consumer is a Swift closure that matches against
+  /// the front of an input range
+  func generateConsumer(
+    // TODO: Better option modeling
+    _ opts: CharacterClass.MatchLevel
+  ) -> Program<String>.ConsumeFunction? {
+    switch self {
+    case .atom(let a):
+      return a.generateConsumer(opts)
+    case .customCharacterClass(let ccc):
+      return ccc.generateConsumer(opts)
+
+    case .alternation, .concatenation, .group,
+        .quantification, .quote, .trivia, .empty,
+        .groupTransform: return nil
+    }
+  }
+}
+
+// TODO: This is basically an AST interpreter, which would
+// be good or interesting to build regardless, and serves
+// as a compiler fall-back path
+
+extension AST.Atom {
+  // TODO: clarify difference between this and
+  // literal character value...
+  //
+  // For now this just extracts `.char` case
+  //
+  // TODO: Shouldn't this be parameterized over matching
+  // level?
+  var singleCharacter: Character? {
+    switch kind {
+    case .char(let c): return c
+    default: return nil
+    }
+  }
+
+  func generateConsumer(
+    _ opts: CharacterClass.MatchLevel
+  ) -> Program<String>.ConsumeFunction? {
+    // TODO: Wean ourselves off of this type...
+    if let cc = self.characterClass?.withMatchLevel(opts) {
+      return { input, bounds in
+        // FIXME: should we worry about out of bounds?
+        cc.matches(in: input, at: bounds.lowerBound)
+      }
+    }
+
+    switch kind {
+    case let .scalar(s):
+      return { input, bounds in
+        // TODO: bounds checking?
+        let low = bounds.lowerBound
+        guard input.unicodeScalars[low] == s else {
+          return nil
+        }
+        return input.unicodeScalars.index(after: low)
+      }
+
+    case let .char(c):
+      // TODO: Match level?
+      return { input, bounds in
+        let low = bounds.lowerBound
+        guard input[low] == c else {
+          return nil
+        }
+        return input.index(after: low)
+      }
+
+    case let .property(p):
+      return p.generateConsumer(opts)
+
+    case .escaped, .keyboardControl, .keyboardMeta, .keyboardMetaControl,
+        .namedCharacter, .any, .startOfLine, .endOfLine,
+        .backreference, .subpattern, .condition:
+      // FIXME: implement
+      return nil
+    }
+  }
+}
+
+extension AST.CustomCharacterClass.Member {
+  func generateConsumer(
+    _ opts: CharacterClass.MatchLevel
+  ) -> Program<String>.ConsumeFunction {
+    switch self {
+    case .custom(let ccc):
+      return ccc.generateConsumer(opts)
+
+    case .range(let lower, let upper):
+      guard let lhs = lower.literalCharacterValue else {
+        fatalError("TODO")
+      }
+      guard let rhs = upper.literalCharacterValue else {
+        fatalError("TODO")
+      }
+
+      return { input, bounds in
+        // TODO: check for out of bounds?
+        let curIdx = bounds.lowerBound
+        if (lhs...rhs).contains(input[curIdx]) {
+          // TODO: semantic level
+          return input.index(after: curIdx)
+        }
+        return nil
+      }
+
+    case .atom(let atom):
+      guard let gen = atom.generateConsumer(opts) else {
+        fatalError("TODO")
+      }
+      return gen
+
+    case .setOperation(let lhs, let op, let rhs):
+      // TODO: We should probably have a component type
+      // instead of a members array... for now we reconstruct
+      // an AST node...
+      let start = AST.Located(
+        faking: AST.CustomCharacterClass.Start.normal)
+
+      let lhs = AST.CustomCharacterClass(
+        start, lhs, .fake
+      ).generateConsumer(opts)
+      let rhs = AST.CustomCharacterClass(
+        start, rhs, .fake
+      ).generateConsumer(opts)
+
+      return { input, bounds in
+        // NOTE: Easy way to implement, not performant
+        let lhsIdxOpt = lhs(input, bounds)
+        let rhsIdxOpt = rhs(input, bounds)
+
+        // TODO: What if lengths don't line up?
+        assert(lhsIdxOpt == rhsIdxOpt || lhsIdxOpt == nil
+               || rhsIdxOpt == nil)
+
+        switch op.value {
+        case .subtraction:
+          guard rhsIdxOpt == nil else { return nil }
+          return lhsIdxOpt
+
+        case .intersection:
+          if let idx = lhsIdxOpt {
+            return rhsIdxOpt == nil ? nil : idx
+          }
+          return nil
+
+        case .symmetricDifference:
+          if let idx = lhsIdxOpt {
+            return rhsIdxOpt == nil ? idx : nil
+          }
+          return rhsIdxOpt
+        }
+      }
+    }
+  }
+}
+
+extension AST.CustomCharacterClass {
+  func generateConsumer(
+    _ opts: CharacterClass.MatchLevel
+  ) -> Program<String>.ConsumeFunction {
+    // NOTE: Easy way to implement, obviously not performant
+    let consumers = members.map { $0.generateConsumer(opts) }
+    return { input, bounds in
+      for consumer in consumers {
+        if let idx = consumer(input, bounds) {
+          return isInverted ? nil : idx
+        }
+      }
+      if isInverted {
+        // FIXME: semantic level
+        return input.index(after: bounds.lowerBound)
+      }
+      return nil
+    }
+  }
+}
+
+// NOTE:
+private func consumeScalarProp(
+  _ p: @escaping (Unicode.Scalar.Properties) -> Bool
+) -> Program<String>.ConsumeFunction {
+  consumeScalar { p($0.properties) }
+}
+private func consumeScalar(
+  _ p: @escaping (Unicode.Scalar) -> Bool
+) -> Program<String>.ConsumeFunction {
+  { input, bounds in
+    // TODO: bounds check?
+    let curIdx = bounds.lowerBound
+    if p(input.unicodeScalars[curIdx]) {
+      // TODO: semantic level?
+      return input.unicodeScalars.index(after: curIdx)
+    }
+    return nil
+  }
+}
+
+extension AST.Atom.CharacterProperty {
+  func generateConsumer(
+    _ opts: CharacterClass.MatchLevel
+  ) -> Program<String>.ConsumeFunction {
+    // TODO: Wean ourselves off of this type...
+    if let cc = self.characterClass?.withMatchLevel(opts) {
+      return { input, bounds in
+        // FIXME: should we worry about out of bounds?
+        cc.matches(in: input, at: bounds.lowerBound)
+      }
+    }
+
+    // Handle inversion for us, albeit not efficiently
+    func invert(
+      _ p: @escaping Program<String>.ConsumeFunction
+    ) -> Program<String>.ConsumeFunction {
+      return { input, bounds in
+        if p(input, bounds) != nil { return nil }
+        // TODO: semantic level
+        // TODO: bounds check
+        return input.unicodeScalars.index(
+          after: bounds.lowerBound)
+      }
+    }
+
+    // FIXME: Below is largely scalar based, for convenience,
+    // but we want a comprehensive treatment to semantic mode
+    // switching.
+    let preInversion: Program<String>.ConsumeFunction = {
+      switch kind {
+        // TODO: is this modeled differently?
+      case .any:
+        return { input, bounds in
+          // TODO: bounds check?
+          return input.index(after: bounds.lowerBound)
+        }
+      case .assigned:
+        return consumeScalar {
+          $0.properties.generalCategory != .unassigned
+        }
+      case .ascii:
+        return consumeScalar(\.isASCII)
+
+      case .generalCategory(let p):
+        fatalError("TODO: Map categories: \(p)")
+
+      case .binary(let prop, value: let value):
+        let cons = prop.generateConsumer(opts)
+        return value ? cons : invert(cons)
+
+      case .script(let s):
+        fatalError("TODO: Map script: \(s)")
+
+      case .scriptExtension(let s):
+        fatalError("TODO: Map script: \(s)")
+
+      case .posix(let p):
+        return p.generateConsumer(opts)
+
+      case .pcreSpecial(let s):
+        fatalError("TODO: map PCRE special: \(s)")
+
+      case .onigurumaSpecial(let s):
+        fatalError("TODO: map Oniguruma special: \(s)")
+
+      case let .other(key, value):
+        fatalError("TODO: map other \(key ?? "")=\(value)")
+      }
+    }()
+
+    if !isInverted { return preInversion }
+    return invert(preInversion)
+  }
+}
+
+extension Unicode.BinaryProperty {
+  // FIXME: Semantic level, vet for precise defs
+  func generateConsumer(
+    _ opts: CharacterClass.MatchLevel
+  ) -> Program<String>.ConsumeFunction {
+    switch self {
+
+    case .asciiHexDigit:
+      return consumeScalarProp {
+        $0.isHexDigit && $0.isASCIIHexDigit
+      }
+    case .alphabetic:
+      return consumeScalarProp(\.isAlphabetic)
+    case .bidiControl:
+      break
+
+
+    case .bidiMirrored: 
+      return consumeScalarProp(\.isBidiMirrored)
+    case .cased:
+      return consumeScalarProp(\.isCased)
+    case .compositionExclusion:
+      break
+    case .caseIgnorable:
+      return consumeScalarProp(\.isCaseIgnorable)
+    case .changesWhenCasefolded:
+      return consumeScalarProp(\.changesWhenCaseFolded)
+    case .changesWhenCasemapped:
+      return consumeScalarProp(\.changesWhenCaseMapped)
+    case .changesWhenNFKCCasefolded:
+      return consumeScalarProp(\.changesWhenNFKCCaseFolded)
+    case .changesWhenLowercased:
+      return consumeScalarProp(\.changesWhenLowercased)
+    case .changesWhenTitlecased:
+      return consumeScalarProp(\.changesWhenTitlecased)
+    case .changesWhenUppercased:
+      return consumeScalarProp(\.changesWhenUppercased)
+    case .dash:
+      return consumeScalarProp(\.isDash)
+    case .deprecated:
+      return consumeScalarProp(\.isDeprecated)
+    case .defaultIgnorableCodePoint:
+      return consumeScalarProp(\.isDefaultIgnorableCodePoint)
+    case .diacratic: // spelling?
+      return consumeScalarProp(\.isDiacritic)
+    case .emojiModifierBase:
+      break // availability
+    case .emojiComponent:
+      break
+    case .emojiModifier:
+      break // availability
+    case .emoji:
+      break // availability
+    case .emojiPresentation:
+      break // availability
+    case .extender:
+      return consumeScalarProp(\.isExtender)
+    case .extendedPictographic:
+      break
+    case .fullCompositionExclusion:
+      return consumeScalarProp(\.isFullCompositionExclusion)
+    case .graphemeBase:
+      return consumeScalarProp(\.isGraphemeBase)
+    case .graphemeExtended:
+      break
+    case .graphemeLink:
+      break
+    case .hexDigit:
+      return consumeScalarProp(\.isHexDigit)
+    case .hyphen:
+      break
+    case .idContinue:
+      return consumeScalarProp(\.isIDContinue)
+    case .ideographic:
+      return consumeScalarProp(\.isIdeographic)
+    case .idStart:
+      return consumeScalarProp(\.isIDStart)
+    case .idsBinaryOperator:
+      return consumeScalarProp(\.isIDSBinaryOperator)
+    case .idsTrinaryOperator:
+      return consumeScalarProp(\.isIDSTrinaryOperator)
+    case .joinControl:
+      return consumeScalarProp(\.isJoinControl)
+    case .logicalOrderException:
+      return consumeScalarProp(\.isLogicalOrderException)
+    case .lowercase:
+      return consumeScalarProp(\.isLowercase)
+    case .math:
+      return consumeScalarProp(\.isMath)
+    case .noncharacterCodePoint:
+      return consumeScalarProp(\.isNoncharacterCodePoint)
+    case .otherAlphabetic:
+      break
+    case .otherDefaultIgnorableCodePoint:
+      break
+    case .otherGraphemeExtended:
+      break
+    case .otherIDContinue:
+      break
+    case .otherIDStart:
+      break
+    case .otherLowercase:
+      break
+    case .otherMath:
+      break
+    case .otherUppercase:
+      break
+    case .patternSyntax:
+      return consumeScalarProp(\.isPatternSyntax)
+    case .patternWhitespace:
+      return consumeScalarProp(\.isPatternWhitespace)
+    case .prependedConcatenationMark:
+      break
+    case .quotationMark:
+      return consumeScalarProp(\.isQuotationMark)
+    case .radical:
+      return consumeScalarProp(\.isRadical)
+    case .regionalIndicator:
+      break
+    case .softDotted:
+      return consumeScalarProp(\.isSoftDotted)
+    case .sentenceTerminal:
+      return consumeScalarProp(\.isSentenceTerminal)
+    case .terminalPunctuation:
+      return consumeScalarProp(\.isTerminalPunctuation)
+    case .unifiedIdiograph: // spelling?
+      return consumeScalarProp(\.isUnifiedIdeograph)
+    case .uppercase:
+      return consumeScalarProp(\.isUppercase)
+    case .variationSelector:
+      return consumeScalarProp(\.isVariationSelector)
+    case .whitespace:
+      return consumeScalarProp(\.isWhitespace)
+    case .xidContinue:
+      return consumeScalarProp(\.isXIDContinue)
+    case .xidStart:
+      return consumeScalarProp(\.isXIDStart)
+    case .expandsOnNFC:
+      break
+    case .expandsOnNFD:
+      break
+    case .expandsOnNFKC:
+      break
+    case .expandsOnNFKD:
+      break
+    }
+
+    fatalError("TODO: map prop \(self)")
+  }
+}
+
+extension Unicode.POSIXProperty {
+  // FIXME: Semantic level, vet for precise defs
+  func generateConsumer(
+    _ opts: CharacterClass.MatchLevel
+  ) -> Program<String>.ConsumeFunction {
+    // FIXME: Below defs are incorrect or approximations
+    switch self {
+    case .alnum:
+      return consumeScalarProp {
+        $0.isAlphabetic || $0.numericType != nil
+      }
+    case .blank:
+      return consumeScalarProp(\.isWhitespace) // incorrect
+
+    case .graph:
+      return consumeScalarProp {
+        !$0.isWhitespace // not control, unassigned, etc
+      }
+    case .print:
+      return consumeScalarProp {
+        _ in true // not control
+      }
+    case .word:
+      return consumeScalarProp {
+        $0.isAlphabetic || $0.numericType != nil
+        || $0.isJoinControl
+        || $0.isDash// marks and connectors...
+      }
+
+    case .xdigit:
+      return consumeScalarProp(\.isHexDigit) // or number
+    }
+  }
+
+}
+
+

--- a/Sources/_StringProcessing/Executor.swift
+++ b/Sources/_StringProcessing/Executor.swift
@@ -1,7 +1,8 @@
 import _MatchingEngine
 
 public struct Executor {
-  let engine: Engine<String>
+  // TODO: consider let, for now lets us toggle tracing
+  var engine: Engine<String>
 
   init(program: RegexProgram, enablesTracing: Bool = false) {
     self.engine = Engine(program.program, enableTracing: enablesTracing)

--- a/Sources/_StringProcessing/RegexDSL/Core.swift
+++ b/Sources/_StringProcessing/RegexDSL/Core.swift
@@ -27,7 +27,7 @@ public struct Regex<Capture>: RegexProtocol {
       }
     }()
     /// The program for execution with the matching engine.
-    lazy private(set) var loweredProgram = Compiler(ast: ast).emit()
+    lazy private(set) var loweredProgram = try! Compiler(ast: ast).emit()
 
     init(ast: AST) {
       self.ast = ast

--- a/Tests/RegexTests/LegacyTests.swift
+++ b/Tests/RegexTests/LegacyTests.swift
@@ -137,7 +137,7 @@ private func performTest<Capture>(
   guard !ast.hasCapture else {
     return
   }
-  let program = Compiler(ast: ast).emit()
+  let program = try! Compiler(ast: ast).emit()
   run(Executor(program: program), name: "Matching Engine")
 }
 
@@ -408,17 +408,17 @@ extension RegexTests {
 //      expecting: .init(captures: "aaaa", capturesEqual: ==))
   }
 
-  func testLegacyMatchLevel() {
+  func testLegacyMatchLevel() throws {
     let tests: Array<(String, chars: [String], unicodes: [String])> = [
       ("..", ["e\u{301}e\u{301}"], ["e\u{301}"]),
     ]
 
     for (regex, characterInputs, scalarInputs) in tests {
-      let ast = try! parse(regex, .traditional)
-      let program = Compiler(ast: ast).emit()
+      let ast = try parse(regex, .traditional)
+      let program = try Compiler(ast: ast).emit()
       let executor = Executor(program: program)
 
-      let scalarProgram = Compiler(
+      let scalarProgram = try Compiler(
         ast: ast, matchLevel: .unicodeScalar
       ).emit()
       let scalarExecutor = Executor(

--- a/Tests/RegexTests/MatchTests.swift
+++ b/Tests/RegexTests/MatchTests.swift
@@ -187,37 +187,43 @@ extension RegexTests {
 
     matchTest(
       #"[ab[:space:]\d[:^upper:]cd]"#,
-      input: "123abcxyz", match: "1", xfail: true)
+      input: "123abcxyz", match: "1")
     matchTest(
       #"[ab[:space:]\d[:^upper:]cd]"#,
-      input: "xyzabc123", match: "x", xfail: true)
+      input: "xyzabc123", match: "x")
     matchTest(
       #"[ab[:space:]\d[:^upper:]cd]"#,
-      input: "XYZabc123", match: "a", xfail: true)
+      input: "XYZabc123", match: "a")
     matchTest(
       #"[ab[:space:]\d[:^upper:]cd]"#,
-      input: "XYZ abc123", match: " ", xfail: true)
+      input: "XYZ abc123", match: " ")
 
-    matchTest("[[[:space:]]]", input: "123 abc xyz", match: " ", xfail: true)
+    matchTest("[[[:space:]]]", input: "123 abc xyz", match: " ")
 
-    matchTest("[[:alnum:]]", input: "[[:alnum:]]", match: "a", xfail: true)
-    matchTest("[[:blank:]]", input: "123\tabc xyz", match: "\t", xfail: true)
+    matchTest("[[:alnum:]]", input: "[[:alnum:]]", match: "a")
+    matchTest("[[:blank:]]", input: "123\tabc xyz", match: "\t")
+
     matchTest(
       "[[:graph:]]",
-      input: "\u{7}\u{1b}\u{a}\n\r\t abc", match: "a", xfail: true)
+      input: "\u{7}\u{1b}\u{a}\n\r\t abc", match: "a")
     matchTest(
       "[[:print:]]",
-      input: "\u{7}\u{1b}\u{a}\n\r\t abc", match: " ", xfail: true)
+      input: "\u{7}\u{1b}\u{a}\n\r\t abc", match: " ")
+
     matchTest(
       "[[:word:]]",
-      input: "\u{7}\u{1b}\u{a}\n\r\t abc", match: "a", xfail: true)
+      input: "\u{7}\u{1b}\u{a}\n\r\t abc", match: "a")
     matchTest(
       "[[:xdigit:]]",
-      input: "\u{7}\u{1b}\u{a}\n\r\t abc", match: "a", xfail: true)
+      input: "\u{7}\u{1b}\u{a}\n\r\t abc", match: "a")
 
-    matchTest("[[:isALNUM:]]", input: "[[:alnum:]]", match: "a", xfail: true)
-    matchTest("[[:AL_NUM:]]", input: "[[:alnum:]]", match: "a", xfail: true)
-    matchTest("[[:script=Greek:]]", input: "123αβγxyz", match: "α", xfail: true)
+    matchTest("[[:isALNUM:]]", input: "[[:alnum:]]", match: "a")
+    matchTest("[[:AL_NUM:]]", input: "[[:alnum:]]", match: "a")
+
+    // Unfortunately, scripts are not part of stdlib...
+    matchTest(
+      "[[:script=Greek:]]", input: "123αβγxyz", match: "α",
+      xfail: true)
 
     // MARK: Operators
 
@@ -250,12 +256,12 @@ extension RegexTests {
 
     // MARK: Character names.
 
-    matchTest(#"\N{ASTERISK}"#, input: "123***xyz", match: "*", xfail: true)
-    matchTest(#"[\N{ASTERISK}]"#, input: "123***xyz", match: "*", xfail: true)
+    matchTest(#"\N{ASTERISK}"#, input: "123***xyz", match: "*")
+    matchTest(#"[\N{ASTERISK}]"#, input: "123***xyz", match: "*")
     matchTest(
-      #"\N{ASTERISK}+"#, input: "123***xyz", match: "***", xfail: true)
+      #"\N{ASTERISK}+"#, input: "123***xyz", match: "***")
     matchTest(
-      #"\N {2}"#, input: "123  xyz", match: "3  ", xfail: true)
+      #"\N {2}"#, input: "123  xyz", match: "3  ")
 
     matchTest(#"\N{U+2C}"#, input: "123,xyz", match: ",")
     matchTest(#"\N{U+1F4BF}"#, input: "123💿xyz", match: "💿")
@@ -263,97 +269,142 @@ extension RegexTests {
 
     // MARK: Character properties.
 
-    matchTest(#"\p{L}"#, input: "123abcXYZ", match: "a", xfail: true)
-    matchTest(#"\p{gc=L}"#, input: "123abcXYZ", match: "a", xfail: true)
-    matchTest(#"\p{Lu}"#, input: "123abcXYZ", match: "X", xfail: true)
-    matchTest(#"\P{Cc}"#, input: "123\n\n\nXYZ", match: "\n", xfail: true)
-    matchTest(#"\P{Z}"#, input: "123 XYZ", match: " ", xfail: true)
+    matchTest(#"\p{L}"#, input: "123abcXYZ", match: "a")
+    matchTest(#"\p{gc=L}"#, input: "123abcXYZ", match: "a")
+    matchTest(#"\p{Lu}"#, input: "123abcXYZ", match: "X")
 
-    matchTest(#"[\p{C}]"#, input: "123\n\n\nXYZ", match: "\n", xfail: true)
-    matchTest(#"\p{C}+"#, input: "123\n\n\nXYZ", match: "\n\n\n", xfail: true)
+    // TODO: diagnose
+    matchTest(
+      #"\P{Cc}"#, input: "123\n\n\nXYZ", match: "\n",
+      xfail: true)
+    matchTest(
+      #"\P{Z}"#, input: "123 XYZ", match: " ",
+      xfail: true)
+
+    matchTest(#"[\p{C}]"#, input: "123\n\n\nXYZ", match: "\n")
+    matchTest(#"\p{C}+"#, input: "123\n\n\nXYZ", match: "\n\n\n")
 
     // UAX44-LM3 means all of the below are equivalent.
-    matchTest(#"\p{ll}"#, input: "123abcXYZ", match: "a", xfail: true)
-    matchTest(#"\p{gc=ll}"#, input: "123abcXYZ", match: "a", xfail: true)
+    matchTest(#"\p{ll}"#, input: "123abcXYZ", match: "a")
+    matchTest(#"\p{gc=ll}"#, input: "123abcXYZ", match: "a")
     matchTest(
-      #"\p{General_Category=Ll}"#, input: "123abcXYZ", match: "a", xfail: true)
+      #"\p{General_Category=Ll}"#, input: "123abcXYZ", match: "a")
     matchTest(
       #"\p{General-Category=isLl}"#,
-      input: "123abcXYZ", match: "a", xfail: true)
-    matchTest(#"\p{  __l_ l  _ }"#, input: "123abcXYZ", match: "a", xfail: true)
+      input: "123abcXYZ", match: "a")
+    matchTest(#"\p{  __l_ l  _ }"#, input: "123abcXYZ", match: "a")
     matchTest(
-      #"\p{ g_ c =-  __l_ l  _ }"#, input: "123abcXYZ", match: "a", xfail: true)
+      #"\p{ g_ c =-  __l_ l  _ }"#, input: "123abcXYZ", match: "a")
     matchTest(
       #"\p{ general ca-tegory =  __l_ l  _ }"#,
-      input: "123abcXYZ", match: "a", xfail: true)
+      input: "123abcXYZ", match: "a")
     matchTest(
       #"\p{- general category =  is__l_ l  _ }"#,
-      input: "123abcXYZ", match: "a", xfail: true)
+      input: "123abcXYZ", match: "a")
     matchTest(
       #"\p{ general category -=  IS__l_ l  _ }"#,
-      input: "123abcXYZ", match: "a", xfail: true)
+      input: "123abcXYZ", match: "a")
 
-    matchTest(#"\p{Any}"#, input: "123abcXYZ", match: "1", xfail: true)
-    matchTest(#"\p{Assigned}"#, input: "123abcXYZ", match: "1", xfail: true)
-    matchTest(#"\p{ascii}"#, input: "123abcXYZ", match: "1", xfail: true)
-    matchTest(#"\p{isAny}"#, input: "123abcXYZ", match: "1", xfail: true)
+    matchTest(#"\p{Any}"#, input: "123abcXYZ", match: "1")
+    matchTest(#"\p{Assigned}"#, input: "123abcXYZ", match: "1")
+    matchTest(#"\p{ascii}"#, input: "123abcXYZ", match: "1")
+    matchTest(#"\p{isAny}"#, input: "123abcXYZ", match: "1")
 
-    matchTest(#"\p{sc=grek}"#, input: "123αβγxyz", match: "α", xfail: true)
-    matchTest(#"\p{sc=isGreek}"#, input: "123αβγxyz", match: "α", xfail: true)
-    matchTest(#"\p{Greek}"#, input: "123αβγxyz", match: "α", xfail: true)
-    matchTest(#"\p{isGreek}"#, input: "123αβγxyz", match: "α", xfail: true)
-    matchTest(#"\P{Script=Latn}"#, input: "abcαβγxyz", match: "α", xfail: true)
-    matchTest(#"\p{script=Greek}"#, input: "123αβγxyz", match: "α", xfail: true)
+    // Unfortunately, scripts are not part of stdlib...
     matchTest(
-      #"\p{ISscript=isGreek}"#, input: "123αβγxyz", match: "α", xfail: true)
-    matchTest(#"\p{scx=bamum}"#, input: "123ꚠꚡꚢxyz", match: "ꚠ", xfail: true)
-    matchTest(#"\p{ISBAMUM}"#, input: "123ꚠꚡꚢxyz", match: "ꚠ", xfail: true)
-
-    matchTest(#"\p{alpha}"#, input: "123abcXYZ", match: "a", xfail: true)
-    matchTest(#"\P{alpha}"#, input: "123abcXYZ", match: "1", xfail: true)
+      #"\p{sc=grek}"#, input: "123αβγxyz", match: "α",
+      xfail: true)
     matchTest(
-      #"\p{alphabetic=True}"#, input: "123abcXYZ", match: "a", xfail: true)
-    matchTest(#"\p{emoji=t}"#, input: "123💿xyz", match: "a", xfail: true)
-    matchTest(#"\p{Alpha=no}"#, input: "123abcXYZ", match: "1", xfail: true)
-    matchTest(#"\P{Alpha=no}"#, input: "123abcXYZ", match: "a", xfail: true)
-    matchTest(#"\p{isAlphabetic}"#, input: "123abcXYZ", match: "a", xfail: true)
+      #"\p{sc=isGreek}"#, input: "123αβγxyz", match: "α",
+      xfail: true)
     matchTest(
-      #"\p{isAlpha=isFalse}"#, input: "123abcXYZ", match: "1", xfail: true)
+      #"\p{Greek}"#, input: "123αβγxyz", match: "α",
+      xfail: true)
+    matchTest(
+      #"\p{isGreek}"#, input: "123αβγxyz", match: "α",
+      xfail: true)
+    matchTest(
+      #"\P{Script=Latn}"#, input: "abcαβγxyz", match: "α",
+      xfail: true)
+    matchTest(
+      #"\p{script=Greek}"#, input: "123αβγxyz", match: "α",
+      xfail: true)
+    matchTest(
+      #"\p{ISscript=isGreek}"#, input: "123αβγxyz", match: "α",
+      xfail: true)
+    matchTest(
+      #"\p{scx=bamum}"#, input: "123ꚠꚡꚢxyz", match: "ꚠ",
+      xfail: true)
+    matchTest(
+      #"\p{ISBAMUM}"#, input: "123ꚠꚡꚢxyz", match: "ꚠ",
+      xfail: true)
 
-    matchTest(#"\p{In_Runic}"#, input: "123ᚠᚡᚢXYZ", match: "ᚠ", xfail: true)
+    matchTest(#"\p{alpha}"#, input: "123abcXYZ", match: "a")
+    matchTest(#"\P{alpha}"#, input: "123abcXYZ", match: "1")
+    matchTest(
+      #"\p{alphabetic=True}"#, input: "123abcXYZ", match: "a")
 
-    matchTest(#"\p{Xan}"#, input: "[[:alnum:]]", match: "a", xfail: true)
-    matchTest(#"\p{Xps}"#, input: "123 abc xyz", match: " ", xfail: true)
-    matchTest(#"\p{Xsp}"#, input: "123 abc xyz", match: " ", xfail: true)
-    matchTest(#"\p{Xuc}"#, input: "$var", match: "$", xfail: true)
-    matchTest(#"\p{Xwd}"#, input: "[[:alnum:]]", match: "a", xfail: true)
+    // This is actually available-ed...
+    matchTest(
+      #"\p{emoji=t}"#, input: "123💿xyz", match: "a",
+      xfail: true)
 
-    matchTest(#"\p{alnum}"#, input: "[[:alnum:]]", match: "a", xfail: true)
-    matchTest(#"\p{is_alnum}"#, input: "[[:alnum:]]", match: "a", xfail: true)
-    matchTest(#"\p{blank}"#, input: "123\tabc xyz", match: "\t", xfail: true)
+    matchTest(#"\p{Alpha=no}"#, input: "123abcXYZ", match: "1")
+    matchTest(#"\P{Alpha=no}"#, input: "123abcXYZ", match: "a")
+    matchTest(#"\p{isAlphabetic}"#, input: "123abcXYZ", match: "a")
+    matchTest(
+      #"\p{isAlpha=isFalse}"#, input: "123abcXYZ", match: "1")
+
+    // Oniguruma special support not in stdlib
+    matchTest(
+      #"\p{In_Runic}"#, input: "123ᚠᚡᚢXYZ", match: "ᚠ",
+    xfail: true)
+
+    // TODO: PCRE special
+    matchTest(
+      #"\p{Xan}"#, input: "[[:alnum:]]", match: "a",
+      xfail: true)
+    matchTest(
+      #"\p{Xps}"#, input: "123 abc xyz", match: " ",
+      xfail: true)
+    matchTest(
+      #"\p{Xsp}"#, input: "123 abc xyz", match: " ",
+      xfail: true)
+    matchTest(
+      #"\p{Xuc}"#, input: "$var", match: "$",
+      xfail: true)
+    matchTest(
+      #"\p{Xwd}"#, input: "[[:alnum:]]", match: "a",
+      xfail: true)
+
+    matchTest(#"\p{alnum}"#, input: "[[:alnum:]]", match: "a")
+    matchTest(#"\p{is_alnum}"#, input: "[[:alnum:]]", match: "a")
+
+    matchTest(#"\p{blank}"#, input: "123\tabc xyz", match: "\t")
     matchTest(
       #"\p{graph}"#,
-      input: "\u{7}\u{1b}\u{a}\n\r\t abc", match: "a", xfail: true)
+      input: "\u{7}\u{1b}\u{a}\n\r\t abc", match: "a")
+
     matchTest(
       #"\p{print}"#,
-      input: "\u{7}\u{1b}\u{a}\n\r\t abc", match: " ", xfail: true)
+      input: "\u{7}\u{1b}\u{a}\n\r\t abc", match: " ")
     matchTest(
       #"\p{word}"#,
-      input: "\u{7}\u{1b}\u{a}\n\r\t abc", match: "a", xfail: true)
+      input: "\u{7}\u{1b}\u{a}\n\r\t abc", match: "a")
     matchTest(
       #"\p{xdigit}"#,
-      input: "\u{7}\u{1b}\u{a}\n\r\t abc", match: "a", xfail: true)
+      input: "\u{7}\u{1b}\u{a}\n\r\t abc", match: "a")
 
-    matchTest("[[:alnum:]]", input: "[[:alnum:]]", match: "a", xfail: true)
-    matchTest("[[:blank:]]", input: "123\tabc xyz", match: "\t", xfail: true)
+    matchTest("[[:alnum:]]", input: "[[:alnum:]]", match: "a")
+    matchTest("[[:blank:]]", input: "123\tabc xyz", match: "\t")
     matchTest("[[:graph:]]",
-      input: "\u{7}\u{1b}\u{a}\n\r\t abc", match: "a", xfail: true)
+      input: "\u{7}\u{1b}\u{a}\n\r\t abc", match: "a")
     matchTest("[[:print:]]",
-      input: "\u{7}\u{1b}\u{a}\n\r\t abc", match: " ", xfail: true)
+      input: "\u{7}\u{1b}\u{a}\n\r\t abc", match: " ")
     matchTest("[[:word:]]",
-      input: "\u{7}\u{1b}\u{a}\n\r\t abc", match: "a", xfail: true)
+      input: "\u{7}\u{1b}\u{a}\n\r\t abc", match: "a")
     matchTest("[[:xdigit:]]",
-      input: "\u{7}\u{1b}\u{a}\n\r\t abc", match: "a", xfail: true)
+      input: "\u{7}\u{1b}\u{a}\n\r\t abc", match: "a")
   }
 
   func testMatchGroups() {

--- a/Tests/RegexTests/MatchTests.swift
+++ b/Tests/RegexTests/MatchTests.swift
@@ -1,13 +1,15 @@
 import XCTest
 @testable import _MatchingEngine
 @testable import _StringProcessing
-import Algorithms
+@testable import Algorithms
 
 func matchTest(
   _ regex: String,
   input: String,
   match: String,
   syntax: SyntaxOptions = .traditional,
+  enableTracing: Bool = false,
+  dumpAST: Bool = false,
   xfail: Bool = false
 ) {
   guard !xfail else {
@@ -18,7 +20,9 @@ func matchTest(
   }
 
   let pattern = Algorithms.Regex(regex)
-  let range = input.firstRange(of: pattern)!
+  var consumer = RegexConsumer(pattern)
+  consumer.vm.engine.enableTracing = enableTracing
+  let range = input.firstRange(of: consumer)!
   XCTAssertEqual(String(input[range]), match)
 }
 

--- a/Tests/RegexTests/MatchTests.swift
+++ b/Tests/RegexTests/MatchTests.swift
@@ -273,13 +273,10 @@ extension RegexTests {
     matchTest(#"\p{gc=L}"#, input: "123abcXYZ", match: "a")
     matchTest(#"\p{Lu}"#, input: "123abcXYZ", match: "X")
 
-    // TODO: diagnose
     matchTest(
-      #"\P{Cc}"#, input: "123\n\n\nXYZ", match: "\n",
-      xfail: true)
+      #"\P{Cc}"#, input: "\n\n\nXYZ", match: "X")
     matchTest(
-      #"\P{Z}"#, input: "123 XYZ", match: " ",
-      xfail: true)
+      #"\P{Z}"#, input: "   XYZ", match: "X")
 
     matchTest(#"[\p{C}]"#, input: "123\n\n\nXYZ", match: "\n")
     matchTest(#"\p{C}+"#, input: "123\n\n\nXYZ", match: "\n\n\n")


### PR DESCRIPTION
Generate consumers for AST nodes that are atoms or custom character classes.

Most of the char class and props tests are now passing, notably except for scripts (which the stdlib doesn't surface yet, cc @Azoy).