### PR TITLE
Parse group-like reference syntax

### DIFF
--- a/Sources/_MatchingEngine/Regex/AST/Atom.swift
+++ b/Sources/_MatchingEngine/Regex/AST/Atom.swift
@@ -400,8 +400,8 @@ extension AST.Atom {
       // (?(<name>)... (?('name')... (?(name)...
       case named(String)
 
-      // ?(R) (?(R)...
-      case recurseWholePattern
+      /// (?R), (?(R)..., which are equivalent to (?0), (?(0)...
+      static var recurseWholePattern: Kind { .absolute(0) }
     }
     public var kind: Kind
 
@@ -413,6 +413,10 @@ extension AST.Atom {
       self.kind = kind
       self.innerLoc = innerLoc
     }
+
+    /// Whether this is a reference that recurses the whole pattern, rather than
+    /// a group.
+    public var recursesWholePattern: Bool { kind == .recurseWholePattern }
   }
 }
 

--- a/Sources/_MatchingEngine/Regex/Parse/Diagnostics.swift
+++ b/Sources/_MatchingEngine/Regex/Parse/Diagnostics.swift
@@ -32,6 +32,11 @@ enum ParseError: Error, Hashable {
 
   case expectedNonEmptyContents
 
+  case unknownGroupKind(String)
+
+  case invalidMatchingOption(Character)
+  case cannotRemoveMatchingOptionsAfterCaret
+
   case expectedCustomCharacterClassMembers
   case invalidCharacterClassRangeOperand
 
@@ -65,6 +70,12 @@ extension ParseError: CustomStringConvertible {
       return s
     case .expectedNonEmptyContents:
       return "expected non-empty contents"
+    case let .unknownGroupKind(str):
+      return "unknown group kind '(\(str)'"
+    case let .invalidMatchingOption(c):
+      return "invalid matching option '\(c)'"
+    case .cannotRemoveMatchingOptionsAfterCaret:
+      return "cannot remove matching options with '^' specifier"
     case let .expectedASCII(c):
       return "expected ASCII for '\(c)'"
     case .expectedCustomCharacterClassMembers:

--- a/Sources/_MatchingEngine/Regex/Parse/Diagnostics.swift
+++ b/Sources/_MatchingEngine/Regex/Parse/Diagnostics.swift
@@ -30,6 +30,8 @@ enum ParseError: Error, Hashable {
 
   case expectedASCII(Character)
 
+  case expectedNonEmptyContents
+
   case expectedCustomCharacterClassMembers
   case invalidCharacterClassRangeOperand
 
@@ -61,6 +63,8 @@ extension ParseError: CustomStringConvertible {
       return "unexpected end of input"
     case let .misc(s):
       return s
+    case .expectedNonEmptyContents:
+      return "expected non-empty contents"
     case let .expectedASCII(c):
       return "expected ASCII for '\(c)'"
     case .expectedCustomCharacterClassMembers:

--- a/Sources/_MatchingEngine/Regex/Parse/LexicalAnalysis.swift
+++ b/Sources/_MatchingEngine/Regex/Parse/LexicalAnalysis.swift
@@ -575,6 +575,9 @@ extension Source {
     // If the sequence begun with a caret '^', options can only be added, so
     // we're done.
     if ateCaret.value {
+      if peek() == "-" {
+        throw ParseError.cannotRemoveMatchingOptionsAfterCaret
+      }
       return .init(caretLoc: ateCaret.location, adding: adding, minusLoc: nil,
                    removing: [])
     }
@@ -620,97 +623,116 @@ extension Source {
   mutating func lexGroupStart(
   ) throws -> Located<AST.Group.Kind>? {
     try recordLoc { src in
-      guard src.tryEat("(") else { return nil }
+      try src.tryEating { src in
+        guard src.tryEat("(") else { return nil }
 
-      if src.tryEat("?") {
-        if src.tryEat(":") { return .nonCapture }
-        if src.tryEat("|") { return .nonCaptureReset }
-        if src.tryEat(">") { return .atomicNonCapturing }
-        if src.tryEat("=") { return .lookahead }
-        if src.tryEat("!") { return .negativeLookahead }
-        if src.tryEat("*") { return .nonAtomicLookahead }
+        if src.tryEat("?") {
+          if src.tryEat(":") { return .nonCapture }
+          if src.tryEat("|") { return .nonCaptureReset }
+          if src.tryEat(">") { return .atomicNonCapturing }
+          if src.tryEat("=") { return .lookahead }
+          if src.tryEat("!") { return .negativeLookahead }
+          if src.tryEat("*") { return .nonAtomicLookahead }
 
-        if src.tryEat(sequence: "<=") { return .lookbehind }
-        if src.tryEat(sequence: "<!") { return .negativeLookbehind }
-        if src.tryEat(sequence: "<*") { return .nonAtomicLookbehind }
+          if src.tryEat(sequence: "<=") { return .lookbehind }
+          if src.tryEat(sequence: "<!") { return .negativeLookbehind }
+          if src.tryEat(sequence: "<*") { return .nonAtomicLookbehind }
 
-        // Named
-        if src.tryEat("<") || src.tryEat(sequence: "P<") {
-          let name = try src.expectQuoted(endingWith: ">")
-          return .namedCapture(name)
-        }
-        if src.tryEat("'") {
-          let name = try src.expectQuoted(endingWith: "'")
-          return .namedCapture(name)
-        }
-
-        // Matching option changing group (?iJmnsUxxxDPSWy{..}-iJmnsUxxxDPSW:).
-        if let seq = try src.lexMatchingOptionSequence() {
-          if src.tryEat(":") {
-            return .changeMatchingOptions(seq, isIsolated: false)
+          // Named
+          // TODO: Group name validation, PCRE (and ICU + Oniguruma as far as I
+          // can tell), enforce word characters only, with the first character
+          // being a non-digit.
+          if src.tryEat("<") || src.tryEat(sequence: "P<") {
+            let name = try src.expectQuoted(endingWith: ">")
+            return .namedCapture(name)
           }
-          // If this isn't start of an explicit group, we should have an
-          // implicit group that covers the remaining elements of the current
-          // group.
-          // TODO: This implicit scoping behavior matches Oniguruma, but PCRE
-          // also does it across alternations, which will require additional
-          // handling.
-          try src.expect(")")
-          return .changeMatchingOptions(seq, isIsolated: true)
+          if src.tryEat("'") {
+            let name = try src.expectQuoted(endingWith: "'")
+            return .namedCapture(name)
+          }
+
+          // Check if we can lex a group-like reference. Do this before matching
+          // options to avoid ambiguity with a group starting with (?-, which
+          // is a subpattern if the next character is a digit, otherwise a
+          // matching option specifier. In addition, we need to be careful with
+          // (?P, which can also be the start of a matching option sequence.
+          if src.canLexGroupLikeReference() {
+            return nil
+          }
+
+          // Matching option changing group (?iJmnsUxxxDPSWy{..}-iJmnsUxxxDPSW:).
+          if let seq = try src.lexMatchingOptionSequence() {
+            if src.tryEat(":") {
+              return .changeMatchingOptions(seq, isIsolated: false)
+            }
+            // If this isn't start of an explicit group, we should have an
+            // implicit group that covers the remaining elements of the current
+            // group.
+            // TODO: This implicit scoping behavior matches Oniguruma, but PCRE
+            // also does it across alternations, which will require additional
+            // handling.
+            guard src.tryEat(")") else {
+              if let next = src.peek() {
+                throw ParseError.invalidMatchingOption(next)
+              }
+              throw ParseError.expected(")")
+            }
+            return .changeMatchingOptions(seq, isIsolated: true)
+          }
+
+          guard let next = src.peek() else {
+            throw ParseError.expectedGroupSpecifier
+          }
+          throw ParseError.unknownGroupKind("?\(next)")
         }
 
-        guard let next = src.peek() else {
-          throw ParseError.expectedGroupSpecifier
+        // Explicitly spelled out PRCE2 syntax for some groups.
+        if src.tryEat("*") {
+          if src.tryEat(sequence: "atomic:") { return .atomicNonCapturing }
+
+          if src.tryEat(sequence: "pla:") ||
+              src.tryEat(sequence: "positive_lookahead:") {
+            return .lookahead
+          }
+          if src.tryEat(sequence: "nla:") ||
+              src.tryEat(sequence: "negative_lookahead:") {
+            return .negativeLookahead
+          }
+          if src.tryEat(sequence: "plb:") ||
+              src.tryEat(sequence: "positive_lookbehind:") {
+            return .lookbehind
+          }
+          if src.tryEat(sequence: "nlb:") ||
+              src.tryEat(sequence: "negative_lookbehind:") {
+            return .negativeLookbehind
+          }
+          if src.tryEat(sequence: "napla:") ||
+              src.tryEat(sequence: "non_atomic_positive_lookahead:") {
+            return .nonAtomicLookahead
+          }
+          if src.tryEat(sequence: "naplb:") ||
+              src.tryEat(sequence: "non_atomic_positive_lookbehind:") {
+            return .nonAtomicLookbehind
+          }
+          if src.tryEat(sequence: "sr:") || src.tryEat(sequence: "script_run:") {
+            return .scriptRun
+          }
+          if src.tryEat(sequence: "asr:") ||
+              src.tryEat(sequence: "atomic_script_run:") {
+            return .atomicScriptRun
+          }
+
+          throw ParseError.misc("Quantifier '*' must follow operand")
         }
-        throw ParseError.misc("Unknown group kind '(?\(next)'")
+
+        // (_:)
+        if src.experimentalCaptures && src.tryEat(sequence: "_:") {
+          return .nonCapture
+        }
+        // TODO: (name:)
+
+        return .capture
       }
-
-      // Explicitly spelled out PRCE2 syntax for some groups.
-      if src.tryEat("*") {
-        if src.tryEat(sequence: "atomic:") { return .atomicNonCapturing }
-
-        if src.tryEat(sequence: "pla:") ||
-            src.tryEat(sequence: "positive_lookahead:") {
-          return .lookahead
-        }
-        if src.tryEat(sequence: "nla:") ||
-            src.tryEat(sequence: "negative_lookahead:") {
-          return .negativeLookahead
-        }
-        if src.tryEat(sequence: "plb:") ||
-            src.tryEat(sequence: "positive_lookbehind:") {
-          return .lookbehind
-        }
-        if src.tryEat(sequence: "nlb:") ||
-            src.tryEat(sequence: "negative_lookbehind:") {
-          return .negativeLookbehind
-        }
-        if src.tryEat(sequence: "napla:") ||
-            src.tryEat(sequence: "non_atomic_positive_lookahead:") {
-          return .nonAtomicLookahead
-        }
-        if src.tryEat(sequence: "naplb:") ||
-            src.tryEat(sequence: "non_atomic_positive_lookbehind:") {
-          return .nonAtomicLookbehind
-        }
-        if src.tryEat(sequence: "sr:") || src.tryEat(sequence: "script_run:") {
-          return .scriptRun
-        }
-        if src.tryEat(sequence: "asr:") ||
-            src.tryEat(sequence: "atomic_script_run:") {
-          return .atomicScriptRun
-        }
-
-        throw ParseError.misc("Quantifier '*' must follow operand")
-      }
-
-      // (_:)
-      if src.experimentalCaptures && src.tryEat(sequence: "_:") {
-        return .nonCapture
-      }
-      // TODO: (name:)
-
-      return .capture
     }
   }
 
@@ -827,6 +849,7 @@ extension Source {
   private mutating func lexNumberedReference(
   ) throws -> AST.Atom.Reference? {
     let kind = try recordLoc { src -> AST.Atom.Reference.Kind? in
+      // Note this logic should match canLexNumberedReference.
       if src.tryEat("+") {
         return .relative(try src.expectNumber().value)
       }
@@ -842,10 +865,19 @@ extension Source {
     return .init(kind.value, innerLoc: kind.location)
   }
 
+  /// Checks whether a numbered reference can be lexed.
+  private func canLexNumberedReference() -> Bool {
+    var src = self
+    _ = src.tryEat(anyOf: "+", "-")
+    guard let next = src.peek() else { return false }
+    return RadixKind.decimal.characterFilter(next)
+  }
+
   /// Eat a named reference up to a given closing delimiter.
   private mutating func expectNamedReference(
     endingWith end: String
   ) throws -> AST.Atom.Reference {
+    // TODO: Group name validation, see comment in lexGroupStart.
     let str = try expectQuoted(endingWith: end)
     return .init(.named(str.value), innerLoc: str.location)
   }
@@ -891,68 +923,124 @@ extension Source {
     priorGroupCount: Int
   ) throws -> Located<AST.Atom.Kind>? {
     try recordLoc { src in
-      if src.tryEat("g") {
-        // PCRE-style backreferences.
-        if src.tryEat("{") {
-          let ref = try src.expectNamedOrNumberedReference(endingWith: "}")
-          return .backreference(ref)
+      try src.tryEating { src in
+        guard let firstChar = src.peek() else { return nil }
+
+        if src.tryEat("g") {
+          // PCRE-style backreferences.
+          if src.tryEat("{") {
+            let ref = try src.expectNamedOrNumberedReference(endingWith: "}")
+            return .backreference(ref)
+          }
+
+          // Oniguruma-style subpatterns.
+          if let openChar = src.tryEat(anyOf: "<", "'") {
+            let closing = String(Source.getClosingDelimiter(for: openChar))
+            return .subpattern(
+              try src.expectNamedOrNumberedReference(endingWith: closing))
+          }
+
+          // PCRE allows \g followed by a bare numeric reference.
+          if let ref = try src.lexNumberedReference() {
+            return .backreference(ref)
+          }
+          return nil
         }
 
-        // Oniguruma-style subpatterns.
-        if let openChar = src.tryEat(anyOf: "<", "'") {
-          let ref = try src.expectNamedOrNumberedReference(
-            endingWith: String(Source.getClosingDelimiter(for: openChar)))
+        if src.tryEat("k") {
+          // Perl/.NET-style backreferences.
+          if let openChar = src.tryEat(anyOf: "<", "'", "{") {
+            let closing = String(Source.getClosingDelimiter(for: openChar))
+            return .backreference(
+              try src.expectNamedReference(endingWith: closing))
+          }
+          return nil
+        }
+
+        // Lexing \n is tricky, as it's ambiguous with octal sequences. In PCRE
+        // it is treated as a backreference if its first digit is not 0 (as that
+        // is always octal) and one of the following holds:
+        //
+        // - It's 0 < n < 10 (as octal would be pointless here)
+        // - Its first digit is 8 or 9 (as not valid octal)
+        // - There have been as many prior groups as the reference.
+        //
+        // Oniguruma follows the same rules except the second one. e.g \81 and
+        // \91 are instead treated as literal 81 and 91 respectively.
+        // TODO: If we want a strict Oniguruma mode, we'll need to add a check
+        // here.
+        if firstChar != "0", let numAndLoc = try src.lexNumber() {
+          let num = numAndLoc.value
+          let loc = numAndLoc.location
+          if num < 10 || firstChar == "8" || firstChar == "9" ||
+              num <= priorGroupCount {
+            return .backreference(.init(.absolute(num), innerLoc: loc))
+          }
+          return nil
+        }
+        return nil
+      }
+    }
+  }
+
+  /// Try to lex a reference that syntactically looks like a group.
+  ///
+  ///     GroupLikeReference -> '(?' GroupLikeReferenceBody ')'
+  ///     GroupLikeReferenceBody -> 'P=' <String>
+  ///                             | 'P>' <String>
+  ///                             | '&' <String>
+  ///                             | 'R'
+  ///                             | NumberRef
+  ///
+  private mutating func lexGroupLikeReference(
+  ) throws -> Located<AST.Atom.Kind>? {
+    try recordLoc { src in
+      try src.tryEating { src in
+        guard src.tryEat(sequence: "(?") else { return nil }
+        let _start = src.currentPosition
+
+        // Note the below should be covered by canLexGroupLikeReference.
+
+        // Python-style references.
+        if src.tryEat(sequence: "P=") {
+          return .backreference(try src.expectNamedReference(endingWith: ")"))
+        }
+        if src.tryEat(sequence: "P>") {
+          return .subpattern(try src.expectNamedReference(endingWith: ")"))
+        }
+
+        // Perl-style subpatterns.
+        if src.tryEat("&") {
+          return .subpattern(try src.expectNamedReference(endingWith: ")"))
+        }
+
+        // Whole-pattern recursion.
+        if src.tryEat("R") {
+          let loc = Location(_start ..< src.currentPosition)
+          try src.expect(")")
+          return .subpattern(.init(.recurseWholePattern, innerLoc: loc))
+        }
+
+        // Numbered subpattern reference.
+        if let ref = try src.lexNumberedReference() {
+          try src.expect(")")
           return .subpattern(ref)
         }
-
-        // PCRE allows \g followed by a bare numeric reference.
-        if let ref = try src.lexNumberedReference() {
-          return .backreference(ref)
-        }
-
-        // Fallback to a literal character. We need to return here as we've
-        // already eaten the 'g'.
-        return .char("g")
+        return nil
       }
-
-      if src.tryEat("k") {
-        // Perl/.NET-style backreferences.
-        if let openChar = src.tryEat(anyOf: "<", "'", "{") {
-          let closing = String(Source.getClosingDelimiter(for: openChar))
-          return .backreference(
-            try src.expectNamedReference(endingWith: closing))
-        }
-        // Fallback to a literal character. We need to return here as we've
-        // already eaten the 'k'.
-        return .char("k")
-      }
-
-      // Lexing \n is tricky, as it's ambiguous with octal sequences. In PCRE it
-      // is treated as a backreference if its first digit is not 0 (as that is
-      // always octal) and one of the following holds:
-      //
-      // - It's 0 < n < 10 (as octal would be pointless here)
-      // - Its first digit is 8 or 9 (as not valid octal)
-      // - There have been as many prior groups as the reference.
-      //
-      // Oniguruma follows the same rules except the second one. e.g \81 and \91
-      // are instead treated as literal 81 and 91 respectively.
-      // TODO: If we want a strict Oniguruma mode, we'll need to add a check
-      // here.
-      if src.peek() != "0", let digits = src.peekPrefix(\.isNumber) {
-        // First lex out the decimal digits and see if we can treat this as a
-        // backreference.
-        let num = try Source.validateNumber(digits.string, Int.self, .decimal)
-        if num < 10 || digits.first == "8" || digits.first == "9" ||
-            num <= priorGroupCount {
-          let _start = src.currentPosition
-          src.advance(digits.count)
-          return .backreference(
-            .init(.absolute(num), innerLoc: Location(_start ..< src.currentPosition)))
-        }
-      }
-      return nil
     }
+  }
+
+  /// Whether we can lex a group-like reference after the specifier '(?'.
+  private func canLexGroupLikeReference() -> Bool {
+    var src = self
+    if src.tryEat("P") {
+      return src.tryEat(anyOf: "=", ">") != nil
+    }
+    if src.tryEat(anyOf: "&", "R") != nil {
+      return true
+    }
+    return src.canLexNumberedReference()
   }
 
   /// Consume an escaped atom, starting from after the backslash
@@ -1045,7 +1133,10 @@ extension Source {
         return .property(prop)
       }
 
-      // TODO: Python-style backreferences (?P=...), which look like groups.
+      // References that look like groups, e.g (?R), (?1), ...
+      if let ref = try src.lexGroupLikeReference() {
+        return ref.value
+      }
 
       let char = src.eat()
       switch char {

--- a/Sources/_MatchingEngine/Regex/Parse/LexicalAnalysis.swift
+++ b/Sources/_MatchingEngine/Regex/Parse/LexicalAnalysis.swift
@@ -1014,7 +1014,7 @@ extension Source {
           return .subpattern(try src.expectNamedReference(endingWith: ")"))
         }
 
-        // Whole-pattern recursion.
+        // Whole-pattern recursion, which is equivalent to (?0).
         if src.tryEat("R") {
           let loc = Location(_start ..< src.currentPosition)
           try src.expect(")")

--- a/Sources/_MatchingEngine/Regex/Printing/DumpAST.swift
+++ b/Sources/_MatchingEngine/Regex/Printing/DumpAST.swift
@@ -107,11 +107,17 @@ extension AST.Atom {
     case .endOfLine:   return "$"
 
     case .backreference(let r), .subpattern(let r), .condition(let r):
-      return "\(r)"
+      return "\(r._dumpBase)"
 
     case .char, .scalar:
       fatalError("Unreachable")
     }
+  }
+}
+
+extension AST.Atom.Reference: _ASTPrintable {
+  public var _dumpBase: String {
+    "\(kind)"
   }
 }
 

--- a/Sources/_StringProcessing/ASTBuilder.swift
+++ b/Sources/_StringProcessing/ASTBuilder.swift
@@ -233,14 +233,14 @@ func scalar_m(_ s: Unicode.Scalar) -> AST.CustomCharacterClass.Member {
   atom_m(.scalar(s))
 }
 
-func backreference(_ r: Reference) -> AST {
-  atom(.backreference(r))
+func backreference(_ r: AST.Atom.Reference.Kind) -> AST {
+  atom(.backreference(.init(r, innerLoc: .fake)))
 }
-func subpattern(_ r: Reference) -> AST {
-  atom(.subpattern(r))
+func subpattern(_ r: AST.Atom.Reference.Kind) -> AST {
+  atom(.subpattern(.init(r, innerLoc: .fake)))
 }
-func condition(_ r: Reference) -> AST {
-  atom(.condition(r))
+func condition(_ r: AST.Atom.Reference.Kind) -> AST {
+  atom(.condition(.init(r, innerLoc: .fake)))
 }
 
 func prop(

--- a/Tests/RegexTests/LexTests.swift
+++ b/Tests/RegexTests/LexTests.swift
@@ -150,6 +150,8 @@ extension RegexTests {
     diagnose(#""ab\""#, expecting: .expected("\""), .experimental) { _ = try $0.lexQuote() }
     diagnose(#""ab\"#, expecting: .unexpectedEndOfInput, .experimental) { _ = try $0.lexQuote() }
 
+    diagnose(#"\k''"#, expecting: .expectedNonEmptyContents) { _ = try $0.lexBasicAtom() }
+
     // TODO: want to dummy print out source ranges, etc, test that.
   }
 

--- a/Tests/RegexTests/LexTests.swift
+++ b/Tests/RegexTests/LexTests.swift
@@ -31,7 +31,7 @@ func diagnose(
       XCTFail("""
 
         Expected: \(expected)
-        Actual: \(e.error)")
+        Actual: \(e.error)
       """)
       return
     }
@@ -130,19 +130,33 @@ extension RegexTests {
 
     diagnose(#"(?^"#, expecting: .expected(")")) { _ = try $0.lexGroupStart() }
     diagnose(#"(?^i"#, expecting: .expected(")")) { _ = try $0.lexGroupStart() }
-    diagnose(#"(?^-"#, expecting: .expected(")")) { _ = try $0.lexGroupStart() }
-    diagnose(#"(?^-)"#, expecting: .expected(")")) { _ = try $0.lexGroupStart() }
-    diagnose(#"(?^i-"#, expecting: .expected(")")) { _ = try $0.lexGroupStart() }
-    diagnose(#"(?^i-m)"#, expecting: .expected(")")) { _ = try $0.lexGroupStart() }
+
+    diagnose(#"(?^-"#, expecting: .cannotRemoveMatchingOptionsAfterCaret) {
+      _ = try $0.lexGroupStart()
+    }
+    diagnose(#"(?^-)"#, expecting: .cannotRemoveMatchingOptionsAfterCaret) {
+      _ = try $0.lexGroupStart()
+    }
+    diagnose(#"(?^i-"#, expecting: .cannotRemoveMatchingOptionsAfterCaret) {
+      _ = try $0.lexGroupStart()
+    }
+    diagnose(#"(?^i-m)"#, expecting: .cannotRemoveMatchingOptionsAfterCaret) {
+      _ = try $0.lexGroupStart()
+    }
 
     diagnose(#"(?y)"#, expecting: .expected("{")) { _ = try $0.lexGroupStart() }
     diagnose(#"(?y{)"#, expecting: .expected("g")) { _ = try $0.lexGroupStart() }
     diagnose(#"(?y{g)"#, expecting: .expected("}")) { _ = try $0.lexGroupStart() }
     diagnose(#"(?y{x})"#, expecting: .expected("g")) { _ = try $0.lexGroupStart() }
 
-    diagnose(#"(?k)"#, expecting: .misc("Unknown group kind '(?k'")) {
+    diagnose(#"(?k)"#, expecting: .unknownGroupKind("?k")) {
       _ = try $0.lexGroupStart()
     }
+    diagnose(#"(?P#)"#, expecting: .invalidMatchingOption("#")) {
+      _ = try $0.lexGroupStart()
+    }
+    diagnose(#"(?P"#, expecting: .expected(")")) { _ = try $0.lexGroupStart() }
+    diagnose(#"(?R"#, expecting: .expected(")")) { _ = try $0.lexBasicAtom() }
 
     diagnose(#"\Qab"#, expecting: .expected("\\E")) { _ = try $0.lexQuote() }
     diagnose(#"\Qab\"#, expecting: .expected("\\E")) { _ = try $0.lexQuote() }
@@ -151,6 +165,8 @@ extension RegexTests {
     diagnose(#""ab\"#, expecting: .unexpectedEndOfInput, .experimental) { _ = try $0.lexQuote() }
 
     diagnose(#"\k''"#, expecting: .expectedNonEmptyContents) { _ = try $0.lexBasicAtom() }
+    diagnose(#"(?&)"#, expecting: .expectedNonEmptyContents) { _ = try $0.lexBasicAtom() }
+    diagnose(#"(?P>)"#, expecting: .expectedNonEmptyContents) { _ = try $0.lexBasicAtom() }
 
     // TODO: want to dummy print out source ranges, etc, test that.
   }

--- a/Tests/RegexTests/ParseTests.swift
+++ b/Tests/RegexTests/ParseTests.swift
@@ -586,6 +586,9 @@ extension RegexTests {
       matchingOptions(adding: .extraExtended, .extended),
       isIsolated: true, empty())
     )
+    parseTest("(?P)", changeMatchingOptions(
+      matchingOptions(adding: .asciiOnlyPOSIXProps), isIsolated: true, empty())
+    )
     parseTest("(?-i)", changeMatchingOptions(
       matchingOptions(removing: .caseInsensitive),
       isIsolated: true, empty())
@@ -611,6 +614,9 @@ extension RegexTests {
     parseTest("(?-i:)", changeMatchingOptions(
       matchingOptions(removing: .caseInsensitive),
       isIsolated: false, empty())
+    )
+    parseTest("(?P:)", changeMatchingOptions(
+      matchingOptions(adding: .asciiOnlyPOSIXProps), isIsolated: false, empty())
     )
 
     parseTest("(?^)", changeMatchingOptions(
@@ -800,6 +806,20 @@ extension RegexTests {
     parseTest(#"\k{a0}"#, backreference(.named("a0")))
     parseTest(#"\k<bc>"#, backreference(.named("bc")))
     parseTest(#"\g{abc}"#, backreference(.named("abc")))
+    parseTest(#"(?P=abc)"#, backreference(.named("abc")))
+
+    parseTest(#"(?R)"#, subpattern(.recurseWholePattern))
+    parseTest(#"(?1)"#, subpattern(.absolute(1)))
+    parseTest(#"(?+12)"#, subpattern(.relative(12)))
+    parseTest(#"(?-2)"#, subpattern(.relative(-2)))
+    parseTest(#"(?&hello)"#, subpattern(.named("hello")))
+    parseTest(#"(?P>P)"#, subpattern(.named("P")))
+
+    // TODO: Should we enforce that names only use certain characters?
+    parseTest(#"(?&&)"#, subpattern(.named("&")))
+    parseTest(#"(?&-1)"#, subpattern(.named("-1")))
+    parseTest(#"(?P>+1)"#, subpattern(.named("+1")))
+    parseTest(#"(?P=+1)"#, backreference(.named("+1")))
 
     parseTest(#"\g<1>"#, subpattern(.absolute(1)))
     parseTest(#"\g<001>"#, subpattern(.absolute(1)))
@@ -952,6 +972,12 @@ extension RegexTests {
     parseNotEqualTest("|", "||")
     parseNotEqualTest("a|", "|")
     parseNotEqualTest("a|b", "|")
+
+    parseNotEqualTest(#"\1"#, #"\2"#)
+    parseNotEqualTest(#"\k'a'"#, #"\k'b'"#)
+    parseNotEqualTest(#"(?1)"#, #"(?2)"#)
+    parseNotEqualTest(#"(?+1)"#, #"(?1)"#)
+    parseNotEqualTest(#"(?&a)"#, #"(?&b)"#)
 
     // TODO: failure tests
   }

--- a/Tests/RegexTests/ParseTests.swift
+++ b/Tests/RegexTests/ParseTests.swift
@@ -799,7 +799,6 @@ extension RegexTests {
 
     parseTest(#"\k{a0}"#, backreference(.named("a0")))
     parseTest(#"\k<bc>"#, backreference(.named("bc")))
-    parseTest(#"\k''"#, backreference(.named("")))
     parseTest(#"\g{abc}"#, backreference(.named("abc")))
 
     parseTest(#"\g<1>"#, subpattern(.absolute(1)))


### PR DESCRIPTION
Parse the remaining backreference and subpattern syntax that look like groups, e.g `(?R)`, `(?P=)`. In addition, add source location info to `Reference` and add some more specific errors for matching option groups.