### PR TITLE
Parse matching options

### DIFF
--- a/Sources/_MatchingEngine/Regex/AST/Group.swift
+++ b/Sources/_MatchingEngine/Regex/AST/Group.swift
@@ -53,6 +53,12 @@ extension AST {
       // (*asr:...)
       case atomicScriptRun
 
+      // (?iJmnsUxxxDPSWy{..}-iJmnsUxxxDPSW:)
+      // If hasImplicitScope is true, it was written as e.g (?i), and implicitly
+      // forms a group containing all the following elements of the current
+      // group.
+      case changeMatchingOptions(MatchingOptionSequence, hasImplicitScope: Bool)
+
       // NOTE: Comments appear to be groups, but are not parsed
       // the same. They parse more like quotes, so are not
       // listed here.
@@ -68,21 +74,38 @@ extension AST.Group.Kind: _ASTPrintable {
     }
   }
 
+  /// Whether this is a group with an implicit scope, e.g matching options
+  /// written as (?i) implicitly become parent groups for the rest of the
+  /// elements in the current group:
+  ///
+  ///      (a(?i)bc)de -> (a(?i:bc))de
+  ///
+  public var hasImplicitScope: Bool {
+    switch self {
+    case .changeMatchingOptions(_, let hasImplicitScope):
+      return hasImplicitScope
+    default:
+      return false
+    }
+  }
+
   public var _dumpBase: String {
     switch self {
-    case .capture:             return "capture"
-    case .namedCapture(let s): return "capture<\(s.value)>"
-    case .nonCapture:          return "nonCapture"
-    case .nonCaptureReset:     return "nonCaptureReset"
-    case .atomicNonCapturing:  return "atomicNonCapturing"
-    case .lookahead:           return "lookahead"
-    case .negativeLookahead:   return "negativeLookahead"
-    case .nonAtomicLookahead:  return "nonAtomicLookahead"
-    case .lookbehind:          return "lookbehind"
-    case .negativeLookbehind:  return "negativeLookbehind"
-    case .nonAtomicLookbehind: return "nonAtomicLookbehind"
-    case .scriptRun:           return "scriptRun"
-    case .atomicScriptRun:     return "atomicScriptRun"
+    case .capture:                         return "capture"
+    case .namedCapture(let s):             return "capture<\(s.value)>"
+    case .nonCapture:                      return "nonCapture"
+    case .nonCaptureReset:                 return "nonCaptureReset"
+    case .atomicNonCapturing:              return "atomicNonCapturing"
+    case .lookahead:                       return "lookahead"
+    case .negativeLookahead:               return "negativeLookahead"
+    case .nonAtomicLookahead:              return "nonAtomicLookahead"
+    case .lookbehind:                      return "lookbehind"
+    case .negativeLookbehind:              return "negativeLookbehind"
+    case .nonAtomicLookbehind:             return "nonAtomicLookbehind"
+    case .scriptRun:                       return "scriptRun"
+    case .atomicScriptRun:                 return "atomicScriptRun"
+    case .changeMatchingOptions(let seq, let hasImplicitScope):
+      return "changeMatchingOptions<\(seq), \(hasImplicitScope)>"
     }
   }
 }

--- a/Sources/_MatchingEngine/Regex/AST/MatchingOptions.swift
+++ b/Sources/_MatchingEngine/Regex/AST/MatchingOptions.swift
@@ -1,0 +1,82 @@
+extension AST {
+  /// An option written in source that changes matching semantics.
+  public struct MatchingOption: Hashable {
+    public enum Kind {
+      // PCRE options
+      case caseInsensitive          // i
+      case allowDuplicateGroupNames // J
+      case multiline                // m
+      case noAutoCapture            // n
+      case singleLine               // s
+      case reluctantByDefault       // U
+      case extended                 // x
+      case extraExtended            // xx
+
+      // ICU options
+      case unicodeWordBoundaries    // w
+
+      // Oniguruma options
+      case asciiOnlyDigit           // D
+      case asciiOnlyPOSIXProps      // P
+      case asciiOnlySpace           // S
+      case asciiOnlyWord            // W
+
+      // Oniguruma text segment options (these are mutually exclusive and cannot
+      // be unset, only flipped between)
+      case textSegmentGraphemeMode  // y{g}
+      case textSegmentWordMode      // y{w}
+    }
+    public var kind: Kind
+    public var location: SourceLocation
+
+    public init(_ kind: Kind, location: SourceLocation) {
+      self.kind = kind
+      self.location = location
+    }
+
+    public var isTextSegmentMode: Bool {
+      switch kind {
+      case .textSegmentGraphemeMode, .textSegmentWordMode:
+        return true
+      default:
+        return false
+      }
+    }
+  }
+
+  /// A sequence of matching options written in source.
+  public struct MatchingOptionSequence: Hashable {
+    /// If the sequence starts with a caret '^', its source location, or nil
+    /// otherwise. If this is set, it indicates that all the matching options
+    /// are unset, except the ones in `adding`.
+    public var caretLoc: SourceLocation?
+
+    /// The options to add.
+    public var adding: [MatchingOption]
+
+    /// The location of the '-' between the options to add and options to
+    /// remove.
+    public var minusLoc: SourceLocation?
+
+    /// The options to remove.
+    public var removing: [MatchingOption]
+
+    public init(caretLoc: SourceLocation?, adding: [MatchingOption],
+                minusLoc: SourceLocation?, removing: [MatchingOption]) {
+      self.caretLoc = caretLoc
+      self.adding = adding
+      self.minusLoc = minusLoc
+      self.removing = removing
+    }
+  }
+}
+
+extension AST.MatchingOption: _ASTPrintable {
+  public var _dumpBase: String { "\(kind)" }
+}
+
+extension AST.MatchingOptionSequence: _ASTPrintable {
+  public var _dumpBase: String {
+    "adding: \(adding), removing: \(removing), hasCaret: \(caretLoc != nil)"
+  }
+}

