### PR TITLE
Heterogenous alternation

### DIFF
--- a/Sources/_StringProcessing/RegexDSL/Concatenation.swift
+++ b/Sources/_StringProcessing/RegexDSL/Concatenation.swift
@@ -2053,6 +2053,1221 @@ public postfix func .*<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexPr
 }
 
 
+public struct _Alternation_0_0<R0, R1>: RegexProtocol where R0: RegexProtocol, R1: RegexProtocol {
+  public typealias Match = Substring
+  public let regex: Regex<Match>
+
+  public init(_ left: R0, _ right: R1) {
+    self.regex = .init(node: left.regex.root.appendingAlternationCase(right.regex.root))
+  }
+}
+
+extension AlternationBuilder {
+  public static func buildBlock<R0, R1>(combining next: R1, into combined: R0) -> _Alternation_0_0<R0, R1> {
+    .init(combined, next)
+  }
+}
+
+public func | <R0, R1>(lhs: R0, rhs: R1) -> _Alternation_0_0<R0, R1> {
+  .init(lhs, rhs)
+}
+public struct _Alternation_0_1<R0, R1, W1, C0>: RegexProtocol where R0: RegexProtocol, R1: RegexProtocol, R1.Match == (W1, C0) {
+  public typealias Match = (Substring, C0?)
+  public let regex: Regex<Match>
+
+  public init(_ left: R0, _ right: R1) {
+    self.regex = .init(node: left.regex.root.appendingAlternationCase(right.regex.root))
+  }
+}
+
+extension AlternationBuilder {
+  public static func buildBlock<R0, R1, W1, C0>(combining next: R1, into combined: R0) -> _Alternation_0_1<R0, R1, W1, C0> {
+    .init(combined, next)
+  }
+}
+
+public func | <R0, R1, W1, C0>(lhs: R0, rhs: R1) -> _Alternation_0_1<R0, R1, W1, C0> {
+  .init(lhs, rhs)
+}
+public struct _Alternation_0_2<R0, R1, W1, C0, C1>: RegexProtocol where R0: RegexProtocol, R1: RegexProtocol, R1.Match == (W1, C0, C1) {
+  public typealias Match = (Substring, C0?, C1?)
+  public let regex: Regex<Match>
+
+  public init(_ left: R0, _ right: R1) {
+    self.regex = .init(node: left.regex.root.appendingAlternationCase(right.regex.root))
+  }
+}
+
+extension AlternationBuilder {
+  public static func buildBlock<R0, R1, W1, C0, C1>(combining next: R1, into combined: R0) -> _Alternation_0_2<R0, R1, W1, C0, C1> {
+    .init(combined, next)
+  }
+}
+
+public func | <R0, R1, W1, C0, C1>(lhs: R0, rhs: R1) -> _Alternation_0_2<R0, R1, W1, C0, C1> {
+  .init(lhs, rhs)
+}
+public struct _Alternation_0_3<R0, R1, W1, C0, C1, C2>: RegexProtocol where R0: RegexProtocol, R1: RegexProtocol, R1.Match == (W1, C0, C1, C2) {
+  public typealias Match = (Substring, C0?, C1?, C2?)
+  public let regex: Regex<Match>
+
+  public init(_ left: R0, _ right: R1) {
+    self.regex = .init(node: left.regex.root.appendingAlternationCase(right.regex.root))
+  }
+}
+
+extension AlternationBuilder {
+  public static func buildBlock<R0, R1, W1, C0, C1, C2>(combining next: R1, into combined: R0) -> _Alternation_0_3<R0, R1, W1, C0, C1, C2> {
+    .init(combined, next)
+  }
+}
+
+public func | <R0, R1, W1, C0, C1, C2>(lhs: R0, rhs: R1) -> _Alternation_0_3<R0, R1, W1, C0, C1, C2> {
+  .init(lhs, rhs)
+}
+public struct _Alternation_0_4<R0, R1, W1, C0, C1, C2, C3>: RegexProtocol where R0: RegexProtocol, R1: RegexProtocol, R1.Match == (W1, C0, C1, C2, C3) {
+  public typealias Match = (Substring, C0?, C1?, C2?, C3?)
+  public let regex: Regex<Match>
+
+  public init(_ left: R0, _ right: R1) {
+    self.regex = .init(node: left.regex.root.appendingAlternationCase(right.regex.root))
+  }
+}
+
+extension AlternationBuilder {
+  public static func buildBlock<R0, R1, W1, C0, C1, C2, C3>(combining next: R1, into combined: R0) -> _Alternation_0_4<R0, R1, W1, C0, C1, C2, C3> {
+    .init(combined, next)
+  }
+}
+
+public func | <R0, R1, W1, C0, C1, C2, C3>(lhs: R0, rhs: R1) -> _Alternation_0_4<R0, R1, W1, C0, C1, C2, C3> {
+  .init(lhs, rhs)
+}
+public struct _Alternation_0_5<R0, R1, W1, C0, C1, C2, C3, C4>: RegexProtocol where R0: RegexProtocol, R1: RegexProtocol, R1.Match == (W1, C0, C1, C2, C3, C4) {
+  public typealias Match = (Substring, C0?, C1?, C2?, C3?, C4?)
+  public let regex: Regex<Match>
+
+  public init(_ left: R0, _ right: R1) {
+    self.regex = .init(node: left.regex.root.appendingAlternationCase(right.regex.root))
+  }
+}
+
+extension AlternationBuilder {
+  public static func buildBlock<R0, R1, W1, C0, C1, C2, C3, C4>(combining next: R1, into combined: R0) -> _Alternation_0_5<R0, R1, W1, C0, C1, C2, C3, C4> {
+    .init(combined, next)
+  }
+}
+
+public func | <R0, R1, W1, C0, C1, C2, C3, C4>(lhs: R0, rhs: R1) -> _Alternation_0_5<R0, R1, W1, C0, C1, C2, C3, C4> {
+  .init(lhs, rhs)
+}
+public struct _Alternation_0_6<R0, R1, W1, C0, C1, C2, C3, C4, C5>: RegexProtocol where R0: RegexProtocol, R1: RegexProtocol, R1.Match == (W1, C0, C1, C2, C3, C4, C5) {
+  public typealias Match = (Substring, C0?, C1?, C2?, C3?, C4?, C5?)
+  public let regex: Regex<Match>
+
+  public init(_ left: R0, _ right: R1) {
+    self.regex = .init(node: left.regex.root.appendingAlternationCase(right.regex.root))
+  }
+}
+
+extension AlternationBuilder {
+  public static func buildBlock<R0, R1, W1, C0, C1, C2, C3, C4, C5>(combining next: R1, into combined: R0) -> _Alternation_0_6<R0, R1, W1, C0, C1, C2, C3, C4, C5> {
+    .init(combined, next)
+  }
+}
+
+public func | <R0, R1, W1, C0, C1, C2, C3, C4, C5>(lhs: R0, rhs: R1) -> _Alternation_0_6<R0, R1, W1, C0, C1, C2, C3, C4, C5> {
+  .init(lhs, rhs)
+}
+public struct _Alternation_0_7<R0, R1, W1, C0, C1, C2, C3, C4, C5, C6>: RegexProtocol where R0: RegexProtocol, R1: RegexProtocol, R1.Match == (W1, C0, C1, C2, C3, C4, C5, C6) {
+  public typealias Match = (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?)
+  public let regex: Regex<Match>
+
+  public init(_ left: R0, _ right: R1) {
+    self.regex = .init(node: left.regex.root.appendingAlternationCase(right.regex.root))
+  }
+}
+
+extension AlternationBuilder {
+  public static func buildBlock<R0, R1, W1, C0, C1, C2, C3, C4, C5, C6>(combining next: R1, into combined: R0) -> _Alternation_0_7<R0, R1, W1, C0, C1, C2, C3, C4, C5, C6> {
+    .init(combined, next)
+  }
+}
+
+public func | <R0, R1, W1, C0, C1, C2, C3, C4, C5, C6>(lhs: R0, rhs: R1) -> _Alternation_0_7<R0, R1, W1, C0, C1, C2, C3, C4, C5, C6> {
+  .init(lhs, rhs)
+}
+public struct _Alternation_0_8<R0, R1, W1, C0, C1, C2, C3, C4, C5, C6, C7>: RegexProtocol where R0: RegexProtocol, R1: RegexProtocol, R1.Match == (W1, C0, C1, C2, C3, C4, C5, C6, C7) {
+  public typealias Match = (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?)
+  public let regex: Regex<Match>
+
+  public init(_ left: R0, _ right: R1) {
+    self.regex = .init(node: left.regex.root.appendingAlternationCase(right.regex.root))
+  }
+}
+
+extension AlternationBuilder {
+  public static func buildBlock<R0, R1, W1, C0, C1, C2, C3, C4, C5, C6, C7>(combining next: R1, into combined: R0) -> _Alternation_0_8<R0, R1, W1, C0, C1, C2, C3, C4, C5, C6, C7> {
+    .init(combined, next)
+  }
+}
+
+public func | <R0, R1, W1, C0, C1, C2, C3, C4, C5, C6, C7>(lhs: R0, rhs: R1) -> _Alternation_0_8<R0, R1, W1, C0, C1, C2, C3, C4, C5, C6, C7> {
+  .init(lhs, rhs)
+}
+public struct _Alternation_0_9<R0, R1, W1, C0, C1, C2, C3, C4, C5, C6, C7, C8>: RegexProtocol where R0: RegexProtocol, R1: RegexProtocol, R1.Match == (W1, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
+  public typealias Match = (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?)
+  public let regex: Regex<Match>
+
+  public init(_ left: R0, _ right: R1) {
+    self.regex = .init(node: left.regex.root.appendingAlternationCase(right.regex.root))
+  }
+}
+
+extension AlternationBuilder {
+  public static func buildBlock<R0, R1, W1, C0, C1, C2, C3, C4, C5, C6, C7, C8>(combining next: R1, into combined: R0) -> _Alternation_0_9<R0, R1, W1, C0, C1, C2, C3, C4, C5, C6, C7, C8> {
+    .init(combined, next)
+  }
+}
+
+public func | <R0, R1, W1, C0, C1, C2, C3, C4, C5, C6, C7, C8>(lhs: R0, rhs: R1) -> _Alternation_0_9<R0, R1, W1, C0, C1, C2, C3, C4, C5, C6, C7, C8> {
+  .init(lhs, rhs)
+}
+public struct _Alternation_0_10<R0, R1, W1, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9>: RegexProtocol where R0: RegexProtocol, R1: RegexProtocol, R1.Match == (W1, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
+  public typealias Match = (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?)
+  public let regex: Regex<Match>
+
+  public init(_ left: R0, _ right: R1) {
+    self.regex = .init(node: left.regex.root.appendingAlternationCase(right.regex.root))
+  }
+}
+
+extension AlternationBuilder {
+  public static func buildBlock<R0, R1, W1, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9>(combining next: R1, into combined: R0) -> _Alternation_0_10<R0, R1, W1, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9> {
+    .init(combined, next)
+  }
+}
+
+public func | <R0, R1, W1, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9>(lhs: R0, rhs: R1) -> _Alternation_0_10<R0, R1, W1, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9> {
+  .init(lhs, rhs)
+}
+public struct _Alternation_1_0<R0, W0, C0, R1>: RegexProtocol where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0) {
+  public typealias Match = (Substring, C0)
+  public let regex: Regex<Match>
+
+  public init(_ left: R0, _ right: R1) {
+    self.regex = .init(node: left.regex.root.appendingAlternationCase(right.regex.root))
+  }
+}
+
+extension AlternationBuilder {
+  public static func buildBlock<R0, W0, C0, R1>(combining next: R1, into combined: R0) -> _Alternation_1_0<R0, W0, C0, R1> {
+    .init(combined, next)
+  }
+}
+
+public func | <R0, W0, C0, R1>(lhs: R0, rhs: R1) -> _Alternation_1_0<R0, W0, C0, R1> {
+  .init(lhs, rhs)
+}
+public struct _Alternation_1_1<R0, W0, C0, R1, W1, C1>: RegexProtocol where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0), R1.Match == (W1, C1) {
+  public typealias Match = (Substring, C0, C1?)
+  public let regex: Regex<Match>
+
+  public init(_ left: R0, _ right: R1) {
+    self.regex = .init(node: left.regex.root.appendingAlternationCase(right.regex.root))
+  }
+}
+
+extension AlternationBuilder {
+  public static func buildBlock<R0, W0, C0, R1, W1, C1>(combining next: R1, into combined: R0) -> _Alternation_1_1<R0, W0, C0, R1, W1, C1> {
+    .init(combined, next)
+  }
+}
+
+public func | <R0, W0, C0, R1, W1, C1>(lhs: R0, rhs: R1) -> _Alternation_1_1<R0, W0, C0, R1, W1, C1> {
+  .init(lhs, rhs)
+}
+public struct _Alternation_1_2<R0, W0, C0, R1, W1, C1, C2>: RegexProtocol where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0), R1.Match == (W1, C1, C2) {
+  public typealias Match = (Substring, C0, C1?, C2?)
+  public let regex: Regex<Match>
+
+  public init(_ left: R0, _ right: R1) {
+    self.regex = .init(node: left.regex.root.appendingAlternationCase(right.regex.root))
+  }
+}
+
+extension AlternationBuilder {
+  public static func buildBlock<R0, W0, C0, R1, W1, C1, C2>(combining next: R1, into combined: R0) -> _Alternation_1_2<R0, W0, C0, R1, W1, C1, C2> {
+    .init(combined, next)
+  }
+}
+
+public func | <R0, W0, C0, R1, W1, C1, C2>(lhs: R0, rhs: R1) -> _Alternation_1_2<R0, W0, C0, R1, W1, C1, C2> {
+  .init(lhs, rhs)
+}
+public struct _Alternation_1_3<R0, W0, C0, R1, W1, C1, C2, C3>: RegexProtocol where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0), R1.Match == (W1, C1, C2, C3) {
+  public typealias Match = (Substring, C0, C1?, C2?, C3?)
+  public let regex: Regex<Match>
+
+  public init(_ left: R0, _ right: R1) {
+    self.regex = .init(node: left.regex.root.appendingAlternationCase(right.regex.root))
+  }
+}
+
+extension AlternationBuilder {
+  public static func buildBlock<R0, W0, C0, R1, W1, C1, C2, C3>(combining next: R1, into combined: R0) -> _Alternation_1_3<R0, W0, C0, R1, W1, C1, C2, C3> {
+    .init(combined, next)
+  }
+}
+
+public func | <R0, W0, C0, R1, W1, C1, C2, C3>(lhs: R0, rhs: R1) -> _Alternation_1_3<R0, W0, C0, R1, W1, C1, C2, C3> {
+  .init(lhs, rhs)
+}
+public struct _Alternation_1_4<R0, W0, C0, R1, W1, C1, C2, C3, C4>: RegexProtocol where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0), R1.Match == (W1, C1, C2, C3, C4) {
+  public typealias Match = (Substring, C0, C1?, C2?, C3?, C4?)
+  public let regex: Regex<Match>
+
+  public init(_ left: R0, _ right: R1) {
+    self.regex = .init(node: left.regex.root.appendingAlternationCase(right.regex.root))
+  }
+}
+
+extension AlternationBuilder {
+  public static func buildBlock<R0, W0, C0, R1, W1, C1, C2, C3, C4>(combining next: R1, into combined: R0) -> _Alternation_1_4<R0, W0, C0, R1, W1, C1, C2, C3, C4> {
+    .init(combined, next)
+  }
+}
+
+public func | <R0, W0, C0, R1, W1, C1, C2, C3, C4>(lhs: R0, rhs: R1) -> _Alternation_1_4<R0, W0, C0, R1, W1, C1, C2, C3, C4> {
+  .init(lhs, rhs)
+}
+public struct _Alternation_1_5<R0, W0, C0, R1, W1, C1, C2, C3, C4, C5>: RegexProtocol where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0), R1.Match == (W1, C1, C2, C3, C4, C5) {
+  public typealias Match = (Substring, C0, C1?, C2?, C3?, C4?, C5?)
+  public let regex: Regex<Match>
+
+  public init(_ left: R0, _ right: R1) {
+    self.regex = .init(node: left.regex.root.appendingAlternationCase(right.regex.root))
+  }
+}
+
+extension AlternationBuilder {
+  public static func buildBlock<R0, W0, C0, R1, W1, C1, C2, C3, C4, C5>(combining next: R1, into combined: R0) -> _Alternation_1_5<R0, W0, C0, R1, W1, C1, C2, C3, C4, C5> {
+    .init(combined, next)
+  }
+}
+
+public func | <R0, W0, C0, R1, W1, C1, C2, C3, C4, C5>(lhs: R0, rhs: R1) -> _Alternation_1_5<R0, W0, C0, R1, W1, C1, C2, C3, C4, C5> {
+  .init(lhs, rhs)
+}
+public struct _Alternation_1_6<R0, W0, C0, R1, W1, C1, C2, C3, C4, C5, C6>: RegexProtocol where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0), R1.Match == (W1, C1, C2, C3, C4, C5, C6) {
+  public typealias Match = (Substring, C0, C1?, C2?, C3?, C4?, C5?, C6?)
+  public let regex: Regex<Match>
+
+  public init(_ left: R0, _ right: R1) {
+    self.regex = .init(node: left.regex.root.appendingAlternationCase(right.regex.root))
+  }
+}
+
+extension AlternationBuilder {
+  public static func buildBlock<R0, W0, C0, R1, W1, C1, C2, C3, C4, C5, C6>(combining next: R1, into combined: R0) -> _Alternation_1_6<R0, W0, C0, R1, W1, C1, C2, C3, C4, C5, C6> {
+    .init(combined, next)
+  }
+}
+
+public func | <R0, W0, C0, R1, W1, C1, C2, C3, C4, C5, C6>(lhs: R0, rhs: R1) -> _Alternation_1_6<R0, W0, C0, R1, W1, C1, C2, C3, C4, C5, C6> {
+  .init(lhs, rhs)
+}
+public struct _Alternation_1_7<R0, W0, C0, R1, W1, C1, C2, C3, C4, C5, C6, C7>: RegexProtocol where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0), R1.Match == (W1, C1, C2, C3, C4, C5, C6, C7) {
+  public typealias Match = (Substring, C0, C1?, C2?, C3?, C4?, C5?, C6?, C7?)
+  public let regex: Regex<Match>
+
+  public init(_ left: R0, _ right: R1) {
+    self.regex = .init(node: left.regex.root.appendingAlternationCase(right.regex.root))
+  }
+}
+
+extension AlternationBuilder {
+  public static func buildBlock<R0, W0, C0, R1, W1, C1, C2, C3, C4, C5, C6, C7>(combining next: R1, into combined: R0) -> _Alternation_1_7<R0, W0, C0, R1, W1, C1, C2, C3, C4, C5, C6, C7> {
+    .init(combined, next)
+  }
+}
+
+public func | <R0, W0, C0, R1, W1, C1, C2, C3, C4, C5, C6, C7>(lhs: R0, rhs: R1) -> _Alternation_1_7<R0, W0, C0, R1, W1, C1, C2, C3, C4, C5, C6, C7> {
+  .init(lhs, rhs)
+}
+public struct _Alternation_1_8<R0, W0, C0, R1, W1, C1, C2, C3, C4, C5, C6, C7, C8>: RegexProtocol where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0), R1.Match == (W1, C1, C2, C3, C4, C5, C6, C7, C8) {
+  public typealias Match = (Substring, C0, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?)
+  public let regex: Regex<Match>
+
+  public init(_ left: R0, _ right: R1) {
+    self.regex = .init(node: left.regex.root.appendingAlternationCase(right.regex.root))
+  }
+}
+
+extension AlternationBuilder {
+  public static func buildBlock<R0, W0, C0, R1, W1, C1, C2, C3, C4, C5, C6, C7, C8>(combining next: R1, into combined: R0) -> _Alternation_1_8<R0, W0, C0, R1, W1, C1, C2, C3, C4, C5, C6, C7, C8> {
+    .init(combined, next)
+  }
+}
+
+public func | <R0, W0, C0, R1, W1, C1, C2, C3, C4, C5, C6, C7, C8>(lhs: R0, rhs: R1) -> _Alternation_1_8<R0, W0, C0, R1, W1, C1, C2, C3, C4, C5, C6, C7, C8> {
+  .init(lhs, rhs)
+}
+public struct _Alternation_1_9<R0, W0, C0, R1, W1, C1, C2, C3, C4, C5, C6, C7, C8, C9>: RegexProtocol where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0), R1.Match == (W1, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
+  public typealias Match = (Substring, C0, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?)
+  public let regex: Regex<Match>
+
+  public init(_ left: R0, _ right: R1) {
+    self.regex = .init(node: left.regex.root.appendingAlternationCase(right.regex.root))
+  }
+}
+
+extension AlternationBuilder {
+  public static func buildBlock<R0, W0, C0, R1, W1, C1, C2, C3, C4, C5, C6, C7, C8, C9>(combining next: R1, into combined: R0) -> _Alternation_1_9<R0, W0, C0, R1, W1, C1, C2, C3, C4, C5, C6, C7, C8, C9> {
+    .init(combined, next)
+  }
+}
+
+public func | <R0, W0, C0, R1, W1, C1, C2, C3, C4, C5, C6, C7, C8, C9>(lhs: R0, rhs: R1) -> _Alternation_1_9<R0, W0, C0, R1, W1, C1, C2, C3, C4, C5, C6, C7, C8, C9> {
+  .init(lhs, rhs)
+}
+public struct _Alternation_2_0<R0, W0, C0, C1, R1>: RegexProtocol where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0, C1) {
+  public typealias Match = (Substring, C0, C1)
+  public let regex: Regex<Match>
+
+  public init(_ left: R0, _ right: R1) {
+    self.regex = .init(node: left.regex.root.appendingAlternationCase(right.regex.root))
+  }
+}
+
+extension AlternationBuilder {
+  public static func buildBlock<R0, W0, C0, C1, R1>(combining next: R1, into combined: R0) -> _Alternation_2_0<R0, W0, C0, C1, R1> {
+    .init(combined, next)
+  }
+}
+
+public func | <R0, W0, C0, C1, R1>(lhs: R0, rhs: R1) -> _Alternation_2_0<R0, W0, C0, C1, R1> {
+  .init(lhs, rhs)
+}
+public struct _Alternation_2_1<R0, W0, C0, C1, R1, W1, C2>: RegexProtocol where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0, C1), R1.Match == (W1, C2) {
+  public typealias Match = (Substring, C0, C1, C2?)
+  public let regex: Regex<Match>
+
+  public init(_ left: R0, _ right: R1) {
+    self.regex = .init(node: left.regex.root.appendingAlternationCase(right.regex.root))
+  }
+}
+
+extension AlternationBuilder {
+  public static func buildBlock<R0, W0, C0, C1, R1, W1, C2>(combining next: R1, into combined: R0) -> _Alternation_2_1<R0, W0, C0, C1, R1, W1, C2> {
+    .init(combined, next)
+  }
+}
+
+public func | <R0, W0, C0, C1, R1, W1, C2>(lhs: R0, rhs: R1) -> _Alternation_2_1<R0, W0, C0, C1, R1, W1, C2> {
+  .init(lhs, rhs)
+}
+public struct _Alternation_2_2<R0, W0, C0, C1, R1, W1, C2, C3>: RegexProtocol where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0, C1), R1.Match == (W1, C2, C3) {
+  public typealias Match = (Substring, C0, C1, C2?, C3?)
+  public let regex: Regex<Match>
+
+  public init(_ left: R0, _ right: R1) {
+    self.regex = .init(node: left.regex.root.appendingAlternationCase(right.regex.root))
+  }
+}
+
+extension AlternationBuilder {
+  public static func buildBlock<R0, W0, C0, C1, R1, W1, C2, C3>(combining next: R1, into combined: R0) -> _Alternation_2_2<R0, W0, C0, C1, R1, W1, C2, C3> {
+    .init(combined, next)
+  }
+}
+
+public func | <R0, W0, C0, C1, R1, W1, C2, C3>(lhs: R0, rhs: R1) -> _Alternation_2_2<R0, W0, C0, C1, R1, W1, C2, C3> {
+  .init(lhs, rhs)
+}
+public struct _Alternation_2_3<R0, W0, C0, C1, R1, W1, C2, C3, C4>: RegexProtocol where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0, C1), R1.Match == (W1, C2, C3, C4) {
+  public typealias Match = (Substring, C0, C1, C2?, C3?, C4?)
+  public let regex: Regex<Match>
+
+  public init(_ left: R0, _ right: R1) {
+    self.regex = .init(node: left.regex.root.appendingAlternationCase(right.regex.root))
+  }
+}
+
+extension AlternationBuilder {
+  public static func buildBlock<R0, W0, C0, C1, R1, W1, C2, C3, C4>(combining next: R1, into combined: R0) -> _Alternation_2_3<R0, W0, C0, C1, R1, W1, C2, C3, C4> {
+    .init(combined, next)
+  }
+}
+
+public func | <R0, W0, C0, C1, R1, W1, C2, C3, C4>(lhs: R0, rhs: R1) -> _Alternation_2_3<R0, W0, C0, C1, R1, W1, C2, C3, C4> {
+  .init(lhs, rhs)
+}
+public struct _Alternation_2_4<R0, W0, C0, C1, R1, W1, C2, C3, C4, C5>: RegexProtocol where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0, C1), R1.Match == (W1, C2, C3, C4, C5) {
+  public typealias Match = (Substring, C0, C1, C2?, C3?, C4?, C5?)
+  public let regex: Regex<Match>
+
+  public init(_ left: R0, _ right: R1) {
+    self.regex = .init(node: left.regex.root.appendingAlternationCase(right.regex.root))
+  }
+}
+
+extension AlternationBuilder {
+  public static func buildBlock<R0, W0, C0, C1, R1, W1, C2, C3, C4, C5>(combining next: R1, into combined: R0) -> _Alternation_2_4<R0, W0, C0, C1, R1, W1, C2, C3, C4, C5> {
+    .init(combined, next)
+  }
+}
+
+public func | <R0, W0, C0, C1, R1, W1, C2, C3, C4, C5>(lhs: R0, rhs: R1) -> _Alternation_2_4<R0, W0, C0, C1, R1, W1, C2, C3, C4, C5> {
+  .init(lhs, rhs)
+}
+public struct _Alternation_2_5<R0, W0, C0, C1, R1, W1, C2, C3, C4, C5, C6>: RegexProtocol where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0, C1), R1.Match == (W1, C2, C3, C4, C5, C6) {
+  public typealias Match = (Substring, C0, C1, C2?, C3?, C4?, C5?, C6?)
+  public let regex: Regex<Match>
+
+  public init(_ left: R0, _ right: R1) {
+    self.regex = .init(node: left.regex.root.appendingAlternationCase(right.regex.root))
+  }
+}
+
+extension AlternationBuilder {
+  public static func buildBlock<R0, W0, C0, C1, R1, W1, C2, C3, C4, C5, C6>(combining next: R1, into combined: R0) -> _Alternation_2_5<R0, W0, C0, C1, R1, W1, C2, C3, C4, C5, C6> {
+    .init(combined, next)
+  }
+}
+
+public func | <R0, W0, C0, C1, R1, W1, C2, C3, C4, C5, C6>(lhs: R0, rhs: R1) -> _Alternation_2_5<R0, W0, C0, C1, R1, W1, C2, C3, C4, C5, C6> {
+  .init(lhs, rhs)
+}
+public struct _Alternation_2_6<R0, W0, C0, C1, R1, W1, C2, C3, C4, C5, C6, C7>: RegexProtocol where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0, C1), R1.Match == (W1, C2, C3, C4, C5, C6, C7) {
+  public typealias Match = (Substring, C0, C1, C2?, C3?, C4?, C5?, C6?, C7?)
+  public let regex: Regex<Match>
+
+  public init(_ left: R0, _ right: R1) {
+    self.regex = .init(node: left.regex.root.appendingAlternationCase(right.regex.root))
+  }
+}
+
+extension AlternationBuilder {
+  public static func buildBlock<R0, W0, C0, C1, R1, W1, C2, C3, C4, C5, C6, C7>(combining next: R1, into combined: R0) -> _Alternation_2_6<R0, W0, C0, C1, R1, W1, C2, C3, C4, C5, C6, C7> {
+    .init(combined, next)
+  }
+}
+
+public func | <R0, W0, C0, C1, R1, W1, C2, C3, C4, C5, C6, C7>(lhs: R0, rhs: R1) -> _Alternation_2_6<R0, W0, C0, C1, R1, W1, C2, C3, C4, C5, C6, C7> {
+  .init(lhs, rhs)
+}
+public struct _Alternation_2_7<R0, W0, C0, C1, R1, W1, C2, C3, C4, C5, C6, C7, C8>: RegexProtocol where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0, C1), R1.Match == (W1, C2, C3, C4, C5, C6, C7, C8) {
+  public typealias Match = (Substring, C0, C1, C2?, C3?, C4?, C5?, C6?, C7?, C8?)
+  public let regex: Regex<Match>
+
+  public init(_ left: R0, _ right: R1) {
+    self.regex = .init(node: left.regex.root.appendingAlternationCase(right.regex.root))
+  }
+}
+
+extension AlternationBuilder {
+  public static func buildBlock<R0, W0, C0, C1, R1, W1, C2, C3, C4, C5, C6, C7, C8>(combining next: R1, into combined: R0) -> _Alternation_2_7<R0, W0, C0, C1, R1, W1, C2, C3, C4, C5, C6, C7, C8> {
+    .init(combined, next)
+  }
+}
+
+public func | <R0, W0, C0, C1, R1, W1, C2, C3, C4, C5, C6, C7, C8>(lhs: R0, rhs: R1) -> _Alternation_2_7<R0, W0, C0, C1, R1, W1, C2, C3, C4, C5, C6, C7, C8> {
+  .init(lhs, rhs)
+}
+public struct _Alternation_2_8<R0, W0, C0, C1, R1, W1, C2, C3, C4, C5, C6, C7, C8, C9>: RegexProtocol where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0, C1), R1.Match == (W1, C2, C3, C4, C5, C6, C7, C8, C9) {
+  public typealias Match = (Substring, C0, C1, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?)
+  public let regex: Regex<Match>
+
+  public init(_ left: R0, _ right: R1) {
+    self.regex = .init(node: left.regex.root.appendingAlternationCase(right.regex.root))
+  }
+}
+
+extension AlternationBuilder {
+  public static func buildBlock<R0, W0, C0, C1, R1, W1, C2, C3, C4, C5, C6, C7, C8, C9>(combining next: R1, into combined: R0) -> _Alternation_2_8<R0, W0, C0, C1, R1, W1, C2, C3, C4, C5, C6, C7, C8, C9> {
+    .init(combined, next)
+  }
+}
+
+public func | <R0, W0, C0, C1, R1, W1, C2, C3, C4, C5, C6, C7, C8, C9>(lhs: R0, rhs: R1) -> _Alternation_2_8<R0, W0, C0, C1, R1, W1, C2, C3, C4, C5, C6, C7, C8, C9> {
+  .init(lhs, rhs)
+}
+public struct _Alternation_3_0<R0, W0, C0, C1, C2, R1>: RegexProtocol where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0, C1, C2) {
+  public typealias Match = (Substring, C0, C1, C2)
+  public let regex: Regex<Match>
+
+  public init(_ left: R0, _ right: R1) {
+    self.regex = .init(node: left.regex.root.appendingAlternationCase(right.regex.root))
+  }
+}
+
+extension AlternationBuilder {
+  public static func buildBlock<R0, W0, C0, C1, C2, R1>(combining next: R1, into combined: R0) -> _Alternation_3_0<R0, W0, C0, C1, C2, R1> {
+    .init(combined, next)
+  }
+}
+
+public func | <R0, W0, C0, C1, C2, R1>(lhs: R0, rhs: R1) -> _Alternation_3_0<R0, W0, C0, C1, C2, R1> {
+  .init(lhs, rhs)
+}
+public struct _Alternation_3_1<R0, W0, C0, C1, C2, R1, W1, C3>: RegexProtocol where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0, C1, C2), R1.Match == (W1, C3) {
+  public typealias Match = (Substring, C0, C1, C2, C3?)
+  public let regex: Regex<Match>
+
+  public init(_ left: R0, _ right: R1) {
+    self.regex = .init(node: left.regex.root.appendingAlternationCase(right.regex.root))
+  }
+}
+
+extension AlternationBuilder {
+  public static func buildBlock<R0, W0, C0, C1, C2, R1, W1, C3>(combining next: R1, into combined: R0) -> _Alternation_3_1<R0, W0, C0, C1, C2, R1, W1, C3> {
+    .init(combined, next)
+  }
+}
+
+public func | <R0, W0, C0, C1, C2, R1, W1, C3>(lhs: R0, rhs: R1) -> _Alternation_3_1<R0, W0, C0, C1, C2, R1, W1, C3> {
+  .init(lhs, rhs)
+}
+public struct _Alternation_3_2<R0, W0, C0, C1, C2, R1, W1, C3, C4>: RegexProtocol where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0, C1, C2), R1.Match == (W1, C3, C4) {
+  public typealias Match = (Substring, C0, C1, C2, C3?, C4?)
+  public let regex: Regex<Match>
+
+  public init(_ left: R0, _ right: R1) {
+    self.regex = .init(node: left.regex.root.appendingAlternationCase(right.regex.root))
+  }
+}
+
+extension AlternationBuilder {
+  public static func buildBlock<R0, W0, C0, C1, C2, R1, W1, C3, C4>(combining next: R1, into combined: R0) -> _Alternation_3_2<R0, W0, C0, C1, C2, R1, W1, C3, C4> {
+    .init(combined, next)
+  }
+}
+
+public func | <R0, W0, C0, C1, C2, R1, W1, C3, C4>(lhs: R0, rhs: R1) -> _Alternation_3_2<R0, W0, C0, C1, C2, R1, W1, C3, C4> {
+  .init(lhs, rhs)
+}
+public struct _Alternation_3_3<R0, W0, C0, C1, C2, R1, W1, C3, C4, C5>: RegexProtocol where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0, C1, C2), R1.Match == (W1, C3, C4, C5) {
+  public typealias Match = (Substring, C0, C1, C2, C3?, C4?, C5?)
+  public let regex: Regex<Match>
+
+  public init(_ left: R0, _ right: R1) {
+    self.regex = .init(node: left.regex.root.appendingAlternationCase(right.regex.root))
+  }
+}
+
+extension AlternationBuilder {
+  public static func buildBlock<R0, W0, C0, C1, C2, R1, W1, C3, C4, C5>(combining next: R1, into combined: R0) -> _Alternation_3_3<R0, W0, C0, C1, C2, R1, W1, C3, C4, C5> {
+    .init(combined, next)
+  }
+}
+
+public func | <R0, W0, C0, C1, C2, R1, W1, C3, C4, C5>(lhs: R0, rhs: R1) -> _Alternation_3_3<R0, W0, C0, C1, C2, R1, W1, C3, C4, C5> {
+  .init(lhs, rhs)
+}
+public struct _Alternation_3_4<R0, W0, C0, C1, C2, R1, W1, C3, C4, C5, C6>: RegexProtocol where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0, C1, C2), R1.Match == (W1, C3, C4, C5, C6) {
+  public typealias Match = (Substring, C0, C1, C2, C3?, C4?, C5?, C6?)
+  public let regex: Regex<Match>
+
+  public init(_ left: R0, _ right: R1) {
+    self.regex = .init(node: left.regex.root.appendingAlternationCase(right.regex.root))
+  }
+}
+
+extension AlternationBuilder {
+  public static func buildBlock<R0, W0, C0, C1, C2, R1, W1, C3, C4, C5, C6>(combining next: R1, into combined: R0) -> _Alternation_3_4<R0, W0, C0, C1, C2, R1, W1, C3, C4, C5, C6> {
+    .init(combined, next)
+  }
+}
+
+public func | <R0, W0, C0, C1, C2, R1, W1, C3, C4, C5, C6>(lhs: R0, rhs: R1) -> _Alternation_3_4<R0, W0, C0, C1, C2, R1, W1, C3, C4, C5, C6> {
+  .init(lhs, rhs)
+}
+public struct _Alternation_3_5<R0, W0, C0, C1, C2, R1, W1, C3, C4, C5, C6, C7>: RegexProtocol where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0, C1, C2), R1.Match == (W1, C3, C4, C5, C6, C7) {
+  public typealias Match = (Substring, C0, C1, C2, C3?, C4?, C5?, C6?, C7?)
+  public let regex: Regex<Match>
+
+  public init(_ left: R0, _ right: R1) {
+    self.regex = .init(node: left.regex.root.appendingAlternationCase(right.regex.root))
+  }
+}
+
+extension AlternationBuilder {
+  public static func buildBlock<R0, W0, C0, C1, C2, R1, W1, C3, C4, C5, C6, C7>(combining next: R1, into combined: R0) -> _Alternation_3_5<R0, W0, C0, C1, C2, R1, W1, C3, C4, C5, C6, C7> {
+    .init(combined, next)
+  }
+}
+
+public func | <R0, W0, C0, C1, C2, R1, W1, C3, C4, C5, C6, C7>(lhs: R0, rhs: R1) -> _Alternation_3_5<R0, W0, C0, C1, C2, R1, W1, C3, C4, C5, C6, C7> {
+  .init(lhs, rhs)
+}
+public struct _Alternation_3_6<R0, W0, C0, C1, C2, R1, W1, C3, C4, C5, C6, C7, C8>: RegexProtocol where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0, C1, C2), R1.Match == (W1, C3, C4, C5, C6, C7, C8) {
+  public typealias Match = (Substring, C0, C1, C2, C3?, C4?, C5?, C6?, C7?, C8?)
+  public let regex: Regex<Match>
+
+  public init(_ left: R0, _ right: R1) {
+    self.regex = .init(node: left.regex.root.appendingAlternationCase(right.regex.root))
+  }
+}
+
+extension AlternationBuilder {
+  public static func buildBlock<R0, W0, C0, C1, C2, R1, W1, C3, C4, C5, C6, C7, C8>(combining next: R1, into combined: R0) -> _Alternation_3_6<R0, W0, C0, C1, C2, R1, W1, C3, C4, C5, C6, C7, C8> {
+    .init(combined, next)
+  }
+}
+
+public func | <R0, W0, C0, C1, C2, R1, W1, C3, C4, C5, C6, C7, C8>(lhs: R0, rhs: R1) -> _Alternation_3_6<R0, W0, C0, C1, C2, R1, W1, C3, C4, C5, C6, C7, C8> {
+  .init(lhs, rhs)
+}
+public struct _Alternation_3_7<R0, W0, C0, C1, C2, R1, W1, C3, C4, C5, C6, C7, C8, C9>: RegexProtocol where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0, C1, C2), R1.Match == (W1, C3, C4, C5, C6, C7, C8, C9) {
+  public typealias Match = (Substring, C0, C1, C2, C3?, C4?, C5?, C6?, C7?, C8?, C9?)
+  public let regex: Regex<Match>
+
+  public init(_ left: R0, _ right: R1) {
+    self.regex = .init(node: left.regex.root.appendingAlternationCase(right.regex.root))
+  }
+}
+
+extension AlternationBuilder {
+  public static func buildBlock<R0, W0, C0, C1, C2, R1, W1, C3, C4, C5, C6, C7, C8, C9>(combining next: R1, into combined: R0) -> _Alternation_3_7<R0, W0, C0, C1, C2, R1, W1, C3, C4, C5, C6, C7, C8, C9> {
+    .init(combined, next)
+  }
+}
+
+public func | <R0, W0, C0, C1, C2, R1, W1, C3, C4, C5, C6, C7, C8, C9>(lhs: R0, rhs: R1) -> _Alternation_3_7<R0, W0, C0, C1, C2, R1, W1, C3, C4, C5, C6, C7, C8, C9> {
+  .init(lhs, rhs)
+}
+public struct _Alternation_4_0<R0, W0, C0, C1, C2, C3, R1>: RegexProtocol where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0, C1, C2, C3) {
+  public typealias Match = (Substring, C0, C1, C2, C3)
+  public let regex: Regex<Match>
+
+  public init(_ left: R0, _ right: R1) {
+    self.regex = .init(node: left.regex.root.appendingAlternationCase(right.regex.root))
+  }
+}
+
+extension AlternationBuilder {
+  public static func buildBlock<R0, W0, C0, C1, C2, C3, R1>(combining next: R1, into combined: R0) -> _Alternation_4_0<R0, W0, C0, C1, C2, C3, R1> {
+    .init(combined, next)
+  }
+}
+
+public func | <R0, W0, C0, C1, C2, C3, R1>(lhs: R0, rhs: R1) -> _Alternation_4_0<R0, W0, C0, C1, C2, C3, R1> {
+  .init(lhs, rhs)
+}
+public struct _Alternation_4_1<R0, W0, C0, C1, C2, C3, R1, W1, C4>: RegexProtocol where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0, C1, C2, C3), R1.Match == (W1, C4) {
+  public typealias Match = (Substring, C0, C1, C2, C3, C4?)
+  public let regex: Regex<Match>
+
+  public init(_ left: R0, _ right: R1) {
+    self.regex = .init(node: left.regex.root.appendingAlternationCase(right.regex.root))
+  }
+}
+
+extension AlternationBuilder {
+  public static func buildBlock<R0, W0, C0, C1, C2, C3, R1, W1, C4>(combining next: R1, into combined: R0) -> _Alternation_4_1<R0, W0, C0, C1, C2, C3, R1, W1, C4> {
+    .init(combined, next)
+  }
+}
+
+public func | <R0, W0, C0, C1, C2, C3, R1, W1, C4>(lhs: R0, rhs: R1) -> _Alternation_4_1<R0, W0, C0, C1, C2, C3, R1, W1, C4> {
+  .init(lhs, rhs)
+}
+public struct _Alternation_4_2<R0, W0, C0, C1, C2, C3, R1, W1, C4, C5>: RegexProtocol where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0, C1, C2, C3), R1.Match == (W1, C4, C5) {
+  public typealias Match = (Substring, C0, C1, C2, C3, C4?, C5?)
+  public let regex: Regex<Match>
+
+  public init(_ left: R0, _ right: R1) {
+    self.regex = .init(node: left.regex.root.appendingAlternationCase(right.regex.root))
+  }
+}
+
+extension AlternationBuilder {
+  public static func buildBlock<R0, W0, C0, C1, C2, C3, R1, W1, C4, C5>(combining next: R1, into combined: R0) -> _Alternation_4_2<R0, W0, C0, C1, C2, C3, R1, W1, C4, C5> {
+    .init(combined, next)
+  }
+}
+
+public func | <R0, W0, C0, C1, C2, C3, R1, W1, C4, C5>(lhs: R0, rhs: R1) -> _Alternation_4_2<R0, W0, C0, C1, C2, C3, R1, W1, C4, C5> {
+  .init(lhs, rhs)
+}
+public struct _Alternation_4_3<R0, W0, C0, C1, C2, C3, R1, W1, C4, C5, C6>: RegexProtocol where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0, C1, C2, C3), R1.Match == (W1, C4, C5, C6) {
+  public typealias Match = (Substring, C0, C1, C2, C3, C4?, C5?, C6?)
+  public let regex: Regex<Match>
+
+  public init(_ left: R0, _ right: R1) {
+    self.regex = .init(node: left.regex.root.appendingAlternationCase(right.regex.root))
+  }
+}
+
+extension AlternationBuilder {
+  public static func buildBlock<R0, W0, C0, C1, C2, C3, R1, W1, C4, C5, C6>(combining next: R1, into combined: R0) -> _Alternation_4_3<R0, W0, C0, C1, C2, C3, R1, W1, C4, C5, C6> {
+    .init(combined, next)
+  }
+}
+
+public func | <R0, W0, C0, C1, C2, C3, R1, W1, C4, C5, C6>(lhs: R0, rhs: R1) -> _Alternation_4_3<R0, W0, C0, C1, C2, C3, R1, W1, C4, C5, C6> {
+  .init(lhs, rhs)
+}
+public struct _Alternation_4_4<R0, W0, C0, C1, C2, C3, R1, W1, C4, C5, C6, C7>: RegexProtocol where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0, C1, C2, C3), R1.Match == (W1, C4, C5, C6, C7) {
+  public typealias Match = (Substring, C0, C1, C2, C3, C4?, C5?, C6?, C7?)
+  public let regex: Regex<Match>
+
+  public init(_ left: R0, _ right: R1) {
+    self.regex = .init(node: left.regex.root.appendingAlternationCase(right.regex.root))
+  }
+}
+
+extension AlternationBuilder {
+  public static func buildBlock<R0, W0, C0, C1, C2, C3, R1, W1, C4, C5, C6, C7>(combining next: R1, into combined: R0) -> _Alternation_4_4<R0, W0, C0, C1, C2, C3, R1, W1, C4, C5, C6, C7> {
+    .init(combined, next)
+  }
+}
+
+public func | <R0, W0, C0, C1, C2, C3, R1, W1, C4, C5, C6, C7>(lhs: R0, rhs: R1) -> _Alternation_4_4<R0, W0, C0, C1, C2, C3, R1, W1, C4, C5, C6, C7> {
+  .init(lhs, rhs)
+}
+public struct _Alternation_4_5<R0, W0, C0, C1, C2, C3, R1, W1, C4, C5, C6, C7, C8>: RegexProtocol where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0, C1, C2, C3), R1.Match == (W1, C4, C5, C6, C7, C8) {
+  public typealias Match = (Substring, C0, C1, C2, C3, C4?, C5?, C6?, C7?, C8?)
+  public let regex: Regex<Match>
+
+  public init(_ left: R0, _ right: R1) {
+    self.regex = .init(node: left.regex.root.appendingAlternationCase(right.regex.root))
+  }
+}
+
+extension AlternationBuilder {
+  public static func buildBlock<R0, W0, C0, C1, C2, C3, R1, W1, C4, C5, C6, C7, C8>(combining next: R1, into combined: R0) -> _Alternation_4_5<R0, W0, C0, C1, C2, C3, R1, W1, C4, C5, C6, C7, C8> {
+    .init(combined, next)
+  }
+}
+
+public func | <R0, W0, C0, C1, C2, C3, R1, W1, C4, C5, C6, C7, C8>(lhs: R0, rhs: R1) -> _Alternation_4_5<R0, W0, C0, C1, C2, C3, R1, W1, C4, C5, C6, C7, C8> {
+  .init(lhs, rhs)
+}
+public struct _Alternation_4_6<R0, W0, C0, C1, C2, C3, R1, W1, C4, C5, C6, C7, C8, C9>: RegexProtocol where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0, C1, C2, C3), R1.Match == (W1, C4, C5, C6, C7, C8, C9) {
+  public typealias Match = (Substring, C0, C1, C2, C3, C4?, C5?, C6?, C7?, C8?, C9?)
+  public let regex: Regex<Match>
+
+  public init(_ left: R0, _ right: R1) {
+    self.regex = .init(node: left.regex.root.appendingAlternationCase(right.regex.root))
+  }
+}
+
+extension AlternationBuilder {
+  public static func buildBlock<R0, W0, C0, C1, C2, C3, R1, W1, C4, C5, C6, C7, C8, C9>(combining next: R1, into combined: R0) -> _Alternation_4_6<R0, W0, C0, C1, C2, C3, R1, W1, C4, C5, C6, C7, C8, C9> {
+    .init(combined, next)
+  }
+}
+
+public func | <R0, W0, C0, C1, C2, C3, R1, W1, C4, C5, C6, C7, C8, C9>(lhs: R0, rhs: R1) -> _Alternation_4_6<R0, W0, C0, C1, C2, C3, R1, W1, C4, C5, C6, C7, C8, C9> {
+  .init(lhs, rhs)
+}
+public struct _Alternation_5_0<R0, W0, C0, C1, C2, C3, C4, R1>: RegexProtocol where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0, C1, C2, C3, C4) {
+  public typealias Match = (Substring, C0, C1, C2, C3, C4)
+  public let regex: Regex<Match>
+
+  public init(_ left: R0, _ right: R1) {
+    self.regex = .init(node: left.regex.root.appendingAlternationCase(right.regex.root))
+  }
+}
+
+extension AlternationBuilder {
+  public static func buildBlock<R0, W0, C0, C1, C2, C3, C4, R1>(combining next: R1, into combined: R0) -> _Alternation_5_0<R0, W0, C0, C1, C2, C3, C4, R1> {
+    .init(combined, next)
+  }
+}
+
+public func | <R0, W0, C0, C1, C2, C3, C4, R1>(lhs: R0, rhs: R1) -> _Alternation_5_0<R0, W0, C0, C1, C2, C3, C4, R1> {
+  .init(lhs, rhs)
+}
+public struct _Alternation_5_1<R0, W0, C0, C1, C2, C3, C4, R1, W1, C5>: RegexProtocol where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0, C1, C2, C3, C4), R1.Match == (W1, C5) {
+  public typealias Match = (Substring, C0, C1, C2, C3, C4, C5?)
+  public let regex: Regex<Match>
+
+  public init(_ left: R0, _ right: R1) {
+    self.regex = .init(node: left.regex.root.appendingAlternationCase(right.regex.root))
+  }
+}
+
+extension AlternationBuilder {
+  public static func buildBlock<R0, W0, C0, C1, C2, C3, C4, R1, W1, C5>(combining next: R1, into combined: R0) -> _Alternation_5_1<R0, W0, C0, C1, C2, C3, C4, R1, W1, C5> {
+    .init(combined, next)
+  }
+}
+
+public func | <R0, W0, C0, C1, C2, C3, C4, R1, W1, C5>(lhs: R0, rhs: R1) -> _Alternation_5_1<R0, W0, C0, C1, C2, C3, C4, R1, W1, C5> {
+  .init(lhs, rhs)
+}
+public struct _Alternation_5_2<R0, W0, C0, C1, C2, C3, C4, R1, W1, C5, C6>: RegexProtocol where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0, C1, C2, C3, C4), R1.Match == (W1, C5, C6) {
+  public typealias Match = (Substring, C0, C1, C2, C3, C4, C5?, C6?)
+  public let regex: Regex<Match>
+
+  public init(_ left: R0, _ right: R1) {
+    self.regex = .init(node: left.regex.root.appendingAlternationCase(right.regex.root))
+  }
+}
+
+extension AlternationBuilder {
+  public static func buildBlock<R0, W0, C0, C1, C2, C3, C4, R1, W1, C5, C6>(combining next: R1, into combined: R0) -> _Alternation_5_2<R0, W0, C0, C1, C2, C3, C4, R1, W1, C5, C6> {
+    .init(combined, next)
+  }
+}
+
+public func | <R0, W0, C0, C1, C2, C3, C4, R1, W1, C5, C6>(lhs: R0, rhs: R1) -> _Alternation_5_2<R0, W0, C0, C1, C2, C3, C4, R1, W1, C5, C6> {
+  .init(lhs, rhs)
+}
+public struct _Alternation_5_3<R0, W0, C0, C1, C2, C3, C4, R1, W1, C5, C6, C7>: RegexProtocol where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0, C1, C2, C3, C4), R1.Match == (W1, C5, C6, C7) {
+  public typealias Match = (Substring, C0, C1, C2, C3, C4, C5?, C6?, C7?)
+  public let regex: Regex<Match>
+
+  public init(_ left: R0, _ right: R1) {
+    self.regex = .init(node: left.regex.root.appendingAlternationCase(right.regex.root))
+  }
+}
+
+extension AlternationBuilder {
+  public static func buildBlock<R0, W0, C0, C1, C2, C3, C4, R1, W1, C5, C6, C7>(combining next: R1, into combined: R0) -> _Alternation_5_3<R0, W0, C0, C1, C2, C3, C4, R1, W1, C5, C6, C7> {
+    .init(combined, next)
+  }
+}
+
+public func | <R0, W0, C0, C1, C2, C3, C4, R1, W1, C5, C6, C7>(lhs: R0, rhs: R1) -> _Alternation_5_3<R0, W0, C0, C1, C2, C3, C4, R1, W1, C5, C6, C7> {
+  .init(lhs, rhs)
+}
+public struct _Alternation_5_4<R0, W0, C0, C1, C2, C3, C4, R1, W1, C5, C6, C7, C8>: RegexProtocol where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0, C1, C2, C3, C4), R1.Match == (W1, C5, C6, C7, C8) {
+  public typealias Match = (Substring, C0, C1, C2, C3, C4, C5?, C6?, C7?, C8?)
+  public let regex: Regex<Match>
+
+  public init(_ left: R0, _ right: R1) {
+    self.regex = .init(node: left.regex.root.appendingAlternationCase(right.regex.root))
+  }
+}
+
+extension AlternationBuilder {
+  public static func buildBlock<R0, W0, C0, C1, C2, C3, C4, R1, W1, C5, C6, C7, C8>(combining next: R1, into combined: R0) -> _Alternation_5_4<R0, W0, C0, C1, C2, C3, C4, R1, W1, C5, C6, C7, C8> {
+    .init(combined, next)
+  }
+}
+
+public func | <R0, W0, C0, C1, C2, C3, C4, R1, W1, C5, C6, C7, C8>(lhs: R0, rhs: R1) -> _Alternation_5_4<R0, W0, C0, C1, C2, C3, C4, R1, W1, C5, C6, C7, C8> {
+  .init(lhs, rhs)
+}
+public struct _Alternation_5_5<R0, W0, C0, C1, C2, C3, C4, R1, W1, C5, C6, C7, C8, C9>: RegexProtocol where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0, C1, C2, C3, C4), R1.Match == (W1, C5, C6, C7, C8, C9) {
+  public typealias Match = (Substring, C0, C1, C2, C3, C4, C5?, C6?, C7?, C8?, C9?)
+  public let regex: Regex<Match>
+
+  public init(_ left: R0, _ right: R1) {
+    self.regex = .init(node: left.regex.root.appendingAlternationCase(right.regex.root))
+  }
+}
+
+extension AlternationBuilder {
+  public static func buildBlock<R0, W0, C0, C1, C2, C3, C4, R1, W1, C5, C6, C7, C8, C9>(combining next: R1, into combined: R0) -> _Alternation_5_5<R0, W0, C0, C1, C2, C3, C4, R1, W1, C5, C6, C7, C8, C9> {
+    .init(combined, next)
+  }
+}
+
+public func | <R0, W0, C0, C1, C2, C3, C4, R1, W1, C5, C6, C7, C8, C9>(lhs: R0, rhs: R1) -> _Alternation_5_5<R0, W0, C0, C1, C2, C3, C4, R1, W1, C5, C6, C7, C8, C9> {
+  .init(lhs, rhs)
+}
+public struct _Alternation_6_0<R0, W0, C0, C1, C2, C3, C4, C5, R1>: RegexProtocol where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0, C1, C2, C3, C4, C5) {
+  public typealias Match = (Substring, C0, C1, C2, C3, C4, C5)
+  public let regex: Regex<Match>
+
+  public init(_ left: R0, _ right: R1) {
+    self.regex = .init(node: left.regex.root.appendingAlternationCase(right.regex.root))
+  }
+}
+
+extension AlternationBuilder {
+  public static func buildBlock<R0, W0, C0, C1, C2, C3, C4, C5, R1>(combining next: R1, into combined: R0) -> _Alternation_6_0<R0, W0, C0, C1, C2, C3, C4, C5, R1> {
+    .init(combined, next)
+  }
+}
+
+public func | <R0, W0, C0, C1, C2, C3, C4, C5, R1>(lhs: R0, rhs: R1) -> _Alternation_6_0<R0, W0, C0, C1, C2, C3, C4, C5, R1> {
+  .init(lhs, rhs)
+}
+public struct _Alternation_6_1<R0, W0, C0, C1, C2, C3, C4, C5, R1, W1, C6>: RegexProtocol where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0, C1, C2, C3, C4, C5), R1.Match == (W1, C6) {
+  public typealias Match = (Substring, C0, C1, C2, C3, C4, C5, C6?)
+  public let regex: Regex<Match>
+
+  public init(_ left: R0, _ right: R1) {
+    self.regex = .init(node: left.regex.root.appendingAlternationCase(right.regex.root))
+  }
+}
+
+extension AlternationBuilder {
+  public static func buildBlock<R0, W0, C0, C1, C2, C3, C4, C5, R1, W1, C6>(combining next: R1, into combined: R0) -> _Alternation_6_1<R0, W0, C0, C1, C2, C3, C4, C5, R1, W1, C6> {
+    .init(combined, next)
+  }
+}
+
+public func | <R0, W0, C0, C1, C2, C3, C4, C5, R1, W1, C6>(lhs: R0, rhs: R1) -> _Alternation_6_1<R0, W0, C0, C1, C2, C3, C4, C5, R1, W1, C6> {
+  .init(lhs, rhs)
+}
+public struct _Alternation_6_2<R0, W0, C0, C1, C2, C3, C4, C5, R1, W1, C6, C7>: RegexProtocol where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0, C1, C2, C3, C4, C5), R1.Match == (W1, C6, C7) {
+  public typealias Match = (Substring, C0, C1, C2, C3, C4, C5, C6?, C7?)
+  public let regex: Regex<Match>
+
+  public init(_ left: R0, _ right: R1) {
+    self.regex = .init(node: left.regex.root.appendingAlternationCase(right.regex.root))
+  }
+}
+
+extension AlternationBuilder {
+  public static func buildBlock<R0, W0, C0, C1, C2, C3, C4, C5, R1, W1, C6, C7>(combining next: R1, into combined: R0) -> _Alternation_6_2<R0, W0, C0, C1, C2, C3, C4, C5, R1, W1, C6, C7> {
+    .init(combined, next)
+  }
+}
+
+public func | <R0, W0, C0, C1, C2, C3, C4, C5, R1, W1, C6, C7>(lhs: R0, rhs: R1) -> _Alternation_6_2<R0, W0, C0, C1, C2, C3, C4, C5, R1, W1, C6, C7> {
+  .init(lhs, rhs)
+}
+public struct _Alternation_6_3<R0, W0, C0, C1, C2, C3, C4, C5, R1, W1, C6, C7, C8>: RegexProtocol where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0, C1, C2, C3, C4, C5), R1.Match == (W1, C6, C7, C8) {
+  public typealias Match = (Substring, C0, C1, C2, C3, C4, C5, C6?, C7?, C8?)
+  public let regex: Regex<Match>
+
+  public init(_ left: R0, _ right: R1) {
+    self.regex = .init(node: left.regex.root.appendingAlternationCase(right.regex.root))
+  }
+}
+
+extension AlternationBuilder {
+  public static func buildBlock<R0, W0, C0, C1, C2, C3, C4, C5, R1, W1, C6, C7, C8>(combining next: R1, into combined: R0) -> _Alternation_6_3<R0, W0, C0, C1, C2, C3, C4, C5, R1, W1, C6, C7, C8> {
+    .init(combined, next)
+  }
+}
+
+public func | <R0, W0, C0, C1, C2, C3, C4, C5, R1, W1, C6, C7, C8>(lhs: R0, rhs: R1) -> _Alternation_6_3<R0, W0, C0, C1, C2, C3, C4, C5, R1, W1, C6, C7, C8> {
+  .init(lhs, rhs)
+}
+public struct _Alternation_6_4<R0, W0, C0, C1, C2, C3, C4, C5, R1, W1, C6, C7, C8, C9>: RegexProtocol where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0, C1, C2, C3, C4, C5), R1.Match == (W1, C6, C7, C8, C9) {
+  public typealias Match = (Substring, C0, C1, C2, C3, C4, C5, C6?, C7?, C8?, C9?)
+  public let regex: Regex<Match>
+
+  public init(_ left: R0, _ right: R1) {
+    self.regex = .init(node: left.regex.root.appendingAlternationCase(right.regex.root))
+  }
+}
+
+extension AlternationBuilder {
+  public static func buildBlock<R0, W0, C0, C1, C2, C3, C4, C5, R1, W1, C6, C7, C8, C9>(combining next: R1, into combined: R0) -> _Alternation_6_4<R0, W0, C0, C1, C2, C3, C4, C5, R1, W1, C6, C7, C8, C9> {
+    .init(combined, next)
+  }
+}
+
+public func | <R0, W0, C0, C1, C2, C3, C4, C5, R1, W1, C6, C7, C8, C9>(lhs: R0, rhs: R1) -> _Alternation_6_4<R0, W0, C0, C1, C2, C3, C4, C5, R1, W1, C6, C7, C8, C9> {
+  .init(lhs, rhs)
+}
+public struct _Alternation_7_0<R0, W0, C0, C1, C2, C3, C4, C5, C6, R1>: RegexProtocol where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0, C1, C2, C3, C4, C5, C6) {
+  public typealias Match = (Substring, C0, C1, C2, C3, C4, C5, C6)
+  public let regex: Regex<Match>
+
+  public init(_ left: R0, _ right: R1) {
+    self.regex = .init(node: left.regex.root.appendingAlternationCase(right.regex.root))
+  }
+}
+
+extension AlternationBuilder {
+  public static func buildBlock<R0, W0, C0, C1, C2, C3, C4, C5, C6, R1>(combining next: R1, into combined: R0) -> _Alternation_7_0<R0, W0, C0, C1, C2, C3, C4, C5, C6, R1> {
+    .init(combined, next)
+  }
+}
+
+public func | <R0, W0, C0, C1, C2, C3, C4, C5, C6, R1>(lhs: R0, rhs: R1) -> _Alternation_7_0<R0, W0, C0, C1, C2, C3, C4, C5, C6, R1> {
+  .init(lhs, rhs)
+}
+public struct _Alternation_7_1<R0, W0, C0, C1, C2, C3, C4, C5, C6, R1, W1, C7>: RegexProtocol where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0, C1, C2, C3, C4, C5, C6), R1.Match == (W1, C7) {
+  public typealias Match = (Substring, C0, C1, C2, C3, C4, C5, C6, C7?)
+  public let regex: Regex<Match>
+
+  public init(_ left: R0, _ right: R1) {
+    self.regex = .init(node: left.regex.root.appendingAlternationCase(right.regex.root))
+  }
+}
+
+extension AlternationBuilder {
+  public static func buildBlock<R0, W0, C0, C1, C2, C3, C4, C5, C6, R1, W1, C7>(combining next: R1, into combined: R0) -> _Alternation_7_1<R0, W0, C0, C1, C2, C3, C4, C5, C6, R1, W1, C7> {
+    .init(combined, next)
+  }
+}
+
+public func | <R0, W0, C0, C1, C2, C3, C4, C5, C6, R1, W1, C7>(lhs: R0, rhs: R1) -> _Alternation_7_1<R0, W0, C0, C1, C2, C3, C4, C5, C6, R1, W1, C7> {
+  .init(lhs, rhs)
+}
+public struct _Alternation_7_2<R0, W0, C0, C1, C2, C3, C4, C5, C6, R1, W1, C7, C8>: RegexProtocol where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0, C1, C2, C3, C4, C5, C6), R1.Match == (W1, C7, C8) {
+  public typealias Match = (Substring, C0, C1, C2, C3, C4, C5, C6, C7?, C8?)
+  public let regex: Regex<Match>
+
+  public init(_ left: R0, _ right: R1) {
+    self.regex = .init(node: left.regex.root.appendingAlternationCase(right.regex.root))
+  }
+}
+
+extension AlternationBuilder {
+  public static func buildBlock<R0, W0, C0, C1, C2, C3, C4, C5, C6, R1, W1, C7, C8>(combining next: R1, into combined: R0) -> _Alternation_7_2<R0, W0, C0, C1, C2, C3, C4, C5, C6, R1, W1, C7, C8> {
+    .init(combined, next)
+  }
+}
+
+public func | <R0, W0, C0, C1, C2, C3, C4, C5, C6, R1, W1, C7, C8>(lhs: R0, rhs: R1) -> _Alternation_7_2<R0, W0, C0, C1, C2, C3, C4, C5, C6, R1, W1, C7, C8> {
+  .init(lhs, rhs)
+}
+public struct _Alternation_7_3<R0, W0, C0, C1, C2, C3, C4, C5, C6, R1, W1, C7, C8, C9>: RegexProtocol where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0, C1, C2, C3, C4, C5, C6), R1.Match == (W1, C7, C8, C9) {
+  public typealias Match = (Substring, C0, C1, C2, C3, C4, C5, C6, C7?, C8?, C9?)
+  public let regex: Regex<Match>
+
+  public init(_ left: R0, _ right: R1) {
+    self.regex = .init(node: left.regex.root.appendingAlternationCase(right.regex.root))
+  }
+}
+
+extension AlternationBuilder {
+  public static func buildBlock<R0, W0, C0, C1, C2, C3, C4, C5, C6, R1, W1, C7, C8, C9>(combining next: R1, into combined: R0) -> _Alternation_7_3<R0, W0, C0, C1, C2, C3, C4, C5, C6, R1, W1, C7, C8, C9> {
+    .init(combined, next)
+  }
+}
+
+public func | <R0, W0, C0, C1, C2, C3, C4, C5, C6, R1, W1, C7, C8, C9>(lhs: R0, rhs: R1) -> _Alternation_7_3<R0, W0, C0, C1, C2, C3, C4, C5, C6, R1, W1, C7, C8, C9> {
+  .init(lhs, rhs)
+}
+public struct _Alternation_8_0<R0, W0, C0, C1, C2, C3, C4, C5, C6, C7, R1>: RegexProtocol where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0, C1, C2, C3, C4, C5, C6, C7) {
+  public typealias Match = (Substring, C0, C1, C2, C3, C4, C5, C6, C7)
+  public let regex: Regex<Match>
+
+  public init(_ left: R0, _ right: R1) {
+    self.regex = .init(node: left.regex.root.appendingAlternationCase(right.regex.root))
+  }
+}
+
+extension AlternationBuilder {
+  public static func buildBlock<R0, W0, C0, C1, C2, C3, C4, C5, C6, C7, R1>(combining next: R1, into combined: R0) -> _Alternation_8_0<R0, W0, C0, C1, C2, C3, C4, C5, C6, C7, R1> {
+    .init(combined, next)
+  }
+}
+
+public func | <R0, W0, C0, C1, C2, C3, C4, C5, C6, C7, R1>(lhs: R0, rhs: R1) -> _Alternation_8_0<R0, W0, C0, C1, C2, C3, C4, C5, C6, C7, R1> {
+  .init(lhs, rhs)
+}
+public struct _Alternation_8_1<R0, W0, C0, C1, C2, C3, C4, C5, C6, C7, R1, W1, C8>: RegexProtocol where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0, C1, C2, C3, C4, C5, C6, C7), R1.Match == (W1, C8) {
+  public typealias Match = (Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8?)
+  public let regex: Regex<Match>
+
+  public init(_ left: R0, _ right: R1) {
+    self.regex = .init(node: left.regex.root.appendingAlternationCase(right.regex.root))
+  }
+}
+
+extension AlternationBuilder {
+  public static func buildBlock<R0, W0, C0, C1, C2, C3, C4, C5, C6, C7, R1, W1, C8>(combining next: R1, into combined: R0) -> _Alternation_8_1<R0, W0, C0, C1, C2, C3, C4, C5, C6, C7, R1, W1, C8> {
+    .init(combined, next)
+  }
+}
+
+public func | <R0, W0, C0, C1, C2, C3, C4, C5, C6, C7, R1, W1, C8>(lhs: R0, rhs: R1) -> _Alternation_8_1<R0, W0, C0, C1, C2, C3, C4, C5, C6, C7, R1, W1, C8> {
+  .init(lhs, rhs)
+}
+public struct _Alternation_8_2<R0, W0, C0, C1, C2, C3, C4, C5, C6, C7, R1, W1, C8, C9>: RegexProtocol where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0, C1, C2, C3, C4, C5, C6, C7), R1.Match == (W1, C8, C9) {
+  public typealias Match = (Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8?, C9?)
+  public let regex: Regex<Match>
+
+  public init(_ left: R0, _ right: R1) {
+    self.regex = .init(node: left.regex.root.appendingAlternationCase(right.regex.root))
+  }
+}
+
+extension AlternationBuilder {
+  public static func buildBlock<R0, W0, C0, C1, C2, C3, C4, C5, C6, C7, R1, W1, C8, C9>(combining next: R1, into combined: R0) -> _Alternation_8_2<R0, W0, C0, C1, C2, C3, C4, C5, C6, C7, R1, W1, C8, C9> {
+    .init(combined, next)
+  }
+}
+
+public func | <R0, W0, C0, C1, C2, C3, C4, C5, C6, C7, R1, W1, C8, C9>(lhs: R0, rhs: R1) -> _Alternation_8_2<R0, W0, C0, C1, C2, C3, C4, C5, C6, C7, R1, W1, C8, C9> {
+  .init(lhs, rhs)
+}
+public struct _Alternation_9_0<R0, W0, C0, C1, C2, C3, C4, C5, C6, C7, C8, R1>: RegexProtocol where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
+  public typealias Match = (Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8)
+  public let regex: Regex<Match>
+
+  public init(_ left: R0, _ right: R1) {
+    self.regex = .init(node: left.regex.root.appendingAlternationCase(right.regex.root))
+  }
+}
+
+extension AlternationBuilder {
+  public static func buildBlock<R0, W0, C0, C1, C2, C3, C4, C5, C6, C7, C8, R1>(combining next: R1, into combined: R0) -> _Alternation_9_0<R0, W0, C0, C1, C2, C3, C4, C5, C6, C7, C8, R1> {
+    .init(combined, next)
+  }
+}
+
+public func | <R0, W0, C0, C1, C2, C3, C4, C5, C6, C7, C8, R1>(lhs: R0, rhs: R1) -> _Alternation_9_0<R0, W0, C0, C1, C2, C3, C4, C5, C6, C7, C8, R1> {
+  .init(lhs, rhs)
+}
+public struct _Alternation_9_1<R0, W0, C0, C1, C2, C3, C4, C5, C6, C7, C8, R1, W1, C9>: RegexProtocol where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0, C1, C2, C3, C4, C5, C6, C7, C8), R1.Match == (W1, C9) {
+  public typealias Match = (Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9?)
+  public let regex: Regex<Match>
+
+  public init(_ left: R0, _ right: R1) {
+    self.regex = .init(node: left.regex.root.appendingAlternationCase(right.regex.root))
+  }
+}
+
+extension AlternationBuilder {
+  public static func buildBlock<R0, W0, C0, C1, C2, C3, C4, C5, C6, C7, C8, R1, W1, C9>(combining next: R1, into combined: R0) -> _Alternation_9_1<R0, W0, C0, C1, C2, C3, C4, C5, C6, C7, C8, R1, W1, C9> {
+    .init(combined, next)
+  }
+}
+
+public func | <R0, W0, C0, C1, C2, C3, C4, C5, C6, C7, C8, R1, W1, C9>(lhs: R0, rhs: R1) -> _Alternation_9_1<R0, W0, C0, C1, C2, C3, C4, C5, C6, C7, C8, R1, W1, C9> {
+  .init(lhs, rhs)
+}
+extension AlternationBuilder {
+  public static func buildBlock<R, W, C0>(_ regex: R) -> Regex<(W, C0?)> where R: RegexProtocol, R.Match == (W, C0) {
+    .init(node: .alternation([regex.regex.root]))
+  }
+}
+extension AlternationBuilder {
+  public static func buildBlock<R, W, C0, C1>(_ regex: R) -> Regex<(W, C0?, C1?)> where R: RegexProtocol, R.Match == (W, C0, C1) {
+    .init(node: .alternation([regex.regex.root]))
+  }
+}
+extension AlternationBuilder {
+  public static func buildBlock<R, W, C0, C1, C2>(_ regex: R) -> Regex<(W, C0?, C1?, C2?)> where R: RegexProtocol, R.Match == (W, C0, C1, C2) {
+    .init(node: .alternation([regex.regex.root]))
+  }
+}
+extension AlternationBuilder {
+  public static func buildBlock<R, W, C0, C1, C2, C3>(_ regex: R) -> Regex<(W, C0?, C1?, C2?, C3?)> where R: RegexProtocol, R.Match == (W, C0, C1, C2, C3) {
+    .init(node: .alternation([regex.regex.root]))
+  }
+}
+extension AlternationBuilder {
+  public static func buildBlock<R, W, C0, C1, C2, C3, C4>(_ regex: R) -> Regex<(W, C0?, C1?, C2?, C3?, C4?)> where R: RegexProtocol, R.Match == (W, C0, C1, C2, C3, C4) {
+    .init(node: .alternation([regex.regex.root]))
+  }
+}
+extension AlternationBuilder {
+  public static func buildBlock<R, W, C0, C1, C2, C3, C4, C5>(_ regex: R) -> Regex<(W, C0?, C1?, C2?, C3?, C4?, C5?)> where R: RegexProtocol, R.Match == (W, C0, C1, C2, C3, C4, C5) {
+    .init(node: .alternation([regex.regex.root]))
+  }
+}
+extension AlternationBuilder {
+  public static func buildBlock<R, W, C0, C1, C2, C3, C4, C5, C6>(_ regex: R) -> Regex<(W, C0?, C1?, C2?, C3?, C4?, C5?, C6?)> where R: RegexProtocol, R.Match == (W, C0, C1, C2, C3, C4, C5, C6) {
+    .init(node: .alternation([regex.regex.root]))
+  }
+}
+extension AlternationBuilder {
+  public static func buildBlock<R, W, C0, C1, C2, C3, C4, C5, C6, C7>(_ regex: R) -> Regex<(W, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?)> where R: RegexProtocol, R.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
+    .init(node: .alternation([regex.regex.root]))
+  }
+}
+extension AlternationBuilder {
+  public static func buildBlock<R, W, C0, C1, C2, C3, C4, C5, C6, C7, C8>(_ regex: R) -> Regex<(W, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?)> where R: RegexProtocol, R.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
+    .init(node: .alternation([regex.regex.root]))
+  }
+}
 
 
 // END AUTO-GENERATED CONTENT

