### PR TITLE
DSL quantifier types -> quantifier functions

### DIFF
--- a/Sources/Exercises/Participants/RegexParticipant.swift
+++ b/Sources/Exercises/Participants/RegexParticipant.swift
@@ -80,16 +80,16 @@ private func graphemeBreakPropertyData(
   forLine line: String
 ) -> GraphemeBreakEntry? {
   line.match {
-    OneOrMore(.hexDigit).tryCapture(Unicode.Scalar.init(hex:))
-    Optionally {
+    oneOrMore(.hexDigit).tryCapture(Unicode.Scalar.init(hex:))
+    optionally {
       ".."
-      OneOrMore(.hexDigit).tryCapture(Unicode.Scalar.init(hex:))
+      oneOrMore(.hexDigit).tryCapture(Unicode.Scalar.init(hex:))
     }
-    OneOrMore(.whitespace)
+    oneOrMore(.whitespace)
     ";"
-    OneOrMore(.whitespace)
-    OneOrMore(.word).tryCapture(Unicode.GraphemeBreakProperty.init)
-    Repeat(.any)
+    oneOrMore(.whitespace)
+    oneOrMore(.word).tryCapture(Unicode.GraphemeBreakProperty.init)
+    many(.any)
   }.map {
     let (_, lower, upper, property) = $0.match.tuple
     return GraphemeBreakEntry(lower...(upper ?? lower), property)

--- a/Sources/_StringProcessing/RegexDSL/Builder.swift
+++ b/Sources/_StringProcessing/RegexDSL/Builder.swift
@@ -33,10 +33,4 @@ public enum RegexBuilder {
   public static func buildEither<R: RegexProtocol>(second component: R) -> R {
     component
   }
-
-  public static func buildLimitedAvailability<R: RegexProtocol>(
-    _ component: R
-  ) -> Optionally<R> {
-    .init(component)
-  }
 }

--- a/Sources/_StringProcessing/RegexDSL/Concatenation.swift
+++ b/Sources/_StringProcessing/RegexDSL/Concatenation.swift
@@ -1410,4 +1410,966 @@ extension RegexBuilder {
 }
 
 
+public struct _ZeroOrOne_0<Component: RegexProtocol>: RegexProtocol  {
+  public typealias Match = Substring
+  public let regex: Regex<Match>
+  public init(component: Component) {
+    self.regex = .init(node: .quantification(.zeroOrOne, .eager, component.regex.root))
+  }
+}
+
+@_disfavoredOverload
+public func optionally<Component: RegexProtocol>(
+  _ component: Component
+) -> _ZeroOrOne_0<Component> {
+  .init(component: component)
+}
+
+@_disfavoredOverload
+public func optionally<Component: RegexProtocol>(
+  @RegexBuilder _ component: () -> Component
+) -> _ZeroOrOne_0<Component> {
+  optionally(component())
+}
+
+@_disfavoredOverload
+public postfix func .?<Component: RegexProtocol>(
+  _ component: Component
+) -> _ZeroOrOne_0<Component> {
+  optionally(component)
+}
+
+extension RegexBuilder {
+  public static func buildLimitedAvailability<Component: RegexProtocol>(
+    _ component: Component
+  ) -> _ZeroOrOne_0<Component> {
+    optionally(component)
+  }
+}
+public struct _ZeroOrMore_0<Component: RegexProtocol>: RegexProtocol  {
+  public typealias Match = Substring
+  public let regex: Regex<Match>
+  public init(component: Component) {
+    self.regex = .init(node: .quantification(.zeroOrMore, .eager, component.regex.root))
+  }
+}
+
+@_disfavoredOverload
+public func many<Component: RegexProtocol>(
+  _ component: Component
+) -> _ZeroOrMore_0<Component> {
+  .init(component: component)
+}
+
+@_disfavoredOverload
+public func many<Component: RegexProtocol>(
+  @RegexBuilder _ component: () -> Component
+) -> _ZeroOrMore_0<Component> {
+  many(component())
+}
+
+@_disfavoredOverload
+public postfix func .+<Component: RegexProtocol>(
+  _ component: Component
+) -> _ZeroOrMore_0<Component> {
+  many(component)
+}
+
+
+public struct _OneOrMore_0<Component: RegexProtocol>: RegexProtocol  {
+  public typealias Match = Substring
+  public let regex: Regex<Match>
+  public init(component: Component) {
+    self.regex = .init(node: .quantification(.oneOrMore, .eager, component.regex.root))
+  }
+}
+
+@_disfavoredOverload
+public func oneOrMore<Component: RegexProtocol>(
+  _ component: Component
+) -> _OneOrMore_0<Component> {
+  .init(component: component)
+}
+
+@_disfavoredOverload
+public func oneOrMore<Component: RegexProtocol>(
+  @RegexBuilder _ component: () -> Component
+) -> _OneOrMore_0<Component> {
+  oneOrMore(component())
+}
+
+@_disfavoredOverload
+public postfix func .*<Component: RegexProtocol>(
+  _ component: Component
+) -> _OneOrMore_0<Component> {
+  oneOrMore(component)
+}
+
+
+public struct _ZeroOrOne_1<W, C0, Component: RegexProtocol>: RegexProtocol where Component.Match == Tuple2<W, C0> {
+  public typealias Match = Tuple2<Substring, C0?>
+  public let regex: Regex<Match>
+  public init(component: Component) {
+    self.regex = .init(node: .quantification(.zeroOrOne, .eager, component.regex.root))
+  }
+}
+
+
+public func optionally<W, C0, Component: RegexProtocol>(
+  _ component: Component
+) -> _ZeroOrOne_1<W, C0, Component> {
+  .init(component: component)
+}
+
+
+public func optionally<W, C0, Component: RegexProtocol>(
+  @RegexBuilder _ component: () -> Component
+) -> _ZeroOrOne_1<W, C0, Component> {
+  optionally(component())
+}
+
+
+public postfix func .?<W, C0, Component: RegexProtocol>(
+  _ component: Component
+) -> _ZeroOrOne_1<W, C0, Component> {
+  optionally(component)
+}
+
+extension RegexBuilder {
+  public static func buildLimitedAvailability<W, C0, Component: RegexProtocol>(
+    _ component: Component
+  ) -> _ZeroOrOne_1<W, C0, Component> {
+    optionally(component)
+  }
+}
+public struct _ZeroOrMore_1<W, C0, Component: RegexProtocol>: RegexProtocol where Component.Match == Tuple2<W, C0> {
+  public typealias Match = Tuple2<Substring, [C0]>
+  public let regex: Regex<Match>
+  public init(component: Component) {
+    self.regex = .init(node: .quantification(.zeroOrMore, .eager, component.regex.root))
+  }
+}
+
+
+public func many<W, C0, Component: RegexProtocol>(
+  _ component: Component
+) -> _ZeroOrMore_1<W, C0, Component> {
+  .init(component: component)
+}
+
+
+public func many<W, C0, Component: RegexProtocol>(
+  @RegexBuilder _ component: () -> Component
+) -> _ZeroOrMore_1<W, C0, Component> {
+  many(component())
+}
+
+
+public postfix func .+<W, C0, Component: RegexProtocol>(
+  _ component: Component
+) -> _ZeroOrMore_1<W, C0, Component> {
+  many(component)
+}
+
+
+public struct _OneOrMore_1<W, C0, Component: RegexProtocol>: RegexProtocol where Component.Match == Tuple2<W, C0> {
+  public typealias Match = Tuple2<Substring, [C0]>
+  public let regex: Regex<Match>
+  public init(component: Component) {
+    self.regex = .init(node: .quantification(.oneOrMore, .eager, component.regex.root))
+  }
+}
+
+
+public func oneOrMore<W, C0, Component: RegexProtocol>(
+  _ component: Component
+) -> _OneOrMore_1<W, C0, Component> {
+  .init(component: component)
+}
+
+
+public func oneOrMore<W, C0, Component: RegexProtocol>(
+  @RegexBuilder _ component: () -> Component
+) -> _OneOrMore_1<W, C0, Component> {
+  oneOrMore(component())
+}
+
+
+public postfix func .*<W, C0, Component: RegexProtocol>(
+  _ component: Component
+) -> _OneOrMore_1<W, C0, Component> {
+  oneOrMore(component)
+}
+
+
+public struct _ZeroOrOne_2<W, C0, C1, Component: RegexProtocol>: RegexProtocol where Component.Match == Tuple3<W, C0, C1> {
+  public typealias Match = Tuple2<Substring, Tuple2<C0, C1>?>
+  public let regex: Regex<Match>
+  public init(component: Component) {
+    self.regex = .init(node: .quantification(.zeroOrOne, .eager, component.regex.root))
+  }
+}
+
+
+public func optionally<W, C0, C1, Component: RegexProtocol>(
+  _ component: Component
+) -> _ZeroOrOne_2<W, C0, C1, Component> {
+  .init(component: component)
+}
+
+
+public func optionally<W, C0, C1, Component: RegexProtocol>(
+  @RegexBuilder _ component: () -> Component
+) -> _ZeroOrOne_2<W, C0, C1, Component> {
+  optionally(component())
+}
+
+
+public postfix func .?<W, C0, C1, Component: RegexProtocol>(
+  _ component: Component
+) -> _ZeroOrOne_2<W, C0, C1, Component> {
+  optionally(component)
+}
+
+extension RegexBuilder {
+  public static func buildLimitedAvailability<W, C0, C1, Component: RegexProtocol>(
+    _ component: Component
+  ) -> _ZeroOrOne_2<W, C0, C1, Component> {
+    optionally(component)
+  }
+}
+public struct _ZeroOrMore_2<W, C0, C1, Component: RegexProtocol>: RegexProtocol where Component.Match == Tuple3<W, C0, C1> {
+  public typealias Match = Tuple2<Substring, [Tuple2<C0, C1>]>
+  public let regex: Regex<Match>
+  public init(component: Component) {
+    self.regex = .init(node: .quantification(.zeroOrMore, .eager, component.regex.root))
+  }
+}
+
+
+public func many<W, C0, C1, Component: RegexProtocol>(
+  _ component: Component
+) -> _ZeroOrMore_2<W, C0, C1, Component> {
+  .init(component: component)
+}
+
+
+public func many<W, C0, C1, Component: RegexProtocol>(
+  @RegexBuilder _ component: () -> Component
+) -> _ZeroOrMore_2<W, C0, C1, Component> {
+  many(component())
+}
+
+
+public postfix func .+<W, C0, C1, Component: RegexProtocol>(
+  _ component: Component
+) -> _ZeroOrMore_2<W, C0, C1, Component> {
+  many(component)
+}
+
+
+public struct _OneOrMore_2<W, C0, C1, Component: RegexProtocol>: RegexProtocol where Component.Match == Tuple3<W, C0, C1> {
+  public typealias Match = Tuple2<Substring, [Tuple2<C0, C1>]>
+  public let regex: Regex<Match>
+  public init(component: Component) {
+    self.regex = .init(node: .quantification(.oneOrMore, .eager, component.regex.root))
+  }
+}
+
+
+public func oneOrMore<W, C0, C1, Component: RegexProtocol>(
+  _ component: Component
+) -> _OneOrMore_2<W, C0, C1, Component> {
+  .init(component: component)
+}
+
+
+public func oneOrMore<W, C0, C1, Component: RegexProtocol>(
+  @RegexBuilder _ component: () -> Component
+) -> _OneOrMore_2<W, C0, C1, Component> {
+  oneOrMore(component())
+}
+
+
+public postfix func .*<W, C0, C1, Component: RegexProtocol>(
+  _ component: Component
+) -> _OneOrMore_2<W, C0, C1, Component> {
+  oneOrMore(component)
+}
+
+
+public struct _ZeroOrOne_3<W, C0, C1, C2, Component: RegexProtocol>: RegexProtocol where Component.Match == Tuple4<W, C0, C1, C2> {
+  public typealias Match = Tuple2<Substring, Tuple3<C0, C1, C2>?>
+  public let regex: Regex<Match>
+  public init(component: Component) {
+    self.regex = .init(node: .quantification(.zeroOrOne, .eager, component.regex.root))
+  }
+}
+
+
+public func optionally<W, C0, C1, C2, Component: RegexProtocol>(
+  _ component: Component
+) -> _ZeroOrOne_3<W, C0, C1, C2, Component> {
+  .init(component: component)
+}
+
+
+public func optionally<W, C0, C1, C2, Component: RegexProtocol>(
+  @RegexBuilder _ component: () -> Component
+) -> _ZeroOrOne_3<W, C0, C1, C2, Component> {
+  optionally(component())
+}
+
+
+public postfix func .?<W, C0, C1, C2, Component: RegexProtocol>(
+  _ component: Component
+) -> _ZeroOrOne_3<W, C0, C1, C2, Component> {
+  optionally(component)
+}
+
+extension RegexBuilder {
+  public static func buildLimitedAvailability<W, C0, C1, C2, Component: RegexProtocol>(
+    _ component: Component
+  ) -> _ZeroOrOne_3<W, C0, C1, C2, Component> {
+    optionally(component)
+  }
+}
+public struct _ZeroOrMore_3<W, C0, C1, C2, Component: RegexProtocol>: RegexProtocol where Component.Match == Tuple4<W, C0, C1, C2> {
+  public typealias Match = Tuple2<Substring, [Tuple3<C0, C1, C2>]>
+  public let regex: Regex<Match>
+  public init(component: Component) {
+    self.regex = .init(node: .quantification(.zeroOrMore, .eager, component.regex.root))
+  }
+}
+
+
+public func many<W, C0, C1, C2, Component: RegexProtocol>(
+  _ component: Component
+) -> _ZeroOrMore_3<W, C0, C1, C2, Component> {
+  .init(component: component)
+}
+
+
+public func many<W, C0, C1, C2, Component: RegexProtocol>(
+  @RegexBuilder _ component: () -> Component
+) -> _ZeroOrMore_3<W, C0, C1, C2, Component> {
+  many(component())
+}
+
+
+public postfix func .+<W, C0, C1, C2, Component: RegexProtocol>(
+  _ component: Component
+) -> _ZeroOrMore_3<W, C0, C1, C2, Component> {
+  many(component)
+}
+
+
+public struct _OneOrMore_3<W, C0, C1, C2, Component: RegexProtocol>: RegexProtocol where Component.Match == Tuple4<W, C0, C1, C2> {
+  public typealias Match = Tuple2<Substring, [Tuple3<C0, C1, C2>]>
+  public let regex: Regex<Match>
+  public init(component: Component) {
+    self.regex = .init(node: .quantification(.oneOrMore, .eager, component.regex.root))
+  }
+}
+
+
+public func oneOrMore<W, C0, C1, C2, Component: RegexProtocol>(
+  _ component: Component
+) -> _OneOrMore_3<W, C0, C1, C2, Component> {
+  .init(component: component)
+}
+
+
+public func oneOrMore<W, C0, C1, C2, Component: RegexProtocol>(
+  @RegexBuilder _ component: () -> Component
+) -> _OneOrMore_3<W, C0, C1, C2, Component> {
+  oneOrMore(component())
+}
+
+
+public postfix func .*<W, C0, C1, C2, Component: RegexProtocol>(
+  _ component: Component
+) -> _OneOrMore_3<W, C0, C1, C2, Component> {
+  oneOrMore(component)
+}
+
+
+public struct _ZeroOrOne_4<W, C0, C1, C2, C3, Component: RegexProtocol>: RegexProtocol where Component.Match == Tuple5<W, C0, C1, C2, C3> {
+  public typealias Match = Tuple2<Substring, Tuple4<C0, C1, C2, C3>?>
+  public let regex: Regex<Match>
+  public init(component: Component) {
+    self.regex = .init(node: .quantification(.zeroOrOne, .eager, component.regex.root))
+  }
+}
+
+
+public func optionally<W, C0, C1, C2, C3, Component: RegexProtocol>(
+  _ component: Component
+) -> _ZeroOrOne_4<W, C0, C1, C2, C3, Component> {
+  .init(component: component)
+}
+
+
+public func optionally<W, C0, C1, C2, C3, Component: RegexProtocol>(
+  @RegexBuilder _ component: () -> Component
+) -> _ZeroOrOne_4<W, C0, C1, C2, C3, Component> {
+  optionally(component())
+}
+
+
+public postfix func .?<W, C0, C1, C2, C3, Component: RegexProtocol>(
+  _ component: Component
+) -> _ZeroOrOne_4<W, C0, C1, C2, C3, Component> {
+  optionally(component)
+}
+
+extension RegexBuilder {
+  public static func buildLimitedAvailability<W, C0, C1, C2, C3, Component: RegexProtocol>(
+    _ component: Component
+  ) -> _ZeroOrOne_4<W, C0, C1, C2, C3, Component> {
+    optionally(component)
+  }
+}
+public struct _ZeroOrMore_4<W, C0, C1, C2, C3, Component: RegexProtocol>: RegexProtocol where Component.Match == Tuple5<W, C0, C1, C2, C3> {
+  public typealias Match = Tuple2<Substring, [Tuple4<C0, C1, C2, C3>]>
+  public let regex: Regex<Match>
+  public init(component: Component) {
+    self.regex = .init(node: .quantification(.zeroOrMore, .eager, component.regex.root))
+  }
+}
+
+
+public func many<W, C0, C1, C2, C3, Component: RegexProtocol>(
+  _ component: Component
+) -> _ZeroOrMore_4<W, C0, C1, C2, C3, Component> {
+  .init(component: component)
+}
+
+
+public func many<W, C0, C1, C2, C3, Component: RegexProtocol>(
+  @RegexBuilder _ component: () -> Component
+) -> _ZeroOrMore_4<W, C0, C1, C2, C3, Component> {
+  many(component())
+}
+
+
+public postfix func .+<W, C0, C1, C2, C3, Component: RegexProtocol>(
+  _ component: Component
+) -> _ZeroOrMore_4<W, C0, C1, C2, C3, Component> {
+  many(component)
+}
+
+
+public struct _OneOrMore_4<W, C0, C1, C2, C3, Component: RegexProtocol>: RegexProtocol where Component.Match == Tuple5<W, C0, C1, C2, C3> {
+  public typealias Match = Tuple2<Substring, [Tuple4<C0, C1, C2, C3>]>
+  public let regex: Regex<Match>
+  public init(component: Component) {
+    self.regex = .init(node: .quantification(.oneOrMore, .eager, component.regex.root))
+  }
+}
+
+
+public func oneOrMore<W, C0, C1, C2, C3, Component: RegexProtocol>(
+  _ component: Component
+) -> _OneOrMore_4<W, C0, C1, C2, C3, Component> {
+  .init(component: component)
+}
+
+
+public func oneOrMore<W, C0, C1, C2, C3, Component: RegexProtocol>(
+  @RegexBuilder _ component: () -> Component
+) -> _OneOrMore_4<W, C0, C1, C2, C3, Component> {
+  oneOrMore(component())
+}
+
+
+public postfix func .*<W, C0, C1, C2, C3, Component: RegexProtocol>(
+  _ component: Component
+) -> _OneOrMore_4<W, C0, C1, C2, C3, Component> {
+  oneOrMore(component)
+}
+
+
+public struct _ZeroOrOne_5<W, C0, C1, C2, C3, C4, Component: RegexProtocol>: RegexProtocol where Component.Match == Tuple6<W, C0, C1, C2, C3, C4> {
+  public typealias Match = Tuple2<Substring, Tuple5<C0, C1, C2, C3, C4>?>
+  public let regex: Regex<Match>
+  public init(component: Component) {
+    self.regex = .init(node: .quantification(.zeroOrOne, .eager, component.regex.root))
+  }
+}
+
+
+public func optionally<W, C0, C1, C2, C3, C4, Component: RegexProtocol>(
+  _ component: Component
+) -> _ZeroOrOne_5<W, C0, C1, C2, C3, C4, Component> {
+  .init(component: component)
+}
+
+
+public func optionally<W, C0, C1, C2, C3, C4, Component: RegexProtocol>(
+  @RegexBuilder _ component: () -> Component
+) -> _ZeroOrOne_5<W, C0, C1, C2, C3, C4, Component> {
+  optionally(component())
+}
+
+
+public postfix func .?<W, C0, C1, C2, C3, C4, Component: RegexProtocol>(
+  _ component: Component
+) -> _ZeroOrOne_5<W, C0, C1, C2, C3, C4, Component> {
+  optionally(component)
+}
+
+extension RegexBuilder {
+  public static func buildLimitedAvailability<W, C0, C1, C2, C3, C4, Component: RegexProtocol>(
+    _ component: Component
+  ) -> _ZeroOrOne_5<W, C0, C1, C2, C3, C4, Component> {
+    optionally(component)
+  }
+}
+public struct _ZeroOrMore_5<W, C0, C1, C2, C3, C4, Component: RegexProtocol>: RegexProtocol where Component.Match == Tuple6<W, C0, C1, C2, C3, C4> {
+  public typealias Match = Tuple2<Substring, [Tuple5<C0, C1, C2, C3, C4>]>
+  public let regex: Regex<Match>
+  public init(component: Component) {
+    self.regex = .init(node: .quantification(.zeroOrMore, .eager, component.regex.root))
+  }
+}
+
+
+public func many<W, C0, C1, C2, C3, C4, Component: RegexProtocol>(
+  _ component: Component
+) -> _ZeroOrMore_5<W, C0, C1, C2, C3, C4, Component> {
+  .init(component: component)
+}
+
+
+public func many<W, C0, C1, C2, C3, C4, Component: RegexProtocol>(
+  @RegexBuilder _ component: () -> Component
+) -> _ZeroOrMore_5<W, C0, C1, C2, C3, C4, Component> {
+  many(component())
+}
+
+
+public postfix func .+<W, C0, C1, C2, C3, C4, Component: RegexProtocol>(
+  _ component: Component
+) -> _ZeroOrMore_5<W, C0, C1, C2, C3, C4, Component> {
+  many(component)
+}
+
+
+public struct _OneOrMore_5<W, C0, C1, C2, C3, C4, Component: RegexProtocol>: RegexProtocol where Component.Match == Tuple6<W, C0, C1, C2, C3, C4> {
+  public typealias Match = Tuple2<Substring, [Tuple5<C0, C1, C2, C3, C4>]>
+  public let regex: Regex<Match>
+  public init(component: Component) {
+    self.regex = .init(node: .quantification(.oneOrMore, .eager, component.regex.root))
+  }
+}
+
+
+public func oneOrMore<W, C0, C1, C2, C3, C4, Component: RegexProtocol>(
+  _ component: Component
+) -> _OneOrMore_5<W, C0, C1, C2, C3, C4, Component> {
+  .init(component: component)
+}
+
+
+public func oneOrMore<W, C0, C1, C2, C3, C4, Component: RegexProtocol>(
+  @RegexBuilder _ component: () -> Component
+) -> _OneOrMore_5<W, C0, C1, C2, C3, C4, Component> {
+  oneOrMore(component())
+}
+
+
+public postfix func .*<W, C0, C1, C2, C3, C4, Component: RegexProtocol>(
+  _ component: Component
+) -> _OneOrMore_5<W, C0, C1, C2, C3, C4, Component> {
+  oneOrMore(component)
+}
+
+
+public struct _ZeroOrOne_6<W, C0, C1, C2, C3, C4, C5, Component: RegexProtocol>: RegexProtocol where Component.Match == Tuple7<W, C0, C1, C2, C3, C4, C5> {
+  public typealias Match = Tuple2<Substring, Tuple6<C0, C1, C2, C3, C4, C5>?>
+  public let regex: Regex<Match>
+  public init(component: Component) {
+    self.regex = .init(node: .quantification(.zeroOrOne, .eager, component.regex.root))
+  }
+}
+
+
+public func optionally<W, C0, C1, C2, C3, C4, C5, Component: RegexProtocol>(
+  _ component: Component
+) -> _ZeroOrOne_6<W, C0, C1, C2, C3, C4, C5, Component> {
+  .init(component: component)
+}
+
+
+public func optionally<W, C0, C1, C2, C3, C4, C5, Component: RegexProtocol>(
+  @RegexBuilder _ component: () -> Component
+) -> _ZeroOrOne_6<W, C0, C1, C2, C3, C4, C5, Component> {
+  optionally(component())
+}
+
+
+public postfix func .?<W, C0, C1, C2, C3, C4, C5, Component: RegexProtocol>(
+  _ component: Component
+) -> _ZeroOrOne_6<W, C0, C1, C2, C3, C4, C5, Component> {
+  optionally(component)
+}
+
+extension RegexBuilder {
+  public static func buildLimitedAvailability<W, C0, C1, C2, C3, C4, C5, Component: RegexProtocol>(
+    _ component: Component
+  ) -> _ZeroOrOne_6<W, C0, C1, C2, C3, C4, C5, Component> {
+    optionally(component)
+  }
+}
+public struct _ZeroOrMore_6<W, C0, C1, C2, C3, C4, C5, Component: RegexProtocol>: RegexProtocol where Component.Match == Tuple7<W, C0, C1, C2, C3, C4, C5> {
+  public typealias Match = Tuple2<Substring, [Tuple6<C0, C1, C2, C3, C4, C5>]>
+  public let regex: Regex<Match>
+  public init(component: Component) {
+    self.regex = .init(node: .quantification(.zeroOrMore, .eager, component.regex.root))
+  }
+}
+
+
+public func many<W, C0, C1, C2, C3, C4, C5, Component: RegexProtocol>(
+  _ component: Component
+) -> _ZeroOrMore_6<W, C0, C1, C2, C3, C4, C5, Component> {
+  .init(component: component)
+}
+
+
+public func many<W, C0, C1, C2, C3, C4, C5, Component: RegexProtocol>(
+  @RegexBuilder _ component: () -> Component
+) -> _ZeroOrMore_6<W, C0, C1, C2, C3, C4, C5, Component> {
+  many(component())
+}
+
+
+public postfix func .+<W, C0, C1, C2, C3, C4, C5, Component: RegexProtocol>(
+  _ component: Component
+) -> _ZeroOrMore_6<W, C0, C1, C2, C3, C4, C5, Component> {
+  many(component)
+}
+
+
+public struct _OneOrMore_6<W, C0, C1, C2, C3, C4, C5, Component: RegexProtocol>: RegexProtocol where Component.Match == Tuple7<W, C0, C1, C2, C3, C4, C5> {
+  public typealias Match = Tuple2<Substring, [Tuple6<C0, C1, C2, C3, C4, C5>]>
+  public let regex: Regex<Match>
+  public init(component: Component) {
+    self.regex = .init(node: .quantification(.oneOrMore, .eager, component.regex.root))
+  }
+}
+
+
+public func oneOrMore<W, C0, C1, C2, C3, C4, C5, Component: RegexProtocol>(
+  _ component: Component
+) -> _OneOrMore_6<W, C0, C1, C2, C3, C4, C5, Component> {
+  .init(component: component)
+}
+
+
+public func oneOrMore<W, C0, C1, C2, C3, C4, C5, Component: RegexProtocol>(
+  @RegexBuilder _ component: () -> Component
+) -> _OneOrMore_6<W, C0, C1, C2, C3, C4, C5, Component> {
+  oneOrMore(component())
+}
+
+
+public postfix func .*<W, C0, C1, C2, C3, C4, C5, Component: RegexProtocol>(
+  _ component: Component
+) -> _OneOrMore_6<W, C0, C1, C2, C3, C4, C5, Component> {
+  oneOrMore(component)
+}
+
+
+public struct _ZeroOrOne_7<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexProtocol>: RegexProtocol where Component.Match == Tuple8<W, C0, C1, C2, C3, C4, C5, C6> {
+  public typealias Match = Tuple2<Substring, Tuple7<C0, C1, C2, C3, C4, C5, C6>?>
+  public let regex: Regex<Match>
+  public init(component: Component) {
+    self.regex = .init(node: .quantification(.zeroOrOne, .eager, component.regex.root))
+  }
+}
+
+
+public func optionally<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexProtocol>(
+  _ component: Component
+) -> _ZeroOrOne_7<W, C0, C1, C2, C3, C4, C5, C6, Component> {
+  .init(component: component)
+}
+
+
+public func optionally<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexProtocol>(
+  @RegexBuilder _ component: () -> Component
+) -> _ZeroOrOne_7<W, C0, C1, C2, C3, C4, C5, C6, Component> {
+  optionally(component())
+}
+
+
+public postfix func .?<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexProtocol>(
+  _ component: Component
+) -> _ZeroOrOne_7<W, C0, C1, C2, C3, C4, C5, C6, Component> {
+  optionally(component)
+}
+
+extension RegexBuilder {
+  public static func buildLimitedAvailability<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexProtocol>(
+    _ component: Component
+  ) -> _ZeroOrOne_7<W, C0, C1, C2, C3, C4, C5, C6, Component> {
+    optionally(component)
+  }
+}
+public struct _ZeroOrMore_7<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexProtocol>: RegexProtocol where Component.Match == Tuple8<W, C0, C1, C2, C3, C4, C5, C6> {
+  public typealias Match = Tuple2<Substring, [Tuple7<C0, C1, C2, C3, C4, C5, C6>]>
+  public let regex: Regex<Match>
+  public init(component: Component) {
+    self.regex = .init(node: .quantification(.zeroOrMore, .eager, component.regex.root))
+  }
+}
+
+
+public func many<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexProtocol>(
+  _ component: Component
+) -> _ZeroOrMore_7<W, C0, C1, C2, C3, C4, C5, C6, Component> {
+  .init(component: component)
+}
+
+
+public func many<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexProtocol>(
+  @RegexBuilder _ component: () -> Component
+) -> _ZeroOrMore_7<W, C0, C1, C2, C3, C4, C5, C6, Component> {
+  many(component())
+}
+
+
+public postfix func .+<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexProtocol>(
+  _ component: Component
+) -> _ZeroOrMore_7<W, C0, C1, C2, C3, C4, C5, C6, Component> {
+  many(component)
+}
+
+
+public struct _OneOrMore_7<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexProtocol>: RegexProtocol where Component.Match == Tuple8<W, C0, C1, C2, C3, C4, C5, C6> {
+  public typealias Match = Tuple2<Substring, [Tuple7<C0, C1, C2, C3, C4, C5, C6>]>
+  public let regex: Regex<Match>
+  public init(component: Component) {
+    self.regex = .init(node: .quantification(.oneOrMore, .eager, component.regex.root))
+  }
+}
+
+
+public func oneOrMore<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexProtocol>(
+  _ component: Component
+) -> _OneOrMore_7<W, C0, C1, C2, C3, C4, C5, C6, Component> {
+  .init(component: component)
+}
+
+
+public func oneOrMore<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexProtocol>(
+  @RegexBuilder _ component: () -> Component
+) -> _OneOrMore_7<W, C0, C1, C2, C3, C4, C5, C6, Component> {
+  oneOrMore(component())
+}
+
+
+public postfix func .*<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexProtocol>(
+  _ component: Component
+) -> _OneOrMore_7<W, C0, C1, C2, C3, C4, C5, C6, Component> {
+  oneOrMore(component)
+}
+
+
+public struct _ZeroOrOne_8<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexProtocol>: RegexProtocol where Component.Match == Tuple9<W, C0, C1, C2, C3, C4, C5, C6, C7> {
+  public typealias Match = Tuple2<Substring, Tuple8<C0, C1, C2, C3, C4, C5, C6, C7>?>
+  public let regex: Regex<Match>
+  public init(component: Component) {
+    self.regex = .init(node: .quantification(.zeroOrOne, .eager, component.regex.root))
+  }
+}
+
+
+public func optionally<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexProtocol>(
+  _ component: Component
+) -> _ZeroOrOne_8<W, C0, C1, C2, C3, C4, C5, C6, C7, Component> {
+  .init(component: component)
+}
+
+
+public func optionally<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexProtocol>(
+  @RegexBuilder _ component: () -> Component
+) -> _ZeroOrOne_8<W, C0, C1, C2, C3, C4, C5, C6, C7, Component> {
+  optionally(component())
+}
+
+
+public postfix func .?<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexProtocol>(
+  _ component: Component
+) -> _ZeroOrOne_8<W, C0, C1, C2, C3, C4, C5, C6, C7, Component> {
+  optionally(component)
+}
+
+extension RegexBuilder {
+  public static func buildLimitedAvailability<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexProtocol>(
+    _ component: Component
+  ) -> _ZeroOrOne_8<W, C0, C1, C2, C3, C4, C5, C6, C7, Component> {
+    optionally(component)
+  }
+}
+public struct _ZeroOrMore_8<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexProtocol>: RegexProtocol where Component.Match == Tuple9<W, C0, C1, C2, C3, C4, C5, C6, C7> {
+  public typealias Match = Tuple2<Substring, [Tuple8<C0, C1, C2, C3, C4, C5, C6, C7>]>
+  public let regex: Regex<Match>
+  public init(component: Component) {
+    self.regex = .init(node: .quantification(.zeroOrMore, .eager, component.regex.root))
+  }
+}
+
+
+public func many<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexProtocol>(
+  _ component: Component
+) -> _ZeroOrMore_8<W, C0, C1, C2, C3, C4, C5, C6, C7, Component> {
+  .init(component: component)
+}
+
+
+public func many<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexProtocol>(
+  @RegexBuilder _ component: () -> Component
+) -> _ZeroOrMore_8<W, C0, C1, C2, C3, C4, C5, C6, C7, Component> {
+  many(component())
+}
+
+
+public postfix func .+<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexProtocol>(
+  _ component: Component
+) -> _ZeroOrMore_8<W, C0, C1, C2, C3, C4, C5, C6, C7, Component> {
+  many(component)
+}
+
+
+public struct _OneOrMore_8<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexProtocol>: RegexProtocol where Component.Match == Tuple9<W, C0, C1, C2, C3, C4, C5, C6, C7> {
+  public typealias Match = Tuple2<Substring, [Tuple8<C0, C1, C2, C3, C4, C5, C6, C7>]>
+  public let regex: Regex<Match>
+  public init(component: Component) {
+    self.regex = .init(node: .quantification(.oneOrMore, .eager, component.regex.root))
+  }
+}
+
+
+public func oneOrMore<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexProtocol>(
+  _ component: Component
+) -> _OneOrMore_8<W, C0, C1, C2, C3, C4, C5, C6, C7, Component> {
+  .init(component: component)
+}
+
+
+public func oneOrMore<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexProtocol>(
+  @RegexBuilder _ component: () -> Component
+) -> _OneOrMore_8<W, C0, C1, C2, C3, C4, C5, C6, C7, Component> {
+  oneOrMore(component())
+}
+
+
+public postfix func .*<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexProtocol>(
+  _ component: Component
+) -> _OneOrMore_8<W, C0, C1, C2, C3, C4, C5, C6, C7, Component> {
+  oneOrMore(component)
+}
+
+
+public struct _ZeroOrOne_9<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexProtocol>: RegexProtocol where Component.Match == Tuple10<W, C0, C1, C2, C3, C4, C5, C6, C7, C8> {
+  public typealias Match = Tuple2<Substring, Tuple9<C0, C1, C2, C3, C4, C5, C6, C7, C8>?>
+  public let regex: Regex<Match>
+  public init(component: Component) {
+    self.regex = .init(node: .quantification(.zeroOrOne, .eager, component.regex.root))
+  }
+}
+
+
+public func optionally<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexProtocol>(
+  _ component: Component
+) -> _ZeroOrOne_9<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component> {
+  .init(component: component)
+}
+
+
+public func optionally<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexProtocol>(
+  @RegexBuilder _ component: () -> Component
+) -> _ZeroOrOne_9<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component> {
+  optionally(component())
+}
+
+
+public postfix func .?<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexProtocol>(
+  _ component: Component
+) -> _ZeroOrOne_9<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component> {
+  optionally(component)
+}
+
+extension RegexBuilder {
+  public static func buildLimitedAvailability<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexProtocol>(
+    _ component: Component
+  ) -> _ZeroOrOne_9<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component> {
+    optionally(component)
+  }
+}
+public struct _ZeroOrMore_9<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexProtocol>: RegexProtocol where Component.Match == Tuple10<W, C0, C1, C2, C3, C4, C5, C6, C7, C8> {
+  public typealias Match = Tuple2<Substring, [Tuple9<C0, C1, C2, C3, C4, C5, C6, C7, C8>]>
+  public let regex: Regex<Match>
+  public init(component: Component) {
+    self.regex = .init(node: .quantification(.zeroOrMore, .eager, component.regex.root))
+  }
+}
+
+
+public func many<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexProtocol>(
+  _ component: Component
+) -> _ZeroOrMore_9<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component> {
+  .init(component: component)
+}
+
+
+public func many<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexProtocol>(
+  @RegexBuilder _ component: () -> Component
+) -> _ZeroOrMore_9<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component> {
+  many(component())
+}
+
+
+public postfix func .+<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexProtocol>(
+  _ component: Component
+) -> _ZeroOrMore_9<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component> {
+  many(component)
+}
+
+
+public struct _OneOrMore_9<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexProtocol>: RegexProtocol where Component.Match == Tuple10<W, C0, C1, C2, C3, C4, C5, C6, C7, C8> {
+  public typealias Match = Tuple2<Substring, [Tuple9<C0, C1, C2, C3, C4, C5, C6, C7, C8>]>
+  public let regex: Regex<Match>
+  public init(component: Component) {
+    self.regex = .init(node: .quantification(.oneOrMore, .eager, component.regex.root))
+  }
+}
+
+
+public func oneOrMore<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexProtocol>(
+  _ component: Component
+) -> _OneOrMore_9<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component> {
+  .init(component: component)
+}
+
+
+public func oneOrMore<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexProtocol>(
+  @RegexBuilder _ component: () -> Component
+) -> _OneOrMore_9<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component> {
+  oneOrMore(component())
+}
+
+
+public postfix func .*<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexProtocol>(
+  _ component: Component
+) -> _OneOrMore_9<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component> {
+  oneOrMore(component)
+}
+
+
+
+
 // END AUTO-GENERATED CONTENT

--- a/Sources/_StringProcessing/RegexDSL/Core.swift
+++ b/Sources/_StringProcessing/RegexDSL/Core.swift
@@ -27,28 +27,6 @@ public protocol RegexProtocol {
   var regex: Regex<Match> { get }
 }
 
-/// A `RegexProtocol` that has a single component child.
-///
-/// This protocol adds an init supporting static lookup for character classes
-public protocol RegexProtocolWithComponent: RegexProtocol {
-  associatedtype Component: RegexProtocol
-
-  // Label needed for disambiguation
-  init(component: Component)
-}
-extension RegexProtocolWithComponent
-where Component == CharacterClass {
-  // This gives us static member lookup
-  public init(_ component: Component) {
-    self.init(component: component)
-  }
-}
-extension RegexProtocolWithComponent {
-  public init(_ component: Component) {
-    self.init(component: component)
-  }
-}
-
 /// A regular expression.
 public struct Regex<Match: MatchProtocol>: RegexProtocol {
   /// A program representation that caches any lowered representation for

--- a/Sources/_StringProcessing/RegexDSL/DSL.swift
+++ b/Sources/_StringProcessing/RegexDSL/DSL.swift
@@ -44,93 +44,79 @@ extension CharacterClass: RegexProtocol {
   }
 }
 
+
 // MARK: - Combinators
 
-// TODO: We want variadic generics!
-// Overloads are auto-generated in Concatenation.swift.
-//
-// public struct Concatenate<R...: RegexContent>: RegexContent {
-//   public let regex: Regex<(R...).filter { $0 != Void.self }>
-//
-//   public init(_ components: R...) {
-//     regex = .init(ast: .concatenation([#splat(components...)]))
+// MARK: Concatenation
+
+// Note: Concatenation overloads are currently gyb'd.
+
+// TODO: Variadic generics
+// struct Concatenation<W0, C0..., R0: RegexProtocol, W1, C1..., R1: RegexProtocol>
+// where R0.Match == (W0, C0...), R1.Match == (W1, C1...)
+// {
+//   typealias Match = (Substring, C0..., C1...)
+//   let regex: Regex<Match>
+//   init(_ first: R0, _ second: R1) {
+//     regex = .init(concat(r0, r1))
 //   }
 // }
 
-// MARK: Repetition
+// MARK: Quantification
 
-/// A regular expression.
-public struct OneOrMore<Component: RegexProtocol>: RegexProtocolWithComponent {
-  public typealias Match = Tuple2<Substring, [Component.Match.Capture]>
+// Note: Quantifiers are currently gyb'd.
 
-  public let regex: Regex<Match>
+// TODO: Variadic generics
+// struct _OneOrMore<W, C..., Component: RegexProtocol>
+// where R.Match == (W, C...)
+// {
+//   typealias Match = (Substring, [(C...)])
+//   let regex: Regex<Match>
+//   init(_ component: Component) {
+//     regex = .init(oneOrMore(r0))
+//   }
+// }
+//
+// struct _OneOrMoreNonCapturing<Component: RegexProtocol> {
+//   typealias Match = Substring
+//   let regex: Regex<Match>
+//   init(_ component: Component) {
+//     regex = .init(oneOrMore(r0))
+//   }
+// }
+//
+// func oneOrMore<W, C..., Component: RegexProtocol>(
+//   _ component: Component
+// ) -> <R: RegexProtocol where R.Match == (Substring, [(C...)])> R {
+//   _OneOrMore(component)
+// }
+//
+// @_disfavoredOverload
+// func oneOrMore<Component: RegexProtocol>(
+//   _ component: Component
+// ) -> <R: RegexProtocol where R.Match == Substring> R {
+//   _OneOrMoreNonCapturing(component)
+// }
 
-  public init(component: Component) {
-    self.regex = .init(node: .quantification(
-      .oneOrMore, .eager, component.regex.root)
-    )
-  }
-
-  public init(@RegexBuilder _ content: () -> Component) {
-    self.init(content())
-  }
-}
-
-postfix operator .+
-
-public postfix func .+ <R: RegexProtocol>(
-  lhs: R
-) -> OneOrMore<R> {
-  .init(lhs)
-}
-
-public struct Repeat<
-  Component: RegexProtocol
->: RegexProtocolWithComponent {
-  public typealias Match = Tuple2<Substring, [Component.Match.Capture]>
-
-  public let regex: Regex<Match>
-
-  public init(component: Component) {
-    self.regex = .init(node: .quantification(
-      .zeroOrMore, .eager, component.regex.root))
-  }
-
-  public init(@RegexBuilder _ content: () -> Component) {
-    self.init(content())
-  }
-}
-
-postfix operator .*
-
-public postfix func .* <R: RegexProtocol>(
-  lhs: R
-) -> Repeat<R> {
-  .init(lhs)
-}
-
-public struct Optionally<Component: RegexProtocol>: RegexProtocolWithComponent {
-  public typealias Match = Tuple2<Substring, Component.Match.Capture?>
-
-  public let regex: Regex<Match>
-
-  public init(component: Component) {
-    self.regex = .init(node: .quantification(
-      .zeroOrOne, .eager, component.regex.root))
-  }
-
-  public init(@RegexBuilder _ content: () -> Component) {
-    self.init(content())
-  }
-}
 
 postfix operator .?
+postfix operator .*
+postfix operator .+
 
-public postfix func .? <R: RegexProtocol>(
-  lhs: R
-) -> Optionally<R> {
-  .init(lhs)
+// Overloads for quantifying over a character class.
+public func zeroOrOne(_ cc: CharacterClass) -> _ZeroOrOne_0<CharacterClass> {
+  .init(component: cc)
 }
+
+public func many(_ cc: CharacterClass) -> _ZeroOrMore_0<CharacterClass> {
+  .init(component: cc)
+}
+
+public func oneOrMore(_ cc: CharacterClass) -> _OneOrMore_0<CharacterClass> {
+  .init(component: cc)
+}
+
+// MARK: Alternation
 
 // TODO: Support heterogeneous capture alternation.
 public struct Alternation<

--- a/Tests/RegexTests/AlgorithmsTests.swift
+++ b/Tests/RegexTests/AlgorithmsTests.swift
@@ -116,7 +116,7 @@ class RegexConsumerTests: XCTestCase {
   }
   
   func testMatches() {
-    let regex = Regex(OneOrMore(.digit).capture { 2 * Int($0)! })
+    let regex = Regex(oneOrMore(.digit).capture { 2 * Int($0)! })
     let str = "foo 160 bar 99 baz"
     XCTAssertEqual(str.matches(of: regex).map(\.result.1), [320, 198])
   }
@@ -133,7 +133,7 @@ class RegexConsumerTests: XCTestCase {
       XCTAssertEqual(input.replacing(regex, with: replace), result)
     }
     
-    let int = OneOrMore(.digit).capture { Int($0)! }
+    let int = oneOrMore(.digit).capture { Int($0)! }
     
     replaceTest(
       int,
@@ -148,13 +148,13 @@ class RegexConsumerTests: XCTestCase {
       { match in "\(match.result.1 + match.result.2)" })
     
     replaceTest(
-      OneOrMore { int; "," },
+      oneOrMore { int; "," },
       input: "3,5,8,0, 1,0,2,-5,x8,8,",
       result: "16 3-5x16",
       { match in "\(match.result.1.reduce(0, +))" })
     
     replaceTest(
-      Regex { int; "x"; int; Optionally { "x"; int } },
+      Regex { int; "x"; int; optionally { "x"; int } },
       input: "2x3 5x4x3 6x0 1x2x3x4",
       result: "6 60 0 6x4",
       { match in "\(match.result.1 * match.result.2 * (match.result.3 ?? 1))" })


### PR DESCRIPTION
Change quantifiers in the DSL from structure types to top-level functions.  This allows for a lot more flexibility with overloading a quantifier based on the input `Match` type.  The immediate benefit of this is getting rid of void and nested void types (see example below), and as a result eliminate the need for void-filtering within concatenation.  A more important benefit (IMO) is being able to get rid of nominal tuples and switch back to Swift tuples, as Swift tuples enable strongly typed named captures and eliminates the complexity that comes with nominal tuples.

This PR is based on #114.  Please review commit b14a85b.

-----

Before:
```swift
let r0 = OneOrMore(.digit) // => `.Match == Tuple2<Substring, [()]>`
let r1 = Optionally(.digit) // => `.Match == Tuple2<Substring, ()?>`
let r2 = OneOrMore(Repeat(Optionally(.digit))) // => `.Match == Tuple2<Substring, [[()?]]>`
"123".match(r2) // => `RegexMatch<Tuple2<Substring, [[()?]]>>?`
```
After:
```swift
let r0 = oneOrMore(.digit) // => `.Match == Substring`
let r1 = optionally(.digit) // => `.Match == Substring`
let r2 = oneOrMore(many(optionally(.digit))) // => `.Match == Substring`
"123".match(r2) // => `RegexMatch<Substring>`
```

-----

Before:
```swift
/(?<number>\d+)/ // => `Regex<Tuple2<Substring, Substring>>`
```

After:
```swift
/(?<number>\d+)/ // => `Regex<(Substring, number: Substring)>`
```