--- a/Sources/_MatchingEngine/Regex/Parse/Diagnostics.swift
+++ b/Sources/_MatchingEngine/Regex/Parse/Diagnostics.swift
@@ -26,6 +26,7 @@ enum ParseError: Error, Hashable {
   case emptyProperty
 
   case expectedGroupSpecifier
+  case cannotRemoveTextSegmentOptions
 }
 
 extension ParseError: CustomStringConvertible {
@@ -61,6 +62,8 @@ extension ParseError: CustomStringConvertible {
       return "empty property"
     case .expectedGroupSpecifier:
       return "expected group specifier"
+    case .cannotRemoveTextSegmentOptions:
+      return "text segment mode cannot be unset, only changed"
     }
   }
 }

--- a/Sources/_MatchingEngine/Regex/Parse/Diagnostics.swift
+++ b/Sources/_MatchingEngine/Regex/Parse/Diagnostics.swift
@@ -24,6 +24,8 @@ enum ParseError: Error, Hashable {
 
   case invalidPOSIXSetName(String)
   case emptyProperty
+
+  case expectedGroupSpecifier
 }
 
 extension ParseError: CustomStringConvertible {
@@ -57,6 +59,8 @@ extension ParseError: CustomStringConvertible {
       return "invalid character set name: '\(n)'"
     case .emptyProperty:
       return "empty property"
+    case .expectedGroupSpecifier:
+      return "expected group specifier"
     }
   }
 }

--- a/Sources/_MatchingEngine/Regex/Parse/LexicalAnalysis.swift
+++ b/Sources/_MatchingEngine/Regex/Parse/LexicalAnalysis.swift
@@ -502,8 +502,10 @@ extension Source {
           return .namedCapture(name)
         }
 
-        throw ParseError.misc(
-          "Unknown group kind '(?\(src.peek()!)'")
+        guard let next = src.peek() else {
+          throw ParseError.expectedGroupSpecifier
+        }
+        throw ParseError.misc("Unknown group kind '(?\(next)'")
       }
 
       // Explicitly spelled out PRCE2 syntax for some groups.

