### PR TITLE
Initial matcher/validator support

### DIFF
--- a/Sources/_StringProcessing/Algorithms/Algorithms/Contains.swift
+++ b/Sources/_StringProcessing/Algorithms/Algorithms/Contains.swift
@@ -40,7 +40,7 @@ extension BidirectionalCollection where Element: Comparable {
 // MARK: Regex algorithms
 
 extension BidirectionalCollection where SubSequence == Substring {
-  public func contains<Capture>(_ regex: Regex<Capture>) -> Bool {
+  public func contains<R: RegexProtocol>(_ regex: R) -> Bool {
     contains(RegexConsumer(regex))
   }
 }

--- a/Sources/_StringProcessing/Algorithms/Algorithms/FirstRange.swift
+++ b/Sources/_StringProcessing/Algorithms/Algorithms/FirstRange.swift
@@ -56,11 +56,11 @@ extension BidirectionalCollection where Element: Comparable {
 // MARK: Regex algorithms
 
 extension BidirectionalCollection where SubSequence == Substring {
-  public func firstRange<Capture>(of regex: Regex<Capture>) -> Range<Index>? {
+  public func firstRange<R: RegexProtocol>(of regex: R) -> Range<Index>? {
     firstRange(of: RegexConsumer(regex))
   }
   
-  public func lastRange<Capture>(of regex: Regex<Capture>) -> Range<Index>? {
+  public func lastRange<R: RegexProtocol>(of regex: R) -> Range<Index>? {
     lastRange(of: RegexConsumer(regex))
   }
 }

--- a/Sources/_StringProcessing/Algorithms/Algorithms/Ranges.swift
+++ b/Sources/_StringProcessing/Algorithms/Algorithms/Ranges.swift
@@ -218,13 +218,13 @@ extension BidirectionalCollection where Element: Comparable {
 extension BidirectionalCollection where SubSequence == Substring {
   public func ranges<Capture>(
     of regex: Regex<Capture>
-  ) -> RangesCollection<RegexConsumer<Self>> {
+  ) -> RangesCollection<RegexConsumer<Self, Capture>> {
     ranges(of: RegexConsumer(regex))
   }
   
   public func rangesFromBack<Capture>(
     of regex: Regex<Capture>
-  ) -> ReversedRangesCollection<RegexConsumer<Self>> {
+  ) -> ReversedRangesCollection<RegexConsumer<Self, Capture>> {
     rangesFromBack(of: RegexConsumer(regex))
   }
 }

--- a/Sources/_StringProcessing/Algorithms/Algorithms/Ranges.swift
+++ b/Sources/_StringProcessing/Algorithms/Algorithms/Ranges.swift
@@ -216,15 +216,15 @@ extension BidirectionalCollection where Element: Comparable {
 // MARK: Regex algorithms
 
 extension BidirectionalCollection where SubSequence == Substring {
-  public func ranges<Capture>(
-    of regex: Regex<Capture>
-  ) -> RangesCollection<RegexConsumer<Self, Capture>> {
+  public func ranges<R: RegexProtocol>(
+    of regex: R
+  ) -> RangesCollection<RegexConsumer<R, Self>> {
     ranges(of: RegexConsumer(regex))
   }
   
-  public func rangesFromBack<Capture>(
-    of regex: Regex<Capture>
-  ) -> ReversedRangesCollection<RegexConsumer<Self, Capture>> {
+  public func rangesFromBack<R: RegexProtocol>(
+    of regex: R
+  ) -> ReversedRangesCollection<RegexConsumer<R, Self>> {
     rangesFromBack(of: RegexConsumer(regex))
   }
 }

--- a/Sources/_StringProcessing/Algorithms/Algorithms/Ranges.swift
+++ b/Sources/_StringProcessing/Algorithms/Algorithms/Ranges.swift
@@ -33,16 +33,6 @@ public struct RangesCollection<Searcher: CollectionSearcher> {
   }
 }
 
-extension RangesCollection where Searcher: BidirectionalCollectionSearcher {
-  public func reversed() -> ReversedRangesCollection<Searcher> {
-    ReversedRangesCollection(base: base, searcher: searcher)
-  }
-  
-  public var last: Range<Base.Index>? {
-    base.lastRange(of: searcher)
-  }
-}
-
 public struct RangesIterator<Searcher: CollectionSearcher>: IteratorProtocol {
   public typealias Base = Searcher.Searched
   
@@ -136,18 +126,6 @@ public struct ReversedRangesCollection<Searcher: BackwardCollectionSearcher> {
   init(base: Base, searcher: Searcher) {
     self.base = base
     self.searcher = searcher
-  }
-}
-
-extension ReversedRangesCollection
-  where Searcher: BidirectionalCollectionSearcher
-{
-  public func reversed() -> RangesCollection<Searcher> {
-    RangesCollection(base: base, searcher: searcher)
-  }
-  
-  public var last: Range<Base.Index>? {
-    base.firstRange(of: searcher)
   }
 }
 

--- a/Sources/_StringProcessing/Algorithms/Algorithms/Replace.swift
+++ b/Sources/_StringProcessing/Algorithms/Algorithms/Replace.swift
@@ -50,11 +50,13 @@ extension RangeReplaceableCollection {
       maxReplacements: maxReplacements)
   }
   
-  public mutating func replace<Searcher: CollectionSearcher, R: Collection>(
+  public mutating func replace<
+    Searcher: CollectionSearcher, Replacement: Collection
+  >(
     _ searcher: Searcher,
-    with replacement: R,
+    with replacement: Replacement,
     maxReplacements: Int = .max
-  ) where Searcher.Searched == SubSequence, R.Element == Element {
+  ) where Searcher.Searched == SubSequence, Replacement.Element == Element {
     self = replacing(
       searcher,
       with: replacement,

--- a/Sources/_StringProcessing/Algorithms/Algorithms/Replace.swift
+++ b/Sources/_StringProcessing/Algorithms/Algorithms/Replace.swift
@@ -149,8 +149,8 @@ extension RangeReplaceableCollection
 // MARK: Regex algorithms
 
 extension RangeReplaceableCollection where SubSequence == Substring {
-  public func replacing<Capture, Replacement: Collection>(
-    _ regex: Regex<Capture>,
+  public func replacing<R: RegexProtocol, Replacement: Collection>(
+    _ regex: R,
     with replacement: Replacement,
     subrange: Range<Index>,
     maxReplacements: Int = .max
@@ -162,8 +162,8 @@ extension RangeReplaceableCollection where SubSequence == Substring {
       maxReplacements: maxReplacements)
   }
   
-  public func replacing<Capture, Replacement: Collection>(
-    _ regex: Regex<Capture>,
+  public func replacing<R: RegexProtocol, Replacement: Collection>(
+    _ regex: R,
     with replacement: Replacement,
     maxReplacements: Int = .max
   ) -> Self where Replacement.Element == Element {
@@ -174,8 +174,8 @@ extension RangeReplaceableCollection where SubSequence == Substring {
       maxReplacements: maxReplacements)
   }
   
-  public mutating func replace<Capture, Replacement: Collection>(
-    _ regex: Regex<Capture>,
+  public mutating func replace<R: RegexProtocol, Replacement: Collection>(
+    _ regex: R,
     with replacement: Replacement,
     maxReplacements: Int = .max
   ) where Replacement.Element == Element {

--- a/Sources/_StringProcessing/Algorithms/Algorithms/Split.swift
+++ b/Sources/_StringProcessing/Algorithms/Algorithms/Split.swift
@@ -275,15 +275,15 @@ extension BidirectionalCollection where Element: Comparable {
 // MARK: Regex algorithms
 
 extension BidirectionalCollection where SubSequence == Substring {
-  public func split<Capture>(
-    by separator: Regex<Capture>
-  ) -> SplitCollection<RegexConsumer<Self, Capture>> {
+  public func split<R: RegexProtocol>(
+    by separator: R
+  ) -> SplitCollection<RegexConsumer<R, Self>> {
     split(by: RegexConsumer(separator))
   }
   
-  public func splitFromBack<Capture>(
-    by separator: Regex<Capture>
-  ) -> ReversedSplitCollection<RegexConsumer<Self, Capture>> {
+  public func splitFromBack<R: RegexProtocol>(
+    by separator: R
+  ) -> ReversedSplitCollection<RegexConsumer<R, Self>> {
     splitFromBack(by: RegexConsumer(separator))
   }
 }

--- a/Sources/_StringProcessing/Algorithms/Algorithms/Split.swift
+++ b/Sources/_StringProcessing/Algorithms/Algorithms/Split.swift
@@ -277,13 +277,13 @@ extension BidirectionalCollection where Element: Comparable {
 extension BidirectionalCollection where SubSequence == Substring {
   public func split<Capture>(
     by separator: Regex<Capture>
-  ) -> SplitCollection<RegexConsumer<Self>> {
+  ) -> SplitCollection<RegexConsumer<Self, Capture>> {
     split(by: RegexConsumer(separator))
   }
   
   public func splitFromBack<Capture>(
     by separator: Regex<Capture>
-  ) -> ReversedSplitCollection<RegexConsumer<Self>> {
+  ) -> ReversedSplitCollection<RegexConsumer<Self, Capture>> {
     splitFromBack(by: RegexConsumer(separator))
   }
 }

--- a/Sources/_StringProcessing/Algorithms/Algorithms/Split.swift
+++ b/Sources/_StringProcessing/Algorithms/Algorithms/Split.swift
@@ -25,12 +25,6 @@ public struct SplitCollection<Searcher: CollectionSearcher> {
   }
 }
 
-extension SplitCollection where Searcher: BidirectionalCollectionSearcher {
-  public func reversed() -> ReversedSplitCollection<Searcher> {
-    ReversedSplitCollection(ranges: ranges.reversed())
-  }
-}
-
 extension SplitCollection: Sequence {
   public struct Iterator: IteratorProtocol {
     let base: Base
@@ -141,14 +135,6 @@ public struct ReversedSplitCollection<Searcher: BackwardCollectionSearcher> {
 
   init(base: Base, searcher: Searcher) {
     self.ranges = base.rangesFromBack(of: searcher)
-  }
-}
-
-extension ReversedSplitCollection
-  where Searcher: BidirectionalCollectionSearcher
-{
-  public func reversed() -> SplitCollection<Searcher> {
-    SplitCollection(ranges: ranges.reversed())
   }
 }
 

--- a/Sources/_StringProcessing/Algorithms/Algorithms/StartsWith.swift
+++ b/Sources/_StringProcessing/Algorithms/Algorithms/StartsWith.swift
@@ -48,11 +48,11 @@ extension BidirectionalCollection where Element: Equatable {
 // MARK: Regex algorithms
 
 extension BidirectionalCollection where SubSequence == Substring {
-  public func starts<Capture>(with regex: Regex<Capture>) -> Bool {
+  public func starts<R: RegexProtocol>(with regex: R) -> Bool {
     starts(with: RegexConsumer(regex))
   }
   
-  public func ends<Capture>(with regex: Regex<Capture>) -> Bool {
+  public func ends<R: RegexProtocol>(with regex: R) -> Bool {
     ends(with: RegexConsumer(regex))
   }
 }

--- a/Sources/_StringProcessing/Algorithms/Algorithms/Trim.swift
+++ b/Sources/_StringProcessing/Algorithms/Algorithms/Trim.swift
@@ -257,15 +257,15 @@ extension RangeReplaceableCollection
 // MARK: Regex algorithms
 
 extension BidirectionalCollection where SubSequence == Substring {
-  public func trimmingPrefix<Capture>(_ regex: Regex<Capture>) -> SubSequence {
+  public func trimmingPrefix<R: RegexProtocol>(_ regex: R) -> SubSequence {
     trimmingPrefix(RegexConsumer(regex))
   }
   
-  public func trimmingSuffix<Capture>(_ regex: Regex<Capture>) -> SubSequence {
+  public func trimmingSuffix<R: RegexProtocol>(_ regex: R) -> SubSequence {
     trimmingSuffix(RegexConsumer(regex))
   }
   
-  public func trimming<Capture>(_ regex: Regex<Capture>) -> SubSequence {
+  public func trimming<R: RegexProtocol>(_ regex: R) -> SubSequence {
     trimming(RegexConsumer(regex))
   }
 }
@@ -273,32 +273,32 @@ extension BidirectionalCollection where SubSequence == Substring {
 extension RangeReplaceableCollection
   where Self: BidirectionalCollection, SubSequence == Substring
 {
-  public mutating func trimPrefix<Capture>(_ regex: Regex<Capture>) {
+  public mutating func trimPrefix<R: RegexProtocol>(_ regex: R) {
     trimPrefix(RegexConsumer(regex))
   }
   
-  public mutating func trimSuffix<Capture>(_ regex: Regex<Capture>) {
+  public mutating func trimSuffix<R: RegexProtocol>(_ regex: R) {
     trimSuffix(RegexConsumer(regex))
   }
   
-  public mutating func trim<Capture>(_ regex: Regex<Capture>) {
-    let consumer = RegexConsumer<Self, Capture>(regex)
+  public mutating func trim<R: RegexProtocol>(_ regex: R) {
+    let consumer = RegexConsumer<R, Self>(regex)
     trimPrefix(consumer)
     trimSuffix(consumer)
   }
 }
 
 extension Substring {
-  public mutating func trimPrefix<Capture>(_ regex: Regex<Capture>) {
+  public mutating func trimPrefix<R: RegexProtocol>(_ regex: R) {
     trimPrefix(RegexConsumer(regex))
   }
   
-  public mutating func trimSuffix<Capture>(_ regex: Regex<Capture>) {
+  public mutating func trimSuffix<R: RegexProtocol>(_ regex: R) {
     trimSuffix(RegexConsumer(regex))
   }
   
-  public mutating func trim<Capture>(_ regex: Regex<Capture>) {
-    let consumer = RegexConsumer<Self, Capture>(regex)
+  public mutating func trim<R: RegexProtocol>(_ regex: R) {
+    let consumer = RegexConsumer<R, Self>(regex)
     trimPrefix(consumer)
     trimSuffix(consumer)
   }

--- a/Sources/_StringProcessing/Algorithms/Algorithms/Trim.swift
+++ b/Sources/_StringProcessing/Algorithms/Algorithms/Trim.swift
@@ -282,7 +282,7 @@ extension RangeReplaceableCollection
   }
   
   public mutating func trim<Capture>(_ regex: Regex<Capture>) {
-    let consumer = RegexConsumer<Self>(regex)
+    let consumer = RegexConsumer<Self, Capture>(regex)
     trimPrefix(consumer)
     trimSuffix(consumer)
   }
@@ -298,7 +298,7 @@ extension Substring {
   }
   
   public mutating func trim<Capture>(_ regex: Regex<Capture>) {
-    let consumer = RegexConsumer<Self>(regex)
+    let consumer = RegexConsumer<Self, Capture>(regex)
     trimPrefix(consumer)
     trimSuffix(consumer)
   }

--- a/Sources/_StringProcessing/Algorithms/Consumers/PredicateConsumer.swift
+++ b/Sources/_StringProcessing/Algorithms/Consumers/PredicateConsumer.swift
@@ -56,7 +56,7 @@ extension PredicateConsumer: StatelessCollectionSearcher {
 }
 
 extension PredicateConsumer: BackwardCollectionSearcher,
-                             StatelessBackwardCollectionSearcher
+                             BackwardStatelessCollectionSearcher
   where Searched: BidirectionalCollection
 {
   public typealias BackwardSearched = Consumed

--- a/Sources/_StringProcessing/Algorithms/Consumers/RegexConsumer.swift
+++ b/Sources/_StringProcessing/Algorithms/Consumers/RegexConsumer.swift
@@ -82,7 +82,7 @@ extension RegexConsumer: StatelessCollectionSearcher {
 }
 
 // TODO: Bake in search-back to engine too
-extension RegexConsumer: StatelessBackwardCollectionSearcher {
+extension RegexConsumer: BackwardStatelessCollectionSearcher {
   public typealias BackwardSearched = Consumed
   
   public func searchBack(

--- a/Sources/_StringProcessing/Algorithms/Consumers/RegexConsumer.swift
+++ b/Sources/_StringProcessing/Algorithms/Consumers/RegexConsumer.swift
@@ -9,56 +9,50 @@
 //
 //===----------------------------------------------------------------------===//
 
-import _MatchingEngine
+public struct RegexConsumer<
+  Consumed: BidirectionalCollection, Capture: MatchProtocol
+> where Consumed.SubSequence == Substring {
+  // TODO: Should `Regex` itself implement these protocols?
+  let regex: Regex<Capture>
 
-public struct RegexConsumer<Consumed: BidirectionalCollection>
-  where Consumed.SubSequence == Substring
-{
-  // TODO: consider let, for now lets us toggle tracing
-  var vm: Executor
-
-  // FIXME: Possibility of fatal error isn't user friendly
-  public init<Capture>(_ regex: Regex<Capture>) {
-    do {
-      self.vm = .init(
-        program: try Compiler(ast: regex.ast).emit())
-    } catch {
-      fatalError("error: \(error)")
-    }
-  }
-
-  public init(parsing regex: String) throws {
-    self.vm = try _compileRegex(regex)
+  public init(_ regex: Regex<Capture>) {
+    self.regex = regex
   }
   
-  func _consuming(
+  func _matchingConsuming(
     _ consumed: Substring, in range: Range<String.Index>
-  ) -> String.Index? {
-    let result = vm.execute(
-      input: consumed.base,
-      in: range,
-      mode: .partialFromFront)
-    return result?.range.upperBound
+  ) -> (Capture, String.Index)? {
+    guard let result = regex._match(
+      consumed.base,
+      in: range, mode: .partialFromFront
+    ) else { return nil }
+    return (result.match, result.range.upperBound)
   }
-  
-  public func consuming(
+}
+
+// TODO: Explicitly implement the non-matching consumer/searcher protocols as
+// well, taking advantage of the fact that the captures can be ignored
+
+extension RegexConsumer: MatchingCollectionConsumer {
+  public func matchingConsuming(
     _ consumed: Consumed, in range: Range<Consumed.Index>
-  ) -> String.Index? {
-    _consuming(consumed[...], in: range)
+  ) -> (Capture, String.Index)? {
+    _matchingConsuming(consumed[...], in: range)
   }
 }
 
 // TODO: We'll want to bake backwards into the engine
-extension RegexConsumer: BidirectionalCollectionConsumer {
-  public func consumingBack(
+extension RegexConsumer: BidirectionalMatchingCollectionConsumer {
+  public func matchingConsumingBack(
     _ consumed: Consumed, in range: Range<Consumed.Index>
-  ) -> String.Index? {
+  ) -> (Capture, String.Index)? {
     var i = range.lowerBound
     while true {
-      if let end = _consuming(consumed[...], in: i..<range.upperBound),
-         end == range.upperBound
-      {
-        return i
+      if let (capture, end) = _matchingConsuming(
+        consumed[...],
+        in: i..<range.upperBound
+      ), end == range.upperBound {
+        return (capture, i)
       } else if i == range.upperBound {
         return nil
       } else {
@@ -68,16 +62,16 @@ extension RegexConsumer: BidirectionalCollectionConsumer {
   }
 }
 
-extension RegexConsumer: StatelessCollectionSearcher {
+extension RegexConsumer: MatchingStatelessCollectionSearcher {
   public typealias Searched = Consumed
 
   // TODO: We'll want to bake search into the engine so it can
   // take advantage of the structure of the regex itself and
   // its own internal state
-  public func search(
+  public func matchingSearch(
     _ searched: Searched, in range: Range<Searched.Index>
-  ) -> Range<String.Index>? {
-    ConsumerSearcher(consumer: self).search(searched, in: range)
+  ) -> (Capture, Range<String.Index>)? {
+    ConsumerSearcher(consumer: self).matchingSearch(searched, in: range)
   }
 }
 

--- a/Sources/_StringProcessing/Algorithms/Consumers/RegexConsumer.swift
+++ b/Sources/_StringProcessing/Algorithms/Consumers/RegexConsumer.swift
@@ -34,6 +34,8 @@ public struct RegexConsumer<
 // well, taking advantage of the fact that the captures can be ignored
 
 extension RegexConsumer: MatchingCollectionConsumer {
+  public typealias Match = Capture
+  
   public func matchingConsuming(
     _ consumed: Consumed, in range: Range<Consumed.Index>
   ) -> (Capture, String.Index)? {
@@ -76,12 +78,12 @@ extension RegexConsumer: MatchingStatelessCollectionSearcher {
 }
 
 // TODO: Bake in search-back to engine too
-extension RegexConsumer: BackwardStatelessCollectionSearcher {
+extension RegexConsumer: BackwardMatchingStatelessCollectionSearcher {
   public typealias BackwardSearched = Consumed
   
-  public func searchBack(
+  public func matchingSearchBack(
     _ searched: BackwardSearched, in range: Range<Searched.Index>
-  ) -> Range<String.Index>? {
-    ConsumerSearcher(consumer: self).searchBack(searched, in: range)
+  ) -> (Capture, Range<String.Index>)? {
+    ConsumerSearcher(consumer: self).matchingSearchBack(searched, in: range)
   }
 }

--- a/Sources/_StringProcessing/Algorithms/Matching/FirstMatch.swift
+++ b/Sources/_StringProcessing/Algorithms/Matching/FirstMatch.swift
@@ -1,0 +1,48 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2021-2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+// MARK: `CollectionSearcher` algorithms
+
+extension Collection {
+  public func firstMatch<S: MatchingCollectionSearcher>(
+    of searcher: S
+  ) -> (S.Match, Range<S.Searched.Index>)? where S.Searched == Self {
+    var state = searcher.state(for: self, in: startIndex..<endIndex)
+    return searcher.matchingSearch(self, &state)
+  }
+}
+
+extension BidirectionalCollection {
+  public func lastMatch<S: BackwardMatchingCollectionSearcher>(
+    of searcher: S
+  ) -> (S.Match, Range<S.BackwardSearched.Index>)?
+    where S.BackwardSearched == Self
+  {
+    var state = searcher.backwardState(for: self, in: startIndex..<endIndex)
+    return searcher.matchingSearchBack(self, &state)
+  }
+}
+
+// MARK: Regex algorithms
+
+extension BidirectionalCollection where SubSequence == Substring {
+  public func firstMatch<Capture>(
+    of regex: Regex<Capture>
+  ) -> (Capture, Range<String.Index>)? {
+    firstMatch(of: RegexConsumer(regex))
+  }
+  
+  public func lastMatch<Capture>(
+    of regex: Regex<Capture>
+  ) -> (Capture, Range<String.Index>)? {
+    lastMatch(of: RegexConsumer(regex))
+  }
+}

--- a/Sources/_StringProcessing/Algorithms/Matching/FirstMatch.swift
+++ b/Sources/_StringProcessing/Algorithms/Matching/FirstMatch.swift
@@ -14,35 +14,39 @@
 extension Collection {
   public func firstMatch<S: MatchingCollectionSearcher>(
     of searcher: S
-  ) -> (S.Match, Range<S.Searched.Index>)? where S.Searched == Self {
+  ) -> _MatchResult<S>? where S.Searched == Self {
     var state = searcher.state(for: self, in: startIndex..<endIndex)
-    return searcher.matchingSearch(self, &state)
+    return searcher.matchingSearch(self, &state).map { range, result in
+      _MatchResult(match: self[range], result: result)
+    }
   }
 }
 
 extension BidirectionalCollection {
   public func lastMatch<S: BackwardMatchingCollectionSearcher>(
     of searcher: S
-  ) -> (S.Match, Range<S.BackwardSearched.Index>)?
+  ) -> _BackwardMatchResult<S>?
     where S.BackwardSearched == Self
   {
     var state = searcher.backwardState(for: self, in: startIndex..<endIndex)
-    return searcher.matchingSearchBack(self, &state)
+    return searcher.matchingSearchBack(self, &state).map { range, result in
+      _BackwardMatchResult(match: self[range], result: result)
+    }
   }
 }
 
 // MARK: Regex algorithms
 
 extension BidirectionalCollection where SubSequence == Substring {
-  public func firstMatch<Capture>(
-    of regex: Regex<Capture>
-  ) -> (Capture, Range<String.Index>)? {
+  public func firstMatch<R: RegexProtocol>(
+    of regex: R
+  ) -> _MatchResult<RegexConsumer<R, Self>>? {
     firstMatch(of: RegexConsumer(regex))
   }
   
-  public func lastMatch<Capture>(
-    of regex: Regex<Capture>
-  ) -> (Capture, Range<String.Index>)? {
+  public func lastMatch<R: RegexProtocol>(
+    of regex: R
+  ) -> _BackwardMatchResult<RegexConsumer<R, Self>>? {
     lastMatch(of: RegexConsumer(regex))
   }
 }

--- a/Sources/_StringProcessing/Algorithms/Matching/MatchReplace.swift
+++ b/Sources/_StringProcessing/Algorithms/Matching/MatchReplace.swift
@@ -1,0 +1,114 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2021-2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+// MARK: `MatchingCollectionSearcher` algorithms
+
+extension RangeReplaceableCollection {
+  public func replacing<
+    Searcher: MatchingCollectionSearcher, Replacement: Collection
+  >(
+    _ searcher: Searcher,
+    with replacement: (Searcher.Match,
+                       Range<Searcher.Searched.Index>) -> Replacement,
+    subrange: Range<Index>,
+    maxReplacements: Int = .max
+  ) -> Self where Searcher.Searched == SubSequence,
+                  Replacement.Element == Element
+  {
+    precondition(maxReplacements >= 0)
+
+    var index = subrange.lowerBound
+    var result = Self()
+    result.append(contentsOf: self[..<index])
+
+    for (match, range) in self[subrange].matches(of: searcher)
+          .prefix(maxReplacements)
+    {
+      result.append(contentsOf: self[index..<range.lowerBound])
+      result.append(contentsOf: replacement(match, range))
+      index = range.upperBound
+    }
+
+    result.append(contentsOf: self[index...])
+    return result
+  }
+
+  public func replacing<
+    Searcher: MatchingCollectionSearcher, Replacement: Collection
+  >(
+    _ searcher: Searcher,
+    with replacement: (Searcher.Match,
+                       Range<Searcher.Searched.Index>) -> Replacement,
+    maxReplacements: Int = .max
+  ) -> Self where Searcher.Searched == SubSequence,
+                  Replacement.Element == Element
+  {
+    replacing(
+      searcher,
+      with: replacement,
+      subrange: startIndex..<endIndex,
+      maxReplacements: maxReplacements)
+  }
+
+  public mutating func replace<
+    Searcher: MatchingCollectionSearcher, Replacement: Collection
+  >(
+    _ searcher: Searcher,
+    with replacement: (Searcher.Match,
+                       Range<Searcher.Searched.Index>) -> Replacement,
+    maxReplacements: Int = .max
+  ) where Searcher.Searched == SubSequence, Replacement.Element == Element {
+    self = replacing(
+      searcher,
+      with: replacement,
+      maxReplacements: maxReplacements)
+  }
+}
+
+// MARK: Regex algorithms
+
+extension RangeReplaceableCollection where SubSequence == Substring {
+  public func replacing<Capture, Replacement: Collection>(
+    _ regex: Regex<Capture>,
+    with replacement: (Capture, Range<String.Index>) -> Replacement,
+    subrange: Range<Index>,
+    maxReplacements: Int = .max
+  ) -> Self where Replacement.Element == Element {
+    replacing(
+      RegexConsumer(regex),
+      with: replacement,
+      subrange: subrange,
+      maxReplacements: maxReplacements)
+  }
+  
+  public func replacing<Capture, Replacement: Collection>(
+    _ regex: Regex<Capture>,
+    with replacement: (Capture, Range<String.Index>) -> Replacement,
+    maxReplacements: Int = .max
+  ) -> Self where Replacement.Element == Element {
+    replacing(
+      regex,
+      with: replacement,
+      subrange: startIndex..<endIndex,
+      maxReplacements: maxReplacements)
+  }
+  
+  public mutating func replace<Capture, Replacement: Collection>(
+    _ regex: Regex<Capture>,
+    with replacement: (Capture, Range<String.Index>) -> Replacement,
+    maxReplacements: Int = .max
+  ) where Replacement.Element == Element {
+    self = replacing(
+      regex,
+      with: replacement,
+      maxReplacements: maxReplacements)
+  }
+}

--- a/Sources/_StringProcessing/Algorithms/Matching/MatchResult.swift
+++ b/Sources/_StringProcessing/Algorithms/Matching/MatchResult.swift
@@ -1,0 +1,28 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2021-2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+public struct _MatchResult<S: MatchingCollectionSearcher> {
+  public let match: S.Searched.SubSequence
+  public let result: S.Match
+  
+  public var range: Range<S.Searched.Index> {
+    match.startIndex..<match.endIndex
+  }
+}
+
+public struct _BackwardMatchResult<S: BackwardMatchingCollectionSearcher> {
+  public let match: S.BackwardSearched.SubSequence
+  public let result: S.Match
+  
+  public var range: Range<S.BackwardSearched.Index> {
+    match.startIndex..<match.endIndex
+  }
+}

--- a/Sources/_StringProcessing/Algorithms/Matching/Matches.swift
+++ b/Sources/_StringProcessing/Algorithms/Matching/Matches.swift
@@ -63,7 +63,7 @@ extension MatchesCollection: Collection {
   // TODO: Custom `SubSequence` for the sake of more efficient slice iteration
   
   public struct Index {
-    var match: (value: Searcher.Match, range: Range<Searcher.Searched.Index>)?
+    var match: (value: Searcher.Match, range: Range<Base.Index>)?
     var state: Searcher.State
   }
 
@@ -157,4 +157,38 @@ extension ReversedMatchesCollection: Sequence {
   }
 }
 
-//// TODO: `Collection` conformance
+// TODO: `Collection` conformance
+
+// MARK: `CollectionSearcher` algorithms
+
+extension Collection {
+  public func matches<S: MatchingCollectionSearcher>(
+    of searcher: S
+  ) -> MatchesCollection<S> where S.Searched == Self {
+    MatchesCollection(base: self, searcher: searcher)
+  }
+}
+
+extension BidirectionalCollection {
+  public func matchesFromBack<S: BackwardMatchingCollectionSearcher>(
+    of searcher: S
+  ) -> ReversedMatchesCollection<S> where S.BackwardSearched == Self {
+    ReversedMatchesCollection(base: self, searcher: searcher)
+  }
+}
+
+// MARK: Regex algorithms
+
+extension BidirectionalCollection where SubSequence == Substring {
+  public func matches<Capture>(
+    of regex: Regex<Capture>
+  ) -> MatchesCollection<RegexConsumer<Self, Capture>> {
+    matches(of: RegexConsumer(regex))
+  }
+  
+  public func matchesFromBack<Capture>(
+    of regex: Regex<Capture>
+  ) -> ReversedMatchesCollection<RegexConsumer<Self, Capture>> {
+    matchesFromBack(of: RegexConsumer(regex))
+  }
+}

--- a/Sources/_StringProcessing/Algorithms/Matching/Matches.swift
+++ b/Sources/_StringProcessing/Algorithms/Matching/Matches.swift
@@ -1,0 +1,160 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2021-2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+// MARK: `MatchesCollection`
+
+public struct MatchesCollection<Searcher: MatchingCollectionSearcher> {
+  public typealias Base = Searcher.Searched
+  
+  let base: Base
+  let searcher: Searcher
+  private(set) public var startIndex: Index
+
+  init(base: Base, searcher: Searcher) {
+    self.base = base
+    self.searcher = searcher
+    
+    var state = searcher.state(for: base, in: base.startIndex..<base.endIndex)
+    self.startIndex = Index(match: nil, state: state)
+
+    if let match = searcher.matchingSearch(base, &state) {
+      self.startIndex = Index(match: match, state: state)
+    } else {
+      self.startIndex = endIndex
+    }
+  }
+}
+
+public struct MatchesIterator<
+  Searcher: MatchingCollectionSearcher
+>: IteratorProtocol {
+  public typealias Base = Searcher.Searched
+  
+  let base: Base
+  let searcher: Searcher
+  var state: Searcher.State
+
+  init(base: Base, searcher: Searcher) {
+    self.base = base
+    self.searcher = searcher
+    self.state = searcher.state(for: base, in: base.startIndex..<base.endIndex)
+  }
+
+  public mutating func next() -> (Searcher.Match, Range<Base.Index>)? {
+    searcher.matchingSearch(base, &state)
+  }
+}
+
+extension MatchesCollection: Sequence {
+  public func makeIterator() -> MatchesIterator<Searcher> {
+    Iterator(base: base, searcher: searcher)
+  }
+}
+
+extension MatchesCollection: Collection {
+  // TODO: Custom `SubSequence` for the sake of more efficient slice iteration
+  
+  public struct Index {
+    var match: (value: Searcher.Match, range: Range<Searcher.Searched.Index>)?
+    var state: Searcher.State
+  }
+
+  public var endIndex: Index {
+    // TODO: Avoid calling `state(for:startingAt)` here
+    Index(
+      match: nil,
+      state: searcher.state(for: base, in: base.startIndex..<base.endIndex))
+  }
+
+  public func formIndex(after index: inout Index) {
+    guard index != endIndex else { fatalError("Cannot advance past endIndex") }
+    index.match = searcher.matchingSearch(base, &index.state)
+  }
+
+  public func index(after index: Index) -> Index {
+    var index = index
+    formIndex(after: &index)
+    return index
+  }
+
+  public subscript(index: Index) -> (Searcher.Match, Range<Base.Index>) {
+    guard let match = index.match else {
+      fatalError("Cannot subscript using endIndex")
+    }
+    return match
+  }
+}
+
+extension MatchesCollection.Index: Comparable {
+  public static func == (lhs: Self, rhs: Self) -> Bool {
+    switch (lhs.match?.range, rhs.match?.range) {
+    case (nil, nil):
+      return true
+    case (nil, _?), (_?, nil):
+      return false
+    case (let lhs?, let rhs?):
+      return lhs.lowerBound == rhs.lowerBound
+    }
+  }
+
+  public static func < (lhs: Self, rhs: Self) -> Bool {
+    switch (lhs.match?.range, rhs.match?.range) {
+    case (nil, _):
+      return false
+    case (_, nil):
+      return true
+    case (let lhs?, let rhs?):
+      return lhs.lowerBound < rhs.lowerBound
+    }
+  }
+}
+
+// MARK: `ReversedMatchesCollection`
+// TODO: reversed matches
+
+public struct ReversedMatchesCollection<
+  Searcher: BackwardMatchingCollectionSearcher
+> {
+  public typealias Base = Searcher.BackwardSearched
+
+  let base: Base
+  let searcher: Searcher
+
+  init(base: Base, searcher: Searcher) {
+    self.base = base
+    self.searcher = searcher
+  }
+}
+
+extension ReversedMatchesCollection: Sequence {
+  public struct Iterator: IteratorProtocol {
+    let base: Base
+    let searcher: Searcher
+    var state: Searcher.BackwardState
+
+    init(base: Base, searcher: Searcher) {
+      self.base = base
+      self.searcher = searcher
+      self.state = searcher.backwardState(
+        for: base, in: base.startIndex..<base.endIndex)
+    }
+
+    public mutating func next() -> (Searcher.Match, Range<Base.Index>)? {
+      searcher.matchingSearchBack(base, &state)
+    }
+  }
+
+  public func makeIterator() -> Iterator {
+    Iterator(base: base, searcher: searcher)
+  }
+}
+
+//// TODO: `Collection` conformance

--- a/Sources/_StringProcessing/Algorithms/Matching/MatchingCollectionConsumer.swift
+++ b/Sources/_StringProcessing/Algorithms/Matching/MatchingCollectionConsumer.swift
@@ -14,7 +14,7 @@ public protocol MatchingCollectionConsumer: CollectionConsumer {
   func matchingConsuming(
     _ consumed: Consumed,
     in range: Range<Consumed.Index>
-  ) -> (Match, Consumed.Index)?
+  ) -> (upperBound: Consumed.Index, match: Match)?
 }
 
 extension MatchingCollectionConsumer {
@@ -22,7 +22,7 @@ extension MatchingCollectionConsumer {
     _ consumed: Consumed,
     in range: Range<Consumed.Index>
   ) -> Consumed.Index? {
-    matchingConsuming(consumed, in: range)?.1
+    matchingConsuming(consumed, in: range)?.upperBound
   }
 }
 
@@ -34,7 +34,7 @@ public protocol BidirectionalMatchingCollectionConsumer:
   func matchingConsumingBack(
     _ consumed: Consumed,
     in range: Range<Consumed.Index>
-  ) -> (Match, Consumed.Index)?
+  ) -> (lowerBound: Consumed.Index, match: Match)?
 }
 
 extension BidirectionalMatchingCollectionConsumer {
@@ -42,7 +42,7 @@ extension BidirectionalMatchingCollectionConsumer {
     _ consumed: Consumed,
     in range: Range<Consumed.Index>
   ) -> Consumed.Index? {
-    matchingConsumingBack(consumed, in: range)?.1
+    matchingConsumingBack(consumed, in: range)?.lowerBound
   }
 }
 

--- a/Sources/_StringProcessing/Algorithms/Matching/MatchingCollectionConsumer.swift
+++ b/Sources/_StringProcessing/Algorithms/Matching/MatchingCollectionConsumer.swift
@@ -1,0 +1,48 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2021-2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+public protocol MatchingCollectionConsumer: CollectionConsumer {
+  associatedtype Match
+  func matchingConsuming(
+    _ consumed: Consumed,
+    in range: Range<Consumed.Index>
+  ) -> (Match, Consumed.Index)?
+}
+
+extension MatchingCollectionConsumer {
+  public func consuming(
+    _ consumed: Consumed,
+    in range: Range<Consumed.Index>
+  ) -> Consumed.Index? {
+    matchingConsuming(consumed, in: range)?.1
+  }
+}
+
+// MARK: Consuming from the back
+
+public protocol BidirectionalMatchingCollectionConsumer:
+  MatchingCollectionConsumer, BidirectionalCollectionConsumer
+{
+  func matchingConsumingBack(
+    _ consumed: Consumed,
+    in range: Range<Consumed.Index>
+  ) -> (Match, Consumed.Index)?
+}
+
+extension BidirectionalMatchingCollectionConsumer {
+  public func consumingBack(
+    _ consumed: Consumed,
+    in range: Range<Consumed.Index>
+  ) -> Consumed.Index? {
+    matchingConsumingBack(consumed, in: range)?.1
+  }
+}
+

--- a/Sources/_StringProcessing/Algorithms/Matching/MatchingCollectionSearcher.swift
+++ b/Sources/_StringProcessing/Algorithms/Matching/MatchingCollectionSearcher.swift
@@ -14,7 +14,7 @@ public protocol MatchingCollectionSearcher: CollectionSearcher {
   func matchingSearch(
     _ searched: Searched,
     _ state: inout State
-  ) -> (Match, Range<Searched.Index>)?
+  ) -> (range: Range<Searched.Index>, match: Match)?
 }
 
 extension MatchingCollectionSearcher {
@@ -22,7 +22,7 @@ extension MatchingCollectionSearcher {
     _ searched: Searched,
     _ state: inout State
   ) -> Range<Searched.Index>? {
-    matchingSearch(searched, &state)?.1
+    matchingSearch(searched, &state)?.range
   }
 }
 
@@ -32,7 +32,7 @@ public protocol MatchingStatelessCollectionSearcher:
   func matchingSearch(
     _ searched: Searched,
     in range: Range<Searched.Index>
-  ) -> (Match, Range<Searched.Index>)?
+  ) -> (range: Range<Searched.Index>, match: Match)?
 }
 
 extension MatchingStatelessCollectionSearcher {
@@ -42,18 +42,18 @@ extension MatchingStatelessCollectionSearcher {
     _ searched: Searched,
     _ state: inout State
   ) -> Range<Searched.Index>? {
-    matchingSearch(searched, &state)?.1
+    matchingSearch(searched, &state)?.range
   }
   
   public func matchingSearch(
     _ searched: Searched,
     _ state: inout State
-  ) -> (Match, Range<Searched.Index>)? {
+  ) -> (range: Range<Searched.Index>, match: Match)? {
     // TODO: deduplicate this logic with `StatelessCollectionSearcher`?
     
     guard
       case .index(let index) = state.position,
-      let (value, range) = matchingSearch(searched, in: index..<state.end)
+      let (range, value) = matchingSearch(searched, in: index..<state.end)
     else { return nil }
     
     if range.isEmpty {
@@ -66,14 +66,14 @@ extension MatchingStatelessCollectionSearcher {
       state.position = .index(range.upperBound)
     }
     
-    return (value, range)
+    return (range, value)
   }
   
   public func search(
     _ searched: Searched,
     in range: Range<Searched.Index>
   ) -> Range<Searched.Index>? {
-    matchingSearch(searched, in: range)?.1
+    matchingSearch(searched, in: range)?.range
   }
 }
 
@@ -84,7 +84,7 @@ public protocol BackwardMatchingCollectionSearcher: BackwardCollectionSearcher {
   func matchingSearchBack(
     _ searched: BackwardSearched,
     _ state: inout BackwardState
-  ) -> (Match, Range<BackwardSearched.Index>)?
+  ) -> (range: Range<BackwardSearched.Index>, match: Match)?
 }
 
 public protocol BackwardMatchingStatelessCollectionSearcher:
@@ -93,7 +93,7 @@ public protocol BackwardMatchingStatelessCollectionSearcher:
   func matchingSearchBack(
     _ searched: BackwardSearched,
     in range: Range<BackwardSearched.Index>
-  ) -> (Match, Range<BackwardSearched.Index>)?
+  ) -> (range: Range<BackwardSearched.Index>, match: Match)?
 }
 
 extension BackwardMatchingStatelessCollectionSearcher {
@@ -101,18 +101,18 @@ extension BackwardMatchingStatelessCollectionSearcher {
     _ searched: BackwardSearched,
     in range: Range<BackwardSearched.Index>
   ) -> Range<BackwardSearched.Index>? {
-    matchingSearchBack(searched, in: range)?.1
+    matchingSearchBack(searched, in: range)?.range
   }
   
   public func matchingSearchBack(
     _ searched: BackwardSearched,
-    _ state: inout BackwardState) -> (Match, Range<BackwardSearched.Index>)?
+    _ state: inout BackwardState) -> (range: Range<BackwardSearched.Index>, match: Match)?
   {
     // TODO: deduplicate this logic with `StatelessBackwardCollectionSearcher`?
     
     guard
       case .index(let index) = state.position,
-      let (value, range) = matchingSearchBack(searched, in: state.end..<index)
+      let (range, value) = matchingSearchBack(searched, in: state.end..<index)
     else { return nil }
     
     
@@ -126,6 +126,6 @@ extension BackwardMatchingStatelessCollectionSearcher {
       state.position = .index(range.lowerBound)
     }
     
-    return (value, range)
+    return (range, value)
   }
 }

--- a/Sources/_StringProcessing/Algorithms/Matching/MatchingCollectionSearcher.swift
+++ b/Sources/_StringProcessing/Algorithms/Matching/MatchingCollectionSearcher.swift
@@ -36,7 +36,8 @@ public protocol MatchingStatelessCollectionSearcher:
 }
 
 extension MatchingStatelessCollectionSearcher {
-  // for disambiguation
+  // for disambiguation between the `MatchingCollectionSearcher` and
+  // `StatelessCollectionSearcher` overloads
   public func search(
     _ searched: Searched,
     _ state: inout State
@@ -96,6 +97,13 @@ public protocol BackwardMatchingStatelessCollectionSearcher:
 }
 
 extension BackwardMatchingStatelessCollectionSearcher {
+  public func searchBack(
+    _ searched: BackwardSearched,
+    in range: Range<BackwardSearched.Index>
+  ) -> Range<BackwardSearched.Index>? {
+    matchingSearchBack(searched, in: range)?.1
+  }
+  
   public func matchingSearchBack(
     _ searched: BackwardSearched,
     _ state: inout BackwardState) -> (Match, Range<BackwardSearched.Index>)?

--- a/Sources/_StringProcessing/Algorithms/Matching/MatchingCollectionSearcher.swift
+++ b/Sources/_StringProcessing/Algorithms/Matching/MatchingCollectionSearcher.swift
@@ -1,0 +1,123 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2021-2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+public protocol MatchingCollectionSearcher: CollectionSearcher {
+  associatedtype Match
+  func matchingSearch(
+    _ searched: Searched,
+    _ state: inout State
+  ) -> (Match, Range<Searched.Index>)?
+}
+
+extension MatchingCollectionSearcher {
+  public func search(
+    _ searched: Searched,
+    _ state: inout State
+  ) -> Range<Searched.Index>? {
+    matchingSearch(searched, &state)?.1
+  }
+}
+
+public protocol MatchingStatelessCollectionSearcher:
+  MatchingCollectionSearcher, StatelessCollectionSearcher
+{
+  func matchingSearch(
+    _ searched: Searched,
+    in range: Range<Searched.Index>
+  ) -> (Match, Range<Searched.Index>)?
+}
+
+extension MatchingStatelessCollectionSearcher {
+  // for disambiguation
+  public func search(
+    _ searched: Searched,
+    _ state: inout State
+  ) -> Range<Searched.Index>? {
+    matchingSearch(searched, &state)?.1
+  }
+  
+  public func matchingSearch(
+    _ searched: Searched,
+    _ state: inout State
+  ) -> (Match, Range<Searched.Index>)? {
+    // TODO: deduplicate this logic with `StatelessCollectionSearcher`?
+    
+    guard
+      case .index(let index) = state.position,
+      let (value, range) = matchingSearch(searched, in: index..<state.end)
+    else { return nil }
+    
+    if range.isEmpty {
+      if range.upperBound == searched.endIndex {
+        state.position = .done
+      } else {
+        state.position = .index(searched.index(after: range.upperBound))
+      }
+    } else {
+      state.position = .index(range.upperBound)
+    }
+    
+    return (value, range)
+  }
+  
+  public func search(
+    _ searched: Searched,
+    in range: Range<Searched.Index>
+  ) -> Range<Searched.Index>? {
+    matchingSearch(searched, in: range)?.1
+  }
+}
+
+// MARK: Searching from the back
+
+public protocol BackwardMatchingCollectionSearcher: BackwardCollectionSearcher {
+  associatedtype Match
+  func matchingSearchBack(
+    _ searched: BackwardSearched,
+    _ state: inout BackwardState
+  ) -> (Match, Range<BackwardSearched.Index>)?
+}
+
+public protocol BackwardMatchingStatelessCollectionSearcher:
+  BackwardMatchingCollectionSearcher, BackwardStatelessCollectionSearcher
+{
+  func matchingSearchBack(
+    _ searched: BackwardSearched,
+    in range: Range<BackwardSearched.Index>
+  ) -> (Match, Range<BackwardSearched.Index>)?
+}
+
+extension BackwardMatchingStatelessCollectionSearcher {
+  public func matchingSearchBack(
+    _ searched: BackwardSearched,
+    _ state: inout BackwardState) -> (Match, Range<BackwardSearched.Index>)?
+  {
+    // TODO: deduplicate this logic with `StatelessBackwardCollectionSearcher`?
+    
+    guard
+      case .index(let index) = state.position,
+      let (value, range) = matchingSearchBack(searched, in: state.end..<index)
+    else { return nil }
+    
+    
+    if range.isEmpty {
+      if range.lowerBound == searched.startIndex {
+        state.position = .done
+      } else {
+        state.position = .index(searched.index(before: range.lowerBound))
+      }
+    } else {
+      state.position = .index(range.lowerBound)
+    }
+    
+    return (value, range)
+  }
+}

--- a/Sources/_StringProcessing/Algorithms/Searchers/CollectionSearcher.swift
+++ b/Sources/_StringProcessing/Algorithms/Searchers/CollectionSearcher.swift
@@ -55,7 +55,6 @@ extension StatelessCollectionSearcher {
       let range = search(searched, in: index..<state.end)
     else { return nil }
     
-    
     if range.isEmpty {
       if range.upperBound == searched.endIndex {
         state.position = .done
@@ -85,7 +84,7 @@ public protocol BackwardCollectionSearcher {
   ) -> Range<BackwardSearched.Index>?
 }
 
-public protocol StatelessBackwardCollectionSearcher: BackwardCollectionSearcher
+public protocol BackwardStatelessCollectionSearcher: BackwardCollectionSearcher
   where BackwardState == DefaultSearcherState<BackwardSearched>
 {
   func searchBack(
@@ -94,7 +93,7 @@ public protocol StatelessBackwardCollectionSearcher: BackwardCollectionSearcher
   ) -> Range<BackwardSearched.Index>?
 }
 
-extension StatelessBackwardCollectionSearcher {
+extension BackwardStatelessCollectionSearcher {
   public func backwardState(
     for searched: BackwardSearched,
     in range: Range<BackwardSearched.Index>
@@ -124,7 +123,3 @@ extension StatelessBackwardCollectionSearcher {
     return range
   }
 }
-
-public protocol BidirectionalCollectionSearcher: CollectionSearcher,
-                                                 BackwardCollectionSearcher
-  where Searched == BackwardSearched {}

--- a/Sources/_StringProcessing/Algorithms/Searchers/ConsumerSearcher.swift
+++ b/Sources/_StringProcessing/Algorithms/Searchers/ConsumerSearcher.swift
@@ -67,14 +67,14 @@ extension ConsumerSearcher: MatchingCollectionSearcher,
   func matchingSearch(
     _ searched: Searched,
     in range: Range<Searched.Index>
-  ) -> (Consumer.Match, Range<Searched.Index>)? {
+  ) -> (range: Range<Searched.Index>, match: Consumer.Match)? {
     var start = range.lowerBound
     while true {
-      if let (value, end) = consumer.matchingConsuming(
+      if let (end, value) = consumer.matchingConsuming(
         searched,
         in: start..<range.upperBound
       ) {
-        return (value, start..<end)
+        return (start..<end, value)
       } else if start == range.upperBound {
         return nil
       } else {
@@ -93,12 +93,12 @@ extension ConsumerSearcher: BackwardMatchingCollectionSearcher,
   func matchingSearchBack(
     _ searched: BackwardSearched,
     in range: Range<Searched.Index>
-  ) -> (Match, Range<Searched.Index>)? {
+  ) -> (range: Range<Searched.Index>, match: Match)? {
     var end = range.upperBound
     while true {
-      if let (value, start) = consumer.matchingConsumingBack(
+      if let (start, value) = consumer.matchingConsumingBack(
         searched, in: range.lowerBound..<end) {
-        return (value, start..<end)
+        return (start..<end, value)
       } else if end == searched.startIndex {
         return nil
       } else {

--- a/Sources/_StringProcessing/Algorithms/Searchers/ConsumerSearcher.swift
+++ b/Sources/_StringProcessing/Algorithms/Searchers/ConsumerSearcher.swift
@@ -35,7 +35,7 @@ extension ConsumerSearcher: StatelessCollectionSearcher {
 }
 
 extension ConsumerSearcher: BackwardCollectionSearcher,
-                            StatelessBackwardCollectionSearcher
+                            BackwardStatelessCollectionSearcher
   where Consumer: BidirectionalCollectionConsumer
 {
   typealias BackwardSearched = Consumer.Consumed
@@ -49,6 +49,56 @@ extension ConsumerSearcher: BackwardCollectionSearcher,
       if let start = consumer.consumingBack(
         searched, in: range.lowerBound..<end) {
         return start..<end
+      } else if end == searched.startIndex {
+        return nil
+      } else {
+        searched.formIndex(before: &end)
+      }
+    }
+  }
+}
+
+extension ConsumerSearcher: MatchingCollectionSearcher,
+                            MatchingStatelessCollectionSearcher
+  where Consumer: MatchingCollectionConsumer
+{
+  typealias Match = Consumer.Match
+  
+  func matchingSearch(
+    _ searched: Searched,
+    in range: Range<Searched.Index>
+  ) -> (Consumer.Match, Range<Searched.Index>)? {
+    var start = range.lowerBound
+    while true {
+      if let (value, end) = consumer.matchingConsuming(
+        searched,
+        in: start..<range.upperBound
+      ) {
+        return (value, start..<end)
+      } else if start == range.upperBound {
+        return nil
+      } else {
+        searched.formIndex(after: &start)
+      }
+    }
+  }
+}
+
+extension ConsumerSearcher: BackwardMatchingCollectionSearcher,
+                            BackwardMatchingStatelessCollectionSearcher
+  where Consumer: BidirectionalMatchingCollectionConsumer
+{
+  typealias Match = Consumer.Match
+  
+  func matchingSearchBack(
+    _ searched: BackwardSearched,
+    in range: Range<Searched.Index>
+  ) -> (Match, Range<Searched.Index>)? {
+    var end = range.upperBound
+    while true {
+      if let (value, start) = consumer.matchingConsumingBack(
+        searched, in: range.lowerBound..<end) {
+        return (value, start..<end)
       } else if end == searched.startIndex {
         return nil
       } else {

--- a/Sources/_StringProcessing/Algorithms/Searchers/NaivePatternSearcher.swift
+++ b/Sources/_StringProcessing/Algorithms/Searchers/NaivePatternSearcher.swift
@@ -51,7 +51,7 @@ extension NaivePatternSearcher: StatelessCollectionSearcher {
 }
 
 extension NaivePatternSearcher: BackwardCollectionSearcher,
-                                StatelessBackwardCollectionSearcher
+                                BackwardStatelessCollectionSearcher
   where Searched: BidirectionalCollection, Pattern: BidirectionalCollection
 {
   typealias BackwardSearched = Searched

--- a/Sources/_StringProcessing/Algorithms/Searchers/PredicateSearcher.swift
+++ b/Sources/_StringProcessing/Algorithms/Searchers/PredicateSearcher.swift
@@ -26,7 +26,7 @@ extension PredicateSearcher: StatelessCollectionSearcher {
 }
 
 extension PredicateSearcher: BackwardCollectionSearcher,
-                             StatelessBackwardCollectionSearcher
+                             BackwardStatelessCollectionSearcher
   where Searched: BidirectionalCollection
 {
   typealias BackwardSearched = Searched
@@ -42,5 +42,3 @@ extension PredicateSearcher: BackwardCollectionSearcher,
   }
 }
 
-extension PredicateSearcher: BidirectionalCollectionSearcher
-  where Searched: BidirectionalCollection {}

--- a/Sources/_StringProcessing/RegexDSL/Core.swift
+++ b/Sources/_StringProcessing/RegexDSL/Core.swift
@@ -126,7 +126,8 @@ extension RegexProtocol {
   // legacy virtual machines.
   func _match(
     _ input: String,
-    in inputRange: Range<String.Index>
+    in inputRange: Range<String.Index>,
+    mode: MatchMode = .wholeString
   ) -> RegexMatch<Match>? {
     // Casts a Swift tuple to the custom `Tuple<n>`, assuming their memory
     // layout is compatible.
@@ -138,7 +139,7 @@ extension RegexProtocol {
     if regex.ast.hasCapture {
       let vm = HareVM(program: regex.program.legacyLoweredProgram)
       guard let (range, captures) = vm.execute(
-        input: input, in: inputRange, mode: .wholeString
+        input: input, in: inputRange, mode: mode
       )?.destructure else {
         return nil
       }
@@ -157,7 +158,7 @@ extension RegexProtocol {
     }
     let executor = Executor(program: regex.program.loweredProgram)
     guard let result = executor.execute(
-      input: input, in: inputRange, mode: .wholeString
+      input: input, in: inputRange, mode: mode
     ) else {
       return nil
     }

--- a/Tests/RegexTests/AlgorithmsTests.swift
+++ b/Tests/RegexTests/AlgorithmsTests.swift
@@ -114,6 +114,20 @@ class RegexConsumerTests: XCTestCase {
     expectReplace("aab", "a+", "X", "Xb")
     expectReplace("aab", "a*", "X", "XXbX")
   }
+  
+  func testMatches() {
+    let regex = Regex(OneOrMore(.digit).capture { 2 * Int($0)! })
+    let str = "foo 160 bar 99 baz"
+    XCTAssertEqual(str.matches(of: regex).map(\.0.1), [320, 198])
+  }
+  
+  func testMatchReplace() {
+    let regex = Regex(OneOrMore(.digit).capture { Int($0)! })
+    let str = "foo 160 bar 99 baz"
+    XCTAssertEqual(
+      str.replacing(regex, with: { match, _ in String(match.1, radix: 8) }),
+      "foo 240 bar 143 baz")
+  }
 
   func testAdHoc() {
     let r = try! Regex("a|b+")

--- a/Tests/RegexTests/AlgorithmsTests.swift
+++ b/Tests/RegexTests/AlgorithmsTests.swift
@@ -118,15 +118,46 @@ class RegexConsumerTests: XCTestCase {
   func testMatches() {
     let regex = Regex(OneOrMore(.digit).capture { 2 * Int($0)! })
     let str = "foo 160 bar 99 baz"
-    XCTAssertEqual(str.matches(of: regex).map(\.0.1), [320, 198])
+    XCTAssertEqual(str.matches(of: regex).map(\.result.1), [320, 198])
   }
   
   func testMatchReplace() {
-    let regex = Regex(OneOrMore(.digit).capture { Int($0)! })
-    let str = "foo 160 bar 99 baz"
-    XCTAssertEqual(
-      str.replacing(regex, with: { match, _ in String(match.1, radix: 8) }),
-      "foo 240 bar 143 baz")
+    func replaceTest<R: RegexProtocol>(
+      _ regex: R,
+      input: String,
+      result: String,
+      _ replace: (_MatchResult<RegexConsumer<R, Substring>>) -> String,
+      file: StaticString = #file,
+      line: UInt = #line
+    ) {
+      XCTAssertEqual(input.replacing(regex, with: replace), result)
+    }
+    
+    let int = OneOrMore(.digit).capture { Int($0)! }
+    
+    replaceTest(
+      int,
+      input: "foo 160 bar 99 baz",
+      result: "foo 240 bar 143 baz",
+      { match in String(match.result.1, radix: 8) })
+    
+    replaceTest(
+      Regex { int; "+"; int },
+      input: "9+16, 0+3, 5+5, 99+1",
+      result: "25, 3, 10, 100",
+      { match in "\(match.result.1 + match.result.2)" })
+    
+    replaceTest(
+      OneOrMore { int; "," },
+      input: "3,5,8,0, 1,0,2,-5,x8,8,",
+      result: "16 3-5x16",
+      { match in "\(match.result.1.reduce(0, +))" })
+    
+    replaceTest(
+      Regex { int; "x"; int; Optionally { "x"; int } },
+      input: "2x3 5x4x3 6x0 1x2x3x4",
+      result: "6 60 0 6x4",
+      { match in "\(match.result.1 * match.result.2 * (match.result.3 ?? 1))" })
   }
 
   func testAdHoc() {


### PR DESCRIPTION
Adds `MatchingCollectionConsumer` and `MatchingCollectionSearcher` as a matching/validating analogues of `CollectionConsumer` and `CollectionSearcher`:

```swift
public protocol MatchingCollectionConsumer: CollectionConsumer {
  associatedtype Value

  func matchingConsuming(
    _ consumed: Consumed,
    in range: Range<Consumed.Index>
  ) -> (Value, Consumed.Index)?
}

public protocol MatchingCollectionSearcher: CollectionSearcher {
  associatedtype Value

  func matchingSearch(
    _ searched: Searched,
    _ state: inout State
  ) -> (Value, Range<Searched.Index>)?
}
```

...as well as matching equivalents of the other consumer/searcher protocols.

Also adds a few algorithms that work with matches:

* `firstMatch`/`lastMatch`
* `matches(of:)`
* `replacing(_:with:)` using a closure:

```swift
let regex = Regex(OneOrMore(.digit).capture { Int($0)! })
let str = "foo 160 bar 99 baz"
print(str.replacing(regex, with: { match, _ in String(match.1, radix: 8) }))
// foo 240 bar 143 baz
```