### PR TITLE
PEG: remove errant XCTest dependency

### DIFF
--- a/Sources/Prototypes/PEG/PEGInterpreter.swift
+++ b/Sources/Prototypes/PEG/PEGInterpreter.swift
@@ -9,7 +9,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-import XCTest
 extension PEG {
   struct Grammar {
     var environment: Dictionary<String, Pattern>


### PR DESCRIPTION
Remove errant `import XCTest`.  The core libraries should not depend on the testing framework.