--- a/Sources/_MatchingEngine/Regex/Parse/Parse.swift
+++ b/Sources/_MatchingEngine/Regex/Parse/Parse.swift
@@ -171,7 +171,10 @@ extension Parser {
     if let kind = try source.lexGroupStart() {
       priorGroupCount += 1
       let child = try parse()
-      try source.expect(")")
+      // An implicit scoped group has already consumed its closing paren.
+      if !kind.value.hasImplicitScope {
+        try source.expect(")")
+      }
       return .group(.init(kind, child, loc(_start)))
     }
     if let cccStart = try source.lexCustomCCStart() {

--- a/Sources/_StringProcessing/ASTBuilder.swift
+++ b/Sources/_StringProcessing/ASTBuilder.swift
@@ -89,6 +89,36 @@ public func scriptRun(_ child: AST) -> AST {
 public func atomicScriptRun(_ child: AST) -> AST {
   group(.atomicScriptRun, child)
 }
+func changeMatchingOptions(
+  _ seq: AST.MatchingOptionSequence, hasImplicitScope: Bool, _ child: AST
+) -> AST {
+  group(.changeMatchingOptions(seq, hasImplicitScope: hasImplicitScope), child)
+}
+
+func matchingOptions(
+  adding: [AST.MatchingOption.Kind] = [],
+  removing: [AST.MatchingOption.Kind] = []
+) -> AST.MatchingOptionSequence {
+  .init(caretLoc: nil, adding: adding.map { .init($0, location: .fake) },
+        minusLoc: nil, removing: removing.map { .init($0, location: .fake)})
+}
+func matchingOptions(
+  adding: AST.MatchingOption.Kind...,
+  removing: AST.MatchingOption.Kind...
+) -> AST.MatchingOptionSequence {
+  matchingOptions(adding: adding, removing: removing)
+}
+func unsetMatchingOptions(
+  adding: [AST.MatchingOption.Kind]
+) -> AST.MatchingOptionSequence {
+  .init(caretLoc: .fake, adding: adding.map { .init($0, location: .fake) },
+        minusLoc: nil, removing: [])
+}
+func unsetMatchingOptions(
+  adding: AST.MatchingOption.Kind...
+) -> AST.MatchingOptionSequence {
+  unsetMatchingOptions(adding: adding)
+}
 
 func quant(
   _ amount: AST.Quantification.Amount,

--- a/Tests/RegexTests/LexTests.swift
+++ b/Tests/RegexTests/LexTests.swift
@@ -107,6 +107,10 @@ extension RegexTests {
     diagnose(#"\p{a="#, expecting: .expected("}")) { try $0.lexBasicAtom() }
     diagnose(#"(?#"#, expecting: .expected(")")) { _ = try $0.lexComment() }
 
+    diagnose(#"(?"#, expecting: .expectedGroupSpecifier) {
+      _ = try $0.lexGroupStart()
+    }
+
     // TODO: want to dummy print out source ranges, etc, test that.
   }
 

--- a/Tests/RegexTests/LexTests.swift
+++ b/Tests/RegexTests/LexTests.swift
@@ -93,6 +93,14 @@ extension RegexTests {
     diagnoseUniScalarOverflow("{123456789}", base: "u")
     diagnoseUniScalarOverflow("{123456789}", base: "x")
 
+    // Text segment options
+    diagnose("(?-y{g})", expecting: .cannotRemoveTextSegmentOptions) {
+      _ = try $0.lexGroupStart()
+    }
+    diagnose("(?-y{w})", expecting: .cannotRemoveTextSegmentOptions) {
+      _ = try $0.lexGroupStart()
+    }
+
     // Test expected group.
     diagnose(#"(*"#, expecting: .misc("Quantifier '*' must follow operand")) {
       _ = try $0.lexGroupStart()
@@ -106,8 +114,25 @@ extension RegexTests {
     diagnose(#"\p{a"#, expecting: .expected("}")) { try $0.lexBasicAtom() }
     diagnose(#"\p{a="#, expecting: .expected("}")) { try $0.lexBasicAtom() }
     diagnose(#"(?#"#, expecting: .expected(")")) { _ = try $0.lexComment() }
+    diagnose(#"(?x"#, expecting: .expected(")")) { _ = try $0.lexGroupStart() }
 
     diagnose(#"(?"#, expecting: .expectedGroupSpecifier) {
+      _ = try $0.lexGroupStart()
+    }
+
+    diagnose(#"(?^"#, expecting: .expected(")")) { _ = try $0.lexGroupStart() }
+    diagnose(#"(?^i"#, expecting: .expected(")")) { _ = try $0.lexGroupStart() }
+    diagnose(#"(?^-"#, expecting: .expected(")")) { _ = try $0.lexGroupStart() }
+    diagnose(#"(?^-)"#, expecting: .expected(")")) { _ = try $0.lexGroupStart() }
+    diagnose(#"(?^i-"#, expecting: .expected(")")) { _ = try $0.lexGroupStart() }
+    diagnose(#"(?^i-m)"#, expecting: .expected(")")) { _ = try $0.lexGroupStart() }
+
+    diagnose(#"(?y)"#, expecting: .expected("{")) { _ = try $0.lexGroupStart() }
+    diagnose(#"(?y{)"#, expecting: .expected("g")) { _ = try $0.lexGroupStart() }
+    diagnose(#"(?y{g)"#, expecting: .expected("}")) { _ = try $0.lexGroupStart() }
+    diagnose(#"(?y{x})"#, expecting: .expected("g")) { _ = try $0.lexGroupStart() }
+
+    diagnose(#"(?k)"#, expecting: .misc("Unknown group kind '(?k'")) {
       _ = try $0.lexGroupStart()
     }
 


### PR DESCRIPTION
Parse both explicitly scoped `(?i:...)`, `(?^i:...)`, `(?i-m:...)` and implicitly scoped `(?i)`, `(?^i)`, `(?i-m)` matching option specifiers, with support for, PCRE, ICU, and Oniguruma options.