### PR TITLE
Parse PCRE callouts, backtracking directives, and .NET balanced captures

### DIFF
--- a/Sources/_MatchingEngine/Regex/AST/AST.swift
+++ b/Sources/_MatchingEngine/Regex/AST/AST.swift
@@ -100,6 +100,20 @@ extension AST {
 
     return self.children?.any(\.hasCapture) ?? false
   }
+
+  /// Whether this AST node may be used as the operand of a quantifier such as
+  /// `?`, `+` or `*`.
+  public var isQuantifiable: Bool {
+    switch self {
+    case .atom(let a):
+      return a.isQuantifiable
+    case .group, .conditional, .customCharacterClass:
+      return true
+    case .alternation, .concatenation, .quantification, .quote, .trivia,
+        .empty, .groupTransform:
+      return false
+    }
+  }
 }
 
 // MARK: - AST types

--- a/Sources/_MatchingEngine/Regex/AST/Atom.swift
+++ b/Sources/_MatchingEngine/Regex/AST/Atom.swift
@@ -66,6 +66,9 @@ extension AST {
       // References
       case backreference(Reference)
       case subpattern(Reference)
+
+      // (?C)
+      case callout(Callout)
     }
   }
 }
@@ -444,6 +447,19 @@ extension AST.Atom {
 }
 
 extension AST.Atom {
+  public struct Callout: Hashable {
+    public enum Argument: Hashable {
+      case number(Int)
+      case string(String)
+    }
+    public var arg: AST.Located<Argument>
+    public init(_ arg: AST.Located<Argument>) {
+      self.arg = arg
+    }
+  }
+}
+
+extension AST.Atom {
   /// Retrieve the character value of the atom if it represents a literal
   /// character or unicode scalar, nil otherwise.
   public var literalCharacterValue: Character? {
@@ -458,7 +474,7 @@ extension AST.Atom {
       fallthrough
 
     case .property, .escaped, .any, .startOfLine, .endOfLine,
-        .backreference, .subpattern, .namedCharacter:
+        .backreference, .subpattern, .namedCharacter, .callout:
       return nil
     }
   }
@@ -483,7 +499,7 @@ extension AST.Atom {
       return "\\M-\\C-\(x)"
 
     case .property, .escaped, .any, .startOfLine, .endOfLine,
-        .backreference, .subpattern, .namedCharacter:
+        .backreference, .subpattern, .namedCharacter, .callout:
       return nil
     }
   }

