### PR TITLE
Compile all quantifications using a generalized (with specializations) quant algorithm

### DIFF
--- a/Sources/Prototypes/PEG/PEGTranspile.swift
+++ b/Sources/Prototypes/PEG/PEGTranspile.swift
@@ -40,7 +40,7 @@ extension PEG.VM {
       case .comment(let s):
         builder.buildNop(s)
       case .consume(let n):
-        builder.buildConsume(Distance(n))
+        builder.buildAdvance(Distance(n))
       case .branch(_):
         builder.buildBranch(to: nextToken())
       case .condBranch(let condition, _):

--- a/Sources/_MatchingEngine/Engine/Builder.swift
+++ b/Sources/_MatchingEngine/Engine/Builder.swift
@@ -8,108 +8,213 @@ extension Program where Input.Element: Hashable {
 
     // Map tokens to actual addresses
     var addressTokens: [InstructionAddress?] = []
-    var addressFixups: [(InstructionAddress, AddressToken)] = []
+    var addressFixups: [(InstructionAddress, AddressFixup)] = []
 
     // Registers
     var nextBoolRegister = BoolRegister(0)
+    var nextIntRegister = IntRegister(0)
+
+    // Special addresses or instructions
+    var failAddressToken: AddressToken? = nil
 
     public init() {}
   }
 }
 
 extension Program.Builder {
+  struct AddressFixup {
+    var first: AddressToken
+    var second: AddressToken? = nil
+
+    init(_ a: AddressToken) { self.first = a }
+    init(_ a: AddressToken, _ b: AddressToken) {
+      self.first = a
+      self.second = b
+    }
+  }
+}
+
+extension Program.Builder {
+  // TODO: We want a better strategy for fixups, leaving
+  // the operand in a differenet form isn't great...
+
   public init<S: Sequence>(staticElements: S) where S.Element == Input.Element {
     staticElements.forEach { elements.store($0) }
   }
 
   public mutating func buildNop(_ r: StringRegister? = nil) {
-    instructions.append(.nop(r))
+    instructions.append(.init(.nop, .init(optionalString: r)))
   }
   public mutating func buildNop(_ s: String) {
     buildNop(strings.store(s))
   }
 
+  public mutating func buildDecrement(
+    _ i: IntRegister, nowZero: BoolRegister
+  ) {
+    instructions.append(.init(
+      .decrement, .init(bool: nowZero, int: i)))
+  }
+
+  public mutating func buildMoveImmediate(
+    _ value: UInt64, into: IntRegister
+  ) {
+    instructions.append(.init(
+      .moveImmediate, .init(immediate: value, int: into)))
+  }
+
+  // TODO: generic
+  public mutating func buildMoveImmediate(
+    _ value: Int, into: IntRegister
+  ) {
+    let uint = UInt64(truncatingIfNeeded: value)
+    assert(uint == value)
+    buildMoveImmediate(uint, into: into)
+  }
+
   public mutating func buildBranch(to t: AddressToken) {
-    instructions.append(.branch())
+    instructions.append(.init(.branch))
     fixup(to: t)
   }
   public mutating func buildCondBranch(
     _ condition: BoolRegister, to t: AddressToken
   ) {
-    instructions.append(.condBranch(condition: condition))
+    instructions.append(
+      .init(.condBranch, .init(bool: condition)))
+    fixup(to: t)
+  }
+
+  public mutating func buildCondBranch(
+    to t: AddressToken, ifZeroElseDecrement i: IntRegister
+  ) {
+    instructions.append(
+      .init(.condBranchZeroElseDecrement, .init(int: i)))
     fixup(to: t)
   }
 
   public mutating func buildSave(_ t: AddressToken) {
-    instructions.append(.save())
+    instructions.append(.init(.save))
     fixup(to: t)
   }
   public mutating func buildSaveAddress(_ t: AddressToken) {
-    instructions.append(.saveAddress())
+    instructions.append(.init(.saveAddress))
     fixup(to: t)
+  }
+  public mutating func buildSplit(
+    to: AddressToken, saving: AddressToken
+  ) {
+    instructions.append(.init(.splitSaving))
+    fixup(to: (to, saving))
   }
 
   public mutating func buildClear() {
-    instructions.append(.clear())
+    instructions.append(.init(.clear))
   }
   public mutating func buildRestore() {
-    instructions.append(.restore())
+    instructions.append(.init(.restore))
   }
   public mutating func buildFail() {
-    instructions.append(.fail())
+    instructions.append(.init(.fail))
   }
   public mutating func buildCall(_ t: AddressToken) {
-    instructions.append(.call())
+    instructions.append(.init(.call))
     fixup(to: t)
   }
   public mutating func buildRet() {
-    instructions.append(.ret())
+    instructions.append(.init(.ret))
   }
 
   public mutating func buildAbort(_ s: StringRegister? = nil) {
-    instructions.append(.abort(s))
+    instructions.append(.init(
+      .abort, .init(optionalString: s)))
   }
   public mutating func buildAbort(_ s: String) {
     buildAbort(strings.store(s))
   }
 
-  public mutating func buildConsume(_ n: Distance) {
-    instructions.append(.consume(n))
+  public mutating func buildAdvance(_ n: Distance) {
+    instructions.append(.init(.advance, .init(distance: n)))
   }
 
   public mutating func buildMatch(_ e: Input.Element) {
-    instructions.append(.match(elements.store(e)))
+    instructions.append(.init(
+      .match, .init(element: elements.store(e))))
   }
 
-  public mutating func buildConsume(by p: @escaping Program.ConsumeFunction) {
-    instructions.append(.consume(by: makeConsumeFunction(p)))
+  public mutating func buildConsume(
+    by p: @escaping Program.ConsumeFunction
+  ) {
+    instructions.append(.init(
+      .consumeBy, .init(consumer: makeConsumeFunction(p))))
   }
 
-  public mutating func buildAssert(_ e: Input.Element, into c: BoolRegister) {
-    instructions.append(.assertion(condition: c, elements.store(e)))
+  public mutating func buildAssert(
+    _ e: Input.Element, into cond: BoolRegister
+  ) {
+    instructions.append(.init(.assertion, .init(
+      element: elements.store(e), bool: cond)))
   }
 
   public mutating func buildAccept() {
-    instructions.append(.accept())
+    instructions.append(.init(.accept))
   }
 
   public mutating func buildPrint(_ s: StringRegister) {
-    instructions.append(.print(s))
+    instructions.append(.init(.print, .init(string: s)))
   }
 
-  public func assemble() -> Program {
+  // TODO: Mutating because of fail address fixup, drop when
+  // that's removed
+  public mutating func assemble() -> Program {
+    // TODO: This will add a fail instruction at the end every
+    // time it's assembled. Better to do to the local instruction
+    // list copy, but that complicates logic. It's possible we
+    // end up going a different route all-together eventually,
+    // though.
+    if let tok = failAddressToken {
+      label(tok)
+      buildFail()
+    }
+
     // Do a pass to map address tokens to addresses
     var instructions = instructions
     for (instAddr, tok) in addressFixups {
-      instructions[instAddr.rawValue].operand.initializePayload(
-        addressTokens[tok.rawValue]!
-      )
+      // FIXME: based on opcode, decide if we split...
+      // Unfortunate...
+      let inst = instructions[instAddr.rawValue]
+      let addr = addressTokens[tok.first.rawValue]!
+      let payload: Instruction.Payload
+
+      switch inst.opcode {
+      case .condBranch:
+        payload = .init(addr: addr, bool: inst.payload.bool)
+
+      case .condBranchZeroElseDecrement:
+        payload = .init(addr: addr, int: inst.payload.int)
+
+      case .branch, .save, .saveAddress, .call:
+        payload = .init(addr: addr)
+
+      case .splitSaving:
+        guard let fix2 = tok.second else {
+          fatalError("unreachable")
+        }
+        let saving = addressTokens[fix2.rawValue]!
+        payload = .init(addr: addr, addr2: saving)
+
+      default: fatalError("unreachable")
+
+      }
+
+      instructions[instAddr.rawValue] = .init(
+        inst.opcode, payload)
     }
 
     var regInfo = Program.RegisterInfo()
     regInfo.elements = elements.count
     regInfo.strings = strings.count
     regInfo.bools = nextBoolRegister.rawValue
+    regInfo.ints = nextIntRegister.rawValue
     regInfo.consumeFunctions = consumeFunctions.count
 
     return Program(
@@ -155,15 +260,66 @@ extension Program.Builder {
   public mutating func fixup(to t: AddressToken) {
     assert(!instructions.isEmpty)
     addressFixups.append(
-      (InstructionAddress(instructions.endIndex-1), t))
+      (InstructionAddress(instructions.endIndex-1), .init(t)))
   }
+
+  // Associate the most recently added instruction with
+  // the provided tokens, ensuring it is fixed up during
+  // assembly
+  public mutating func fixup(
+    to ts: (AddressToken, AddressToken)
+  ) {
+    assert(!instructions.isEmpty)
+    addressFixups.append((
+      InstructionAddress(instructions.endIndex-1),
+      .init(ts.0, ts.1)))
+  }
+
+  // Push an "empty" save point which will, upon restore, just restore from
+  // the next save point. Currently, this is modelled by a branch to a "fail"
+  // instruction, which the builder will ensure exists for us.
+  //
+  // This is useful for possessive quantification that needs some initial save
+  // point to "ratchet" upon a successful match.
+  public mutating func pushEmptySavePoint() {
+    if failAddressToken == nil {
+      failAddressToken = makeAddress()
+    }
+    buildSaveAddress(failAddressToken!)
+  }
+
 }
 
 // Register helpers
 extension Program.Builder {
-  public mutating func makeRegister() -> BoolRegister {
+  public mutating func makeBoolRegister() -> BoolRegister {
     defer { nextBoolRegister.rawValue += 1 }
     return nextBoolRegister
+  }
+  public mutating func makeIntRegister() -> IntRegister {
+    defer { nextIntRegister.rawValue += 1 }
+    return nextIntRegister
+  }
+
+  // Allocate and initialize a register
+  public mutating func makeIntRegister(
+    initialValue: Int
+  ) -> IntRegister {
+    let r = makeIntRegister()
+    self.buildMoveImmediate(initialValue, into: r)
+    return r
+  }
+
+  // 'kill' or release allocated registers
+  public mutating func kill(_ r: IntRegister) {
+    // TODO: Release/reuse registers, for now nop makes
+    // reading the code easier
+    buildNop("kill \(r)")
+  }
+  public mutating func kill(_ r: BoolRegister) {
+    // TODO: Release/reuse registers, for now nop makes
+    // reading the code easier
+    buildNop("kill \(r)")
   }
 
   public mutating func makeConsumeFunction(
@@ -172,5 +328,8 @@ extension Program.Builder {
     defer { consumeFunctions.append(f) }
     return ConsumeFunctionRegister(consumeFunctions.count)
   }
+
+  // TODO: consider releasing registers
+
 }
 

--- a/Sources/_MatchingEngine/Engine/Consume.swift
+++ b/Sources/_MatchingEngine/Engine/Consume.swift
@@ -33,7 +33,7 @@ extension Engine {
           return cpu.currentPosition
         case .fail:
           return nil
-        case .inprogress: cpu.cycle()
+        case .inProgress: cpu.cycle()
         }
       }
     }()

--- a/Sources/_MatchingEngine/Engine/InstPayload.swift
+++ b/Sources/_MatchingEngine/Engine/InstPayload.swift
@@ -1,0 +1,232 @@
+
+extension Instruction {
+  /// An instruction's payload packs operands and destination
+  /// registers.
+  ///
+  /// A payload is 56 bits and its contents structurally depend
+  /// on the specific instruction
+  struct Payload: RawRepresentable {
+    var rawValue: UInt64
+    init(rawValue: UInt64) {
+      assert(rawValue == rawValue & _payloadMask)
+      self.rawValue = rawValue
+      // TODO: post conditions
+    }
+  }
+}
+
+extension Instruction.Payload {
+  // For modeling, perhaps tooling, but likely not for
+  // execution
+  private enum Kind {
+    // TODO: We should choose operand ordering based on codegen
+    //
+    // For now, we do:
+    //   Immediate < InstAddr < ConsumeFuncReg < ElementReg
+    //   (compile)   (link)     (link)           (link)
+    //
+    //   ... < BoolReg < IntReg
+    //
+    // That is, optimization-time constant, link-time constant,
+    // and variables
+
+    case string(StringRegister)
+    case optionalString(StringRegister?)
+    case int(IntRegister)
+    case distance(Distance)
+    case bool(BoolRegister)
+    case element(ElementRegister)
+    case consumer(ConsumeFunctionRegister)
+    case addr(InstructionAddress)
+
+    case packedImmInt(Int, IntRegister)
+    case packedAddrBool(InstructionAddress, BoolRegister)
+    case packedAddrInt(InstructionAddress, IntRegister)
+    case packedAddrAddr(InstructionAddress, InstructionAddress)
+    case packedBoolInt(BoolRegister, IntRegister)
+    case packedEltBool(ElementRegister, BoolRegister)
+  }
+}
+
+// MARK: - Payload getters
+
+extension Instruction.Payload {
+  /// A `nil` payload, for e.g. StringRegister?
+  static var nilPayload: Self {
+    self.init(rawValue: _payloadMask)
+  }
+
+  private init(_ r: UInt64) {
+    self.init(rawValue: r)
+  }
+  private init<👻>(_ r: TypedInt<👻>) {
+    self.init(r.bits)
+  }
+  private init<👻>(_ r: TypedInt<👻>?) {
+    if let r = r {
+      self.init(r)
+    } else {
+      self = .nilPayload
+    }
+  }
+
+  // Two values packed together
+  //
+  // For now, we just use 16 bits, because if that's good enough
+  // for 1990s Unicode it's good enough for us.
+  //
+  // TODO: but really, let's come up with something
+  private var firstSplitMask: UInt64 { 0x0000_FFFF }
+  private var secondSplitMask: UInt64 { 0xFFFF_0000 }
+
+  private var split: (first: UInt64, second: UInt64) {
+    assert(rawValue == ((firstSplitMask|secondSplitMask) & rawValue))
+
+    // TODO: Which order is better?
+    let first = rawValue & firstSplitMask
+    let second = (rawValue & secondSplitMask) &>> 16
+    return (first, second)
+  }
+
+  private init(_ a: UInt64, _ b: UInt64) {
+    self.init(a | (b &<< 16))
+    assert(a == a & firstSplitMask)
+    assert(b == b & firstSplitMask)
+  }
+  private init<👻>(_ a: UInt64, _ b: TypedInt<👻>) {
+    self.init(a, b.bits)
+  }
+  private init<👻, 👺>(_ a: TypedInt<👻>, _ b: TypedInt<👺>) {
+    self.init(a.bits, b.bits)
+  }
+
+  private func interpret<👻>(
+    as: TypedInt<👻>.Type = TypedInt<👻>.self
+  ) -> TypedInt<👻> {
+    // TODO: We'd like to use shadow bits to assert on kind
+    return TypedInt(rawValue)
+  }
+  private func interpretPair<👻>(
+    secondAs: TypedInt<👻>.Type = TypedInt<👻>.self
+  ) -> (UInt64, TypedInt<👻>) {
+    (split.first, TypedInt(split.second) )
+  }
+  private func interpretPair<👻, 👺>(
+    firstAs: TypedInt<👻>.Type = TypedInt<👻>.self,
+    secondAs: TypedInt<👺>.Type = TypedInt<👺>.self
+  ) -> (TypedInt<👻>, TypedInt<👺>) {
+    (TypedInt(split.first), TypedInt(split.second) )
+  }
+
+  // MARK: Single operand payloads
+
+  init(string: StringRegister) {
+    self.init(string)
+  }
+  var string: StringRegister {
+    interpret()
+  }
+
+  init(optionalString: StringRegister?) {
+    self.init(optionalString)
+  }
+  var optionalString: StringRegister? {
+    interpret()
+  }
+
+  init(int: IntRegister) {
+    self.init(int)
+  }
+  var int: IntRegister {
+    interpret()
+  }
+
+  init(distance: Distance) {
+    self.init(distance)
+  }
+  var distance: Distance {
+    interpret()
+  }
+
+  init(bool: BoolRegister) {
+    self.init(bool)
+  }
+  var bool: BoolRegister {
+    interpret()
+  }
+
+  init(element: ElementRegister) {
+    self.init(element)
+  }
+  var element: ElementRegister {
+    interpret()
+  }
+
+  init(consumer: ConsumeFunctionRegister) {
+    self.init(consumer)
+  }
+  var consumer: ConsumeFunctionRegister {
+    interpret()
+  }
+
+  init(addr: InstructionAddress) {
+    self.init(addr)
+  }
+  var addr: InstructionAddress {
+    interpret()
+  }
+
+
+  // MARK: Packed operand payloads
+
+  init(immediate: UInt64, int: IntRegister) {
+    self.init(immediate, int)
+  }
+  var pairedImmediateInt: (UInt64, IntRegister) {
+    interpretPair()
+  }
+
+  init(immediate: UInt64, bool: BoolRegister) {
+    self.init(immediate, bool)
+  }
+  var pairedImmediateBool: (UInt64, BoolRegister) {
+    interpretPair()
+  }
+
+  init(addr: InstructionAddress, bool: BoolRegister) {
+    self.init(addr, bool)
+  }
+  var pairedAddrBool: (InstructionAddress, BoolRegister) {
+    interpretPair()
+  }
+
+  init(addr: InstructionAddress, int: IntRegister) {
+    self.init(addr, int)
+  }
+  var pairedAddrInt: (InstructionAddress, IntRegister) {
+    interpretPair()
+  }
+
+  init(addr: InstructionAddress, addr2: InstructionAddress) {
+    self.init(addr, addr2)
+  }
+  var pairedAddrAddr: (InstructionAddress, InstructionAddress) {
+    interpretPair()
+  }
+
+  init(bool: BoolRegister, int: IntRegister) {
+    self.init(bool, int)
+  }
+  var pairedBoolInt: (BoolRegister, IntRegister) {
+    interpretPair()
+  }
+
+  init(element: ElementRegister, bool: BoolRegister) {
+    self.init(element, bool)
+  }
+  var pairedElementBool: (ElementRegister, BoolRegister) {
+    interpretPair()
+  }
+
+}
+

--- a/Sources/_MatchingEngine/Engine/Instruction.swift
+++ b/Sources/_MatchingEngine/Engine/Instruction.swift
@@ -1,417 +1,319 @@
-enum State {
-  /// Still running
-  case inprogress
-
-  /// FAIL: halt and signal failure
-  case fail
-
-  /// ACCEPT: halt and signal success
-  case accept
-}
-// TODO: better names for accept/fail/etc. Instruction
-// conflates backtracking with signaling failure or success,
-// could be clearer.
-
-
-// TODO: Save point and call stack interactions should be more formalized.
-// It's too easy to have unbalanced save/clears amongst function calls
-
-/*
-
-We're looking at 8-byte instructions, which allow us to really
-pack in complex series of operations into fewer
-fetch/decode/execute cycles.
-
-We'll want
-
- A) A general-purpose RISC core
- B) A customization-hook opcode area carved out
- C) A specialized pattern-matching opcode area carved out
- D) An extensible-for-other-purposes opcode area carved out
-
- Where C and D can provide decompositions into A for testing,
- and even B. A and B become extension mechanisms for the future:
-
- Ideally, we'd avoid hot-switching between bytecode and normal
- code execution. It's likely that the RISC core will be highly
- valuable for this purpose. B will be necessary sometimes, but
- ideally we'd avoid it when possible.
-
- While we want some core operations to be fixed-length, there's
- not necessarily (until I'm wrong, of course) a detriment to
- allowing D to have other widths. Also, 8 bytes is a lot for A...
-
-
- */
-
-enum OpCode: UInt64 {
-  case invalid = 0
-
-  /// Do nothing
-  ///
-  /// Operand: optional string register containing a comment
-  case nop
-
-  // MARK: - Control flow
-
-  /// Branch to a new instruction
-  ///
-  /// Operand: instruction address to branch to
-  case branch
-
-  /// Conditionally branch
-  ///
-  /// Operand: packed condition register and address to branch to
-  case condBranch
-
-  // MARK: - Save points (e.g. for backtracking)
-
-  /// Add a save point
-  ///
-  /// Operand: instruction address to resume from
-  ///
-  /// A save point is:
-  ///   - a position in the input to restore
-  ///   - a position in the call stack to cut off
-  ///   - an instruction address to resume from
-  ///
-  /// TODO: Consider if separating would improve generality
-  case save
-
-  ///
-  /// Add a save point that doesn't preserve input position
-  ///
-  /// NOTE: This is a prototype for now, but exposes
-  /// flaws in our formulation of back tracking. We could
-  /// instead have an instruction to update the top
-  /// most saved position instead
-  case saveAddress
-
-  /// Remove the most recently saved point
-  ///
-  /// Precondition: There is a save point to remove
-  case clear
-
-  /// View the most recently saved point
-  ///
-  /// UNIMPLEMENTED
-  case peek
-
-  /// Composite peek-branch-clear else FAIL
-  case restore
-
-  // MARK: - Function call stack
-
-  /// Push an instruction address to the stack
-  ///
-  /// Operand: the instruction address
-  ///
-  /// UNIMPLEMENTED
-  case push
-
-  /// Pop return address from call stack
-  ///
-  /// UNIMPLEMENTED
-  case pop
-
-  /// Composite push-next-branch instruction
-  ///
-  /// Operand: the function's start address
-  case call
-
-  /// Composite pop-branch instruction
-  ///
-  /// Operand: the instruction address
-  ///
-  /// NOTE: Currently, empty stack -> ACCEPT
-  case ret
-
-  // MARK: - State transitions
-
-  // TODO: State transitions need more work. We want
-  // granular core but also composite ones that will
-  // interact with save points
-
-  /// Transition into ACCEPT and halt
-  case accept
-
-  /// Signal failure (currently same as `restore`)
-  case fail
-
-  /// Halt, fail, and signal failure
-  ///
-  /// Operand: optional string register specifying the reason
-  ///
-  /// TODO: Could have an Error existential area instead
-  case abort
-
-  // MARK: - Interact with the input
-
-  /// Advance the input position.
-  ///
-  /// Operand: Amount to advance by.
-  case consume
-
-  // TODO: assert, hooks, etc
-
-  /// Composite assert-consume else restore.
-  ///
-  /// Operand: Element register to compare against.
-  case match
-
-  /// Advance the input position based on the result by calling the consume
-  /// function.
-  ///
-  /// Operand: Consume function register to call.
-  case consumeBy
-
-  /// Match against a provided element.
-  ///
-  /// Operand: Packed condition register to write to and element register to
-  /// compare against.
-  case assertion
-
-  // TODO: Fused assertions. It seems like we often want to
-  // branch based on assertion fail or success.
-
-
-  // MARK: - Debugging instructions
-
-  /// Print a string to the output
-  ///
-  /// Operand: String register
-  case print
-
-  /// Custom assertion operation
-  ///
-  /// Operands: destination bool register, assert hook register
-  static var assertHook: OpCode { fatalError() }
-
-  // ...
-
-
-}
-// TODO: Instructions for interacting with the various
-// registers and stack
-
-// TODO: Nominal type for conditions, which can have an invert bit
-// set
-
-// TODO: Better bit allocation for operand. Consider having an
-// address and register number concept: addresses get ~48bits while
-// registers get ~16 bits currently.
-
-// TODO: pack in a discriminator so we can assert on types
-
-// TODO: see if switching on top or bottom byte is better
-
-// TODO: store relative offsets for instructions, allows for
-// smaller bit-width addresses and arbitrary length programs
-// using jump islands
-
-// TODO: Explore if predication bit (or full register) would
-// make it more feasible to SIMD some common programs.
-
-//
-//
-// Internal NOTE: Currently stored 1-biased so that we can
-// provide assertions when this is accessed incorrectly.
-// Likely to remove later.
-//
-// TODO: Consider hoisting the bias and un-bias up into Instruction
-struct Operand: RawRepresentable {
-  // Store conditions in high bits, rest in low bits
+/// A single instruction for the matching engine to execute
+///
+/// Instructions are 64-bits, consisting of an 8-bit opcode
+/// and a 56-bit payload, which packs operands.
+///
+struct Instruction: RawRepresentable, Hashable {
   var rawValue: UInt64
-
-  init(rawValue: UInt64) {
+  init(rawValue: UInt64){
     self.rawValue = rawValue
   }
-  init<👻>(
-    condition: BoolRegister? = nil,
-    _ payload: TypedInt<👻>? = nil
-  ) {
-    self.rawValue = 0
-    if let c = condition {
-      assert(c < 65_536) // How do I exponentiate in Swift?...
-      self.rawValue |= (c.bits&+1) &<< 48
-    }
-    if let p = payload { initializePayload(p) }
-  }
-  init() {
-    // Workaround: have to invent phantom type
-    let payload: TypedInt<_PositionStackAddressRegister>? = nil
-    self.init(condition: nil, payload)
-  }
-
-  var payloadMask: UInt64 { _payloadMask()  }
-
-  // Weird workaround: I want my masks to just be the literals,
-  // semantically similar to if I had pasted this value into the
-  // source code. Swift doesn't support generic vars, so we do
-  // this
-  //
-  // NOTE: Is Operand's un-descriminated union similar?
-  func _payloadMask<
-    I: ExpressibleByIntegerLiteral
-  >() -> I {
-    0x0000_FFFF_FFFF_FFFF
-  }
-
-  var hasPayload: Bool { payloadBits > 0 }
-  var payloadBits: UInt64 { rawValue & payloadMask }
-
-  func payload<👻>(
-    as ty: TypedInt<👻>.Type = TypedInt<👻>.self
-  ) -> TypedInt<👻> {
-    assert(hasPayload)
-    return TypedInt(payloadBits &- 1)
-  }
-
-  mutating func initializePayload<👻>(_ value: TypedInt<👻>) {
-    assert(!hasPayload)
-    assert(value < _payloadMask())
-    self.rawValue |= (value.bits&+1)
-  }
-
-  var hasCondition: Bool { conditionBits > 0 }
-  var conditionBits: UInt64 { (rawValue & ~payloadMask) &>> 48 }
-
-  var condition: BoolRegister {
-    assert(hasCondition)
-    return BoolRegister(conditionBits &- 1)
-  }
-
 }
 
-struct Instruction: RawRepresentable {
-  var rawValue: UInt64
+extension Instruction {
+  enum OpCode: UInt64 {
+    case invalid = 0
 
+    // MARK: - General Purpose
+
+    /// Do nothing
+    ///
+    ///     nop(comment: String?)
+    ///
+    /// Operand:
+    ///   - Optional string register containing a comment or reason
+    ///
+    case nop
+
+    /// Decrement the value stored in a register.
+    /// Returns whether the value was set to zero
+    ///
+    ///     decrement(_ i: IntReg) -> Bool
+    ///
+    /// Operands:
+    ///   - Int register to decrease
+    ///   - Condition register set if now zero
+    ///
+    case decrement
+
+    /// Move an immediate value into a register
+    ///
+    ///     moveImmediate(_ i: Int, into: IntReg)
+    ///
+    /// Operands:
+    ///   - TODO
+    ///
+    case moveImmediate
+
+    // MARK: General Purpose: Control flow
+
+    /// Branch to a new instruction
+    ///
+    /// Operand: instruction address to branch to
+    case branch
+
+    /// Conditionally branch
+    ///
+    /// Operand: packed condition register and address to branch to
+    case condBranch
+
+    /// Conditionally branch if zero, otherwise decrement
+    ///
+    ///     branch_cond_zero_else_decrement(_ i: IntReg, to: InstructionAddress)
+    ///
+    /// Operands:
+    ///   - Int register to check for zero, otherwise decrease
+    ///   - Instruction address to branch to, if zero
+    ///
+    case condBranchZeroElseDecrement
+
+    // MARK: General Purpose: Function calls
+
+    /// Push an instruction address to the stack
+    ///
+    /// Operand: the instruction address
+    ///
+    /// UNIMPLEMENTED
+    case push
+
+    /// Pop return address from call stack
+    ///
+    /// UNIMPLEMENTED
+    case pop
+
+    /// Composite push-next-branch instruction
+    ///
+    /// Operand: the function's start address
+    case call
+
+    /// Composite pop-branch instruction
+    ///
+    /// Operand: the instruction address
+    ///
+    /// NOTE: Currently, empty stack -> ACCEPT
+    case ret
+
+    // MARK: General Purpose: Debugging instructions
+
+    /// Print a string to the output
+    ///
+    /// Operand: String register
+    case print
+
+
+
+    // MARK: - Matching
+
+    /// Advance the input position.
+    ///
+    /// Operand: Amount to advance by.
+    case advance
+
+    // TODO: Is the amount useful here? Is it commonly more than 1?
+
+    /// Composite assert-advance else restore.
+    ///
+    /// Operand: Element register to compare against.
+    case match
+
+    /// Match against a provided element.
+    ///
+    /// Operand: Packed condition register to write to and element register to
+    /// compare against.
+    case assertion
+
+    /// Advance the input position based on the result by calling the consume
+    /// function.
+    ///
+    /// Operand: Consume function register to call.
+    case consumeBy
+
+    /// Custom assertion operation
+    ///
+    /// Operands: destination bool register, assert hook register
+    static var assertHook: OpCode { fatalError() }
+
+
+    // MARK: Matching: Save points
+
+    /// Add a save point
+    ///
+    /// Operand: instruction address to resume from
+    ///
+    /// A save point is:
+    ///   - a position in the input to restore
+    ///   - a position in the call stack to cut off
+    ///   - an instruction address to resume from
+    ///
+    /// TODO: Consider if separating would improve generality
+    case save
+
+    ///
+    /// Add a save point that doesn't preserve input position
+    ///
+    /// NOTE: This is a prototype for now, but exposes
+    /// flaws in our formulation of back tracking. We could
+    /// instead have an instruction to update the top
+    /// most saved position instead
+    case saveAddress
+
+    /// Remove the most recently saved point
+    ///
+    /// Precondition: There is a save point to remove
+    case clear
+
+    /// View the most recently saved point
+    ///
+    /// UNIMPLEMENTED
+    case peek
+
+    /// Composite peek-branch-clear else FAIL
+    case restore
+
+    /// Fused save-and-branch. 
+    ///
+    ///   split(to: target, saving: backtrackPoint)
+    ///
+    case splitSaving
+
+    // MARK: Matching: State transitions
+
+    // TODO: State transitions need more work. We want
+    // granular core but also composite ones that will
+    // interact with save points
+
+    /// Transition into ACCEPT and halt
+    case accept
+
+    /// Signal failure (currently same as `restore`)
+    case fail
+
+    /// Halt, fail, and signal failure
+    ///
+    /// Operand: optional string register specifying the reason
+    ///
+    /// TODO: Could have an Error existential area instead
+    case abort
+
+    // TODO: Fused assertions. It seems like we often want to
+    // branch based on assertion fail or success.
+  }
+}
+
+internal var _opcodeMask: UInt64 { 0xFF00_0000_0000_0000 }
+
+// TODO: internal after compiler moves in
+public var _payloadMask: UInt64 { ~_opcodeMask }
+
+extension Instruction {
   var opcodeMask: UInt64 { 0xFF00_0000_0000_0000 }
 
   var opcode: OpCode {
     get {
       OpCode(
-        rawValue: (rawValue & opcodeMask) &>> 56
+        rawValue: (rawValue & _opcodeMask) &>> 56
       ).unsafelyUnwrapped
     }
     set {
       assert(newValue != .invalid, "consider hoisting this")
       assert(newValue.rawValue < 256)
-      self.rawValue &= ~opcodeMask
+      self.rawValue &= ~_opcodeMask
       self.rawValue |= newValue.rawValue &<< 56
     }
   }
-  var operand: Operand {
-    get { Operand(rawValue: rawValue & ~opcodeMask) }
+  var payload: Payload {
+    get { Payload(rawValue: rawValue & ~opcodeMask) }
     set {
-      assert(newValue.rawValue & opcodeMask == 0)
       self.rawValue &= opcodeMask
       self.rawValue |= newValue.rawValue
     }
   }
 
-  var destructure: (opcode: OpCode, operand: Operand) {
-    get { (opcode, operand) }
-    set { self = Self(opcode, operand) }
+  var destructure: (opcode: OpCode, payload: Payload) {
+    get { (opcode, payload) }
+    set { self = Self(opcode, payload) }
   }
 
-  init(rawValue: UInt64){
-    self.rawValue = rawValue
-  }
-  init(_ opcode: OpCode, _ operand: Operand = Operand()) {
+  init(_ opcode: OpCode, _ payload: Payload/* = Payload()*/) {
     self.init(rawValue: 0)
     self.opcode = opcode
-    self.operand = operand
+    self.payload = payload
+    // TODO: check invariants
   }
-}
-extension Instruction {
-  static func nop(_ s: StringRegister? = nil) -> Instruction {
-    Instruction(.nop, Operand(s))
-  }
-  static func branch(to: InstructionAddress? = nil) -> Instruction {
-    Instruction(.branch, Operand(to))
-  }
-  static func condBranch(condition: BoolRegister? = nil, to: InstructionAddress? = nil) -> Instruction {
-    Instruction(.condBranch, Operand(condition: condition, to))
-  }
-  static func save(resumingFrom: InstructionAddress? = nil) -> Instruction {
-    Instruction(.save, Operand(resumingFrom))
-  }
-  static func saveAddress(resumingFrom: InstructionAddress? = nil) -> Instruction {
-    Instruction(.saveAddress, Operand(resumingFrom))
-  }
-  static func clear() -> Instruction {
-    Instruction(.clear)
-  }
-  static func restore() -> Instruction {
-    Instruction(.restore)
-  }
-  static func fail() -> Instruction {
-    Instruction(.fail)
-  }
-  static func call(start: InstructionAddress? = nil) -> Instruction {
-    Instruction(.call, Operand(start))
-  }
-  static func ret() -> Instruction {
-    Instruction(.ret, Operand())
-  }
-  static func abort(_ s: StringRegister? = nil) -> Instruction {
-    Instruction(.abort, Operand(s))
-  }
-  static func accept() -> Instruction {
-    Instruction(.accept)
-  }
-  static func consume(_ n: Distance? = nil) -> Instruction {
-    Instruction(.consume, Operand(n))
-  }
-  static func match(_ e: ElementRegister? = nil) -> Instruction {
-    Instruction(.match, Operand(e))
-  }
-  static func consume(by e: ConsumeFunctionRegister? = nil) -> Instruction {
-    Instruction(.consumeBy, Operand(e))
-  }
-  static func assertion(
-    condition: BoolRegister? = nil, _ e: ElementRegister? = nil
-  ) -> Instruction {
-    Instruction(.assertion, Operand(condition: condition, e))
-  }
-  static func print(_ s: StringRegister? = nil) -> Instruction {
-    Instruction(.match, Operand(s))
+  init(_ opcode: OpCode) {
+    self.init(rawValue: 0)
+    self.opcode = opcode
+    //self.payload = payload
+    // TODO: check invariants
+    // TODO: placeholder bit pattern for fill-in-later
   }
 }
 
+/*
+
+ This is in need of more refactoring and design, the following
+ are a rough listing of TODOs:
+
+ - Save point and call stack interactions should be more formalized.
+ - It's too easy to have unbalanced save/clears amongst function calls
+ - Nominal type for conditions with an invert bit
+ - Better bit allocation and layout for operand, instruction, etc
+ - Use spare bits for better assertions
+ - Check low-level compiler code gen for switches
+ - Consider relative addresses instead of absolute addresses
+ - Explore a predication bit
+ - Explore using SIMD
+ - Explore a larger opcode, so that we can have variant flags
+   - E.g., opcode-local bits instead of flattening opcode space
+
+ We'd like to eventually design:
+
+ - A general-purpose core (future extensibility)
+ - A matching-specific instruction area carved out
+ - Leave a large area for future usage of run-time bytecode interpretation
+ - Debate: allow for future variable-width instructions
+
+ We'd like a testing / performance setup that lets us
+
+ - Define new instructions in terms of old ones (testing, perf)
+ - Version our instruction set in case we need future fixes
+
+ */
+
+// TODO: replace with instruction formatters...
 extension Instruction {
   var stringRegister: StringRegister? {
     switch opcode {
-    case .nop: fallthrough
-    case .abort: fallthrough
+    case .nop, .abort:
+      return payload.optionalString
     case .print:
-      return operand.hasPayload ? operand.payload() : nil
+      return payload.string
     default: return nil
     }
   }
   var instructionAddress: InstructionAddress? {
     switch opcode {
-    case .branch: fallthrough
-    case .condBranch: fallthrough
-    case .save: fallthrough
-    case .saveAddress: fallthrough
-    case .call:
-      return operand.hasPayload ? operand.payload() : nil
+    case .branch, .save, .saveAddress, .call:
+      return payload.addr
+
+    case .condBranch:
+      return payload.pairedAddrBool.0
+
     default: return nil
     }
   }
   var elementRegister: ElementRegister? {
     switch opcode {
-    case .match: fallthrough
+    case .match:
+      return payload.element
     case .assertion:
-      return operand.hasPayload ? operand.payload() : nil
+      return payload.pairedElementBool.0
     default: return nil
     }
   }
   var consumeFunctionRegister: ConsumeFunctionRegister? {
     switch opcode {
-    case .consumeBy: return operand.payload()
+    case .consumeBy: return payload.consumer
     default: return nil
     }
   }
@@ -422,3 +324,17 @@ extension Instruction: InstructionProtocol {
   var operandPC: InstructionAddress? { instructionAddress }
 }
 
+
+// TODO: better names for accept/fail/etc. Instruction
+// conflates backtracking with signaling failure or success,
+// could be clearer.
+enum State {
+  /// Still running
+  case inProgress
+
+  /// FAIL: halt and signal failure
+  case fail
+
+  /// ACCEPT: halt and signal success
+  case accept
+}

--- a/Sources/_MatchingEngine/Engine/Registers.swift
+++ b/Sources/_MatchingEngine/Engine/Registers.swift
@@ -13,8 +13,8 @@ extension Processor {
     // currently, these are for comments and abort messages
     var strings: [String]
 
-    // unused
-    var ints: [Int] = []
+    // currently, useful for range-based quantification
+    var ints: [Int]
 
     // unused
     var floats: [Double] = []
@@ -39,6 +39,10 @@ extension Processor {
 
     subscript(_ i: StringRegister) -> String {
       strings[i.rawValue]
+    }
+    subscript(_ i: IntRegister) -> Int {
+      get { ints[i.rawValue] }
+      set { ints[i.rawValue] = newValue }
     }
     subscript(_ i: BoolRegister) -> Bool {
       get { bools[i.rawValue] }

--- a/Sources/_MatchingEngine/Engine/Tracing.swift
+++ b/Sources/_MatchingEngine/Engine/Tracing.swift
@@ -18,21 +18,27 @@ extension Processor: TracedProcessor {
 
 extension Instruction: CustomStringConvertible {
   var description: String {
-    "\(opcode) \(operand)"
+    // TODO: opcode specific rendering
+    "\(opcode) \(payload)"
   }
 }
 
-extension Operand: CustomStringConvertible {
+extension Instruction.Payload: CustomStringConvertible {
   var description: String {
-    var result = ""
-    if hasCondition {
-      result += "\(condition) "
-    }
-    if hasPayload {
-      let payload: TypedInt<_Boo> = payload()
-      result += payload.description
-    }
-    return result
+//    var result = ""
+//    if hasCondition {
+//      result += "\(condition) "
+//    }
+//    if hasPayload {
+//      let payload: TypedInt<_Boo> = payload()
+//      result += payload.description
+//    }
+//    return result
+
+    // TODO: Without bit packing our representation, what
+    // should we do? I'd say a payload cannot be printed
+    // in isolation of the instruction...
+    return "\(rawValue)"
   }
 }
 

--- a/Sources/_MatchingEngine/Regex/AST/Quantification.swift
+++ b/Sources/_MatchingEngine/Regex/AST/Quantification.swift
@@ -89,3 +89,21 @@ extension AST.Quantification: _ASTPrintable {
     """
   }
 }
+
+/// MARK: - Semantic API
+
+extension AST.Quantification.Amount {
+  /// Get the bounds
+  public var bounds: (atLeast: Int, atMost: Int?) {
+    switch self {
+    case .zeroOrMore: return (0, nil)
+    case .oneOrMore:  return (1, nil)
+    case .zeroOrOne:  return (0, 1)
+
+    case let .exactly(n):  return (n.value, n.value)
+    case let .nOrMore(n):  return (n.value, nil)
+    case let .upToN(n):    return (0, n.value)
+    case let .range(n, m): return (n.value, m.value)
+    }
+  }
+}

--- a/Sources/_MatchingEngine/Utility/Formatting.swift
+++ b/Sources/_MatchingEngine/Utility/Formatting.swift
@@ -180,6 +180,8 @@ extension Collection where Element: InstructionProtocol, Index == InstructionAdd
       // TODO: consider pruning anything in the rendered
       // instruction window...
       //result += " // \(pcChain(argPC, depth: depth))"
+      _ = argPC
+      result += ""
     }
     return result
   }

--- a/Sources/_MatchingEngine/Utility/TypedInt.swift
+++ b/Sources/_MatchingEngine/Utility/TypedInt.swift
@@ -138,7 +138,7 @@ public typealias StringRegister = TypedInt<_StringRegister>
 public enum _StringRegister {}
 
 /// Used for consume functions, e.g. character classes
-public typealias ConsumeFunctionRegister = TypedInt<_StringRegister>
+public typealias ConsumeFunctionRegister = TypedInt<_ConsumeFunctionRegister>
 public enum _ConsumeFunctionRegister {}
 
 /// UNIMPLEMENTED

--- a/Sources/_StringProcessing/Compiler.swift
+++ b/Sources/_StringProcessing/Compiler.swift
@@ -24,7 +24,8 @@ class Compiler {
   __consuming func emit() throws -> RegexProgram {
     try emit(ast)
     builder.buildAccept()
-    return RegexProgram(program: builder.assemble())
+    let program = builder.assemble()
+    return RegexProgram(program: program)
   }
 
   func emit(_ node: AST) throws {
@@ -33,7 +34,7 @@ class Compiler {
     // Any: .
     //     consume 1
     case .atom(let a) where a.kind == .any && matchLevel == .graphemeCluster:
-      builder.buildConsume(1)
+      builder.buildAdvance(1)
 
     // Single characters we just match
     case .atom(let a) where a.singleCharacter != nil :
@@ -96,113 +97,204 @@ class Compiler {
     }
   }
 
+  func compileQuantification(
+    low: Int,
+    high: Int?,
+    kind: AST.Quantification.Kind,
+    child: AST
+  ) throws {
+    // Compiler and/or parser should enforce these invariants
+    // before we are called
+    assert(high != 0)
+    assert((0...(high ?? Int.max)).contains(low))
+
+    let extraTrips: Int?
+    if let h = high {
+      extraTrips = h - low
+    } else {
+      extraTrips = nil
+    }
+    let minTrips = low
+    assert((extraTrips ?? 1) >= 0)
+
+    // The below is a general algorithm for bounded and unbounded
+    // quantification. It can be specialized when the min
+    // is 0 or 1, or when extra trips is 1 or unbounded.
+    //
+    // Stuff inside `<` and `>` are decided at compile time,
+    // while run-time values stored in registers start with a `%`
+    _ = """
+      min-trip-count control block:
+        if %minTrips is zero:
+          goto exit-policy control block
+        else:
+          decrement %minTrips and fallthrough
+
+      loop-body:
+        evaluate the subexpression
+        goto min-trip-count control block
+
+      exit-policy control block:
+        if %extraTrips is zero:
+          goto exit
+        else:
+          decrement %extraTrips and fallthrough
+
+        <if eager>:
+          save exit and goto loop-body
+        <if possessive>:
+          ratchet and goto loop
+        <if reluctant>:
+          save loop-body and fallthrough (i.e. goto exit)
+
+      exit
+        ... the rest of the program ...
+    """
+
+    // Specialization based on `minTrips` for 0 or 1:
+    _ = """
+      min-trip-count control block:
+        <if minTrips == 0>:
+          goto exit-policy
+        <if minTrips == 1>:
+          /* fallthrough */
+
+      loop-body:
+        evaluate the subexpression
+        <if minTrips <= 1>
+          /* fallthrough */
+    """
+
+    // Specialization based on `extraTrips` for 0 or unbounded
+    _ = """
+      exit-policy control block:
+        <if extraTrips == 0>:
+          goto exit
+        <if extraTrips == .unbounded>:
+          /* fallthrough */
+    """
+
+    /*
+      NOTE: These specializations don't emit the optimal
+      code layout (e.g. fallthrough vs goto), but that's better
+      done later (not prematurely) and certainly better
+      done by an optimizing compiler.
+
+      NOTE: We're intentionally emitting essentially the same
+      algorithm for all quantifications for now, for better
+      testing and surfacing difficult bugs. We can specialize
+      for other things, like `.*`, later.
+
+      When it comes time for optimizing, we can also look into
+      quantification instructions (e.g. reduce save-point traffic)
+    */
+
+    let minTripsControl = builder.makeAddress()
+    let loopBody = builder.makeAddress()
+    let exitPolicy = builder.makeAddress()
+    let exit = builder.makeAddress()
+
+    // We'll need registers if we're (non-trivially) bounded
+    let minTripsReg: IntRegister?
+    if minTrips > 1 {
+      minTripsReg = builder.makeIntRegister(
+        initialValue: minTrips)
+    } else {
+      minTripsReg = nil
+    }
+
+    let extraTripsReg: IntRegister?
+    if (extraTrips ?? 0) > 0 {
+      extraTripsReg = builder.makeIntRegister(
+        initialValue: extraTrips!)
+    } else {
+      extraTripsReg = nil
+    }
+
+    // Set up a dummy save point for possessive to update
+    if kind == .possessive {
+      builder.pushEmptySavePoint()
+    }
+
+    // min-trip-count:
+    //   condBranch(to: exitPolicy, ifZeroElseDecrement: %min)
+    builder.label(minTripsControl)
+    switch minTrips {
+    case 0: builder.buildBranch(to: exitPolicy)
+    case 1: break
+    default:
+      assert(minTripsReg != nil, "logic inconsistency")
+      builder.buildCondBranch(
+        to: exitPolicy, ifZeroElseDecrement: minTripsReg!)
+    }
+
+    // FIXME: Possessive needs a "dummy" save point to ratchet
+
+    // loop:
+    //   <subexpression>
+    //   branch min-trip-count
+    builder.label(loopBody)
+    try emit(child)
+    if minTrips <= 1 {
+      // fallthrough
+    } else {
+      builder.buildBranch(to: minTripsControl)
+    }
+
+    // exit-policy:
+    //   condBranch(to: exit, ifZeroElseDecrement: %extraTrips)
+    //   <eager: split(to: loop, saving: exit)>
+    //   <possesive:
+    //     clearSavePoint
+    //     split(to: loop, saving: exit)>
+    //   <reluctant: save(restoringAt: loop)
+    builder.label(exitPolicy)
+    switch extraTrips {
+    case nil: break
+    case 0:   builder.buildBranch(to: exit)
+    default:
+      assert(extraTripsReg != nil, "logic inconsistency")
+      builder.buildCondBranch(
+        to: exit, ifZeroElseDecrement: extraTripsReg!)
+    }
+
+    switch kind {
+    case .eager:
+      builder.buildSplit(to: loopBody, saving: exit)
+    case .possessive:
+      builder.buildClear()
+      builder.buildSplit(to: loopBody, saving: exit)
+    case .reluctant:
+      builder.buildSave(loopBody)
+      // FIXME: Is this re-entrant? That is would nested
+      // quantification break if trying to restore to a prior
+      // iteration because the register got overwritten?
+      //
+    }
+
+    builder.label(exit)
+  }
+
   func emitQuantification(_ quant: AST.Quantification) throws {
     let child = quant.child
-    switch (quant.amount.value, quant.kind.value) {
-    // Lazy zero or more: *?
-    //   start:
-    //     save element
-    //     branch after
-    //   element:
-    //     <code for component>
-    //     branch start
-    //   after:
-    case (.zeroOrMore, .reluctant):
-      let start = builder.makeAddress()
-      let element = builder.makeAddress()
-      let after = builder.makeAddress()
-      builder.label(start)
-      builder.buildSave(element)
-      builder.buildBranch(to: after)
-      builder.label(element)
-      try emit(child)
-      builder.buildBranch(to: start)
-      builder.label(after)
+    let kind = quant.kind.value
 
-    // Lazy one or more: +?
-    //   element:
-    //     <code for component>
-    //     save element
-    //   after:
-    case (.oneOrMore, .reluctant):
-      let element = builder.makeAddress()
-      let after = builder.makeAddress()
-      builder.label(element)
-      try emit(child)
-      builder.buildSave(element)
-      builder.label(after)
+    switch quant.amount.value.bounds {
+    case (_, atMost: 0):
+      // TODO: Parser should warn
+      return
+    case let (atLeast: n, atMost: m?) where n > m:
+      // TODO: Parser should warn
+      // TODO: Should we error?
+      return
 
-    // Lazy zero or one: ??
-    //     save element
-    //     branch after
-    //   element:
-    //     <code for component>
-    //   after:
-    case (.zeroOrOne, .reluctant):
-      let element = builder.makeAddress()
-      let after = builder.makeAddress()
-      builder.buildSave(element)
-      builder.buildBranch(to: after)
-      builder.label(element)
-      try emit(child)
-      builder.label(after)
+    case let (atLeast: n, atMost: m) where m == nil || n <= m!:
+      try compileQuantification(
+        low: n, high: m, kind: kind, child: child)
+      return
 
-    // Zero or more: *
-    //   start:
-    //     save end
-    //     <code for component>
-    //     branch start
-    //   end:
-    case (.zeroOrMore, .eager):
-      let end = builder.makeAddress()
-      let start = builder.makeAddress()
-      builder.label(start)
-      builder.buildSave(end)
-      try emit(child)
-      builder.buildBranch(to: start)
-      builder.label(end)
-
-    // One or more: +
-    //   element:
-    //     <code for component>
-    //     save end
-    //     branch element
-    //   end:
-    case (.oneOrMore, .eager):
-      let element = builder.makeAddress()
-      let end = builder.makeAddress()
-      builder.label(element)
-      try emit(child)
-      builder.buildSave(end)
-      builder.buildBranch(to: element)
-      builder.label(end)
-
-    // Zero or one: ?
-    //     save end
-    //     <code for component>
-    //   end:
-    case (.zeroOrOne, .eager):
-      let end = builder.makeAddress()
-      builder.buildSave(end)
-      try emit(child)
-      builder.label(end)
-
-    // Exactly: {n}
-    //
-    //
-    //
-    //
-    case (.exactly(let n), _):
-      // FIXME: This works, but better to emit a loop
-      for _ in 0..<n.value {
-        try emit(child)
-      }
-
-      case (.nOrMore, _),
-      (.upToN, _),
-      (.range, _),
-      (_, .possessive):
-      throw unsupported("\(quant._dumpBase)")
+    default:
+      fatalError("unreachable")
     }
   }
 }

--- a/Tests/MatchingEngineTests/MatchingEngineTests.swift
+++ b/Tests/MatchingEngineTests/MatchingEngineTests.swift
@@ -182,7 +182,7 @@ let manyAEater: Engine<String> = {
 //
 //   [0] assert #0 #0
 //   [1] condBranch #0 [x] // accept
-//   [2] consume(1)
+//   [2] advance(1)
 //   [3] goto 0
 //   [4] accept
 //
@@ -191,13 +191,13 @@ let manyAEater: Engine<String> = {
 // instruction.
 let eatUntilA: Engine<String> = {
   makeEngine { builder in 
-    let reg = builder.makeRegister()
+    let reg = builder.makeBoolRegister()
     let accTok = builder.makeAddress()
     let assertTok = builder.makeAddress()
     builder.buildAssert("A", into: reg)
     builder.resolve(assertTok)
     builder.buildCondBranch(reg, to: accTok)
-    builder.buildConsume(1)
+    builder.buildAdvance(1)
     builder.buildBranch(to: assertTok)
     builder.buildAccept()
     builder.resolve(accTok)
@@ -207,18 +207,18 @@ let eatUntilA: Engine<String> = {
 // Eat through the first A (FAIL if no A)
 //
 //   [0] assert #0 #0
-//   [1] consume(1)
+//   [1] advance(1)
 //   [2] condBranch #0 [x] // accept
 //   [3] goto 0
 //   [4] accept
 let eatThroughA: Engine<String> = {
   makeEngine { builder in
-    let reg = builder.makeRegister()
+    let reg = builder.makeBoolRegister()
     let accTok = builder.makeAddress()
     let assertTok = builder.makeAddress()
     builder.buildAssert("A", into: reg)
     builder.resolve(assertTok)
-    builder.buildConsume(1)
+    builder.buildAdvance(1)
     builder.buildCondBranch(reg, to: accTok)
     builder.buildBranch(to: assertTok)
     builder.buildAccept()

--- a/Tests/RegexTests/CompileTests.swift
+++ b/Tests/RegexTests/CompileTests.swift
@@ -1,0 +1,40 @@
+
+@testable import _MatchingEngine
+@testable import _StringProcessing
+
+import XCTest
+
+extension RegexTests {
+
+  func testCompileQuantification() throws {
+
+    // NOTE: While we might change how we compile
+    // quantifications, they should be compiled equivalently
+    // for different syntactic expressions.
+    let equivalents: Array<[String]> = [
+      ["a*", "a{0,}"],
+      ["a+", "a{1,}"],
+      ["a?", "a{0,1}", "a{,1}"],
+
+      ["a*?", "a{0,}?"],
+      ["a+?", "a{1,}?"],
+      ["a??", "a{0,1}?", "a{,1}?"],
+
+      ["a*+", "a{0,}+"],
+      ["a++", "a{1,}+"],
+      ["a?+", "a{0,1}+", "a{,1}+"],
+    ]
+
+    for row in equivalents {
+      let progs = try row.map {
+        try _compileRegex($0).engine.program
+      }
+      let ref = progs.first!
+      for prog in progs.dropFirst() {
+        XCTAssert(ref.instructions.elementsEqual(
+          prog.instructions))
+
+      }
+    }
+  }
+}


### PR DESCRIPTION
Adds a general purpose quantification algorithm with specializations for common bounds (`0`, `1`, `unbounded`).

Expands testing.

Overhauls some parts of ME's instruction and operand structure.

Note that we continue to suffer from reluctant restores being reentrant, at least as long as we have non-restorable state such as global register values.

