### PR TITLE
Parse global matching options

### DIFF
--- a/Sources/_MatchingEngine/Regex/AST/AST.swift
+++ b/Sources/_MatchingEngine/Regex/AST/AST.swift
@@ -13,8 +13,11 @@
 /// node.
 public struct AST: Hashable {
   public var root: AST.Node
-  public init(_ root: AST.Node) {
+  public var globalOptions: GlobalMatchingOptionSequence?
+
+  public init(_ root: AST.Node, globalOptions: GlobalMatchingOptionSequence?) {
     self.root = root
+    self.globalOptions = globalOptions
   }
 }
 
@@ -290,6 +293,20 @@ extension AST {
     /// Whether this is a reference that recurses the whole pattern, rather than
     /// a group.
     public var recursesWholePattern: Bool { kind == .recurseWholePattern }
+  }
+
+  /// A set of global matching options in a regular expression literal.
+  public struct GlobalMatchingOptionSequence: Hashable {
+    public var options: [AST.GlobalMatchingOption]
+
+    public init?(_ options: [AST.GlobalMatchingOption]) {
+      guard !options.isEmpty else { return nil }
+      self.options = options
+    }
+
+    public var location: SourceLocation {
+      options.first!.location.union(with: options.last!.location)
+    }
   }
 }
 

--- a/Sources/_MatchingEngine/Regex/AST/MatchingOptions.swift
+++ b/Sources/_MatchingEngine/Regex/AST/MatchingOptions.swift
@@ -105,3 +105,82 @@ extension AST.MatchingOptionSequence: _ASTPrintable {
     "adding: \(adding), removing: \(removing), hasCaret: \(caretLoc != nil)"
   }
 }
+
+extension AST {
+  /// Global matching option specifiers. Unlike `MatchingOptionSequence`,
+  /// these must appear at the start of the pattern, and apply globally.
+  public struct GlobalMatchingOption: _ASTNode, Hashable {
+    /// Determines the definition of a newline for the '.' character class.
+    public enum NewlineMatching: Hashable {
+      /// (*CR*)
+      case carriageReturnOnly
+      
+      /// (*LF)
+      case linefeedOnly
+
+      /// (*CRLF)
+      case carriageAndLinefeedOnly
+
+      /// (*ANYCRLF)
+      case anyCarriageReturnOrLinefeed
+
+      /// (*ANY)
+      case anyUnicode
+
+      /// (*NUL)
+      case nulCharacter
+    }
+    /// Determines what `\R` matches.
+    public enum NewlineSequenceMatching: Hashable {
+      /// (*BSR_ANYCRLF)
+      case anyCarriageReturnOrLinefeed
+
+      /// (*BSR_UNICODE)
+      case anyUnicode
+    }
+    public enum Kind: Hashable {
+      /// (*LIMIT_DEPTH=d)
+      case limitDepth(Located<Int>)
+
+      /// (*LIMIT_HEAP=d)
+      case limitHeap(Located<Int>)
+
+      /// (*LIMIT_MATCH=d)
+      case limitMatch(Located<Int>)
+
+      /// (*NOTEMPTY)
+      case notEmpty
+
+      /// (*NOTEMPTY_ATSTART)
+      case notEmptyAtStart
+
+      /// (*NO_AUTO_POSSESS)
+      case noAutoPossess
+
+      /// (*NO_DOTSTAR_ANCHOR)
+      case noDotStarAnchor
+
+      /// (*NO_JIT)
+      case noJIT
+
+      /// (*NO_START_OPT)
+      case noStartOpt
+
+      /// (*UTF)
+      case utfMode
+
+      /// (*UCP)
+      case unicodeProperties
+
+      case newlineMatching(NewlineMatching)
+      case newlineSequenceMatching(NewlineSequenceMatching)
+    }
+    public var kind: Kind
+    public var location: SourceLocation
+
+    public init(_ kind: Kind, _ location: SourceLocation) {
+      self.kind = kind
+      self.location = location
+    }
+  }
+}

