### PR TITLE
Parse global matching options and Oniguruma recursion levels

### DIFF
--- a/Sources/_MatchingEngine/Regex/AST/AST.swift
+++ b/Sources/_MatchingEngine/Regex/AST/AST.swift
@@ -38,6 +38,8 @@ public indirect enum AST:
 
   case customCharacterClass(CustomCharacterClass)
 
+  case globalMatchingOptions(GlobalMatchingOptions)
+
   case empty(Empty)
 
   // FIXME: Move off the regex literal AST
@@ -55,16 +57,17 @@ extension AST {
   // over `self` _everywhere_ we want to do anything.
   var _associatedValue: _ASTNode {
     switch self {
-    case let .alternation(v):          return v
-    case let .concatenation(v):        return v
-    case let .group(v):                return v
-    case let .conditional(v):          return v
-    case let .quantification(v):       return v
-    case let .quote(v):                return v
-    case let .trivia(v):               return v
-    case let .atom(v):                 return v
-    case let .customCharacterClass(v): return v
-    case let .empty(v):                return v
+    case let .alternation(v):           return v
+    case let .concatenation(v):         return v
+    case let .group(v):                 return v
+    case let .conditional(v):           return v
+    case let .quantification(v):        return v
+    case let .quote(v):                 return v
+    case let .trivia(v):                return v
+    case let .atom(v):                  return v
+    case let .customCharacterClass(v):  return v
+    case let .empty(v):                 return v
+    case let .globalMatchingOptions(v): return v
 
     case let .groupTransform(g, _):
       return g // FIXME: get this out of here
@@ -113,7 +116,7 @@ extension AST {
     case .group, .conditional, .customCharacterClass:
       return true
     case .alternation, .concatenation, .quantification, .quote, .trivia,
-        .empty, .groupTransform:
+        .empty, .groupTransform, .globalMatchingOptions:
       return false
     }
   }
@@ -226,6 +229,23 @@ extension AST {
     /// Whether this is a reference that recurses the whole pattern, rather than
     /// a group.
     public var recursesWholePattern: Bool { kind == .recurseWholePattern }
+  }
+
+  /// An AST node containing global matching options along with a child that
+  /// uses those options.
+  /// TODO: Should this be subsumed into a top-level AST type?
+  public struct GlobalMatchingOptions: Hashable, _ASTNode {
+    public var options: [AST.GlobalMatchingOption]
+    public var ast: AST
+
+    public init(_ ast: AST, options: [AST.GlobalMatchingOption]) {
+      self.ast = ast
+      self.options = options
+    }
+
+    public var location: SourceLocation {
+      options.first?.location.union(with: ast.location) ?? ast.location
+    }
   }
 }
 

--- a/Sources/_MatchingEngine/Regex/AST/AST.swift
+++ b/Sources/_MatchingEngine/Regex/AST/AST.swift
@@ -207,12 +207,19 @@ extension AST {
     }
     public var kind: Kind
 
+    /// An additional specifier supported by Oniguruma that specifies what
+    /// recursion level the group being referenced belongs to.
+    public var recursionLevel: Located<Int>?
+
     /// The location of the inner numeric or textual reference, e.g the location
-    /// of '-2' in '\g{-2}'.
+    /// of '-2' in '\g{-2}'. Note this includes the recursion level for e.g
+    /// '\k<a+2>'.
     public var innerLoc: SourceLocation
 
-    public init(_ kind: Kind, innerLoc: SourceLocation) {
+    public init(_ kind: Kind, recursionLevel: Located<Int>? = nil,
+                innerLoc: SourceLocation) {
       self.kind = kind
+      self.recursionLevel = recursionLevel
       self.innerLoc = innerLoc
     }
 

--- a/Sources/_MatchingEngine/Regex/AST/ASTProtocols.swift
+++ b/Sources/_MatchingEngine/Regex/AST/ASTProtocols.swift
@@ -40,3 +40,6 @@ extension AST.Group: _ASTParent {
 extension AST.Quantification: _ASTParent {
   var children: [AST] { [child] }
 }
+extension AST.GlobalMatchingOptions: _ASTParent {
+  var children: [AST] { [ast] }
+}

--- a/Sources/_MatchingEngine/Regex/AST/Atom.swift
+++ b/Sources/_MatchingEngine/Regex/AST/Atom.swift
@@ -77,6 +77,32 @@ extension AST {
 }
 
 extension AST.Atom {
+  private var _associatedValue: Any? {
+    switch kind {
+    case .char(let v):                  return v
+    case .scalar(let v):                return v
+    case .property(let v):              return v
+    case .escaped(let v):               return v
+    case .keyboardControl(let v):       return v
+    case .keyboardMeta(let v):          return v
+    case .keyboardMetaControl(let v):   return v
+    case .namedCharacter(let v):        return v
+    case .backreference(let v):         return v
+    case .subpattern(let v):            return v
+    case .callout(let v):               return v
+    case .backtrackingDirective(let v): return v
+    case .any:                          return nil
+    case .startOfLine:                  return nil
+    case .endOfLine:                    return nil
+    }
+  }
+
+  func `as`<T>(_ t: T.Type = T.self) -> T? {
+    _associatedValue as? T
+  }
+}
+
+extension AST.Atom {
 
   // TODO: We might scrap this and break out a few categories so
   // we can pull in `^`, `$`, and `.`, but we probably want to

--- a/Sources/_MatchingEngine/Regex/AST/Atom.swift
+++ b/Sources/_MatchingEngine/Regex/AST/Atom.swift
@@ -594,7 +594,7 @@ extension AST {
     case .alternation, .concatenation, .group,
         .conditional, .quantification, .quote,
         .trivia, .customCharacterClass, .empty,
-        .groupTransform:
+        .groupTransform, .globalMatchingOptions:
       return nil
     }
   }

--- a/Sources/_MatchingEngine/Regex/AST/MatchingOptions.swift
+++ b/Sources/_MatchingEngine/Regex/AST/MatchingOptions.swift
@@ -91,3 +91,90 @@ extension AST.MatchingOptionSequence: _ASTPrintable {
     "adding: \(adding), removing: \(removing), hasCaret: \(caretLoc != nil)"
   }
 }
+
+extension AST {
+  /// Global matching option specifiers. Unlike `MatchingOptionSequence`,
+  /// these must appear at the start of the pattern, and apply globally.
+  public struct GlobalMatchingOption: _ASTNode, Hashable {
+    /// Determines what the definition of a newline for the '.' character class.
+    public enum NewlineMatching: Hashable {
+      /// (*CR*)
+      case carriageReturnOnly
+      
+      /// (*LF)
+      case linefeedOnly
+
+      /// (*CRLF)
+      case carriageAndLinefeedOnly
+
+      /// (*ANYCRLF)
+      case anyCarriageReturnOrLinefeed
+
+      /// (*ANY)
+      case anyUnicode
+
+      /// (*NUL)
+      case nulCharacter
+    }
+    /// Determines what `\R` matches.
+    public enum NewlineSequenceMatching: Hashable {
+      /// (*BSR_ANYCRLF)
+      case anyCarriageReturnOrLinefeed
+
+      /// (*BSR_UNICODE)
+      case anyUnicode
+    }
+    public enum Kind: Hashable {
+      /// (*LIMIT_DEPTH=d)
+      case limitDepth(Located<Int>)
+
+      /// (*LIMIT_HEAP=d)
+      case limitHeap(Located<Int>)
+
+      /// (*LIMIT_MATCH=d)
+      case limitMatch(Located<Int>)
+
+      /// (*NOTEMPTY)
+      case notEmpty
+
+      /// (*NOTEMPTY_ATSTART)
+      case notEmptyAtStart
+
+      /// (*NO_AUTO_POSSESS)
+      case noAutoPossess
+
+      /// (*NO_DOTSTAR_ANCHOR)
+      case noDotStarAnchor
+
+      /// (*NO_JIT)
+      case noJIT
+
+      /// (*NO_START_OPT)
+      case noStartOpt
+
+      /// (*UTF)
+      case utfMode
+
+      /// (*UCP)
+      case unicodeProperties
+
+      case newlineMatching(NewlineMatching)
+      case newlineSequenceMatching(NewlineSequenceMatching)
+    }
+    public var kind: Kind
+    public var location: SourceLocation
+
+    public init(_ kind: Kind, _ location: SourceLocation) {
+      self.kind = kind
+      self.location = location
+    }
+  }
+}
+
+extension AST.GlobalMatchingOption: _ASTPrintable {
+  public var _dumpBase: String { "\(kind)" }
+}
+
+extension AST.GlobalMatchingOption.Kind: _ASTPrintable {
+  public var _dumpBase: String { _canonicalBase }
+}

--- a/Sources/_MatchingEngine/Regex/Parse/CaptureStructure.swift
+++ b/Sources/_MatchingEngine/Regex/Parse/CaptureStructure.swift
@@ -29,6 +29,8 @@ extension AST {
   public var captureStructure: CaptureStructure {
     // Note: This implementation could be more optimized.
     switch self {
+    case .globalMatchingOptions(let o):
+      return o.ast.captureStructure
     case .alternation(let alternation):
       assert(alternation.children.count > 1)
       return alternation.children

--- a/Sources/_MatchingEngine/Regex/Parse/Diagnostics.swift
+++ b/Sources/_MatchingEngine/Regex/Parse/Diagnostics.swift
@@ -31,6 +31,8 @@ enum ParseError: Error, Hashable {
   case tooManyBranchesInConditional(Int)
   case unsupportedCondition(String)
 
+  case globalMatchingOptionNotAtStart(String)
+
   case expectedASCII(Character)
 
   case expectedNonEmptyContents
@@ -96,6 +98,8 @@ extension ParseError: CustomStringConvertible {
       return "expected 2 branches in conditional, have \(i)"
     case let .unsupportedCondition(str):
       return "\(str) cannot be used as condition"
+    case let .globalMatchingOptionNotAtStart(opt):
+      return "matching option '\(opt)' may only appear at the start of the regex"
     case let .unknownGroupKind(str):
       return "unknown group kind '(\(str)'"
     case let .unknownCalloutKind(str):

--- a/Sources/_MatchingEngine/Regex/Parse/LexicalAnalysis.swift
+++ b/Sources/_MatchingEngine/Regex/Parse/LexicalAnalysis.swift
@@ -1495,6 +1495,12 @@ extension Source {
         return .backtrackingDirective(b)
       }
 
+      // Global matching options can only appear at the very start.
+      if let opt = try src.lexGlobalMatchingOption() {
+        throw ParseError.globalMatchingOptionNotAtStart(
+          String(src[opt.location.range]))
+      }
+
       // If we didn't produce an atom, consume up until a reasonable end-point
       // and throw an error.
       try src.expect("(")
@@ -1583,6 +1589,103 @@ extension Source {
       return nil
     }
     return (dash, end)
+  }
+
+  /// Try to consume a newline sequence matching option kind.
+  ///
+  ///     NewlineSequenceKind -> 'BSR_ANYCRLF' | 'BSR_UNICODE'
+  ///
+  private mutating func lexNewlineSequenceMatchingOption(
+  ) throws -> AST.GlobalMatchingOption.NewlineSequenceMatching? {
+    if tryEat(sequence: "BSR_ANYCRLF") { return .anyCarriageReturnOrLinefeed }
+    if tryEat(sequence: "BSR_UNICODE") { return .anyUnicode }
+    return nil
+  }
+
+  /// Try to consume a newline matching option kind.
+  ///
+  ///     NewlineKind -> 'CRLF' | 'CR' | 'ANYCRLF' | 'ANY' | 'LF' | 'NUL'
+  ///
+  private mutating func lexNewlineMatchingOption(
+  ) throws -> AST.GlobalMatchingOption.NewlineMatching? {
+    // The ordering here is important: CRLF needs to precede CR, and ANYCRLF
+    // needs to precede ANY to ensure we don't short circuit on the wrong one.
+    if tryEat(sequence: "CRLF") { return .carriageAndLinefeedOnly }
+    if tryEat(sequence: "CR") { return .carriageReturnOnly }
+    if tryEat(sequence: "ANYCRLF") { return .anyCarriageReturnOrLinefeed }
+    if tryEat(sequence: "ANY") { return .anyUnicode }
+
+    if tryEat(sequence: "LF") { return .linefeedOnly }
+    if tryEat(sequence: "NUL") { return .nulCharacter }
+    return nil
+  }
+
+  /// Try to consume a global matching option kind, returning `nil` if
+  /// unsuccessful.
+  ///
+  ///     GlobalMatchingOptionKind -> LimitOptionKind '=' <Int>
+  ///                               | NewlineKind | NewlineSequenceKind
+  ///                               | 'NOTEMPTY_ATSTART' | 'NOTEMPTY'
+  ///                               | 'NO_AUTO_POSSESS' | 'NO_DOTSTAR_ANCHOR'
+  ///                               | 'NO_JIT' | 'NO_START_OPT' | 'UTF' | 'UCP'
+  ///
+  ///     LimitOptionKind          -> 'LIMIT_DEPTH' | 'LIMIT_HEAP'
+  ///                               | 'LIMIT_MATCH'
+  ///
+  private mutating func lexGlobalMatchingOptionKind(
+  ) throws -> Located<AST.GlobalMatchingOption.Kind>? {
+    try recordLoc { src in
+      if let opt = try src.lexNewlineSequenceMatchingOption() {
+        return .newlineSequenceMatching(opt)
+      }
+      if let opt = try src.lexNewlineMatchingOption() {
+        return .newlineMatching(opt)
+      }
+      if src.tryEat(sequence: "LIMIT_DEPTH") {
+        try src.expect("=")
+        return .limitDepth(try src.expectNumber())
+      }
+      if src.tryEat(sequence: "LIMIT_HEAP") {
+        try src.expect("=")
+        return .limitHeap(try src.expectNumber())
+      }
+      if src.tryEat(sequence: "LIMIT_MATCH") {
+        try src.expect("=")
+        return .limitMatch(try src.expectNumber())
+      }
+
+      // The ordering here is important: NOTEMPTY_ATSTART needs to precede
+      // NOTEMPTY to ensure we don't short circuit on the wrong one.
+      if src.tryEat(sequence: "NOTEMPTY_ATSTART") { return .notEmptyAtStart }
+      if src.tryEat(sequence: "NOTEMPTY") { return .notEmpty }
+
+      if src.tryEat(sequence: "NO_AUTO_POSSESS") { return .noAutoPossess }
+      if src.tryEat(sequence: "NO_DOTSTAR_ANCHOR") { return .noDotStarAnchor }
+      if src.tryEat(sequence: "NO_JIT") { return .noJIT }
+      if src.tryEat(sequence: "NO_START_OPT") { return .noStartOpt }
+      if src.tryEat(sequence: "UTF") { return .utfMode }
+      if src.tryEat(sequence: "UCP") { return .unicodeProperties }
+      return nil
+    }
+  }
+
+  /// Try to consume a global matching option, returning `nil` if unsuccessful.
+  ///
+  ///     GlobalMatchingOption -> '(*' GlobalMatchingOptionKind ')'
+  ///
+  mutating func lexGlobalMatchingOption(
+  ) throws -> AST.GlobalMatchingOption? {
+    let kind = try recordLoc { src -> AST.GlobalMatchingOption.Kind? in
+      try src.tryEating { src in
+        guard src.tryEat(sequence: "(*"),
+              let kind = try src.lexGlobalMatchingOptionKind()?.value
+        else { return nil }
+        try src.expect(")")
+        return kind
+      }
+    }
+    guard let kind = kind else { return nil }
+    return .init(kind.value, kind.location)
   }
 }
 

--- a/Sources/_MatchingEngine/Regex/Parse/LexicalAnalysis.swift
+++ b/Sources/_MatchingEngine/Regex/Parse/LexicalAnalysis.swift
@@ -865,8 +865,6 @@ extension Source {
           return .recursionCheck
         }
 
-        // TODO: Oniguruma can also parse an additional recursion level for
-        // group-matched checks.
         if let open = src.tryEat(anyOf: "<", "'") {
           // In PCRE, this can only be a named reference. In Oniguruma, it can
           // also be a numbered reference.
@@ -884,9 +882,9 @@ extension Source {
         }
 
         // If we have a numbered reference, this is a check to see if a group
-        // matched.
-        if let numRef = try src.lexNumberedReference() {
-          return .groupMatched(numRef)
+        // matched. Oniguruma also permits a recursion level here.
+        if let num = try src.lexNumberedReference(allowRecursionLevel: true) {
+          return .groupMatched(num)
         }
 
         // PCRE and .NET also allow a named reference to be parsed here. PCRE
@@ -896,9 +894,9 @@ extension Source {
         // FIXME: This should apply to future groups too.
         // TODO: We should probably advise users to use the more explicit
         // syntax.
-        if let nameRef = src.lexNamedReference(endingWith: ")",
-                                               eatEnding: false),
-           context.isPriorGroupRef(nameRef.kind) {
+        let nameRef = src.lexNamedReference(
+          endingWith: ")", eatEnding: false, allowRecursionLevel: true)
+        if let nameRef = nameRef, context.isPriorGroupRef(nameRef.kind) {
           return .groupMatched(nameRef)
         }
         return nil
@@ -1052,10 +1050,10 @@ extension Source {
 
   /// Try to lex an absolute or relative numbered reference.
   ///
-  ///     NumberRef -> ('+' | '-')? <Decimal Number>
+  ///     NumberRef -> ('+' | '-')? <Decimal Number> RecursionLevel?
   ///
   private mutating func lexNumberedReference(
-    allowWholePatternRef: Bool = false
+    allowWholePatternRef: Bool = false, allowRecursionLevel: Bool = false
   ) throws -> AST.Reference? {
     let kind = try recordLoc { src -> AST.Reference.Kind? in
       // Note this logic should match canLexNumberedReference.
@@ -1074,7 +1072,22 @@ extension Source {
     guard allowWholePatternRef || kind.value != .recurseWholePattern else {
       throw ParseError.cannotReferToWholePattern
     }
-    return .init(kind.value, innerLoc: kind.location)
+    let recLevel = allowRecursionLevel ? try lexRecursionLevel() : nil
+    let loc = recLevel?.location.union(with: kind.location) ?? kind.location
+    return .init(kind.value, recursionLevel: recLevel, innerLoc: loc)
+  }
+
+  /// Try to consume a recursion level for a group reference.
+  ///
+  ///     RecursionLevel -> '+' <Int> | '-' <Int>
+  ///
+  private mutating func lexRecursionLevel(
+  ) throws -> Located<Int>? {
+    try recordLoc { src in
+      if src.tryEat("+") { return try src.expectNumber().value }
+      if src.tryEat("-") { return try -src.expectNumber().value }
+      return nil
+    }
   }
 
   /// Checks whether a numbered reference can be lexed.
@@ -1087,19 +1100,34 @@ extension Source {
 
   /// Eat a named reference up to a given closing delimiter.
   private mutating func expectNamedReference(
-    endingWith end: String, eatEnding: Bool = true
+    endingWith end: String, eatEnding: Bool = true,
+    allowRecursionLevel: Bool = false
   ) throws -> AST.Reference {
-    let str = try expectGroupName(endingWith: end, eatEnding: eatEnding)
-    return .init(.named(str.value), innerLoc: str.location)
+    // Note we don't want to eat the ending as we may also want to parse a
+    // recursion level.
+    let str = try expectGroupName(endingWith: end, eatEnding: false)
+
+    // If we're allowed to, try parse a recursion level.
+    let recLevel = allowRecursionLevel ? try lexRecursionLevel() : nil
+    let loc = recLevel?.location.union(with: str.location) ?? str.location
+
+    if eatEnding {
+      try expect(sequence: end)
+    }
+    return .init(.named(str.value), recursionLevel: recLevel, innerLoc: loc)
   }
 
   /// Try to consume a named reference up to a closing delimiter, returning
   /// `nil` if the characters aren't valid for a named reference.
   private mutating func lexNamedReference(
-    endingWith end: String, eatEnding: Bool = true
+    endingWith end: String, eatEnding: Bool = true,
+    allowRecursionLevel: Bool = false
   ) -> AST.Reference? {
     tryEating { src in
-      try? src.expectNamedReference(endingWith: end, eatEnding: eatEnding)
+      try? src.expectNamedReference(
+        endingWith: end, eatEnding: eatEnding,
+        allowRecursionLevel: allowRecursionLevel
+      )
     }
   }
 
@@ -1109,17 +1137,22 @@ extension Source {
   ///
   private mutating func expectNamedOrNumberedReference(
     endingWith ending: String, eatEnding: Bool = true,
-    allowWholePatternRef: Bool = false
+    allowWholePatternRef: Bool = false, allowRecursionLevel: Bool = false
   ) throws -> AST.Reference {
-    if let numbered = try lexNumberedReference(
-      allowWholePatternRef: allowWholePatternRef
-    ) {
+    let num = try lexNumberedReference(
+      allowWholePatternRef: allowWholePatternRef,
+      allowRecursionLevel: allowRecursionLevel
+    )
+    if let num = num {
       if eatEnding {
         try expect(sequence: ending)
       }
-      return numbered
+      return num
     }
-    return try expectNamedReference(endingWith: ending, eatEnding: eatEnding)
+    return try expectNamedReference(
+      endingWith: ending, eatEnding: eatEnding,
+      allowRecursionLevel: allowRecursionLevel
+    )
   }
 
   private static func getClosingDelimiter(
@@ -1183,10 +1216,9 @@ extension Source {
             // Perl only accept named references here, but Oniguruma and .NET
             // also accepts numbered references. This shouldn't be an ambiguity
             // as named references may not begin with a digit, '-', or '+'.
-            let ref = try src.expectNamedOrNumberedReference(
-              endingWith: closing)
-
-            return .backreference(ref)
+            // Oniguruma also allows a recursion level to be specified.
+            return .backreference(try src.expectNamedOrNumberedReference(
+              endingWith: closing, allowRecursionLevel: true))
           }
           // Perl/.NET also allow a named references with the '{' delimiter.
           if src.tryEat("{") {
@@ -1210,10 +1242,10 @@ extension Source {
         // here.
         if firstChar != "0", let numAndLoc = try src.lexNumber() {
           let num = numAndLoc.value
-          let loc = numAndLoc.location
+          let ref = AST.Reference(.absolute(num), innerLoc: numAndLoc.location)
           if num < 10 || firstChar == "8" || firstChar == "9" ||
-              context.isPriorGroupRef(.absolute(num)) {
-            return .backreference(.init(.absolute(num), innerLoc: loc))
+              context.isPriorGroupRef(ref.kind) {
+            return .backreference(ref)
           }
           return nil
         }

--- a/Sources/_MatchingEngine/Regex/Parse/SourceLocation.swift
+++ b/Sources/_MatchingEngine/Regex/Parse/SourceLocation.swift
@@ -36,6 +36,12 @@ extension Source {
     }
     public var isFake: Bool { self == Self.fake }
     public var isReal: Bool { !isFake }
+
+    /// Returns the smallest location that contains both this location and
+    /// another.
+    public func union(with other: Location) -> SourceLocation {
+      .init(min(start, other.start) ..< max(end, other.end))
+    }
   }
 }
 public typealias SourceLocation = Source.Location

--- a/Sources/_MatchingEngine/Regex/Printing/DumpAST.swift
+++ b/Sources/_MatchingEngine/Regex/Printing/DumpAST.swift
@@ -149,7 +149,11 @@ extension AST.Atom.Callout: _ASTPrintable {
 
 extension AST.Reference: _ASTPrintable {
   public var _dumpBase: String {
-    "\(kind)"
+    var result = "\(kind)"
+    if let recursionLevel = recursionLevel {
+      result += "\(recursionLevel.value)"
+    }
+    return result
   }
 }
 

--- a/Sources/_MatchingEngine/Regex/Printing/DumpAST.swift
+++ b/Sources/_MatchingEngine/Regex/Printing/DumpAST.swift
@@ -268,3 +268,10 @@ extension AST.Group.BalancedCapture: _ASTPrintable {
    "\(name?.value ?? "")-\(priorName.value)"
   }
 }
+
+extension AST.GlobalMatchingOptions: _ASTPrintable {
+  public var _dumpBase: String {
+    if options.isEmpty { return "\(ast)" }
+    return "globalMatchingOptions<options: \(options)> \(ast)"
+  }
+}

--- a/Sources/_MatchingEngine/Regex/Printing/PrintAsCanonical.swift
+++ b/Sources/_MatchingEngine/Regex/Printing/PrintAsCanonical.swift
@@ -47,6 +47,12 @@ extension PrettyPrinter {
   /// or affect internal state
   mutating func outputAsCanonical(_ ast: AST) {
     switch ast {
+    case let .globalMatchingOptions(o):
+      for opt in o.options {
+        outputAsCanonical(opt)
+      }
+      outputAsCanonical(o.ast)
+
     case let .alternation(a):
       for idx in a.children.indices {
         outputAsCanonical(a.children[idx])
@@ -125,6 +131,10 @@ extension PrettyPrinter {
 
   mutating func outputAsCanonical(_ condition: AST.Conditional.Condition) {
     output("(/*TODO: conditional \(condition) */)")
+  }
+
+  mutating func outputAsCanonical(_ opt: AST.GlobalMatchingOption) {
+    output(opt._canonicalBase)
   }
 }
 
@@ -226,4 +236,50 @@ extension AST.Group.BalancedCapture {
   var _canonicalBase: String {
     "\(name?.value ?? "")-\(priorName.value)"
   }
+}
+
+extension AST.GlobalMatchingOption.NewlineMatching {
+  var _canonicalBase: String {
+    switch self {
+    case .carriageReturnOnly:          return "CR"
+    case .linefeedOnly:                return "LF"
+    case .carriageAndLinefeedOnly:     return "CRLF"
+    case .anyCarriageReturnOrLinefeed: return "ANYCRLF"
+    case .anyUnicode:                  return "ANY"
+    case .nulCharacter:                return "NUL"
+    }
+  }
+}
+
+extension AST.GlobalMatchingOption.NewlineSequenceMatching {
+  var _canonicalBase: String {
+    switch self {
+    case .anyCarriageReturnOrLinefeed: return "BSR_ANYCRLF"
+    case .anyUnicode:                  return "BSR_UNICODE"
+    }
+  }
+}
+
+extension AST.GlobalMatchingOption.Kind {
+  var _canonicalBase: String {
+    switch self {
+    case .limitDepth(let i):              return "LIMIT_DEPTH=\(i.value)"
+    case .limitHeap(let i):               return "LIMIT_HEAP=\(i.value)"
+    case .limitMatch(let i):              return "LIMIT_MATCH=\(i.value)"
+    case .notEmpty:                       return "NOTEMPTY"
+    case .notEmptyAtStart:                return "NOTEMPTY_ATSTART"
+    case .noAutoPossess:                  return "NO_AUTO_POSSESS"
+    case .noDotStarAnchor:                return "NO_DOTSTAR_ANCHOR"
+    case .noJIT:                          return "NO_JIT"
+    case .noStartOpt:                     return "NO_START_OPT"
+    case .utfMode:                        return "UTF"
+    case .unicodeProperties:              return "UCP"
+    case .newlineMatching(let m):         return m._canonicalBase
+    case .newlineSequenceMatching(let m): return m._canonicalBase
+    }
+  }
+}
+
+extension AST.GlobalMatchingOption {
+  var _canonicalBase: String { "(*\(kind))"}
 }

--- a/Sources/_MatchingEngine/Regex/Printing/PrintAsPattern.swift
+++ b/Sources/_MatchingEngine/Regex/Printing/PrintAsPattern.swift
@@ -48,6 +48,10 @@ extension PrettyPrinter {
     }
 
     switch ast {
+    case let .globalMatchingOptions(o):
+      // TODO: Global options.
+      printAsPattern(o.ast)
+
     case let .alternation(a):
       printBlock("Alternation") { printer in
         a.children.forEach { printer.printAsPattern($0) }

--- a/Sources/_StringProcessing/ASTBuilder.swift
+++ b/Sources/_StringProcessing/ASTBuilder.swift
@@ -47,6 +47,12 @@ func empty() -> AST {
   .empty(.init(.fake))
 }
 
+func globalMatchingOptions(
+  _ opts: [AST.GlobalMatchingOption.Kind], _ child: AST
+) -> AST {
+  .globalMatchingOptions(.init(child, options: opts.map { .init($0, .fake) }))
+}
+
 func group(
   _ kind: AST.Group.Kind, _ child: AST
 ) -> AST {

--- a/Sources/_StringProcessing/ASTBuilder.swift
+++ b/Sources/_StringProcessing/ASTBuilder.swift
@@ -139,17 +139,21 @@ func unsetMatchingOptions(
   unsetMatchingOptions(adding: adding)
 }
 
-func ref(_ i: Int) -> AST.Reference {
-  .init(.absolute(i), innerLoc: .fake)
+func ref(_ i: Int, recursionLevel: Int? = nil) -> AST.Reference {
+  .init(.absolute(i), recursionLevel: recursionLevel.map { .init(faking: $0) },
+        innerLoc: .fake)
 }
-func ref(plus n: Int) -> AST.Reference {
-  .init(.relative(n), innerLoc: .fake)
+func ref(plus n: Int, recursionLevel: Int? = nil) -> AST.Reference {
+  .init(.relative(n), recursionLevel: recursionLevel.map { .init(faking: $0) },
+        innerLoc: .fake)
 }
-func ref(minus n: Int) -> AST.Reference {
-  .init(.relative(-n), innerLoc: .fake)
+func ref(minus n: Int, recursionLevel: Int? = nil) -> AST.Reference {
+  .init(.relative(-n), recursionLevel: recursionLevel.map { .init(faking: $0) },
+        innerLoc: .fake)
 }
-func ref(_ s: String) -> AST.Reference {
-  .init(.named(s), innerLoc: .fake)
+func ref(_ s: String, recursionLevel: Int? = nil) -> AST.Reference {
+  .init(.named(s), recursionLevel: recursionLevel.map { .init(faking: $0) },
+        innerLoc: .fake)
 }
 func conditional(
   _ cond: AST.Conditional.Condition.Kind, trueBranch: AST, falseBranch: AST
@@ -286,8 +290,10 @@ func scalar_m(_ s: Unicode.Scalar) -> AST.CustomCharacterClass.Member {
   atom_m(.scalar(s))
 }
 
-func backreference(_ r: AST.Reference.Kind) -> AST {
-  atom(.backreference(.init(r, innerLoc: .fake)))
+func backreference(_ r: AST.Reference.Kind, recursionLevel: Int? = nil) -> AST {
+  atom(.backreference(.init(
+    r, recursionLevel: recursionLevel.map { .init(faking: $0) }, innerLoc: .fake
+  )))
 }
 func subpattern(_ r: AST.Reference.Kind) -> AST {
   atom(.subpattern(.init(r, innerLoc: .fake)))

--- a/Sources/_StringProcessing/Compiler.swift
+++ b/Sources/_StringProcessing/Compiler.swift
@@ -42,6 +42,10 @@ class Compiler {
   func emit(_ node: AST) throws {
 
     switch node {
+    case .globalMatchingOptions(let o):
+      // TODO: Global matching options
+      try emit(o.ast)
+
     // Any: .
     //     consume 1
     case .atom(let a) where a.kind == .any && matchLevel == .graphemeCluster:

--- a/Sources/_StringProcessing/ConsumerInterface.swift
+++ b/Sources/_StringProcessing/ConsumerInterface.swift
@@ -46,6 +46,9 @@ extension AST {
     _ opts: CharacterClass.MatchLevel
   ) throws -> Program<String>.ConsumeFunction? {
     switch self {
+    case .globalMatchingOptions(let o):
+      // TODO: Handle global options.
+      return try o.ast.generateConsumer(opts)
     case .atom(let a):
       return try a.generateConsumer(opts)
     case .customCharacterClass(let ccc):

--- a/Sources/_StringProcessing/Legacy/LegacyCompile.swift
+++ b/Sources/_StringProcessing/Legacy/LegacyCompile.swift
@@ -28,6 +28,11 @@ func compile(
     }
 
     switch ast {
+    case .globalMatchingOptions(let o):
+      // TODO: Global matching options?
+      try compileNode(o.ast)
+      return
+
     case .trivia, .empty: return
 
     case .quote(let s):

--- a/Tests/RegexTests/ParseTests.swift
+++ b/Tests/RegexTests/ParseTests.swift
@@ -846,6 +846,10 @@ extension RegexTests {
     parseTest(#"\g{52}"#, backreference(.absolute(52)))
     parseTest(#"\g{-01}"#, backreference(.relative(-1)))
     parseTest(#"\g{+30}"#, backreference(.relative(30)))
+    parseTest(#"\k<+4>"#, backreference(.relative(4)))
+    parseTest(#"\k<2>"#, backreference(.absolute(2)))
+    parseTest(#"\k'-3'"#, backreference(.relative(-3)))
+    parseTest(#"\k'1'"#, backreference(.absolute(1)))
 
     parseTest(#"\k{a0}"#, backreference(.named("a0")))
     parseTest(#"\k<bc>"#, backreference(.named("bc")))
@@ -1335,8 +1339,8 @@ extension RegexTests {
     diagnosticTest(#"\k'#'"#, .groupNameMustBeAlphaNumeric)
     diagnosticTest(#"(?&#)"#, .groupNameMustBeAlphaNumeric)
 
-    diagnosticTest(#"\k'1'"#, .groupNameCannotStartWithNumber)
     diagnosticTest(#"(?P>1)"#, .groupNameCannotStartWithNumber)
+    diagnosticTest(#"\k{1}"#, .groupNameCannotStartWithNumber)
 
     // MARK: Conditionals
 


### PR DESCRIPTION
- Parse the PCRE global matching options e.g `(*CR)`, `(*UTF)`, and `(*LIMIT_DEPTH=d)`. Such options may only appear at the very start of the regex. For now, this forms a new AST node, but in the future we may want to subsume it into a top-level AST type.

- Parse an additional `+n` or `-n` suffix on references in conditionals and the `\k` backreference, which is valid Oniguruma that allows a recursion level to be specified for the reference.

- Also correct parsing for `\k<...>` such that it allows a numeric reference, which is permitted by Oniguruma and .NET.