### PR TITLE
Parse Oniguruma callout and absent function syntax

### DIFF
--- a/Sources/_MatchingEngine/Regex/AST/ASTProtocols.swift
+++ b/Sources/_MatchingEngine/Regex/AST/ASTProtocols.swift
@@ -40,3 +40,12 @@ extension AST.Group: _ASTParent {
 extension AST.Quantification: _ASTParent {
   var children: [AST] { [child] }
 }
+extension AST.AbsentFunction: _ASTParent {
+  var children: [AST] {
+    switch kind {
+    case .repeater(let a), .stopper(let a): return [a]
+    case .expression(let a, _, let c):      return [a, c]
+    case .clearer:                          return []
+    }
+  }
+}

--- a/Sources/_MatchingEngine/Regex/AST/Atom.swift
+++ b/Sources/_MatchingEngine/Regex/AST/Atom.swift
@@ -697,7 +697,7 @@ extension AST {
     case .alternation, .concatenation, .group,
         .conditional, .quantification, .quote,
         .trivia, .customCharacterClass, .empty,
-        .groupTransform:
+        .groupTransform, .absentFunction:
       return nil
     }
   }

--- a/Sources/_MatchingEngine/Regex/AST/Atom.swift
+++ b/Sources/_MatchingEngine/Regex/AST/Atom.swift
@@ -476,14 +476,117 @@ extension AST.Atom {
 }
 
 extension AST.Atom {
-  public struct Callout: Hashable {
-    public enum Argument: Hashable {
-      case number(Int)
-      case string(String)
+  public enum Callout: Hashable {
+    /// A PCRE callout written `(?C...)`
+    public struct PCRE: Hashable {
+      public enum Argument: Hashable {
+        case number(Int)
+        case string(String)
+      }
+      public var arg: AST.Located<Argument>
+
+      public init(_ arg: AST.Located<Argument>) {
+        self.arg = arg
+      }
+
+      /// Whether the argument isn't written explicitly in the source, e.g
+      /// `(?C)` which is implicitly `(?C0)`.
+      public var isImplicit: Bool { arg.location.isEmpty }
     }
-    public var arg: AST.Located<Argument>
-    public init(_ arg: AST.Located<Argument>) {
-      self.arg = arg
+
+    /// A named Oniguruma callout written `(*name[tag]{args, ...})`
+    public struct OnigurumaNamed: Hashable {
+      public struct ArgList: Hashable {
+        public var leftBrace: SourceLocation
+        public var args: [AST.Located<String>]
+        public var rightBrace: SourceLocation
+
+        public init(
+          _ leftBrace: SourceLocation,
+          _ args: [AST.Located<String>],
+          _ rightBrace: SourceLocation
+        ) {
+          self.leftBrace = leftBrace
+          self.args = args
+          self.rightBrace = rightBrace
+        }
+      }
+
+      public var name: AST.Located<String>
+      public var tag: OnigurumaTag?
+      public var args: ArgList?
+
+      public init(
+        _ name: AST.Located<String>, tag: OnigurumaTag?, args: ArgList?
+      ) {
+        self.name = name
+        self.tag = tag
+        self.args = args
+      }
+    }
+
+    /// An Oniguruma callout 'of contents', written `(?{...}[tag]D)`
+    public struct OnigurumaOfContents: Hashable {
+      public enum Direction: Hashable {
+        case inProgress   // > (the default)
+        case inRetraction // <
+        case both         // X
+      }
+      public var openBraces: SourceLocation
+      public var contents: AST.Located<String>
+      public var closeBraces: SourceLocation
+      public var tag: OnigurumaTag?
+      public var direction: AST.Located<Direction>
+
+      public init(
+        _ openBraces: SourceLocation, _ contents: AST.Located<String>,
+        _ closeBraces: SourceLocation, tag: OnigurumaTag?,
+        direction: AST.Located<Direction>
+      ) {
+        self.openBraces = openBraces
+        self.contents = contents
+        self.closeBraces = closeBraces
+        self.tag = tag
+        self.direction = direction
+      }
+
+      /// Whether the direction flag isn't written explicitly in the
+      /// source, e.g `(?{x})` which is implicitly `(?{x}>)`.
+      public var isDirectionImplicit: Bool { direction.location.isEmpty }
+    }
+    case pcre(PCRE)
+    case onigurumaNamed(OnigurumaNamed)
+    case onigurumaOfContents(OnigurumaOfContents)
+
+    private var _associatedValue: Any {
+      switch self {
+      case .pcre(let v):                return v
+      case .onigurumaNamed(let v):      return v
+      case .onigurumaOfContents(let v): return v
+      }
+    }
+
+    func `as`<T>(_ t: T.Type = T.self) -> T? {
+      _associatedValue as? T
+    }
+  }
+}
+
+extension AST.Atom.Callout {
+  /// A tag specifier `[...]` which may appear in an Oniguruma callout.
+  public struct OnigurumaTag: Hashable {
+    public var leftBracket: SourceLocation
+    public var name: AST.Located<String>
+    public var rightBracket: SourceLocation
+
+    public init(
+      _ leftBracket: SourceLocation,
+      _ name: AST.Located<String>,
+      _ rightBracket: SourceLocation
+    ) {
+      self.leftBracket = leftBracket
+      self.name = name
+      self.rightBracket = rightBracket
     }
   }
 }

--- a/Sources/_MatchingEngine/Regex/Parse/CaptureStructure.swift
+++ b/Sources/_MatchingEngine/Regex/Parse/CaptureStructure.swift
@@ -81,6 +81,15 @@ extension AST {
         quantification.amount.value == .zeroOrOne
           ? CaptureStructure.optional
           : CaptureStructure.array)
+    case .absentFunction(let abs):
+      // Only the child of an expression absent function is relevant, as the
+      // other expressions don't actually get matched against.
+      switch abs.kind {
+      case .expression(_, _, let child):
+        return child.captureStructure
+      case .clearer, .repeater, .stopper:
+        return .empty
+      }
     case .quote, .trivia, .atom, .customCharacterClass, .empty:
       return .empty
     }

--- a/Sources/_MatchingEngine/Regex/Parse/Diagnostics.swift
+++ b/Sources/_MatchingEngine/Regex/Parse/Diagnostics.swift
@@ -55,9 +55,11 @@ enum ParseError: Error, Hashable {
   case emptyProperty
 
   case expectedGroupSpecifier
+  case unbalancedEndOfGroup
   case expectedGroupName
   case groupNameMustBeAlphaNumeric
   case groupNameCannotStartWithNumber
+
   case cannotRemoveTextSegmentOptions
 }
 
@@ -116,6 +118,8 @@ extension ParseError: CustomStringConvertible {
       return "empty property"
     case .expectedGroupSpecifier:
       return "expected group specifier"
+    case .unbalancedEndOfGroup:
+      return "closing ')' does not balance any groups openings"
     case .expectedGroupName:
       return "expected group name"
     case .groupNameMustBeAlphaNumeric:

--- a/Sources/_MatchingEngine/Regex/Parse/Diagnostics.swift
+++ b/Sources/_MatchingEngine/Regex/Parse/Diagnostics.swift
@@ -31,6 +31,8 @@ enum ParseError: Error, Hashable {
   case tooManyBranchesInConditional(Int)
   case unsupportedCondition(String)
 
+  case tooManyAbsentExpressionChildren(Int)
+
   case expectedASCII(Character)
 
   case expectedNonEmptyContents
@@ -111,6 +113,8 @@ extension ParseError: CustomStringConvertible {
       return "expected 2 branches in conditional, have \(i)"
     case let .unsupportedCondition(str):
       return "\(str) cannot be used as condition"
+    case let .tooManyAbsentExpressionChildren(i):
+      return "expected 2 expressions in absent expression, have \(i)"
     case let .unknownGroupKind(str):
       return "unknown group kind '(\(str)'"
     case let .unknownCalloutKind(str):

--- a/Sources/_MatchingEngine/Regex/Parse/Diagnostics.swift
+++ b/Sources/_MatchingEngine/Regex/Parse/Diagnostics.swift
@@ -56,11 +56,24 @@ enum ParseError: Error, Hashable {
 
   case expectedGroupSpecifier
   case unbalancedEndOfGroup
-  case expectedGroupName
-  case groupNameMustBeAlphaNumeric
-  case groupNameCannotStartWithNumber
+
+  // Identifier diagnostics.
+  case expectedIdentifier(IdentifierKind)
+  case identifierMustBeAlphaNumeric(IdentifierKind)
+  case identifierCannotStartWithNumber(IdentifierKind)
 
   case cannotRemoveTextSegmentOptions
+  case expectedCalloutArgument
+}
+
+extension IdentifierKind {
+  fileprivate var diagDescription: String {
+    switch self {
+    case .groupName:            return "group name"
+    case .onigurumaCalloutName: return "callout name"
+    case .onigurumaCalloutTag:  return "callout tag"
+    }
+  }
 }
 
 extension ParseError: CustomStringConvertible {
@@ -120,14 +133,16 @@ extension ParseError: CustomStringConvertible {
       return "expected group specifier"
     case .unbalancedEndOfGroup:
       return "closing ')' does not balance any groups openings"
-    case .expectedGroupName:
-      return "expected group name"
-    case .groupNameMustBeAlphaNumeric:
-      return "group name must only contain alphanumeric characters"
-    case .groupNameCannotStartWithNumber:
-      return "group name must not start with number"
+    case .expectedIdentifier(let i):
+      return "expected \(i.diagDescription)"
+    case .identifierMustBeAlphaNumeric(let i):
+      return "\(i.diagDescription) must only contain alphanumeric characters"
+    case .identifierCannotStartWithNumber(let i):
+      return "\(i.diagDescription) must not start with number"
     case .cannotRemoveTextSegmentOptions:
       return "text segment mode cannot be unset, only changed"
+    case .expectedCalloutArgument:
+      return "expected argument to callout"
     }
   }
 }

--- a/Sources/_MatchingEngine/Regex/Parse/LexicalAnalysis.swift
+++ b/Sources/_MatchingEngine/Regex/Parse/LexicalAnalysis.swift
@@ -967,6 +967,19 @@ extension Source {
     }
   }
 
+  /// Try to consume the start of an absent function.
+  ///
+  ///     AbsentFunctionStart -> '(?~' '|'?
+  ///
+  mutating func lexAbsentFunctionStart(
+  ) -> Located<AST.AbsentFunction.Start>? {
+    recordLoc { src in
+      if src.tryEat(sequence: "(?~|") { return .withPipe }
+      if src.tryEat(sequence: "(?~") { return .withoutPipe }
+      return nil
+    }
+  }
+
   mutating func lexCustomCCStart(
   ) throws -> Located<CustomCC.Start>? {
     recordLoc { src in

--- a/Sources/_MatchingEngine/Regex/Parse/LexicalAnalysis.swift
+++ b/Sources/_MatchingEngine/Regex/Parse/LexicalAnalysis.swift
@@ -62,12 +62,14 @@ extension Source {
 
   /// Record source loc before processing and return
   /// or throw the value/error with source locations.
+  @discardableResult
   fileprivate mutating func recordLoc(
     _ f: (inout Self) throws -> ()
-  ) rethrows {
+  ) rethrows -> SourceLocation {
     let start = currentPosition
     do {
       try f(&self)
+      return SourceLocation(start..<currentPosition)
     } catch let e as Source.LocatedError<ParseError> {
       throw e
     } catch let e as ParseError {
@@ -83,8 +85,9 @@ extension Source {
   typealias Quant = AST.Quantification
 
   /// Throws an expected character error if not matched
-  mutating func expect(_ c: Character) throws {
-    _ = try recordLoc { src in
+  @discardableResult
+  mutating func expect(_ c: Character) throws -> SourceLocation {
+    try recordLoc { src in
       guard src.tryEat(c) else {
         throw ParseError.expected(String(c))
       }
@@ -180,6 +183,12 @@ enum RadixKind {
     case .hex:     return 16
     }
   }
+}
+
+enum IdentifierKind {
+  case groupName
+  case onigurumaCalloutName
+  case onigurumaCalloutTag
 }
 
 extension Source {
@@ -428,14 +437,16 @@ extension Source {
   /// delimiter. If `ignoreEscaped` is true, escaped characters will not be
   /// considered for the ending delimiter.
   private mutating func expectQuoted(
-    endingWith end: String, ignoreEscaped: Bool = false, eatEnding: Bool = true
+    endingWith endSingle: String, count: Int = 1, ignoreEscaped: Bool = false,
+    eatEnding: Bool = true
   ) throws -> Located<String> {
+    let end = String(repeating: endSingle, count: count)
     let result = try recordLoc { src -> String in
       try src.lexUntil { src in
         if src.starts(with: end) {
           return true
         }
-        try src.expectNonEmpty(.expected(end))
+        try src.expectNonEmpty(.expected(endSingle))
 
         // Ignore escapes if we're allowed to. lexUntil will consume the next
         // character.
@@ -659,19 +670,22 @@ extension Source {
     }
   }
 
-  /// Consume a group name.
-  private mutating func expectGroupName(
-    endingWith ending: String, eatEnding: Bool = true
+  /// Consume an identifier.
+  ///
+  ///     Identifier -> [\w--\d] \w*
+  ///
+  private mutating func expectIdentifier(
+    _ kind: IdentifierKind, endingWith ending: String, eatEnding: Bool = true
   ) throws -> Located<String> {
     let str = try recordLoc { src -> String in
       if src.isEmpty || src.tryEat(sequence: ending) {
-        throw ParseError.expectedGroupName
+        throw ParseError.expectedIdentifier(kind)
       }
       if src.peek()!.isNumber {
-        throw ParseError.groupNameCannotStartWithNumber
+        throw ParseError.identifierCannotStartWithNumber(kind)
       }
       guard let str = src.tryEatPrefix(\.isWordCharacter)?.string else {
-        throw ParseError.groupNameMustBeAlphaNumeric
+        throw ParseError.identifierMustBeAlphaNumeric(kind)
       }
       return str
     }
@@ -681,13 +695,22 @@ extension Source {
     return str
   }
 
+  /// Try to consume an identifier, returning `nil` if unsuccessful.
+  private mutating func lexIdentifier(
+    _ kind: IdentifierKind, endingWith end: String, eatEnding: Bool = true
+  ) -> Located<String>? {
+    tryEating { src in
+      try? src.expectIdentifier(kind, endingWith: end, eatEnding: eatEnding)
+    }
+  }
+
   /// Consume a named group field, producing either a named capture or balanced
   /// capture.
   ///
   ///     NamedGroup    -> 'P<' GroupNameBody '>'
   ///                    | '<' GroupNameBody '>'
   ///                    | "'" GroupNameBody "'"
-  ///     GroupNameBody -> \w+ | \w* '-' \w+
+  ///     GroupNameBody -> Identifier | Identifier? '-' Identifier
   ///
   private mutating func expectNamedGroup(
     endingWith ending: String
@@ -695,14 +718,16 @@ extension Source {
     func lexBalanced(_ lhs: Located<String>? = nil) throws -> AST.Group.Kind? {
       // If we have a '-', this is a .NET-style 'balanced group'.
       guard let dash = tryEatWithLoc("-") else { return nil }
-      let rhs = try expectGroupName(endingWith: ending)
+      let rhs = try expectIdentifier(.groupName, endingWith: ending)
       return .balancedCapture(.init(name: lhs, dash: dash, priorName: rhs))
     }
 
     // Lex a group name, trying to lex a '-rhs' for a balanced capture group
     // both before and after.
     if let b = try lexBalanced() { return b }
-    let name = try expectGroupName(endingWith: ending, eatEnding: false)
+    let name = try expectIdentifier(
+      .groupName, endingWith: ending, eatEnding: false
+    )
     if let b = try lexBalanced(name) { return b }
 
     try expect(sequence: ending)
@@ -1105,7 +1130,8 @@ extension Source {
   ) throws -> AST.Reference {
     // Note we don't want to eat the ending as we may also want to parse a
     // recursion level.
-    let str = try expectGroupName(endingWith: end, eatEnding: false)
+    let str = try expectIdentifier(
+      .groupName, endingWith: end, eatEnding: false)
 
     // If we're allowed to, try parse a recursion level.
     let recLevel = allowRecursionLevel ? try lexRecursionLevel() : nil
@@ -1321,12 +1347,15 @@ extension Source {
       // The start of a reference '(?P=', '(?R', ...
       if src.canLexGroupLikeReference() { return true }
 
-      // The start of a callout.
+      // The start of a PCRE callout.
       if src.tryEat("C") { return true }
+
+      // The start of an Oniguruma 'of-contents' callout.
+      if src.tryEat("{") { return true }
 
       return false
     }
-    // The start of a backreference directive.
+    // The start of a backreference directive or Oniguruma named callout.
     if src.tryEat("*") { return true }
 
     return false
@@ -1393,22 +1422,22 @@ extension Source {
     }
   }
 
-  /// Try to consume a callout.
+  /// Try to consume a PCRE callout.
   ///
-  ///     Callout     -> '(?C' CalloutBody ')'
-  ///     CalloutBody -> '' | <Number>
-  ///                  | '`' <String> '`'
-  ///                  | "'" <String> "'"
-  ///                  | '"' <String> '"'
-  ///                  | '^' <String> '^'
-  ///                  | '%' <String> '%'
-  ///                  | '#' <String> '#'
-  ///                  | '$' <String> '$'
-  ///                  | '{' <String> '}'
+  ///     PCRECallout     -> '(?C' CalloutBody ')'
+  ///     PCRECalloutBody -> '' | <Number>
+  ///                      | '`' <String> '`'
+  ///                      | "'" <String> "'"
+  ///                      | '"' <String> '"'
+  ///                      | '^' <String> '^'
+  ///                      | '%' <String> '%'
+  ///                      | '#' <String> '#'
+  ///                      | '$' <String> '$'
+  ///                      | '{' <String> '}'
   ///
-  mutating func lexCallout() throws -> AST.Atom.Callout? {
+  mutating func lexPCRECallout() throws -> AST.Atom.Callout? {
     guard tryEat(sequence: "(?C") else { return nil }
-    let arg = try recordLoc { src -> AST.Atom.Callout.Argument in
+    let arg = try recordLoc { src -> AST.Atom.Callout.PCRE.Argument in
       // Parse '(?C' followed by a number.
       if let num = try src.lexNumber() {
         return .number(num.value)
@@ -1432,7 +1461,104 @@ extension Source {
       throw ParseError.unknownCalloutKind("(?C\(remaining))")
     }
     try expect(")")
-    return .init(arg)
+    return .pcre(.init(arg))
+  }
+
+  /// Consume a list of arguments for an Oniguruma callout.
+  ///
+  ///     OnigurumaCalloutArgList -> OnigurumaCalloutArg (',' OnigurumaCalloutArgList)*
+  ///     OnigurumaCalloutArg -> [^,}]+
+  ///
+  mutating func expectOnigurumaCalloutArgList(
+    leftBrace: SourceLocation
+  ) throws -> AST.Atom.Callout.OnigurumaNamed.ArgList {
+    var args: [Located<String>] = []
+    while true {
+      let arg = try recordLoc { src -> String in
+        // TODO: Warn about whitespace being included?
+        guard let arg = src.tryEatPrefix({ $0 != "," && $0 != "}" }) else {
+          throw ParseError.expectedCalloutArgument
+        }
+        return arg.string
+      }
+      args.append(arg)
+
+      if peek() == "}" { break }
+      try expect(",")
+    }
+    let rightBrace = try expect("}")
+    return .init(leftBrace, args,  rightBrace)
+  }
+
+  /// Try to consume an Oniguruma callout tag.
+  ///
+  ///     OnigurumaTag -> '[' Identifier ']'
+  ///
+  mutating func lexOnigurumaCalloutTag(
+  ) throws -> AST.Atom.Callout.OnigurumaTag? {
+    guard let leftBracket = tryEatWithLoc("[") else { return nil }
+    let name = try expectIdentifier(
+      .onigurumaCalloutTag, endingWith: "]", eatEnding: false
+    )
+    let rightBracket = try expect("]")
+    return .init(leftBracket, name, rightBracket)
+  }
+
+  /// Try to consume a named Oniguruma callout.
+  ///
+  ///     OnigurumaNamedCallout -> '(*' Identifier OnigurumaTag? Args? ')'
+  ///     Args                  -> '{' OnigurumaCalloutArgList '}'
+  ///
+  mutating func lexOnigurumaNamedCallout() throws -> AST.Atom.Callout? {
+    try tryEating { src in
+      guard src.tryEat(sequence: "(*") else { return nil }
+      guard let name = src.lexIdentifier(
+        .onigurumaCalloutName, endingWith: ")", eatEnding: false)
+      else { return nil }
+
+      let tag = try src.lexOnigurumaCalloutTag()
+
+      let args = try src.tryEatWithLoc("{").map {
+        try src.expectOnigurumaCalloutArgList(leftBrace: $0)
+      }
+      try src.expect(")")
+      return .onigurumaNamed(.init(name, tag: tag, args: args))
+    }
+  }
+
+  /// Try to consume an Oniguruma callout 'of contents'.
+  ///
+  ///     OnigurumaCalloutOfContents -> '(?' '{'+ Contents '}'+ OnigurumaTag? Direction? ')'
+  ///     Contents                   -> <String>
+  ///     Direction                  -> 'X' | '<' | '>'
+  ///
+  mutating func lexOnigurumaCalloutOfContents() throws -> AST.Atom.Callout? {
+    try tryEating { src in
+      guard src.tryEat(sequence: "(?"),
+            let openBraces = src.tryEatPrefix({ $0 == "{" })
+      else { return nil }
+
+      let contents = try src.expectQuoted(
+        endingWith: "}", count: openBraces.count)
+      let closeBraces = SourceLocation(
+        contents.location.end ..< src.currentPosition)
+
+      let tag = try src.lexOnigurumaCalloutTag()
+
+      typealias Direction = AST.Atom.Callout.OnigurumaOfContents.Direction
+      let direction = src.recordLoc { src -> Direction in
+        if src.tryEat(">") { return .inProgress }
+        if src.tryEat("<") { return .inRetraction }
+        if src.tryEat("X") { return .both }
+        // The default is in-progress.
+        return .inProgress
+      }
+      try src.expect(")")
+
+      let openBracesLoc = SourceLocation(from: openBraces)
+      return .onigurumaOfContents(.init(
+        openBracesLoc, contents, closeBraces, tag: tag, direction: direction))
+    }
   }
 
   /// Try to consume a backtracking directive.
@@ -1485,14 +1611,25 @@ extension Source {
         return ref.value
       }
 
-      // (?C)
-      if let callout = try src.lexCallout() {
-        return .callout(callout)
-      }
-
       // (*ACCEPT), (*FAIL), (*MARK), ...
       if let b = try src.lexBacktrackingDirective() {
         return .backtrackingDirective(b)
+      }
+
+      // (?C)
+      if let callout = try src.lexPCRECallout() {
+        return .callout(callout)
+      }
+
+      // Try to consume an Oniguruma named callout '(*name)', which should be
+      // done after backtracking directives and global options.
+      if let callout = try src.lexOnigurumaNamedCallout() {
+        return .callout(callout)
+      }
+
+      // (?{...})
+      if let callout = try src.lexOnigurumaCalloutOfContents() {
+        return .callout(callout)
       }
 
       // If we didn't produce an atom, consume up until a reasonable end-point

--- a/Sources/_MatchingEngine/Regex/Parse/Parse.swift
+++ b/Sources/_MatchingEngine/Regex/Parse/Parse.swift
@@ -262,11 +262,58 @@ extension Parser {
     return .init(kind, child, loc(start))
   }
 
+  /// Consume the body of an absent function.
+  ///
+  ///     AbsentFunction -> '(?~' RegexNode ')'
+  ///                     | '(?~|' Concatenation '|' Concatenation ')'
+  ///                     | '(?~|' Concatenation ')'
+  ///                     | '(?~|)'
+  ///
+  mutating func parseAbsentFunctionBody(
+    _ start: AST.Located<AST.AbsentFunction.Start>
+  ) throws -> AST.AbsentFunction {
+    let startLoc = start.location
+
+    // TODO: Diagnose on nested absent functions, which Oniguruma states is
+    // undefined behavior.
+    let kind: AST.AbsentFunction.Kind
+    switch start.value {
+    case .withoutPipe:
+      // Must be a repeater.
+      kind = .repeater(try parseNode())
+    case .withPipe where source.peek() == ")":
+      kind = .clearer
+    case .withPipe:
+      // Can either be an expression or stopper depending on whether we have a
+      // any additional '|'s.
+      let child = try parseNode()
+      switch child {
+      case .alternation(let alt):
+        // A pipe, so an expression.
+        let numChildren = alt.children.count
+        guard numChildren == 2 else {
+          throw Source.LocatedError(
+            ParseError.tooManyAbsentExpressionChildren(numChildren),
+            child.location
+          )
+        }
+        kind = .expression(
+          absentee: alt.children[0], pipe: alt.pipes[0], expr: alt.children[1])
+      default:
+        // No pipes, so a stopper.
+        kind = .stopper(child)
+      }
+    }
+    try source.expect(")")
+    return .init(kind, start: startLoc, location: loc(startLoc.start))
+  }
+
   /// Parse a (potentially quantified) component
   ///
-  ///     QuantOperand -> Conditional | Group | CustomCharClass | Atom
-  ///     Group        -> GroupStart Regex ')'
-  ///     Conditional  -> ConditionalStart Concatenation ('|' Concatenation)? ')'
+  ///     QuantOperand     -> Conditional | Group | CustomCharClass | Atom
+  ///                       | AbsentFunction
+  ///     Group            -> GroupStart RecursiveRegex ')'
+  ///     Conditional      -> ConditionalStart Concatenation ('|' Concatenation)? ')'
   ///     ConditionalStart -> KnownConditionalStart | GroupConditionalStart
   ///
   mutating func parseQuantifierOperand() throws -> AST? {
@@ -284,6 +331,11 @@ extension Parser {
       let group = try parseGroupBody(start: groupStart, kind)
       return try parseConditionalBranches(
         start: _start, .init(.group(group), group.location))
+    }
+
+    // Check if we have an Oniguruma absent function.
+    if let start = source.lexAbsentFunctionStart() {
+      return .absentFunction(try parseAbsentFunctionBody(start))
     }
 
     // Check if we have the start of a group '('.

--- a/Sources/_MatchingEngine/Regex/Parse/SourceLocation.swift
+++ b/Sources/_MatchingEngine/Regex/Parse/SourceLocation.swift
@@ -27,6 +27,9 @@ extension Source {
     ) where R.Bound == Source.Position {
       self.init(r.relative(to: input.input))
     }
+    public init(from sub: Input.SubSequence) {
+      self.init(sub.startIndex ..< sub.endIndex)
+    }
 
     /// NOTE: This is a temporary measure to unblock DSL efforts and
     /// incremental source location tracking. This shouldn't be called from
@@ -36,6 +39,9 @@ extension Source {
     }
     public var isFake: Bool { self == Self.fake }
     public var isReal: Bool { !isFake }
+
+    /// Whether this location covers an empty range. This includes `isFake`.
+    public var isEmpty: Bool { start == end }
 
     /// Returns the smallest location that contains both this location and
     /// another.

--- a/Sources/_MatchingEngine/Regex/Printing/DumpAST.swift
+++ b/Sources/_MatchingEngine/Regex/Printing/DumpAST.swift
@@ -144,7 +144,53 @@ extension AST.Atom {
 }
 
 extension AST.Atom.Callout: _ASTPrintable {
-  public var _dumpBase: String { "callout <\(arg.value)>" }
+  public var _dumpBase: String {
+    switch self {
+    case .pcre(let p):                  return "\(p)"
+    case .onigurumaNamed(let o):        return "\(o)"
+    case .onigurumaOfContents(let o):   return "\(o)"
+    }
+  }
+}
+
+extension AST.Atom.Callout.PCRE: _ASTPrintable {
+  public var _dumpBase: String {
+    "PCRE callout \(arg.value)"
+  }
+}
+
+extension AST.Atom.Callout.OnigurumaTag: _ASTPrintable {
+  public var _dumpBase: String { "[\(name.value)]" }
+}
+
+extension AST.Atom.Callout.OnigurumaNamed.ArgList: _ASTPrintable {
+  public var _dumpBase: String {
+    "{\(args.map { $0.value }.joined(separator: ","))}"
+  }
+}
+
+extension AST.Atom.Callout.OnigurumaNamed: _ASTPrintable {
+  public var _dumpBase: String {
+    var result = "named oniguruma callout \(name.value)"
+    if let tag = tag {
+      result += "\(tag)"
+    }
+    if let args = args {
+      result += "\(args)"
+    }
+    return result
+  }
+}
+
+extension AST.Atom.Callout.OnigurumaOfContents: _ASTPrintable {
+  public var _dumpBase: String {
+    var result = "oniguruma callout of contents {\(contents.value)}"
+    if let tag = tag {
+      result += "\(tag)"
+    }
+    result += " \(direction.value)"
+    return result
+  }
 }
 
 extension AST.Reference: _ASTPrintable {

--- a/Sources/_MatchingEngine/Regex/Printing/DumpAST.swift
+++ b/Sources/_MatchingEngine/Regex/Printing/DumpAST.swift
@@ -314,3 +314,24 @@ extension AST.Group.BalancedCapture: _ASTPrintable {
    "\(name?.value ?? "")-\(priorName.value)"
   }
 }
+
+extension AST.AbsentFunction.Kind {
+  public var _dumpBase: String {
+    switch self {
+    case .repeater:
+      return "repeater"
+    case .expression:
+      return "expression"
+    case .stopper:
+      return "stopper"
+    case .clearer:
+      return "clearer"
+    }
+  }
+}
+
+extension AST.AbsentFunction {
+  public var _dumpBase: String {
+    "absent function \(kind._dumpBase)"
+  }
+}

--- a/Sources/_MatchingEngine/Regex/Printing/PrintAsCanonical.swift
+++ b/Sources/_MatchingEngine/Regex/Printing/PrintAsCanonical.swift
@@ -87,6 +87,9 @@ extension PrettyPrinter {
     case let .customCharacterClass(ccc):
       outputAsCanonical(ccc)
 
+    case let .absentFunction(abs):
+      outputAsCanonical(abs)
+
     case .empty:
       output("")
 
@@ -125,6 +128,25 @@ extension PrettyPrinter {
 
   mutating func outputAsCanonical(_ condition: AST.Conditional.Condition) {
     output("(/*TODO: conditional \(condition) */)")
+  }
+
+  mutating func outputAsCanonical(_ abs: AST.AbsentFunction) {
+    output("(?~")
+    switch abs.kind {
+    case .repeater(let a):
+      outputAsCanonical(a)
+    case .expression(let a, _, let child):
+      output("|")
+      outputAsCanonical(a)
+      output("|")
+      outputAsCanonical(child)
+    case .stopper(let a):
+      output("|")
+      outputAsCanonical(a)
+    case .clearer:
+      output("|")
+    }
+    output(")")
   }
 }
 

--- a/Sources/_MatchingEngine/Regex/Printing/PrintAsPattern.swift
+++ b/Sources/_MatchingEngine/Regex/Printing/PrintAsPattern.swift
@@ -128,6 +128,9 @@ extension PrettyPrinter {
     case let .customCharacterClass(ccc):
       printAsPattern(ccc)
 
+    case let .absentFunction(abs):
+      print("/*TODO: absent function \(abs)*/")
+
     case .empty: print("")
     case .groupTransform:
       print("// FIXME: get group transform out of here!")

--- a/Sources/_StringProcessing/ASTBuilder.swift
+++ b/Sources/_StringProcessing/ASTBuilder.swift
@@ -179,6 +179,23 @@ func pcreCallout(_ arg: AST.Atom.Callout.PCRE.Argument) -> AST {
   atom(.callout(.pcre(.init(.init(faking: arg)))))
 }
 
+func absentRepeater(_ child: AST) -> AST {
+  .absentFunction(.init(.repeater(child), start: .fake, location: .fake))
+}
+func absentExpression(_ absentee: AST, _ child: AST) -> AST {
+  .absentFunction(.init(
+    .expression(absentee: absentee, pipe: .fake, expr: child),
+    start: .fake, location: .fake
+  ))
+}
+func absentStopper(_ absentee: AST) -> AST {
+  .absentFunction(.init(.stopper(absentee), start: .fake, location: .fake))
+
+}
+func absentRangeClear() -> AST {
+  .absentFunction(.init(.clearer, start: .fake, location: .fake))
+}
+
 func onigurumaNamedCallout(
   _ name: String, tag: String? = nil, args: String...
 ) -> AST {

--- a/Sources/_StringProcessing/ASTBuilder.swift
+++ b/Sources/_StringProcessing/ASTBuilder.swift
@@ -175,8 +175,29 @@ func groupCondition(
   .group(.init(.init(faking: kind), child, .fake))
 }
 
-func callout(_ arg: AST.Atom.Callout.Argument) -> AST {
-  atom(.callout(.init(.init(faking: arg))))
+func pcreCallout(_ arg: AST.Atom.Callout.PCRE.Argument) -> AST {
+  atom(.callout(.pcre(.init(.init(faking: arg)))))
+}
+
+func onigurumaNamedCallout(
+  _ name: String, tag: String? = nil, args: String...
+) -> AST {
+  atom(.callout(.onigurumaNamed(.init(
+    .init(faking: name),
+    tag: tag.map { .init(.fake, .init(faking: $0), .fake) },
+    args: args.isEmpty ? nil : .init(.fake, args.map { .init(faking: $0) }, .fake)
+  ))))
+}
+
+func onigurumaCalloutOfContents(
+  _ contents: String, tag: String? = nil,
+  direction: AST.Atom.Callout.OnigurumaOfContents.Direction = .inProgress
+) -> AST {
+  atom(.callout(.onigurumaOfContents(.init(
+    .fake, .init(faking: contents), .fake,
+    tag: tag.map { .init(.fake, .init(faking: $0), .fake) },
+    direction: .init(faking: direction)
+  ))))
 }
 
 func backtrackingDirective(

--- a/Sources/_StringProcessing/Compiler.swift
+++ b/Sources/_StringProcessing/Compiler.swift
@@ -93,6 +93,9 @@ class Compiler {
     case .trivia, .empty:
       break
 
+    case .absentFunction:
+      throw unsupported(node.renderAsCanonical())
+
     case .group(let g):
       if let lookaround = g.lookaroundKind {
         try emitLookaround(lookaround, g.child)

--- a/Sources/_StringProcessing/ConsumerInterface.swift
+++ b/Sources/_StringProcessing/ConsumerInterface.swift
@@ -52,7 +52,7 @@ extension AST {
       return try ccc.generateConsumer(opts)
     case .alternation, .conditional, .concatenation, .group,
         .quantification, .quote, .trivia, .empty,
-        .groupTransform: return nil
+        .groupTransform, .absentFunction: return nil
     }
   }
 }

--- a/Sources/_StringProcessing/Legacy/LegacyCompile.swift
+++ b/Sources/_StringProcessing/Legacy/LegacyCompile.swift
@@ -260,6 +260,9 @@ func compile(
     case .conditional:
       throw unsupported(ast.renderAsCanonical())
 
+    case .absentFunction:
+      throw unsupported(ast.renderAsCanonical())
+
     case .customCharacterClass:
       fatalError("unreachable")
 

--- a/Tests/RegexTests/ParseTests.swift
+++ b/Tests/RegexTests/ParseTests.swift
@@ -1312,9 +1312,12 @@ extension RegexTests {
   }
 
   func testParseErrors() {
-    // MARK: Closing delimiters.
+    // MARK: Unbalanced delimiters.
 
     diagnosticTest("(", .expected(")"))
+    diagnosticTest(")", .unbalancedEndOfGroup)
+    diagnosticTest(")))", .unbalancedEndOfGroup)
+    diagnosticTest("())()", .unbalancedEndOfGroup)
 
     diagnosticTest(#"\u{5"#, .expected("}"))
     diagnosticTest(#"\x{5"#, .expected("}"))


### PR DESCRIPTION
Parse both variants of Oniguruma callout syntax `(*name[tag]{args, ...})` and `(?{...}[])`, as well as Oniguruma absent functions `(?~|)`. In addition, diagnose ending `)`s that don't close any groups.