### PR TITLE
Fix two crashers with quantification on transformed capture.

### DIFF
--- a/Sources/_MatchingEngine/Regex/Parse/CaptureStructure.swift
+++ b/Sources/_MatchingEngine/Regex/Parse/CaptureStructure.swift
@@ -11,7 +11,7 @@
 
 // A tree representing the type of some captures.
 public enum CaptureStructure: Equatable {
-  case atom(name: String? = nil)
+  case atom(name: String? = nil, type: AnyType? = nil)
   indirect case array(CaptureStructure)
   indirect case optional(CaptureStructure)
   indirect case tuple([CaptureStructure])
@@ -47,6 +47,17 @@ extension AST {
       default:
         return innerCaptures
       }
+    case .groupTransform(let group, let transform):
+      let innerCaptures = group.child.captureStructure
+      switch group.kind.value {
+      case .capture:
+        return .atom(type: AnyType(transform.resultType)) + innerCaptures
+      case .namedCapture(let name):
+        return .atom(name: name.value, type: AnyType(transform.resultType))
+          + innerCaptures
+      default:
+        return innerCaptures
+      }
     case .conditional(let c):
       // A conditional's capture structure is effectively that of an alternation
       // between the true and false branches. However the condition may also
@@ -67,8 +78,6 @@ extension AST {
         quantification.amount.value == .zeroOrOne
           ? CaptureStructure.optional
           : CaptureStructure.array)
-    case .groupTransform:
-      fatalError("Unreachable. Case will be removed later.")
     case .quote, .trivia, .atom, .customCharacterClass, .empty:
       return .empty
     }
@@ -135,8 +144,10 @@ extension CaptureStructure {
 
   public func type(withAtomType atomType: Any.Type) -> Any.Type {
     switch self {
-    case .atom:
+    case .atom(_, type: nil):
       return atomType
+    case .atom(_, type: let type?):
+      return type.base
     case .array(let child):
       return TypeConstruction.arrayType(of: child.type(withAtomType: atomType))
     case .optional(let child):
@@ -213,16 +224,18 @@ extension CaptureStructure {
     func encode(_ node: CaptureStructure, isTopLevel: Bool = false) {
       switch node {
       // 〚`T` (atom)〛 ==> .atom
-      case .atom(name: nil):
+      case .atom(name: nil, type: nil):
         append(.atom)
       // 〚`name: T` (atom)〛 ==> .atom, `name`, '\0'
-      case .atom(name: let name?):
+      case .atom(name: let name?, type: nil):
         append(.namedAtom)
         let nameCString = name.utf8CString
         let nameSlot = UnsafeMutableRawBufferPointer(
           rebasing: buffer[offset ..< offset+nameCString.count])
         nameCString.withUnsafeBytes(nameSlot.copyMemory(from:))
         offset += nameCString.count
+      case .atom(_, _?):
+        fatalError("Cannot encode a capture structure with explicit types")
       // 〚`[T]`〛 ==> 〚`T`〛, .formArray
       case .array(let child):
         encode(child)

--- a/Sources/_MatchingEngine/Utility/Misc.swift
+++ b/Sources/_MatchingEngine/Utility/Misc.swift
@@ -149,3 +149,19 @@ extension BinaryInteger {
   }
 }
 
+/// A wrapper of an existential metatype, equatable and hashable by reference.
+public struct AnyType: Equatable, Hashable {
+  public var base: Any.Type
+
+  public init(_ type: Any.Type) {
+    base = type
+  }
+
+  public static func == (lhs: AnyType, rhs: AnyType) -> Bool {
+    lhs.base == rhs.base
+  }
+
+  public func hash(into hasher: inout Hasher) {
+    hasher.combine(ObjectIdentifier(base))
+  }
+}

--- a/Sources/_StringProcessing/Capture.swift
+++ b/Sources/_StringProcessing/Capture.swift
@@ -51,7 +51,10 @@ extension Capture {
       }
       return _openExistential(childType.base, do: helper)
     case .some(let subcapture):
-      return subcapture.value
+      func helper<T>(_ value: T) -> Any {
+        Optional(value) as Any
+      }
+      return _openExistential(subcapture.value, do: helper)
     case .none(let childType):
       func helper<T>(_: T.Type) -> Any {
         nil as T? as Any

--- a/Sources/_StringProcessing/RegexDSL/DSL.swift
+++ b/Sources/_StringProcessing/RegexDSL/DSL.swift
@@ -179,7 +179,7 @@ public struct CapturingGroup<Match: MatchProtocol>: RegexProtocol {
     self.regex = .init(ast:
       .groupTransform(
         .init(.init(faking: .capture), component.regex.ast, .fake),
-        transform: CaptureTransform {
+        transform: CaptureTransform(resultType: NewCapture.self) {
           transform($0) as Any
         }))
   }


### PR DESCRIPTION
This patch fixes two issues:
- When an optional quantification matches 1 occurrence, the capture type constructed by the engine unexpectedly drops the `Optional` wrapper type. `Capture.value` is fixed by including the `Optional` wrapper type.
- When an optional or array quantification matches 0 occurrence, the capture type constructed by the engine unexpectedly uses `Substring` as the atom type instead of the transformed type from `CaptureTransform`. This is fixed by propagating capture transform result type information from the DSL API down to `captureNil` and `captureArray` instructions in the bytecode. The engine will use the type information to construct the correct types for `nil` and `[]`.