### PR TITLE
Parse escaped backreferences and subpatterns

### DIFF
--- a/Sources/_MatchingEngine/Regex/AST/Atom.swift
+++ b/Sources/_MatchingEngine/Regex/AST/Atom.swift
@@ -373,9 +373,7 @@ extension AST.Atom.CharacterProperty {
 public enum Reference: Hashable {
   // \n \gn \g{n} \g<n> \g'n' (?n) (?(n)...
   // Oniguruma: \k<n>, \k'n'
-  // If the reference was written as \n, and n could potentially be an octal
-  // sequence, `couldBeOctal` will be set to true.
-  case absolute(Int, couldBeOctal: Bool = false)
+  case absolute(Int)
 
   // \g{-n} \g<+n> \g'+n' \g<-n> \g'-n' (?+n) (?-n)
   // (?(+n)... (?(-n)...

--- a/Sources/_MatchingEngine/Regex/AST/Atom.swift
+++ b/Sources/_MatchingEngine/Regex/AST/Atom.swift
@@ -52,8 +52,6 @@ extension AST {
       case endOfLine
 
       // References
-      //
-      // TODO: Haven't thought through these a ton
       case backreference(Reference)
       case subpattern(Reference)
       case condition(Reference)
@@ -375,7 +373,9 @@ extension AST.Atom.CharacterProperty {
 public enum Reference: Hashable {
   // \n \gn \g{n} \g<n> \g'n' (?n) (?(n)...
   // Oniguruma: \k<n>, \k'n'
-  case absolute(Int)
+  // If the reference was written as \n, and n could potentially be an octal
+  // sequence, `couldBeOctal` will be set to true.
+  case absolute(Int, couldBeOctal: Bool = false)
 
   // \g{-n} \g<+n> \g'+n' \g<-n> \g'-n' (?+n) (?-n)
   // (?(+n)... (?(-n)...
@@ -414,12 +414,8 @@ extension AST.Atom: _ASTPrintable {
     case .startOfLine: return "^"
     case .endOfLine:   return "$"
 
-    case .backreference(_):
-      fatalError("TODO")
-    case .subpattern(_):
-      fatalError("TODO")
-    case .condition(_):
-      fatalError("TODO")
+    case .backreference(let r), .subpattern(let r), .condition(let r):
+      return "\(r)"
 
     case .char, .scalar:
       fatalError("Unreachable")

--- a/Sources/_MatchingEngine/Regex/Parse/LexicalAnalysis.swift
+++ b/Sources/_MatchingEngine/Regex/Parse/LexicalAnalysis.swift
@@ -516,6 +516,8 @@ extension Source {
             src.tryEat(sequence: "atomic_script_run:") {
           return .atomicScriptRun
         }
+
+        throw ParseError.misc("Quantifier '*' must follow operand")
       }
 
       // (_:)

--- a/Sources/_MatchingEngine/Regex/Parse/Source.swift
+++ b/Sources/_MatchingEngine/Regex/Parse/Source.swift
@@ -76,6 +76,17 @@ extension Source {
     return true
   }
 
+  mutating func tryEat<C: Collection>(anyOf set: C) -> Char?
+    where C.Element == Char
+  {
+    guard let c = peek(), set.contains(c) else { return nil }
+    advance()
+    return c
+  }
+  mutating func tryEat(anyOf set: Char...) -> Char? {
+    tryEat(anyOf: set)
+  }
+
   mutating func eat(asserting c: Char) {
     assert(peek() == c)
     advance()

--- a/Sources/_MatchingEngine/Regex/Parse/Source.swift
+++ b/Sources/_MatchingEngine/Regex/Parse/Source.swift
@@ -120,6 +120,15 @@ extension Source {
     maxLength: Int? = nil,
     _ f: (Char) -> Bool
   ) -> Input.SubSequence? {
+    guard let pre = peekPrefix(maxLength: maxLength, f) else { return nil }
+    defer { self.advance(pre.count) }
+    return pre
+  }
+
+  func peekPrefix(
+    maxLength: Int? = nil,
+    _ f: (Char) -> Bool
+  ) -> Input.SubSequence? {
     let chunk: Input.SubSequence
     if let maxLength = maxLength {
       chunk = _slice.prefix(maxLength)
@@ -129,7 +138,6 @@ extension Source {
     let pre = chunk.prefix(while: f)
     guard !pre.isEmpty else { return nil }
 
-    defer { self.advance(pre.count) }
     return pre
   }
 

--- a/Sources/_StringProcessing/ASTBuilder.swift
+++ b/Sources/_StringProcessing/ASTBuilder.swift
@@ -30,6 +30,10 @@ func concat(_ asts: AST...) -> AST {
   concat(asts)
 }
 
+func empty() -> AST {
+  .empty(.init(.fake))
+}
+
 func group(
   _ kind: AST.Group.Kind, _ child: AST
 ) -> AST {
@@ -181,6 +185,19 @@ func escaped(
 }
 func scalar(_ s: Unicode.Scalar) -> AST {
   atom(.scalar(s))
+}
+func scalar_m(_ s: Unicode.Scalar) -> AST.CustomCharacterClass.Member {
+  atom_m(.scalar(s))
+}
+
+func backreference(_ r: Reference) -> AST {
+  atom(.backreference(r))
+}
+func subpattern(_ r: Reference) -> AST {
+  atom(.subpattern(r))
+}
+func condition(_ r: Reference) -> AST {
+  atom(.condition(r))
 }
 
 func prop(

--- a/Tests/RegexTests/LexTests.swift
+++ b/Tests/RegexTests/LexTests.swift
@@ -29,6 +29,13 @@ func diagnose(
   }
 }
 
+extension Source {
+  @discardableResult
+  fileprivate mutating func lexBasicAtom() throws -> AST.Atom? {
+    try lexAtom(isInCustomCharacterClass: false, priorGroupCount: 0)
+  }
+}
+
 extension RegexTests {
   func testLexicalAnalysis() {
     diagnose("a", expecting: .expected("b")) { src in
@@ -92,27 +99,13 @@ extension RegexTests {
     }
 
     // Test expected closing delimiters.
-    diagnose(#"\u{5"#, expecting: .expected("}")) { src in
-      _ = try src.lexAtom(isInCustomCharacterClass: false)
-    }
-    diagnose(#"\x{5"#, expecting: .expected("}")) { src in
-      _ = try src.lexAtom(isInCustomCharacterClass: false)
-    }
-    diagnose(#"\N{A"#, expecting: .expected("}")) { src in
-      _ = try src.lexAtom(isInCustomCharacterClass: false)
-    }
-    diagnose(#"\N{U+A"#, expecting: .expected("}")) { src in
-      _ = try src.lexAtom(isInCustomCharacterClass: false)
-    }
-    diagnose(#"\p{a"#, expecting: .expected("}")) { src in
-      _ = try src.lexAtom(isInCustomCharacterClass: false)
-    }
-    diagnose(#"\p{a="#, expecting: .expected("}")) { src in
-      _ = try src.lexAtom(isInCustomCharacterClass: false)
-    }
-    diagnose(#"(?#"#, expecting: .expected(")")) { src in
-      _ = try src.lexComment()
-    }
+    diagnose(#"\u{5"#, expecting: .expected("}")) { try $0.lexBasicAtom() }
+    diagnose(#"\x{5"#, expecting: .expected("}")) { try $0.lexBasicAtom() }
+    diagnose(#"\N{A"#, expecting: .expected("}")) { try $0.lexBasicAtom() }
+    diagnose(#"\N{U+A"#, expecting: .expected("}")) { try $0.lexBasicAtom() }
+    diagnose(#"\p{a"#, expecting: .expected("}")) { try $0.lexBasicAtom() }
+    diagnose(#"\p{a="#, expecting: .expected("}")) { try $0.lexBasicAtom() }
+    diagnose(#"(?#"#, expecting: .expected(")")) { _ = try $0.lexComment() }
 
     // TODO: want to dummy print out source ranges, etc, test that.
   }

--- a/Tests/RegexTests/LexTests.swift
+++ b/Tests/RegexTests/LexTests.swift
@@ -85,7 +85,12 @@ extension RegexTests {
       "12", base: "U", expectedDigits: 8)
     diagnoseUniScalarOverflow("{123456789}", base: "u")
     diagnoseUniScalarOverflow("{123456789}", base: "x")
-    
+
+    // Test expected group.
+    diagnose(#"(*"#, expecting: .misc("Quantifier '*' must follow operand")) {
+      _ = try $0.lexGroupStart()
+    }
+
     // TODO: want to dummy print out source ranges, etc, test that.
   }
 

--- a/Tests/RegexTests/LexTests.swift
+++ b/Tests/RegexTests/LexTests.swift
@@ -91,6 +91,29 @@ extension RegexTests {
       _ = try $0.lexGroupStart()
     }
 
+    // Test expected closing delimiters.
+    diagnose(#"\u{5"#, expecting: .expected("}")) { src in
+      _ = try src.lexAtom(isInCustomCharacterClass: false)
+    }
+    diagnose(#"\x{5"#, expecting: .expected("}")) { src in
+      _ = try src.lexAtom(isInCustomCharacterClass: false)
+    }
+    diagnose(#"\N{A"#, expecting: .expected("}")) { src in
+      _ = try src.lexAtom(isInCustomCharacterClass: false)
+    }
+    diagnose(#"\N{U+A"#, expecting: .expected("}")) { src in
+      _ = try src.lexAtom(isInCustomCharacterClass: false)
+    }
+    diagnose(#"\p{a"#, expecting: .expected("}")) { src in
+      _ = try src.lexAtom(isInCustomCharacterClass: false)
+    }
+    diagnose(#"\p{a="#, expecting: .expected("}")) { src in
+      _ = try src.lexAtom(isInCustomCharacterClass: false)
+    }
+    diagnose(#"(?#"#, expecting: .expected(")")) { src in
+      _ = try src.lexComment()
+    }
+
     // TODO: want to dummy print out source ranges, etc, test that.
   }
 

--- a/Tests/RegexTests/MatchTests.swift
+++ b/Tests/RegexTests/MatchTests.swift
@@ -531,7 +531,7 @@ extension RegexTests {
     matchTest(#"(.)\1"#, input: "112", match: "11", xfail: true)
     matchTest(#"(.)(.)(.)(.)(.)(.)(.)(.)(.)(.)\10"#,
               input: "aaaaaaaaabbc", match: "aaaaaaaaabb", xfail: true)
-    matchTest(#"(.)\10"#, input: "a\u{8}b", match: "a\u{8}", xfail: true)
+    matchTest(#"(.)\10"#, input: "a\u{8}b", match: "a\u{8}")
 
     matchTest(#"(.)\g001"#, input: "112", match: "11", xfail: true)
     matchTest(#"(.)(.)\g-02"#, input: "abac", match: "aba", xfail: true)

--- a/Tests/RegexTests/MatchTests.swift
+++ b/Tests/RegexTests/MatchTests.swift
@@ -525,5 +525,18 @@ extension RegexTests {
 
 
   }
+
+  func testMatchReferences() {
+    // TODO: Implement backreference/subpattern matching.
+    matchTest(#"(.)\1"#, input: "112", match: "11", xfail: true)
+    matchTest(#"(.)(.)(.)(.)(.)(.)(.)(.)(.)(.)\10"#,
+              input: "aaaaaaaaabbc", match: "aaaaaaaaabb", xfail: true)
+    matchTest(#"(.)\10"#, input: "a\u{8}b", match: "a\u{8}", xfail: true)
+
+    matchTest(#"(.)\g001"#, input: "112", match: "11", xfail: true)
+    matchTest(#"(.)(.)\g-02"#, input: "abac", match: "aba", xfail: true)
+    matchTest(#"(?<a>.)(.)\k<a>"#, input: "abac", match: "aba", xfail: true)
+    matchTest(#"\g'+2'(.)(.)"#, input: "abac", match: "aba", xfail: true)
+  }
 }
 

--- a/Tests/RegexTests/ParseTests.swift
+++ b/Tests/RegexTests/ParseTests.swift
@@ -363,6 +363,40 @@ extension RegexTests {
     parseTest("a(*atomic_script_run:b)c",
               concat("a", atomicScriptRun("b"), "c"))
 
+    // MARK: References
+
+    parseTest(#"\1"#, atom(.backreference(.absolute(1))))
+    parseTest(#"\10"#, atom(.backreference(.absolute(10, couldBeOctal: true))))
+    parseTest(#"\18"#, atom(.backreference(.absolute(18, couldBeOctal: false))))
+    parseTest(#"\7777"#, atom(.backreference(.absolute(7777, couldBeOctal: true))))
+
+    parseTest(#"\g1"#, atom(.backreference(.absolute(1))))
+    parseTest(#"\g001"#, atom(.backreference(.absolute(1))))
+    parseTest(#"\g52"#, atom(.backreference(.absolute(52))))
+    parseTest(#"\g-01"#, atom(.backreference(.relative(-1))))
+    parseTest(#"\g+30"#, atom(.backreference(.relative(30))))
+
+    parseTest(#"\g{1}"#, atom(.backreference(.absolute(1))))
+    parseTest(#"\g{001}"#, atom(.backreference(.absolute(1))))
+    parseTest(#"\g{52}"#, atom(.backreference(.absolute(52))))
+    parseTest(#"\g{-01}"#, atom(.backreference(.relative(-1))))
+    parseTest(#"\g{+30}"#, atom(.backreference(.relative(30))))
+
+    parseTest(#"\k{a0}"#, atom(.backreference(.named("a0"))))
+    parseTest(#"\k<bc>"#, atom(.backreference(.named("bc"))))
+    parseTest(#"\k''"#, atom(.backreference(.named(""))))
+    parseTest(#"\g{abc}"#, atom(.backreference(.named("abc"))))
+
+    parseTest(#"\g<1>"#, atom(.subpattern(.absolute(1))))
+    parseTest(#"\g<001>"#, atom(.subpattern(.absolute(1))))
+    parseTest(#"\g'52'"#, atom(.subpattern(.absolute(52))))
+    parseTest(#"\g'-01'"#, atom(.subpattern(.relative(-1))))
+    parseTest(#"\g'+30'"#, atom(.subpattern(.relative(30))))
+    parseTest(#"\g'abc'"#, atom(.subpattern(.named("abc"))))
+
+    parseTest(#"\g"#, atom(.char("g")))
+    parseTest(#"\k"#, atom(.char("k")))
+
     // MARK: Character names.
 
     parseTest(#"\N{abc}"#, atom(.namedCharacter("abc")))
@@ -476,6 +510,8 @@ extension RegexTests {
 
     parseNotEqualTest(#"([a-c&&e]*)+"#,
                       #"([a-d&&e]*)+"#)
+
+    parseNotEqualTest(#"\1"#, #"\10"#)
 
     // TODO: failure tests
   }


### PR DESCRIPTION
Parse the escaped syntaxes for backreferences and subpatterns (the latter are so syntactically similar, it made sense to also parse them).

This doesn't yet handle the non-escaped syntax for either, in particular Python-style backreferences `(?P=...)`. These are syntactically similar to groups (despite being atoms), so will require some more thought on how to parse.