### PR TITLE
Source locations for alternation pipes and char class ranges

### DIFF
--- a/Sources/_MatchingEngine/Regex/AST/AST.swift
+++ b/Sources/_MatchingEngine/Regex/AST/AST.swift
@@ -92,11 +92,20 @@ extension AST {
 
   public struct Alternation: Hashable, _ASTNode {
     public let children: [AST]
-    public let location: SourceLocation
+    public let pipes: [SourceLocation]
 
-    public init(_ mems: [AST], _ location: SourceLocation) {
+    public init(_ mems: [AST], pipes: [SourceLocation]) {
+      // An alternation must have at least two branches (though the branches
+      // may be empty AST nodes), and n - 1 pipes.
+      precondition(mems.count >= 2)
+      precondition(pipes.count == mems.count - 1)
+
       self.children = mems
-      self.location = location
+      self.pipes = pipes
+    }
+
+    public var location: SourceLocation {
+      .init(children.first!.location.start ..< children.last!.location.end)
     }
   }
 

--- a/Sources/_MatchingEngine/Regex/AST/Atom.swift
+++ b/Sources/_MatchingEngine/Regex/AST/Atom.swift
@@ -314,7 +314,7 @@ extension AST.Atom {
 
     public var _dumpBase: String {
       // FIXME: better printing...
-      "\(kind)\(isInverted)"
+      "\(kind)\(isInverted)\(isPOSIX)"
     }
   }
 }

--- a/Sources/_MatchingEngine/Regex/AST/CustomCharClass.swift
+++ b/Sources/_MatchingEngine/Regex/AST/CustomCharClass.swift
@@ -21,13 +21,24 @@ extension AST {
       case custom(CustomCharacterClass)
 
       /// A character range `a-z`
-      case range(Atom, Atom)
+      case range(Range)
 
       /// A single character or escape
       case atom(Atom)
 
       /// A binary operator applied to sets of members `abc&&def`
       case setOperation([Member], Located<SetOp>, [Member])
+    }
+    public struct Range: Hashable {
+      public var lhs: Atom
+      public var dashLoc: SourceLocation
+      public var rhs: Atom
+
+      public init(_ lhs: Atom, _ dashLoc: SourceLocation, _ rhs: Atom) {
+        self.lhs = lhs
+        self.dashLoc = dashLoc
+        self.rhs = rhs
+      }
     }
     public enum SetOp: String, Hashable {
       case subtraction = "--"
@@ -44,4 +55,19 @@ extension AST {
 
 extension AST.CustomCharacterClass {
   public var isInverted: Bool { start.value == .inverted }
+}
+
+extension CustomCC.Member {
+  private var _associatedValue: Any {
+    switch self {
+    case .custom(let c): return c
+    case .range(let r): return r
+    case .atom(let a): return a
+    case .setOperation(let lhs, let op, let rhs): return (lhs, op, rhs)
+    }
+  }
+
+  func `as`<T>(_ t: T.Type = T.self) -> T? {
+    _associatedValue as? T
+  }
 }

--- a/Sources/_MatchingEngine/Regex/AST/Group.swift
+++ b/Sources/_MatchingEngine/Regex/AST/Group.swift
@@ -54,10 +54,9 @@ extension AST {
       case atomicScriptRun
 
       // (?iJmnsUxxxDPSWy{..}-iJmnsUxxxDPSW:)
-      // If hasImplicitScope is true, it was written as e.g (?i), and implicitly
-      // forms a group containing all the following elements of the current
-      // group.
-      case changeMatchingOptions(MatchingOptionSequence, hasImplicitScope: Bool)
+      // Isolated options are written as e.g (?i), and implicitly form a group
+      // containing all the following elements of the current group.
+      case changeMatchingOptions(MatchingOptionSequence, isIsolated: Bool)
 
       // NOTE: Comments appear to be groups, but are not parsed
       // the same. They parse more like quotes, so are not
@@ -74,16 +73,16 @@ extension AST.Group.Kind {
     }
   }
 
-  /// Whether this is a group with an implicit scope, e.g matching options
-  /// written as (?i) implicitly become parent groups for the rest of the
-  /// elements in the current group:
+  /// Whether this is a group with an implicit scope, e.g isolated matching
+  /// options implicitly become parent groups for the rest of the elements in
+  /// the current group:
   ///
   ///      (a(?i)bc)de -> (a(?i:bc))de
   ///
   public var hasImplicitScope: Bool {
     switch self {
-    case .changeMatchingOptions(_, let hasImplicitScope):
-      return hasImplicitScope
+    case .changeMatchingOptions(_, let isIsolated):
+      return isIsolated
     default:
       return false
     }

--- a/Sources/_MatchingEngine/Regex/Parse/LexicalAnalysis.swift
+++ b/Sources/_MatchingEngine/Regex/Parse/LexicalAnalysis.swift
@@ -1026,14 +1026,19 @@ extension Source {
   /// of a '-' character followed by an atom.
   mutating func lexCustomCharClassRangeEnd(
     priorGroupCount: Int
-  ) throws -> AST.Atom? {
+  ) throws -> (dashLoc: SourceLocation, AST.Atom)? {
     // Make sure we don't have a binary operator e.g '--', and the '-' is not
     // ending the custom character class (in which case it is literal).
+    let start = currentPosition
     guard peekCCBinOp() == nil && !starts(with: "-]") && tryEat("-") else {
       return nil
     }
-    return try lexAtom(isInCustomCharacterClass: true,
-                       priorGroupCount: priorGroupCount)
+    let dashLoc = Location(start ..< currentPosition)
+    guard let end = try lexAtom(isInCustomCharacterClass: true,
+                                priorGroupCount: priorGroupCount) else {
+      return nil
+    }
+    return (dashLoc, end)
   }
 }
 

--- a/Sources/_MatchingEngine/Regex/Parse/LexicalAnalysis.swift
+++ b/Sources/_MatchingEngine/Regex/Parse/LexicalAnalysis.swift
@@ -602,7 +602,7 @@ extension Source {
         // Matching option changing group (?iJmnsUxxxDPSWy{..}-iJmnsUxxxDPSW:).
         if let seq = try src.lexMatchingOptionSequence() {
           if src.tryEat(":") {
-            return .changeMatchingOptions(seq, hasImplicitScope: false)
+            return .changeMatchingOptions(seq, isIsolated: false)
           }
           // If this isn't start of an explicit group, we should have an
           // implicit group that covers the remaining elements of the current
@@ -611,7 +611,7 @@ extension Source {
           // also does it across alternations, which will require additional
           // handling.
           try src.expect(")")
-          return .changeMatchingOptions(seq, hasImplicitScope: true)
+          return .changeMatchingOptions(seq, isIsolated: true)
         }
 
         guard let next = src.peek() else {

--- a/Sources/_MatchingEngine/Regex/Parse/Parse.swift
+++ b/Sources/_MatchingEngine/Regex/Parse/Parse.swift
@@ -269,14 +269,14 @@ extension Parser {
       else { break }
 
       // Range between atoms.
-      if let rhs = try source.lexCustomCharClassRangeEnd(
+      if let (dashLoc, rhs) = try source.lexCustomCharClassRangeEnd(
         priorGroupCount: priorGroupCount
       ) {
         guard atom.literalCharacterValue != nil &&
               rhs.literalCharacterValue != nil else {
           throw ParseError.invalidCharacterClassRangeOperand
         }
-        members.append(.range(atom, rhs))
+        members.append(.range(.init(atom, dashLoc, rhs)))
         continue
       }
 

--- a/Sources/_MatchingEngine/Regex/Parse/Parse.swift
+++ b/Sources/_MatchingEngine/Regex/Parse/Parse.swift
@@ -89,9 +89,12 @@ extension Parser {
 
     if source.isEmpty { return .empty(.init(loc(_start))) }
 
-    var result = Array<AST>(singleElement: try parseConcatenation())
-    while source.tryEat("|") {
-      // TODO: track pipe locations too...
+    var result = [try parseConcatenation()]
+    var pipes: [SourceLocation] = []
+    while true {
+      let pipeStart = source.currentPosition
+      guard source.tryEat("|") else { break }
+      pipes.append(loc(pipeStart))
       result.append(try parseConcatenation())
     }
 
@@ -99,7 +102,7 @@ extension Parser {
       return result[0]
     }
 
-    return .alternation(.init(result, loc(_start)))
+    return .alternation(.init(result, pipes: pipes))
   }
 
   /// Parse a term, potentially separated from others by `|`

--- a/Sources/_MatchingEngine/Regex/Printing/DumpAST.swift
+++ b/Sources/_MatchingEngine/Regex/Printing/DumpAST.swift
@@ -185,10 +185,15 @@ extension AST.CustomCharacterClass.Member: _ASTPrintable {
     switch self {
     case .custom(let cc): return "\(cc)"
     case .atom(let a): return "\(a)"
-    case .range(let lhs, let rhs):
-      return "range \(lhs) to \(rhs)"
+    case .range(let r): return "\(r)"
     case .setOperation(let lhs, let op, let rhs):
       return "op \(lhs) \(op.value) \(rhs)"
     }
+  }
+}
+
+extension AST.CustomCharacterClass.Range: _ASTPrintable {
+  public var _dumpBase: String {
+    "\(lhs)-\(rhs)"
   }
 }

--- a/Sources/_MatchingEngine/Regex/Printing/DumpAST.swift
+++ b/Sources/_MatchingEngine/Regex/Printing/DumpAST.swift
@@ -120,8 +120,8 @@ extension AST.Group.Kind: _ASTPrintable {
     case .nonAtomicLookbehind:   return "nonAtomicLookbehind"
     case .scriptRun:             return "scriptRun"
     case .atomicScriptRun:       return "atomicScriptRun"
-    case .changeMatchingOptions(let seq, let hasImplicitScope):
-      return "changeMatchingOptions<\(seq), \(hasImplicitScope)>"
+    case .changeMatchingOptions(let seq, let isIsolated):
+      return "changeMatchingOptions<\(seq), \(isIsolated)>"
     }
   }
 }

--- a/Sources/_MatchingEngine/Regex/Printing/PrintAsCanonical.swift
+++ b/Sources/_MatchingEngine/Regex/Printing/PrintAsCanonical.swift
@@ -85,10 +85,10 @@ extension PrettyPrinter {
     switch member {
     case .custom(let ccc):
       outputAsCanonical(ccc)
-    case .range(let a, let b):
-      output(a._canonicalBase)
+    case .range(let r):
+      output(r.lhs._canonicalBase)
       output("-")
-      output(b._canonicalBase)
+      output(r.rhs._canonicalBase)
     case .atom(let a):
       output(a._canonicalBase)
     case .setOperation:

--- a/Sources/_MatchingEngine/Regex/Printing/PrintAsPattern.swift
+++ b/Sources/_MatchingEngine/Regex/Printing/PrintAsPattern.swift
@@ -139,16 +139,16 @@ extension PrettyPrinter {
     switch member {
     case .custom(let ccc):
       printAsPattern(ccc)
-    case .range(let a, let b):
-      if let lhs = a.literalStringValue,
-         let rhs = b.literalStringValue {
+    case .range(let r):
+      if let lhs = r.lhs.literalStringValue,
+         let rhs = r.rhs.literalStringValue {
         indent()
         output(lhs._quoted)
         output("...")
         output(rhs._quoted)
         terminateLine()
       } else {
-        print("// TODO: Range \(a) to \(b)")
+        print("// TODO: Range \(r.lhs) to \(r.rhs)")
       }
     case .atom(let a):
       if let s = a.literalStringValue {

--- a/Sources/_MatchingEngine/Utility/Misc_2.swift
+++ b/Sources/_MatchingEngine/Utility/Misc_2.swift
@@ -93,6 +93,10 @@ extension Collection {
     distance(from: startIndex, to: i)
   }
 
+  public func offsets(of r: Range<Index>) -> Range<Int> {
+    offset(of: r.lowerBound) ..< offset(of: r.upperBound)
+  }
+
   public func convertByOffset<
     C: Collection
   >(_ range: Range<Index>, in c: C) -> Range<C.Index> {

--- a/Sources/_StringProcessing/ASTBuilder.swift
+++ b/Sources/_StringProcessing/ASTBuilder.swift
@@ -264,8 +264,12 @@ func prop_m(
   atom_m(.property(.init(kind, isInverted: inverted, isPOSIX: false)))
 }
 func range_m(
+  _ lower: AST.Atom, _ upper: AST.Atom
+) -> AST.CustomCharacterClass.Member {
+  .range(.init(lower, .fake, upper))
+}
+func range_m(
   _ lower: AST.Atom.Kind, _ upper: AST.Atom.Kind
 ) -> AST.CustomCharacterClass.Member {
-  .range(atom_a(lower), atom_a(upper))
+  range_m(atom_a(lower), atom_a(upper))
 }
-

--- a/Sources/_StringProcessing/ASTBuilder.swift
+++ b/Sources/_StringProcessing/ASTBuilder.swift
@@ -17,7 +17,9 @@ AST.
 import _MatchingEngine
 
 func alt(_ asts: [AST]) -> AST {
-  .alternation(.init(asts, .fake))
+  return .alternation(
+    .init(asts, pipes: Array(repeating: .fake, count: asts.count - 1))
+  )
 }
 func alt(_ asts: AST...) -> AST {
   alt(asts)

--- a/Sources/_StringProcessing/ASTBuilder.swift
+++ b/Sources/_StringProcessing/ASTBuilder.swift
@@ -90,9 +90,9 @@ public func atomicScriptRun(_ child: AST) -> AST {
   group(.atomicScriptRun, child)
 }
 func changeMatchingOptions(
-  _ seq: AST.MatchingOptionSequence, hasImplicitScope: Bool, _ child: AST
+  _ seq: AST.MatchingOptionSequence, isIsolated: Bool, _ child: AST
 ) -> AST {
-  group(.changeMatchingOptions(seq, hasImplicitScope: hasImplicitScope), child)
+  group(.changeMatchingOptions(seq, isIsolated: isIsolated), child)
 }
 
 func matchingOptions(

--- a/Sources/_StringProcessing/CharacterClass.swift
+++ b/Sources/_StringProcessing/CharacterClass.swift
@@ -384,10 +384,10 @@ extension AST.CustomCharacterClass {
             return nil
           }
           result.append(.characterClass(cc))
-        case .range(let lhs, let rhs):
+        case .range(let r):
           result.append(.range(
-            lhs.literalCharacterValue! ...
-            rhs.literalCharacterValue!))
+            r.lhs.literalCharacterValue! ...
+            r.rhs.literalCharacterValue!))
 
         case .atom(let a):
           if let cc = a.characterClass {

--- a/Sources/_StringProcessing/ConsumerInterface.swift
+++ b/Sources/_StringProcessing/ConsumerInterface.swift
@@ -117,12 +117,12 @@ extension AST.CustomCharacterClass.Member {
     case .custom(let ccc):
       return try ccc.generateConsumer(opts)
 
-    case .range(let lower, let upper):
-      guard let lhs = lower.literalCharacterValue else {
-        throw unsupported("\(lower) in range")
+    case .range(let r):
+      guard let lhs = r.lhs.literalCharacterValue else {
+        throw unsupported("\(r.lhs) in range")
       }
-      guard let rhs = upper.literalCharacterValue else {
-        throw unsupported("\(upper) in range")
+      guard let rhs = r.rhs.literalCharacterValue else {
+        throw unsupported("\(r.rhs) in range")
       }
 
       return { input, bounds in

--- a/Tests/RegexTests/ParseTests.swift
+++ b/Tests/RegexTests/ParseTests.swift
@@ -210,12 +210,9 @@ extension RegexTests {
     parseTest(#"\08"#, concat(scalar("\u{0}"), "8"))
     parseTest(#"\0707"#, concat(scalar("\u{38}"), "7"))
 
-    // FIXME(Hamish): These now get printed using the unicode
-    // literal syntax instead of rendered as Character. Adjust
-    // testing infra to handle that.
-//    parseTest(#"[\0]"#, charClass("\u{0}"))
-//    parseTest(#"[\01]"#, charClass("\u{1}"))
-//    parseTest(#"[\070]"#, charClass("\u{38}"))
+    parseTest(#"[\0]"#, charClass(scalar_m("\u{0}")))
+    parseTest(#"[\01]"#, charClass(scalar_m("\u{1}")))
+    parseTest(#"[\070]"#, charClass(scalar_m("\u{38}")))
 
     parseTest(#"[\07A]"#, charClass(scalar_m("\u{7}"), "A"))
     parseTest(#"[\08]"#, charClass(scalar_m("\u{0}"), "8"))
@@ -597,7 +594,7 @@ extension RegexTests {
       parseTest("\\\(i)", backreference(.absolute(i)))
       parseTest(
         "()()()()()()()()()\\\(i)",
-        concat((0..<9).map { _ in capture(empty()) }
+        concat(Array(repeating: capture(empty()), count: 9)
                + [backreference(.absolute(i))]),
         captures: .tuple(Array(repeating: .atom(), count: 9))
       )
@@ -612,13 +609,13 @@ extension RegexTests {
 
     parseTest(
       #"()()()()()()()()()()\10"#,
-      concat((0..<10).map { _ in capture(empty()) }
+      concat(Array(repeating: capture(empty()), count: 10)
              + [backreference(.absolute(10))]),
       captures: .tuple(Array(repeating: .atom(), count: 10))
     )
     parseTest(
       #"()()()()()()()()()\10()"#,
-      concat((0..<9).map { _ in capture(empty()) }
+      concat(Array(repeating: capture(empty()), count: 9)
              + [scalar("\u{8}"), capture(empty())]),
       captures: .tuple(Array(repeating: .atom(), count: 10))
     )
@@ -655,13 +652,13 @@ extension RegexTests {
     parseTest(#"\040"#, scalar(" "))
     parseTest(
       String(repeating: "()", count: 40) + #"\040"#,
-      concat((0..<40).map { _ in capture(empty()) } + [scalar(" ")]),
+      concat(Array(repeating: capture(empty()), count: 40) + [scalar(" ")]),
       captures: .tuple(Array(repeating: .atom(), count: 40))
     )
     parseTest(#"\40"#, scalar(" "))
     parseTest(
       String(repeating: "()", count: 40) + #"\40"#,
-      concat((0..<40).map { _ in capture(empty()) }
+      concat(Array(repeating: capture(empty()), count: 40)
              + [backreference(.absolute(40))]),
       captures: .tuple(Array(repeating: .atom(), count: 40))
     )
@@ -671,14 +668,14 @@ extension RegexTests {
     parseTest(#"\11"#, scalar("\u{9}"))
     parseTest(
       String(repeating: "()", count: 11) + #"\11"#,
-      concat((0..<11).map { _ in capture(empty()) }
+      concat(Array(repeating: capture(empty()), count: 11)
              + [backreference(.absolute(11))]),
       captures: .tuple(Array(repeating: .atom(), count: 11))
     )
     parseTest(#"\011"#, scalar("\u{9}"))
     parseTest(
       String(repeating: "()", count: 11) + #"\011"#,
-      concat((0..<11).map { _ in capture(empty()) } + [scalar("\u{9}")]),
+      concat(Array(repeating: capture(empty()), count: 11) + [scalar("\u{9}")]),
       captures: .tuple(Array(repeating: .atom(), count: 11))
     )
 

--- a/Tests/RegexTests/ParseTests.swift
+++ b/Tests/RegexTests/ParseTests.swift
@@ -475,74 +475,74 @@ extension RegexTests {
 
     // Matching option changing groups.
     parseTest("(?-)", changeMatchingOptions(
-      matchingOptions(), hasImplicitScope: true, empty())
+      matchingOptions(), isIsolated: true, empty())
     )
     parseTest("(?i)", changeMatchingOptions(
       matchingOptions(adding: .caseInsensitive),
-      hasImplicitScope: true, empty())
+      isIsolated: true, empty())
     )
     parseTest("(?m)", changeMatchingOptions(
       matchingOptions(adding: .multiline),
-      hasImplicitScope: true, empty())
+      isIsolated: true, empty())
     )
     parseTest("(?x)", changeMatchingOptions(
       matchingOptions(adding: .extended),
-      hasImplicitScope: true, empty())
+      isIsolated: true, empty())
     )
     parseTest("(?xx)", changeMatchingOptions(
       matchingOptions(adding: .extraExtended),
-      hasImplicitScope: true, empty())
+      isIsolated: true, empty())
     )
     parseTest("(?xxx)", changeMatchingOptions(
       matchingOptions(adding: .extraExtended, .extended),
-      hasImplicitScope: true, empty())
+      isIsolated: true, empty())
     )
     parseTest("(?-i)", changeMatchingOptions(
       matchingOptions(removing: .caseInsensitive),
-      hasImplicitScope: true, empty())
+      isIsolated: true, empty())
     )
     parseTest("(?i-s)", changeMatchingOptions(
       matchingOptions(adding: .caseInsensitive, removing: .singleLine),
-      hasImplicitScope: true, empty())
+      isIsolated: true, empty())
     )
     parseTest("(?i-is)", changeMatchingOptions(
       matchingOptions(adding: .caseInsensitive,
                       removing: .caseInsensitive, .singleLine),
-      hasImplicitScope: true, empty())
+      isIsolated: true, empty())
     )
 
     parseTest("(?:)", nonCapture(empty()))
     parseTest("(?-:)", changeMatchingOptions(
-      matchingOptions(), hasImplicitScope: false, empty())
+      matchingOptions(), isIsolated: false, empty())
     )
     parseTest("(?i:)", changeMatchingOptions(
       matchingOptions(adding: .caseInsensitive),
-      hasImplicitScope: false, empty())
+      isIsolated: false, empty())
     )
     parseTest("(?-i:)", changeMatchingOptions(
       matchingOptions(removing: .caseInsensitive),
-      hasImplicitScope: false, empty())
+      isIsolated: false, empty())
     )
 
     parseTest("(?^)", changeMatchingOptions(
       unsetMatchingOptions(),
-      hasImplicitScope: true, empty())
+      isIsolated: true, empty())
     )
     parseTest("(?^:)", changeMatchingOptions(
       unsetMatchingOptions(),
-      hasImplicitScope: false, empty())
+      isIsolated: false, empty())
     )
     parseTest("(?^ims:)", changeMatchingOptions(
       unsetMatchingOptions(adding: .caseInsensitive, .multiline, .singleLine),
-      hasImplicitScope: false, empty())
+      isIsolated: false, empty())
     )
     parseTest("(?^J:)", changeMatchingOptions(
       unsetMatchingOptions(adding: .allowDuplicateGroupNames),
-      hasImplicitScope: false, empty())
+      isIsolated: false, empty())
     )
     parseTest("(?^y{w}:)", changeMatchingOptions(
       unsetMatchingOptions(adding: .textSegmentWordMode),
-      hasImplicitScope: false, empty())
+      isIsolated: false, empty())
     )
 
     let allOptions: [AST.MatchingOption.Kind] = [
@@ -557,32 +557,32 @@ extension RegexTests {
         adding: allOptions,
         removing: allOptions.dropLast(2)
       ),
-      hasImplicitScope: true, empty())
+      isIsolated: true, empty())
     )
     parseTest("(?iJmnsUxxxwDPSWy{g}y{w}-iJmnsUxxxwDPSW:)", changeMatchingOptions(
       matchingOptions(
         adding: allOptions,
         removing: allOptions.dropLast(2)
       ),
-      hasImplicitScope: false, empty())
+      isIsolated: false, empty())
     )
 
     parseTest(
       "a(b(?i)c)d", concat("a", capture(concat("b", changeMatchingOptions(
         matchingOptions(adding: .caseInsensitive),
-        hasImplicitScope: true, "c"))), "d"),
+        isIsolated: true, "c"))), "d"),
       captures: .atom()
     )
     parseTest(
       "(a(?i)b(c)d)", capture(concat("a", changeMatchingOptions(
         matchingOptions(adding: .caseInsensitive),
-        hasImplicitScope: true, concat("b", capture("c"), "d")))),
+        isIsolated: true, concat("b", capture("c"), "d")))),
       captures: .tuple(.atom(), .atom())
     )
     parseTest(
       "(a(?i)b(?#hello)c)", capture(concat("a", changeMatchingOptions(
         matchingOptions(adding: .caseInsensitive),
-        hasImplicitScope: true, concat("b", "c")))),
+        isIsolated: true, concat("b", "c")))),
       captures: .atom()
     )
 
@@ -590,11 +590,11 @@ extension RegexTests {
     //     ab(?i:c)|(?i:def)|(?i:gh)
     // instead. We ought to have a mode to emulate that.
     parseTest("ab(?i)c|def|gh", concat("a", "b", changeMatchingOptions(
-      matchingOptions(adding: .caseInsensitive), hasImplicitScope: true,
+      matchingOptions(adding: .caseInsensitive), isIsolated: true,
       alt("c", concat("d", "e", "f"), concat("g", "h")))))
 
     parseTest("(a|b(?i)c|d)", capture(alt("a", concat("b", changeMatchingOptions(
-      matchingOptions(adding: .caseInsensitive), hasImplicitScope: true,
+      matchingOptions(adding: .caseInsensitive), isIsolated: true,
       alt("c", "d"))))),
       captures: .atom())
 

--- a/Tests/RegexTests/ParseTests.swift
+++ b/Tests/RegexTests/ParseTests.swift
@@ -278,18 +278,18 @@ extension RegexTests {
       "[-|$^:?+*())(*-+-]",
       charClass(
         "-", "|", "$", "^", ":", "?", "+", "*", "(", ")", ")",
-        "(", .range("*", "+"), "-"))
+        "(", range_m("*", "+"), "-"))
 
     parseTest(
-      "[a-b-c]", charClass(.range("a", "b"), "-", "c"))
+      "[a-b-c]", charClass(range_m("a", "b"), "-", "c"))
 
     parseTest("[-a-]", charClass("-", "a", "-"))
 
-    parseTest("[a-z]", charClass(.range("a", "z")))
+    parseTest("[a-z]", charClass(range_m("a", "z")))
 
     // FIXME: AST builder helpers for custom char class types
     parseTest("[a-d--a-c]", charClass(
-      .setOperation([.range("a", "d")], .init(faking: .subtraction), [.range("a", "c")])
+      .setOperation([range_m("a", "d")], .init(faking: .subtraction), [range_m("a", "c")])
     ))
 
     parseTest("[-]", charClass("-"))
@@ -933,6 +933,12 @@ extension RegexTests {
     rangeTest("a|", range(1 ..< 2), at: { $0.as(Alt.self)!.pipes[0] })
     rangeTest("a|b", range(1 ..< 2), at: { $0.as(Alt.self)!.pipes[0] })
     rangeTest("|||", range(1 ..< 2), at: { $0.as(Alt.self)!.pipes[1] })
+
+    // MARK: Custom character classes
+
+    rangeTest("[a-z]", range(2 ..< 3), at: {
+      $0.as(CustomCC.self)!.members[0].as(CustomCC.Range.self)!.dashLoc
+    })
   }
 
   func testParseErrors() {

--- a/Tests/RegexTests/ParseTests.swift
+++ b/Tests/RegexTests/ParseTests.swift
@@ -928,6 +928,11 @@ extension RegexTests {
       rangeTest(alt, entireRange)
       rangeTest("(\(alt))", insetRange(by: 1), at: \.children![0].location)
     }
+
+    rangeTest("|", entireRange, at: { $0.as(Alt.self)!.pipes[0] })
+    rangeTest("a|", range(1 ..< 2), at: { $0.as(Alt.self)!.pipes[0] })
+    rangeTest("a|b", range(1 ..< 2), at: { $0.as(Alt.self)!.pipes[0] })
+    rangeTest("|||", range(1 ..< 2), at: { $0.as(Alt.self)!.pipes[1] })
   }
 
   func testParseErrors() {

--- a/Tests/RegexTests/ParseTests.swift
+++ b/Tests/RegexTests/ParseTests.swift
@@ -822,6 +822,8 @@ extension RegexTests {
     // Make sure dumping output correctly reflects differences in AST.
     parseNotEqualTest(#"abc"#, #"abd"#)
 
+    parseNotEqualTest(#"[\p{Any}]"#, #"[[:Any:]]"#)
+
     parseNotEqualTest(#"[abc[:space:]\d]+"#,
                       #"[abc[:upper:]\d]+"#)
 

--- a/Tests/RegexTests/ParseTests.swift
+++ b/Tests/RegexTests/ParseTests.swift
@@ -83,6 +83,17 @@ func parseWithDelimitersTest(
   _ input: String, _ expecting: AST,
   file: StaticString = #file, line: UInt = #line
 ) {
+  // First try lexing.
+  input.withCString { ptr in
+    let (contents, delim, end) = try! lexRegex(start: ptr,
+                                               end: ptr + input.count)
+    XCTAssertEqual(end, ptr + input.count, file: file, line: line)
+
+    let (parseContents, parseDelim) = droppingRegexDelimiters(input)
+    XCTAssertEqual(contents, parseContents, file: file, line: line)
+    XCTAssertEqual(delim, parseDelim, file: file, line: line)
+  }
+
   let orig = try! parseWithDelimiters(input)
   let ast = orig
   guard ast == expecting


### PR DESCRIPTION
Add source location info to the AST for alternation pipes, and for the `-` character in custom char class ranges. In addition, add some extra test cases for alternations, including some that test the expected source locations are parsed.