### PR TITLE
Treat range quantifiers as literal if invalid

### DIFF
--- a/Sources/_MatchingEngine/Regex/Parse/LexicalAnalysis.swift
+++ b/Sources/_MatchingEngine/Regex/Parse/LexicalAnalysis.swift
@@ -100,16 +100,17 @@ extension Source {
     }
   }
 
-  mutating func tryEatNonEmpty(_ c: Char) throws -> Bool {
-    guard !isEmpty else { throw ParseError.expected(String(c)) }
-    return tryEat(c)
-  }
-
   mutating func tryEatNonEmpty<C: Collection>(sequence c: C) throws -> Bool
     where C.Element == Char
   {
-    guard !isEmpty else { throw ParseError.expected(String(c)) }
+    _ = try recordLoc { src in
+      guard !src.isEmpty else { throw ParseError.expected(String(c)) }
+    }
     return tryEat(sequence: c)
+  }
+
+  mutating func tryEatNonEmpty(_ c: Char) throws -> Bool {
+    try tryEatNonEmpty(sequence: String(c))
   }
 
   /// Throws an expected ASCII character error if not matched

--- a/Sources/_MatchingEngine/Regex/Parse/LexicalAnalysis.swift
+++ b/Sources/_MatchingEngine/Regex/Parse/LexicalAnalysis.swift
@@ -277,7 +277,7 @@ extension Source {
         return try Source.validateUnicodeScalar(str, .octal)
 
       default:
-        throw ParseError.misc("TODO: Or is this an assert?")
+        fatalError("Unexpected scalar start")
       }
     }
   }

--- a/Sources/_MatchingEngine/Regex/Parse/SourceLocation.swift
+++ b/Sources/_MatchingEngine/Regex/Parse/SourceLocation.swift
@@ -76,6 +76,10 @@ extension Source {
       // externally?
       self.init(v, .fake)
     }
+
+    public func map<U>(_ fn: (T) throws -> U) rethrows -> Located<U> {
+      Located<U>(try fn(value), location)
+    }
   }
 }
 extension AST {

--- a/Tests/RegexTests/LexTests.swift
+++ b/Tests/RegexTests/LexTests.swift
@@ -133,6 +133,12 @@ extension RegexTests {
       _ = try $0.lexGroupStart()
     }
 
+    diagnose(#"\Qab"#, expecting: .expected("\\E")) { _ = try $0.lexQuote() }
+    diagnose(#"\Qab\"#, expecting: .expected("\\E")) { _ = try $0.lexQuote() }
+    diagnose(#""ab"#, expecting: .expected("\""), .experimental) { _ = try $0.lexQuote() }
+    diagnose(#""ab\""#, expecting: .expected("\""), .experimental) { _ = try $0.lexQuote() }
+    diagnose(#""ab\"#, expecting: .unexpectedEndOfInput, .experimental) { _ = try $0.lexQuote() }
+
     // TODO: want to dummy print out source ranges, etc, test that.
   }
 

--- a/Tests/RegexTests/MatchTests.swift
+++ b/Tests/RegexTests/MatchTests.swift
@@ -181,6 +181,10 @@ extension RegexTests {
       #"a{1,2}?"#, input: "123aaaxyz", match: "a")
     matchTest(
       #"a{1,2}?x"#, input: "123aaaxyz", match: "aax")
+    matchTest(
+      #"xa{0}y"#, input: "123aaaxyz", match: "xy")
+    matchTest(
+      #"xa{0,0}y"#, input: "123aaaxyz", match: "xy")
 
     matchTest("a.*", input: "dcba", match: "a")
 

--- a/Tests/RegexTests/ParseTests.swift
+++ b/Tests/RegexTests/ParseTests.swift
@@ -414,6 +414,14 @@ extension RegexTests {
       #"a\Q \Q \\.\Eb"#,
       concat("a", quote(#" \Q \\."#), "b"))
 
+    parseTest(#"a" ."b"#, concat("a", quote(" ."), "b"),
+              syntax: .experimental)
+    parseTest(#"a" .""b""#, concat("a", quote(" ."), quote("b")),
+              syntax: .experimental)
+    parseTest(#"a" .\"\"b""#, concat("a", quote(" .\"\"b")),
+              syntax: .experimental)
+    parseTest(#""\"""#, quote("\""), syntax: .experimental)
+
     // MARK: Comments
 
     parseTest(

--- a/Tests/RegexTests/ParseTests.swift
+++ b/Tests/RegexTests/ParseTests.swift
@@ -448,6 +448,34 @@ extension RegexTests {
     parseTest(
       #"a{1,2}?"#,
       quantRange(.reluctant, 1...2, "a"))
+    parseTest(
+      #"a{0}"#,
+      exactly(.eager, 0, "a"))
+    parseTest(
+      #"a{0,0}"#,
+      quantRange(.eager, 0...0, "a"))
+
+    // Make sure ranges get treated as literal if invalid.
+    parseTest("{", "{")
+    parseTest("{,", concat("{", ","))
+    parseTest("{}", concat("{", "}"))
+    parseTest("{,}", concat("{", ",", "}"))
+    parseTest("{,6", concat("{", ",", "6"))
+    parseTest("{6", concat("{", "6"))
+    parseTest("{6,", concat("{", "6", ","))
+    parseTest("{+", oneOrMore(.eager, "{"))
+    parseTest("{6,+", concat("{", "6", oneOrMore(.eager, ",")))
+    parseTest("x{", concat("x", "{"))
+    parseTest("x{}", concat("x", "{", "}"))
+    parseTest("x{,}", concat("x", "{", ",", "}"))
+    parseTest("x{,6", concat("x", "{", ",", "6"))
+    parseTest("x{6", concat("x", "{", "6"))
+    parseTest("x{6,", concat("x", "{", "6", ","))
+    parseTest("x{+", concat("x", oneOrMore(.eager, "{")))
+    parseTest("x{6,+", concat("x", "{", "6", oneOrMore(.eager, ",")))
+
+    // TODO: We should emit a diagnostic for this.
+    parseTest("x{3, 5}", concat("x", "{", "3", ",", " ", "5", "}"))
 
     // MARK: Groups
 


### PR DESCRIPTION
This matches the PCRE and Oniguruma behavior. In addition, allow escaped quotes in experimental syntax, allowing for e.g `"\""`.