--- a/Sources/_MatchingEngine/Regex/Parse/Diagnostics.swift
+++ b/Sources/_MatchingEngine/Regex/Parse/Diagnostics.swift
@@ -33,6 +33,8 @@ enum ParseError: Error, Hashable {
 
   case tooManyAbsentExpressionChildren(Int)
 
+  case globalMatchingOptionNotAtStart(String)
+
   case expectedASCII(Character)
 
   case expectedNonEmptyContents
@@ -116,6 +118,8 @@ extension ParseError: CustomStringConvertible {
       return "\(str) cannot be used as condition"
     case let .tooManyAbsentExpressionChildren(i):
       return "expected 2 expressions in absent expression, have \(i)"
+    case let .globalMatchingOptionNotAtStart(opt):
+      return "matching option '\(opt)' may only appear at the start of the regex"
     case let .unknownGroupKind(str):
       return "unknown group kind '(\(str)'"
     case let .unknownCalloutKind(str):

--- a/Sources/_MatchingEngine/Regex/Printing/DumpAST.swift
+++ b/Sources/_MatchingEngine/Regex/Printing/DumpAST.swift
@@ -58,7 +58,12 @@ extension _ASTPrintable {
 
 extension AST: _ASTPrintable {
   public var _dumpBase: String {
-    root._dumpBase
+    var result = ""
+    if let opts = globalOptions {
+      result += "\(opts) "
+    }
+    result += root._dump()
+    return result
   }
 }
 
@@ -339,5 +344,19 @@ extension AST.AbsentFunction.Kind {
 extension AST.AbsentFunction {
   public var _dumpBase: String {
     "absent function \(kind._dumpBase)"
+  }
+}
+
+extension AST.GlobalMatchingOption.Kind: _ASTPrintable {
+  public var _dumpBase: String { _canonicalBase }
+}
+
+extension AST.GlobalMatchingOption: _ASTPrintable {
+  public var _dumpBase: String { "\(kind._dumpBase)" }
+}
+
+extension AST.GlobalMatchingOptionSequence: _ASTPrintable {
+  public var _dumpBase: String {
+    "GlobalMatchingOptionSequence<\(options)>"
   }
 }

--- a/Sources/_MatchingEngine/Regex/Printing/PrintAsPattern.swift
+++ b/Sources/_MatchingEngine/Regex/Printing/PrintAsPattern.swift
@@ -42,12 +42,13 @@ extension PrettyPrinter {
   }
 
   mutating func printAsPattern(_ ast: AST) {
+    // TODO: Global matching options?
     printAsPattern(ast.root)
   }
 
   mutating func printAsPattern(_ ast: AST.Node) {
     if patternBackoff(ast) {
-      printAsCanonical(ast, delimiters: true)
+      printAsCanonical(.init(ast, globalOptions: nil), delimiters: true)
       return
     }
 

--- a/Sources/_StringProcessing/ASTBuilder.swift
+++ b/Sources/_StringProcessing/ASTBuilder.swift
@@ -47,6 +47,14 @@ func empty() -> AST.Node {
   .empty(.init(.fake))
 }
 
+func ast(_ root: AST.Node, opts: [AST.GlobalMatchingOption.Kind]) -> AST {
+  .init(root, globalOptions: .init(opts.map { .init($0, .fake) }))
+}
+
+func ast(_ root: AST.Node, opts: AST.GlobalMatchingOption.Kind...) -> AST {
+  ast(root, opts: opts)
+}
+
 func group(
   _ kind: AST.Group.Kind, _ child: AST.Node
 ) -> AST.Node {

--- a/Sources/_StringProcessing/Compiler.swift
+++ b/Sources/_StringProcessing/Compiler.swift
@@ -28,6 +28,7 @@ class Compiler {
   }
 
   __consuming func emit() throws -> RegexProgram {
+    // TODO: Global matching options?
     try emit(ast.root)
     builder.buildAccept()
     let program = builder.assemble()

--- a/Sources/_StringProcessing/RegexDSL/Core.swift
+++ b/Sources/_StringProcessing/RegexDSL/Core.swift
@@ -79,7 +79,7 @@ public struct Regex<Match: MatchProtocol>: RegexProtocol {
     self.program = Program(ast: ast)
   }
   init(ast: AST.Node) {
-    self.program = Program(ast: .init(ast))
+    self.program = Program(ast: .init(ast, globalOptions: nil))
   }
 
   // Compiler interface. Do not change independently.


### PR DESCRIPTION
Parse the PCRE global matching options e.g `(*CR)`, `(*UTF)`, and `(*LIMIT_DEPTH=d)`. Such options may only appear at the very start of the regex, and as such are stored on the top-level AST type.