--- a/Sources/_MatchingEngine/Regex/AST/Group.swift
+++ b/Sources/_MatchingEngine/Regex/AST/Group.swift
@@ -31,6 +31,9 @@ extension AST {
       // (?<name>...) (?'name'...) (?P<name>...)
       case namedCapture(Located<String>)
 
+      // (?<name-priorName>) (?'name-priorName')
+      case balancedCapture(BalancedCapture)
+
       // (?:...)
       case nonCapture
 
@@ -79,7 +82,7 @@ extension AST {
 extension AST.Group.Kind {
   public var isCapturing: Bool {
     switch self {
-    case .capture, .namedCapture: return true
+    case .capture, .namedCapture, .balancedCapture: return true
     default: return false
     }
   }
@@ -103,6 +106,7 @@ extension AST.Group.Kind {
   public var name: String? {
     switch self {
     case .namedCapture(let name): return name.value
+    case .balancedCapture(let b): return b.name?.value
     default: return nil
     }
   }
@@ -121,5 +125,26 @@ extension AST.Group {
     default: return nil
     }
   }
+}
 
+extension AST.Group {
+  public struct BalancedCapture: Hashable {
+    /// The name of the group, or nil if the group has no name.
+    public var name: AST.Located<String>?
+
+    /// The location of the `-` in the group.
+    public var dash: SourceLocation
+
+    /// The name of the prior group that the balancing group references.
+    public var priorName: AST.Located<String>
+
+    public init(
+      name: AST.Located<String>?, dash: SourceLocation,
+      priorName: AST.Located<String>
+    ) {
+      self.name = name
+      self.dash = dash
+      self.priorName = priorName
+    }
+  }
 }

--- a/Sources/_MatchingEngine/Regex/Parse/CaptureStructure.swift
+++ b/Sources/_MatchingEngine/Regex/Parse/CaptureStructure.swift
@@ -44,7 +44,10 @@ extension AST {
         return .atom() + innerCaptures
       case .namedCapture(let name):
         return .atom(name: name.value) + innerCaptures
+      case .balancedCapture(let b):
+        return .atom(name: b.name?.value) + innerCaptures
       default:
+        precondition(!group.kind.value.isCapturing)
         return innerCaptures
       }
     case .conditional(let c):

--- a/Sources/_MatchingEngine/Regex/Parse/Diagnostics.swift
+++ b/Sources/_MatchingEngine/Regex/Parse/Diagnostics.swift
@@ -38,6 +38,10 @@ enum ParseError: Error, Hashable {
 
   case cannotReferToWholePattern
 
+  case notQuantifiable
+
+  case backtrackingDirectiveMustHaveName(String)
+
   case unknownGroupKind(String)
   case unknownCalloutKind(String)
 
@@ -81,6 +85,10 @@ extension ParseError: CustomStringConvertible {
       return "expected escape sequence"
     case .cannotReferToWholePattern:
       return "cannot refer to whole pattern here"
+    case .notQuantifiable:
+      return "expression is not quantifiable"
+    case .backtrackingDirectiveMustHaveName(let b):
+      return "backtracking directive '\(b)' must include name"
     case let .tooManyBranchesInConditional(i):
       return "expected 2 branches in conditional, have \(i)"
     case let .unsupportedCondition(str):

--- a/Sources/_MatchingEngine/Regex/Parse/Diagnostics.swift
+++ b/Sources/_MatchingEngine/Regex/Parse/Diagnostics.swift
@@ -55,6 +55,9 @@ enum ParseError: Error, Hashable {
   case emptyProperty
 
   case expectedGroupSpecifier
+  case expectedGroupName
+  case groupNameMustBeAlphaNumeric
+  case groupNameCannotStartWithNumber
   case cannotRemoveTextSegmentOptions
 }
 
@@ -113,6 +116,12 @@ extension ParseError: CustomStringConvertible {
       return "empty property"
     case .expectedGroupSpecifier:
       return "expected group specifier"
+    case .expectedGroupName:
+      return "expected group name"
+    case .groupNameMustBeAlphaNumeric:
+      return "group name must only contain alphanumeric characters"
+    case .groupNameCannotStartWithNumber:
+      return "group name must not start with number"
     case .cannotRemoveTextSegmentOptions:
       return "text segment mode cannot be unset, only changed"
     }

--- a/Sources/_MatchingEngine/Regex/Parse/Diagnostics.swift
+++ b/Sources/_MatchingEngine/Regex/Parse/Diagnostics.swift
@@ -39,6 +39,7 @@ enum ParseError: Error, Hashable {
   case cannotReferToWholePattern
 
   case unknownGroupKind(String)
+  case unknownCalloutKind(String)
 
   case invalidMatchingOption(Character)
   case cannotRemoveMatchingOptionsAfterCaret
@@ -86,6 +87,8 @@ extension ParseError: CustomStringConvertible {
       return "\(str) cannot be used as condition"
     case let .unknownGroupKind(str):
       return "unknown group kind '(\(str)'"
+    case let .unknownCalloutKind(str):
+      return "unknown callout kind '\(str)'"
     case let .invalidMatchingOption(c):
       return "invalid matching option '\(c)'"
     case .cannotRemoveMatchingOptionsAfterCaret:

--- a/Sources/_MatchingEngine/Regex/Parse/Parse.swift
+++ b/Sources/_MatchingEngine/Regex/Parse/Parse.swift
@@ -176,8 +176,11 @@ extension Parser {
       //     Quantification  -> QuantOperand Quantifier?
       if let operand = try parseQuantifierOperand() {
         if let (amt, kind) = try source.lexQuantifier() {
-           result.append(.quantification(.init(
-            amt, kind, operand, loc(_start))))
+          let location = loc(_start)
+          guard operand.isQuantifiable else {
+            throw Source.LocatedError(ParseError.notQuantifiable, location)
+          }
+          result.append(.quantification(.init(amt, kind, operand, location)))
         } else {
           result.append(operand)
         }

--- a/Sources/_MatchingEngine/Regex/Parse/Source.swift
+++ b/Sources/_MatchingEngine/Regex/Parse/Source.swift
@@ -27,6 +27,8 @@ public struct Source {
     self.bounds = str.startIndex ..< str.endIndex
     self.syntax = syntax
   }
+
+  subscript(_ range: Range<Input.Index>) -> Input.SubSequence { input[range] }
 }
 
 // MARK: - Prototype uses String

--- a/Sources/_MatchingEngine/Regex/Parse/Source.swift
+++ b/Sources/_MatchingEngine/Regex/Parse/Source.swift
@@ -60,7 +60,7 @@ extension Source {
 
   var isEmpty: Bool { _slice.isEmpty }
 
-  mutating func peek() -> Char? { _slice.first }
+  func peek() -> Char? { _slice.first }
 
   mutating func advance() {
     assert(!isEmpty)

--- a/Sources/_MatchingEngine/Regex/Printing/DumpAST.swift
+++ b/Sources/_MatchingEngine/Regex/Printing/DumpAST.swift
@@ -135,6 +135,8 @@ extension AST.Atom {
 
     case .callout(let c): return "\(c)"
 
+    case .backtrackingDirective(let d): return "\(d)"
+
     case .char, .scalar:
       fatalError("Unreachable")
     }
@@ -243,5 +245,15 @@ extension AST.CustomCharacterClass.Member: _ASTPrintable {
 extension AST.CustomCharacterClass.Range: _ASTPrintable {
   public var _dumpBase: String {
     "\(lhs)-\(rhs)"
+  }
+}
+
+extension AST.Atom.BacktrackingDirective: _ASTPrintable {
+  public var _dumpBase: String {
+    var result = "\(kind.value)"
+    if let name = name {
+      result += ": \(name.value)"
+    }
+    return result
   }
 }

--- a/Sources/_MatchingEngine/Regex/Printing/DumpAST.swift
+++ b/Sources/_MatchingEngine/Regex/Printing/DumpAST.swift
@@ -156,19 +156,20 @@ extension AST.Reference: _ASTPrintable {
 extension AST.Group.Kind: _ASTPrintable {
   public var _dumpBase: String {
     switch self {
-    case .capture:               return "capture"
-    case .namedCapture(let s):   return "capture<\(s.value)>"
-    case .nonCapture:            return "nonCapture"
-    case .nonCaptureReset:       return "nonCaptureReset"
-    case .atomicNonCapturing:    return "atomicNonCapturing"
-    case .lookahead:             return "lookahead"
-    case .negativeLookahead:     return "negativeLookahead"
-    case .nonAtomicLookahead:    return "nonAtomicLookahead"
-    case .lookbehind:            return "lookbehind"
-    case .negativeLookbehind:    return "negativeLookbehind"
-    case .nonAtomicLookbehind:   return "nonAtomicLookbehind"
-    case .scriptRun:             return "scriptRun"
-    case .atomicScriptRun:       return "atomicScriptRun"
+    case .capture:                return "capture"
+    case .namedCapture(let s):    return "capture<\(s.value)>"
+    case .balancedCapture(let b): return "balanced capture \(b)"
+    case .nonCapture:             return "nonCapture"
+    case .nonCaptureReset:        return "nonCaptureReset"
+    case .atomicNonCapturing:     return "atomicNonCapturing"
+    case .lookahead:              return "lookahead"
+    case .negativeLookahead:      return "negativeLookahead"
+    case .nonAtomicLookahead:     return "nonAtomicLookahead"
+    case .lookbehind:             return "lookbehind"
+    case .negativeLookbehind:     return "negativeLookbehind"
+    case .nonAtomicLookbehind:    return "nonAtomicLookbehind"
+    case .scriptRun:              return "scriptRun"
+    case .atomicScriptRun:        return "atomicScriptRun"
     case .changeMatchingOptions(let seq, let isIsolated):
       return "changeMatchingOptions<\(seq), \(isIsolated)>"
     }
@@ -255,5 +256,11 @@ extension AST.Atom.BacktrackingDirective: _ASTPrintable {
       result += ": \(name.value)"
     }
     return result
+  }
+}
+
+extension AST.Group.BalancedCapture: _ASTPrintable {
+  public var _dumpBase: String {
+   "\(name?.value ?? "")-\(priorName.value)"
   }
 }

--- a/Sources/_MatchingEngine/Regex/Printing/DumpAST.swift
+++ b/Sources/_MatchingEngine/Regex/Printing/DumpAST.swift
@@ -133,10 +133,16 @@ extension AST.Atom {
     case .backreference(let r), .subpattern(let r):
       return "\(r._dumpBase)"
 
+    case .callout(let c): return "\(c)"
+
     case .char, .scalar:
       fatalError("Unreachable")
     }
   }
+}
+
+extension AST.Atom.Callout: _ASTPrintable {
+  public var _dumpBase: String { "callout <\(arg.value)>" }
 }
 
 extension AST.Reference: _ASTPrintable {

--- a/Sources/_MatchingEngine/Regex/Printing/PrintAsCanonical.swift
+++ b/Sources/_MatchingEngine/Regex/Printing/PrintAsCanonical.swift
@@ -138,19 +138,20 @@ extension AST.Quote {
 extension AST.Group.Kind {
   var _canonicalBase: String {
     switch self {
-    case .capture:              return "("
-    case .namedCapture(let n):  return "(?<\(n.value)>"
-    case .nonCapture:           return "(?:"
-    case .nonCaptureReset:      return "(?|"
-    case .atomicNonCapturing:   return "(?>"
-    case .lookahead:            return "(?="
-    case .negativeLookahead:    return "(?!"
-    case .nonAtomicLookahead:   return "(?*"
-    case .lookbehind:           return "(?<="
-    case .negativeLookbehind:   return "(?<!"
-    case .nonAtomicLookbehind:  return "(?<*"
-    case .scriptRun:            return "(*sr:"
-    case .atomicScriptRun:      return "(*asr:"
+    case .capture:                return "("
+    case .namedCapture(let n):    return "(?<\(n.value)>"
+    case .balancedCapture(let b): return "(?<\(b._canonicalBase)>"
+    case .nonCapture:             return "(?:"
+    case .nonCaptureReset:        return "(?|"
+    case .atomicNonCapturing:     return "(?>"
+    case .lookahead:              return "(?="
+    case .negativeLookahead:      return "(?!"
+    case .nonAtomicLookahead:     return "(?*"
+    case .lookbehind:             return "(?<="
+    case .negativeLookbehind:     return "(?<!"
+    case .nonAtomicLookbehind:    return "(?<*"
+    case .scriptRun:              return "(*sr:"
+    case .atomicScriptRun:        return "(*asr:"
 
     case .changeMatchingOptions:
       return "(/* TODO: matchign options in canonical form */"
@@ -219,4 +220,10 @@ extension AST.Reference {
 
 extension AST.CustomCharacterClass.Start {
   var _canonicalBase: String { self.rawValue }
+}
+
+extension AST.Group.BalancedCapture {
+  var _canonicalBase: String {
+    "\(name?.value ?? "")-\(priorName.value)"
+  }
 }

--- a/Sources/_MatchingEngine/Regex/Printing/PrintAsPattern.swift
+++ b/Sources/_MatchingEngine/Regex/Printing/PrintAsPattern.swift
@@ -269,6 +269,9 @@ extension AST.Atom {
 
     case .callout:
       return " /* TODO: callout */"
+
+    case .backtrackingDirective:
+      return " /* TODO: backtracking directive */"
     }
   }
 }

--- a/Sources/_MatchingEngine/Regex/Printing/PrintAsPattern.swift
+++ b/Sources/_MatchingEngine/Regex/Printing/PrintAsPattern.swift
@@ -286,6 +286,9 @@ extension AST.Group.Kind {
     case .namedCapture(let n):
       return "name: \"\(n)\""
 
+    case .balancedCapture:
+      return "/* TODO: balanced captures */"
+
     case .nonCapture: return ""
 
     case .nonCaptureReset:

--- a/Sources/_MatchingEngine/Regex/Printing/PrintAsPattern.swift
+++ b/Sources/_MatchingEngine/Regex/Printing/PrintAsPattern.swift
@@ -266,6 +266,9 @@ extension AST.Atom {
 
     case .subpattern:
       return " /* TODO: subpattern */"
+
+    case .callout:
+      return " /* TODO: callout */"
     }
   }
 }

--- a/Sources/_MatchingEngine/Utility/MissingUnicode.swift
+++ b/Sources/_MatchingEngine/Utility/MissingUnicode.swift
@@ -657,5 +657,7 @@ public enum OnigurumaSpecialProperty: String, Hashable {
 }
 
 extension Character {
-  var isOctalDigit: Bool { ("0"..."7").contains(self) }
+  public var isOctalDigit: Bool { ("0"..."7").contains(self) }
+
+  public var isWordCharacter: Bool { isLetter || isNumber || self == "_" }
 }

--- a/Sources/_StringProcessing/ASTBuilder.swift
+++ b/Sources/_StringProcessing/ASTBuilder.swift
@@ -169,6 +169,14 @@ func callout(_ arg: AST.Atom.Callout.Argument) -> AST {
   atom(.callout(.init(.init(faking: arg))))
 }
 
+func backtrackingDirective(
+  _ kind: AST.Atom.BacktrackingDirective.Kind, name: String? = nil
+) -> AST {
+  atom(.backtrackingDirective(
+    .init(.init(faking: kind), name: name.map { .init(faking: $0) })
+  ))
+}
+
 func quant(
   _ amount: AST.Quantification.Amount,
   _ kind: AST.Quantification.Kind = .eager,

--- a/Sources/_StringProcessing/ASTBuilder.swift
+++ b/Sources/_StringProcessing/ASTBuilder.swift
@@ -165,6 +165,10 @@ func groupCondition(
   .group(.init(.init(faking: kind), child, .fake))
 }
 
+func callout(_ arg: AST.Atom.Callout.Argument) -> AST {
+  atom(.callout(.init(.init(faking: arg))))
+}
+
 func quant(
   _ amount: AST.Quantification.Amount,
   _ kind: AST.Quantification.Kind = .eager,

--- a/Sources/_StringProcessing/ASTBuilder.swift
+++ b/Sources/_StringProcessing/ASTBuilder.swift
@@ -68,6 +68,12 @@ func namedCapture(
 ) -> AST {
   group(.namedCapture(.init(faking: name)), child)
 }
+func balancedCapture(name: String?, priorName: String, _ child: AST) -> AST {
+  group(.balancedCapture(
+    .init(name: name.map { .init(faking: $0) }, dash: .fake,
+          priorName: .init(faking: priorName))
+  ), child)
+}
 func nonCaptureReset(
   _ child: AST
 ) -> AST {

--- a/Sources/_StringProcessing/CharacterClass.swift
+++ b/Sources/_StringProcessing/CharacterClass.swift
@@ -148,7 +148,7 @@ public struct CharacterClass: Hashable {
       case .newlineSequence: matched = c.isNewline
       case .verticalWhitespace: fatalError("Not implemented")
       case .whitespace: matched = c.isWhitespace
-      case .word: matched = c.isLetter || c.isNumber || c == "_"
+      case .word: matched = c.isWordCharacter
       case .custom(let set): matched = set.any { $0.matches(c) }
       }
       if isInverted {

--- a/Sources/_StringProcessing/ConsumerInterface.swift
+++ b/Sources/_StringProcessing/ConsumerInterface.swift
@@ -112,7 +112,7 @@ extension AST.Atom {
 
     case .escaped, .keyboardControl, .keyboardMeta, .keyboardMetaControl,
         .any, .startOfLine, .endOfLine,
-        .backreference, .subpattern:
+        .backreference, .subpattern, .callout:
       // FIXME: implement
       return nil
     }

--- a/Sources/_StringProcessing/ConsumerInterface.swift
+++ b/Sources/_StringProcessing/ConsumerInterface.swift
@@ -112,7 +112,7 @@ extension AST.Atom {
 
     case .escaped, .keyboardControl, .keyboardMeta, .keyboardMetaControl,
         .any, .startOfLine, .endOfLine,
-        .backreference, .subpattern, .callout:
+        .backreference, .subpattern, .callout, .backtrackingDirective:
       // FIXME: implement
       return nil
     }

--- a/Tests/RegexTests/ParseTests.swift
+++ b/Tests/RegexTests/ParseTests.swift
@@ -1087,6 +1087,17 @@ extension RegexTests {
       trueBranch: empty(), falseBranch: empty())
     )
 
+    // MARK: Callouts
+
+    parseTest(#"(?C)"#, callout(.number(0)))
+    parseTest(#"(?C0)"#, callout(.number(0)))
+    parseTest(#"(?C20)"#, callout(.number(20)))
+    parseTest("(?C{abc})", callout(.string("abc")))
+
+    for delim in ["`", "'", "\"", "^", "%", "#", "$"] {
+      parseTest("(?C\(delim)hello\(delim))", callout(.string("hello")))
+    }
+
     // MARK: Parse with delimiters
 
     parseWithDelimitersTest("'/a b/'", concat("a", " ", "b"))
@@ -1149,6 +1160,9 @@ extension RegexTests {
     parseNotEqualTest(#"(?(R&abc)|)"#, #"(?(R&def)|)"#)
     parseNotEqualTest(#"(?(VERSION=0.1))"#, #"(?(VERSION=0.2))"#)
     parseNotEqualTest(#"(?(VERSION=0.1))"#, #"(?(VERSION>=0.1))"#)
+
+    parseNotEqualTest("(?C0)", "(?C1)")
+    parseNotEqualTest("(?C0)", "(?C'hello')")
 
     // TODO: failure tests
   }
@@ -1242,6 +1256,8 @@ extension RegexTests {
     diagnosticTest(#""ab\""#, .expected("\""), syntax: .experimental)
     diagnosticTest("\"ab\\", .expectedEscape, syntax: .experimental)
 
+    diagnosticTest("(?C", .expected(")"))
+
     // MARK: Text Segment options
 
     diagnosticTest("(?-y{g})", .cannotRemoveTextSegmentOptions)
@@ -1277,5 +1293,10 @@ extension RegexTests {
     diagnosticTest(#"(?(1)a|b|c)"#, .tooManyBranchesInConditional(3))
     diagnosticTest(#"(?(1)||)"#, .tooManyBranchesInConditional(3))
     diagnosticTest(#"(?(?i))"#, .unsupportedCondition("implicitly scoped group"))
+
+    // MARK: Callouts
+
+    diagnosticTest("(?C-1)", .unknownCalloutKind("(?C-1)"))
+    diagnosticTest("(?C-1", .unknownCalloutKind("(?C-1)"))
   }
 }


### PR DESCRIPTION
- Parse PCRE callouts `(?C)` with an integer or string argument. This doesn't yet handle the Oniguruma-specific callout syntax, which is a little more involved.

- Parse PCRE backtracking directives e.g `(*ACCEPT)`. This requires generalizing `canLexGroupLikeAtom` a bit to treat all `(*` groups as being atoms, and as such we need to special-case the PCRE2 explicit group syntax. We do it this way around to accommodate the extended Oniguruma callout syntax which also uses `(*`, which we aim to support.

- Parse .NET balanced captures. This requires imposing some restrictions on what can be used as a group name to allow for the syntax `(?<a-b>)`. For now, restrict the characters to letters, numbers and `_`, and forbid the first character from being a number. This should be no stricter than the rules imposed by PCRE, Oniguruma, ICU, Java and .NET.