### PR TITLE
Add the underpinnings of capture and back references to the backend

### DIFF
--- a/Sources/_MatchingEngine/Engine/InstPayload.swift
+++ b/Sources/_MatchingEngine/Engine/InstPayload.swift
@@ -32,6 +32,7 @@ extension Instruction.Payload {
 
     case string(StringRegister)
     case sequence(SequenceRegister)
+    case position(PositionRegister)
     case optionalString(StringRegister?)
     case int(IntRegister)
     case distance(Distance)
@@ -46,6 +47,7 @@ extension Instruction.Payload {
     case packedAddrAddr(InstructionAddress, InstructionAddress)
     case packedBoolInt(BoolRegister, IntRegister)
     case packedEltBool(ElementRegister, BoolRegister)
+    case packedPosPos(PositionRegister, PositionRegister)
   }
 }
 
@@ -142,6 +144,13 @@ extension Instruction.Payload {
     interpret()
   }
 
+  init(position: PositionRegister) {
+    self.init(position)
+  }
+  var position: PositionRegister {
+    interpret()
+  }
+
   init(int: IntRegister) {
     self.init(int)
   }
@@ -233,6 +242,13 @@ extension Instruction.Payload {
     self.init(element, bool)
   }
   var pairedElementBool: (ElementRegister, BoolRegister) {
+    interpretPair()
+  }
+
+  init(pos: PositionRegister, pos2: PositionRegister) {
+    self.init(pos, pos2)
+  }
+  var pairedPosPos: (PositionRegister, PositionRegister) {
     interpretPair()
   }
 

--- a/Sources/_MatchingEngine/Engine/Instruction.swift
+++ b/Sources/_MatchingEngine/Engine/Instruction.swift
@@ -20,8 +20,7 @@ extension Instruction {
     ///
     ///     nop(comment: String?)
     ///
-    /// Operand:
-    ///   - Optional string register containing a comment or reason
+    /// Operand: Optional string register containing a comment or reason
     ///
     case nop
 
@@ -41,7 +40,8 @@ extension Instruction {
     ///     moveImmediate(_ i: Int, into: IntReg)
     ///
     /// Operands:
-    ///   - TODO
+    ///   - Immediate value to move
+    ///   - Int register to move into
     ///
     case moveImmediate
 
@@ -49,21 +49,28 @@ extension Instruction {
 
     /// Branch to a new instruction
     ///
+    ///     branch(to: InstAddr)
+    ///
     /// Operand: instruction address to branch to
     case branch
 
     /// Conditionally branch
     ///
-    /// Operand: packed condition register and address to branch to
+    ///     condBranch(to: InstAddr, if: BoolReg)
+    ///
+    /// Operands:
+    ///   - Address to branch to
+    ///   - Condition register to check
     case condBranch
 
     /// Conditionally branch if zero, otherwise decrement
     ///
-    ///     branch_cond_zero_else_decrement(_ i: IntReg, to: InstructionAddress)
+    ///     condBranch(
+    ///       to: InstAddr, ifZeroElseDecrement: IntReg)
     ///
     /// Operands:
-    ///   - Int register to check for zero, otherwise decrease
     ///   - Instruction address to branch to, if zero
+    ///   - Int register to check for zero, otherwise decrease
     ///
     case condBranchZeroElseDecrement
 
@@ -101,10 +108,11 @@ extension Instruction {
     case print
 
 
-
     // MARK: - Matching
 
     /// Advance the input position.
+    ///
+    ///     advance(_ amount: Distance)
     ///
     /// Operand: Amount to advance by.
     case advance
@@ -113,13 +121,34 @@ extension Instruction {
 
     /// Composite assert-advance else restore.
     ///
+    ///     match(_: EltReg)
+    ///
     /// Operand: Element register to compare against.
     case match
 
     /// Match against a sequence of elements
     ///
+    ///     matchSequence(_: SeqReg)
+    ///
     /// Operand: Sequence register to compare against.
     case matchSequence
+
+    /// Match against a slice of the input
+    ///
+    ///     matchSlice(
+    ///       lowerBound: PositionReg, upperBound: PositionReg)
+    ///
+    /// Operands:
+    ///   - Lowerbound position in the input
+    ///   - Upperbound position in the input
+    case matchSlice
+
+    /// Save the current position in the input in a register
+    ///
+    ///     movePosition(into: PositionReg)
+    ///
+    /// Operand: The position register to move into
+    case movePosition
 
     /// Match against a provided element.
     ///

--- a/Sources/_MatchingEngine/Engine/Registers.swift
+++ b/Sources/_MatchingEngine/Engine/Registers.swift
@@ -24,10 +24,7 @@ extension Processor {
     // unused
     var floats: [Double] = []
 
-    // unused
-    //
-    // Unlikely to be static, as that means input must be bound
-    // at compile time
+    // Currently, used for `movePosition` and `matchSlice`
     var positions: [Position] = []
 
     // unused
@@ -55,6 +52,10 @@ extension Processor {
     subscript(_ i: BoolRegister) -> Bool {
       get { bools[i.rawValue] }
       set { bools[i.rawValue] = newValue }
+    }
+    subscript(_ i: PositionRegister) -> Position {
+      get { positions[i.rawValue] }
+      set { positions[i.rawValue] = newValue }
     }
     subscript(_ i: ElementRegister) -> Element {
       elements[i.rawValue]

--- a/Tests/MatchingEngineTests/MatchingEngineTests.swift
+++ b/Tests/MatchingEngineTests/MatchingEngineTests.swift
@@ -226,6 +226,8 @@ let eatThroughA: Engine<String> = {
   }
 }()
 
+
+
 class MatchingEngineTests: XCTestCase {
 
   func testAEaters() {
@@ -245,6 +247,44 @@ class MatchingEngineTests: XCTestCase {
       test.check(manyAEater: manyAEater)
       test.check(eatUntilA: eatUntilA)
       test.check(eatThroughA: eatThroughA)
+    }
+  }
+
+  func testThreeLetterRepeat() {
+    // Check for a repeated 3-letter sequence, such as in
+    //   `(...)\1`
+    //
+    //   [0] movePosition(into: %low)
+    //   [1] advance(3)
+    //   [2] movePosition(into: %high)
+    //   [3] matchSlice(%low, %high)
+    //   [4] accept
+    let threeLetterRepeat: Engine<String> = {
+      makeEngine { builder in
+        let low = builder.makePositionRegister(
+          initializingWithCurrentPosition: ())
+        builder.buildAdvance(3)
+        let high = builder.makePositionRegister(
+          initializingWithCurrentPosition: ())
+        builder.buildMatchSlice(lower: low, upper: high)
+        builder.buildAccept()
+      }
+    }()
+
+    let tests: Array<(String, Bool)> = [
+      ("abcabc", true),
+      ("abcabc_____", true),
+      ("dddddd_____", true),
+      ("🥳🧟‍♀️c🥳🧟‍♀️c", true),
+      ("abccba", false),
+      ("abcabb", false),
+      ("abcbac", false),
+      ("🥳🧟‍♀️c🥳🧟‍♂️c", false),
+    ]
+
+    for (test, expect) in tests {
+      let match = threeLetterRepeat.consume(test) != nil
+      XCTAssertEqual(expect, match)
     }
   }
 }


### PR DESCRIPTION
Builds on top of https://github.com/apple/swift-experimental-string-processing/pull/90 and https://github.com/apple/swift-experimental-string-processing/pull/93 to add some backend underpinnings for capture and back-reference-like support.

Compilation will be much more work, but can in theory map to this.

