### PR TITLE
Enable resilience for _MatchingEngine and _StringProcessing.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -31,13 +31,19 @@ let package = Package(
         // Targets can depend on other targets in this package, and on products in packages which this package depends on.
         .target(
             name: "_MatchingEngine",
-            dependencies: [/*"_Unicode"*/]),
+            dependencies: [/*"_Unicode"*/],
+            swiftSettings: [
+                .unsafeFlags(["-enable-library-evolution"])
+            ]),
         .testTarget(
             name: "MatchingEngineTests",
             dependencies: ["_MatchingEngine"]),
         .target(
             name: "_StringProcessing",
-            dependencies: ["_MatchingEngine"]),
+            dependencies: ["_MatchingEngine"],
+            swiftSettings: [
+                .unsafeFlags(["-enable-library-evolution"])
+            ]),
         .target(
             name: "_Unicode",
             dependencies: []),

--- a/Sources/_MatchingEngine/Regex/AST/AST.swift
+++ b/Sources/_MatchingEngine/Regex/AST/AST.swift
@@ -1,4 +1,5 @@
 /// A regex abstract syntax tree
+@frozen
 public indirect enum AST:
   Hashable/*, _ASTPrintable ASTValue, ASTAction*/
 {

--- a/Sources/_MatchingEngine/Regex/AST/Atom.swift
+++ b/Sources/_MatchingEngine/Regex/AST/Atom.swift
@@ -8,6 +8,7 @@ extension AST {
       self.location = loc
     }
 
+    @frozen
     public enum Kind: Hashable {
       /// Just a character
       ///
@@ -68,6 +69,7 @@ extension AST.Atom {
 
   // Characters, character types, literals, etc., derived from
   // an escape sequence.
+  @frozen
   public enum EscapedBuiltin: Hashable {
     // TOOD: better doc comments
 
@@ -320,6 +322,7 @@ extension AST.Atom {
 }
 
 extension AST.Atom.CharacterProperty {
+  @frozen
   public enum Kind: Hashable {
     /// Matches any character, equivalent to Oniguruma's '\O'.
     case any
@@ -358,6 +361,7 @@ extension AST.Atom.CharacterProperty {
   }
 
   // TODO: erm, separate out or fold into something? splat it in?
+  @frozen
   public enum PCRESpecialCategory: String, Hashable {
     case alphanumeric     = "Xan"
     case posixSpace       = "Xps"
@@ -371,6 +375,7 @@ extension AST.Atom.CharacterProperty {
 // TODO: I haven't thought through this a bunch; this seems like
 // a sensible type to have and break down this way. But it could
 // easily get folded in with the kind of reference
+@frozen
 public enum Reference: Hashable {
   // \n \gn \g{n} \g<n> \g'n' (?n) (?(n)...
   // Oniguruma: \k<n>, \k'n'
@@ -397,6 +402,7 @@ public enum Reference: Hashable {
 
 extension AST.Atom {
   /// Anchors and other built-in zero-width assertions
+  @frozen
   public enum AssertionKind: String {
     /// \A
     case startOfSubject = #"\A"#

--- a/Sources/_MatchingEngine/Regex/AST/CustomCharClass.swift
+++ b/Sources/_MatchingEngine/Regex/AST/CustomCharClass.swift
@@ -16,6 +16,7 @@ extension AST {
       self.location = sr
     }
 
+    @frozen
     public enum Member: Hashable {
       /// A nested custom character class `[[ab][cd]]`
       case custom(CustomCharacterClass)
@@ -40,14 +41,15 @@ extension AST {
         self.rhs = rhs
       }
     }
+    @frozen
     public enum SetOp: String, Hashable {
       case subtraction = "--"
       case intersection = "&&"
       case symmetricDifference = "~~"
     }
+    @frozen
     public enum Start: String {
       case normal = "["
-
       case inverted = "[^"
     }
   }

--- a/Sources/_MatchingEngine/Regex/AST/Quantification.swift
+++ b/Sources/_MatchingEngine/Regex/AST/Quantification.swift
@@ -18,6 +18,7 @@ extension AST {
       self.location = r
     }
 
+    @frozen
     public enum Amount: Hashable {
       case zeroOrMore              // *
       case oneOrMore               // +
@@ -28,6 +29,7 @@ extension AST {
       case range(Located<Int>, Located<Int>) // {n,m}
     }
 
+    @frozen
     public enum Kind: String, Hashable {
       case eager      = ""
       case reluctant  = "?"

--- a/Sources/_MatchingEngine/Utility/MissingUnicode.swift
+++ b/Sources/_MatchingEngine/Utility/MissingUnicode.swift
@@ -8,6 +8,7 @@ extension Unicode {
   /// but is defined by https://www.unicode.org/Public/UCD/latest/ucd/PropertyValueAliases.txt.
   /// We may want to split it out, as it's the only case that is a union of
   /// other script types.
+  @frozen
   public enum Script: String, Hashable {
     case adlam = "Adlam"
     case ahom = "Ahom"
@@ -176,6 +177,7 @@ extension Unicode {
 
   /// POSIX character properties not already covered by general categories or
   /// binary properties.
+  @frozen
   public enum POSIXProperty: String, Hashable {
     case alnum = "alnum"
     case blank = "blank"
@@ -193,6 +195,7 @@ extension Unicode {
 
   /// Unicode.GeneralCategory + cases for "meta categories" such as "L", which
   /// encompasses Lu | Ll | Lt | Lm | Lo.
+  @frozen
   public enum ExtendedGeneralCategory: String, Hashable {
     case other = "C"
     case control = "Cc"
@@ -242,6 +245,7 @@ extension Unicode {
 
   /// A list of unicode properties that can either be true or false.
   /// https://www.unicode.org/Public/UCD/latest/ucd/PropertyAliases.txt
+  @frozen
   public enum BinaryProperty: String, Hashable {
     case asciiHexDigit = "ASCII_Hex_Digit"
     case alphabetic = "Alphabetic"
@@ -316,6 +320,7 @@ extension Unicode {
 /// Oniguruma properties that are not covered by Unicode spellings.
 /// TODO: These should become aliases for the Block (blk) Unicode character
 /// property.
+@frozen
 public enum OnigurumaSpecialProperty: String, Hashable {
   case inBasicLatin = "In_Basic_Latin"
   case inLatin1Supplement = "In_Latin_1_Supplement"

--- a/Sources/_StringProcessing/ConsumerInterface.swift
+++ b/Sources/_StringProcessing/ConsumerInterface.swift
@@ -39,7 +39,6 @@ extension AST {
       return try a.generateConsumer(opts)
     case .customCharacterClass(let ccc):
       return try ccc.generateConsumer(opts)
-
     case .alternation, .concatenation, .group,
         .quantification, .quote, .trivia, .empty,
         .groupTransform: return nil
@@ -513,9 +512,9 @@ extension Unicode.POSIXProperty {
 
     case .xdigit:
       return consumeScalarProp(\.isHexDigit) // or number
+
     }
   }
-
 }
 
 extension Unicode.ExtendedGeneralCategory {

--- a/Sources/_StringProcessing/Legacy/LegacyCompile.swift
+++ b/Sources/_StringProcessing/Legacy/LegacyCompile.swift
@@ -252,7 +252,6 @@ func compile(
     case .atom(let a) where a.characterClass != nil:
       fatalError("unreachable")
     }
-
   }
 
   try compileNode(ast)


### PR DESCRIPTION
_MatchingEngine and _StringProcessing are built with resilience enabled in Swift core libs. Currently the compiler build produces lots of warnings of missing `@unknown default`. We enable resilience in this package so that we can catch these issues early.