--- a/Sources/_StringProcessing/RegexDSL/Core.swift
+++ b/Sources/_StringProcessing/RegexDSL/Core.swift
@@ -130,12 +130,6 @@ extension RegexProtocol {
     in inputRange: Range<String.Index>,
     mode: MatchMode = .wholeString
   ) -> RegexMatch<Match>? {
-    // Casts a Swift tuple to the custom `Tuple<n>`, assuming their memory
-    // layout is compatible.
-    func bitCastToMatch<T>(_ x: T) -> Match {
-      assert(MemoryLayout<T>.size == MemoryLayout<Match>.size)
-      return unsafeBitCast(x, to: Match.self)
-    }
     // TODO: Remove this branch when the matching engine supports captures.
     if regex.hasCapture {
       let vm = HareVM(program: regex.program.legacyLoweredProgram)
@@ -151,7 +145,7 @@ extension RegexProtocol {
         let typeErasedMatch = captures.matchValue(
           withWholeMatch: input[range]
         )
-        convertedMatch = _openExistential(typeErasedMatch, do: bitCastToMatch)
+        convertedMatch = typeErasedMatch as! Match
       }
       return RegexMatch(range: range, match: convertedMatch)
     }

--- a/Sources/_StringProcessing/RegexDSL/DSL.swift
+++ b/Sources/_StringProcessing/RegexDSL/DSL.swift
@@ -113,31 +113,42 @@ public func oneOrMore(_ cc: CharacterClass) -> _OneOrMore_0<CharacterClass> {
 
 // MARK: Alternation
 
-// TODO: Support heterogeneous capture alternation.
-public struct Alternation<
-  Component1: RegexProtocol, Component2: RegexProtocol
->: RegexProtocol {
-  public typealias Match = Component1.Match
+// TODO: Variadic generics
+// @resultBuilder
+// struct AlternationBuilder {
+//   @_disfavoredOverload
+//   func buildBlock<R: RegexProtocol>(_ regex: R) -> R
+//   func buildBlock<
+//     R: RegexProtocol, W0, C0...
+//   >(
+//     _ regex: R
+//   ) -> R where R.Match == (W, C...)
+// }
 
-  public let regex: Regex<Match>
-
-  public init(_ first: Component1, _ second: Component2) {
-    regex = .init(node: .alternation([
-      first.regex.root, second.regex.root
-    ]))
+@resultBuilder
+public struct AlternationBuilder {
+  @_disfavoredOverload
+  public static func buildBlock<R: RegexProtocol>(_ regex: R) -> R {
+    regex
   }
 
-  public init(
-    @RegexBuilder _ content: () -> Alternation<Component1, Component2>
-  ) {
-    self = content()
+  public static func buildExpression<R: RegexProtocol>(_ regex: R) -> R {
+    regex
+  }
+
+  public static func buildEither<R: RegexProtocol>(first component: R) -> R {
+    component
+  }
+
+  public static func buildEither<R: RegexProtocol>(second component: R) -> R {
+    component
   }
 }
 
-public func | <Component1, Component2>(
-  lhs: Component1, rhs: Component2
-) -> Alternation<Component1, Component2> {
-  .init(lhs, rhs)
+public func oneOf<R: RegexProtocol>(
+  @AlternationBuilder builder: () -> R
+) -> R {
+  builder()
 }
 
 // MARK: - Capture

--- a/Sources/_StringProcessing/RegexDSL/DSLTree.swift
+++ b/Sources/_StringProcessing/RegexDSL/DSLTree.swift
@@ -493,4 +493,11 @@ extension DSLTree.Node {
     }
     return .concatenation([self, newNode])
   }
+
+  func appendingAlternationCase(_ newNode: DSLTree.Node) -> DSLTree.Node {
+    if case .alternation(let components) = self {
+      return .alternation(components + [newNode])
+    }
+    return .alternation([self, newNode])
+  }
 }


### PR DESCRIPTION
Introduce `oneOf` combinator, which takes a builder block and joins all elements into a regex alterantion. Fix the legacy VM to support alternation with captures.

-----

Example:

    oneOf {
      "a".capture()
      "b".capture()
      "c"
    } => `.Match = (Substring, Substring?, Substring?)`