### PR TITLE
Parse extended syntax (?x)

### DIFF
--- a/Sources/_MatchingEngine/Regex/AST/CustomCharClass.swift
+++ b/Sources/_MatchingEngine/Regex/AST/CustomCharClass.swift
@@ -42,6 +42,9 @@ extension AST {
       /// the contents should be interpreted literally.
       case quote(Quote)
 
+      /// Trivia such as non-semantic whitespace.
+      case trivia(Trivia)
+
       /// A binary operator applied to sets of members `abc&&def`
       case setOperation([Member], Located<SetOp>, [Member])
     }
@@ -81,11 +84,27 @@ extension CustomCC.Member {
     case .range(let r): return r
     case .atom(let a): return a
     case .quote(let q): return q
+    case .trivia(let t): return t
     case .setOperation(let lhs, let op, let rhs): return (lhs, op, rhs)
     }
   }
 
   func `as`<T>(_ t: T.Type = T.self) -> T? {
     _associatedValue as? T
+  }
+
+  public var isTrivia: Bool {
+    if case .trivia = self { return true }
+    return false
+  }
+}
+
+extension AST.CustomCharacterClass {
+  /// Strip trivia from the character class members. This does not recurse into
+  /// nested custom character classes.
+  public var strippingTriviaShallow: Self {
+    var copy = self
+    copy.members = copy.members.filter { !$0.isTrivia }
+    return copy
   }
 }

--- a/Sources/_MatchingEngine/Regex/AST/MatchingOptions.swift
+++ b/Sources/_MatchingEngine/Regex/AST/MatchingOptions.swift
@@ -50,6 +50,16 @@ extension AST {
       self.location = location
     }
 
+    /// If this is either the regular or extra extended syntax option.
+    public var isAnyExtended: Bool {
+      switch kind {
+      case .extended, .extraExtended:
+        return true
+      default:
+        return false
+      }
+    }
+
     public var isTextSegmentMode: Bool {
       switch kind {
       case .textSegmentGraphemeMode, .textSegmentWordMode:
@@ -93,6 +103,10 @@ extension AST {
       self.minusLoc = minusLoc
       self.removing = removing
     }
+
+    /// Whether this set of matching options first resets the options before
+    /// adding onto them.
+    public var resetsCurrentOptions: Bool { caretLoc != nil }
   }
 }
 
@@ -102,7 +116,10 @@ extension AST.MatchingOption: _ASTPrintable {
 
 extension AST.MatchingOptionSequence: _ASTPrintable {
   public var _dumpBase: String {
-    "adding: \(adding), removing: \(removing), hasCaret: \(caretLoc != nil)"
+    """
+    adding: \(adding), removing: \(removing), \
+    resetsCurrentOptions: \(resetsCurrentOptions)
+    """
   }
 }
 

--- a/Sources/_MatchingEngine/Regex/AST/Quantification.swift
+++ b/Sources/_MatchingEngine/Regex/AST/Quantification.swift
@@ -17,16 +17,23 @@ extension AST {
     public let child: AST.Node
     public let location: SourceLocation
 
+    /// Any trivia intermixed between the operand and the quantifier, as well
+    /// as between the quantifier characters themselves. This can occur in
+    /// extended syntax mode where PCRE permits e.g `x * +`.
+    public let trivia: [AST.Trivia]
+
     public init(
       _ amount: Located<Amount>,
       _ kind: Located<Kind>,
       _ child: AST.Node,
-      _ r: SourceLocation
+      _ r: SourceLocation,
+      trivia: [AST.Trivia]
     ) {
       self.amount = amount
       self.kind = kind
       self.child = child
       self.location = r
+      self.trivia = trivia
     }
 
     @frozen

--- a/Sources/_MatchingEngine/Regex/Parse/Source.swift
+++ b/Sources/_MatchingEngine/Regex/Parse/Source.swift
@@ -17,15 +17,13 @@
 public struct Source {
   var input: Input
   var bounds: Range<Input.Index>
-  var syntax: SyntaxOptions
 
   // TODO: source should hold outer collection and range, at least
   // for error reporting if nothing else
 
-  init(_ str: Input, _ syntax: SyntaxOptions) {
+  init(_ str: Input) {
     self.input = str
     self.bounds = str.startIndex ..< str.endIndex
-    self.syntax = syntax
   }
 
   subscript(_ range: Range<Input.Index>) -> Input.SubSequence { input[range] }
@@ -41,18 +39,6 @@ extension Source {
 
   /// A precise point in the input, commonly used for bounded ranges
   public typealias Position = String.Index
-}
-
-// MARK: - Syntax
-
-extension Source {
-  var experimentalRanges: Bool { syntax.contains(.experimentalRanges) }
-  var experimentalCaptures: Bool { syntax.contains(.experimentalCaptures) }
-  var experimentalQuotes: Bool { syntax.contains(.experimentalQuotes) }
-  var experimentalComments: Bool { syntax.contains(.experimentalComments) }
-  var nonSemanticWhitespace: Bool {
-    syntax.contains(.nonSemanticWhitespace)
-  }
 }
 
 // MARK: - Source as a peekable consumer

--- a/Sources/_MatchingEngine/Regex/Parse/SyntaxOptions.swift
+++ b/Sources/_MatchingEngine/Regex/Parse/SyntaxOptions.swift
@@ -23,11 +23,19 @@ public struct SyntaxOptions: OptionSet {
   /// `'a \. b' == '/a\.b/'`
   public static var nonSemanticWhitespace: Self { Self(1 << 0) }
 
+  /// `abc # comment`
+  public static var endOfLineComments: Self { Self(1 << 1) }
+
+  /// `(?x)` `(?xx)`
+  public static var extendedSyntax: Self {
+    [.endOfLineComments, .nonSemanticWhitespace]
+  }
+
   /// `'a "." b' == '/a\Q.\Eb/'`
   ///
   /// NOTE: Currently, this means we have raw quotes.
   /// Better would be to have real Swift string delimiter parsing logic.
-  public static var experimentalQuotes: Self { Self(1 << 1) }
+  public static var experimentalQuotes: Self { Self(1 << 2) }
 
   /// `'a /* comment */ b' == '/a(?#. comment )b/'`
   ///
@@ -35,7 +43,7 @@ public struct SyntaxOptions: OptionSet {
   /// Traditional comments can't have `)`, not even escaped in them either, we
   /// can. Traditional comments can have `*/` in them, we can't without
   /// escaping. We don't currently do escaping.
-  public static var experimentalComments: Self { Self(1 << 2) }
+  public static var experimentalComments: Self { Self(1 << 3) }
 
   /// ```
   ///   'a{n...m}' == '/a{n,m}/'
@@ -44,11 +52,11 @@ public struct SyntaxOptions: OptionSet {
   ///   'a{...m}'  == '/a{,m}/'
   ///   'a{..<m}'  == '/a{,m-1}/'
   /// ```
-  public static var experimentalRanges: Self { Self(1 << 3) }
+  public static var experimentalRanges: Self { Self(1 << 4) }
 
   /// `(name: .*)` == `(?<name>.*)`
   ///  `(_: .*)` == `(?:.*)`
-  public static var experimentalCaptures: Self { Self(1 << 4) }
+  public static var experimentalCaptures: Self { Self(1 << 5) }
 
   /*
 
@@ -59,10 +67,9 @@ public struct SyntaxOptions: OptionSet {
 
   public static var traditional: Self { Self(0) }
 
-  public static var experimental: Self { Self(~0) }
-
-  public var ignoreWhitespace: Bool {
-    contains(.nonSemanticWhitespace)
+  public static var experimental: Self {
+    // Experimental syntax enables everything except end-of-line comments.
+    Self(~0).subtracting(.endOfLineComments)
   }
 
   // TODO: Probably want to model strict-PCRE etc. options too.

--- a/Sources/_MatchingEngine/Regex/Printing/DumpAST.swift
+++ b/Sources/_MatchingEngine/Regex/Printing/DumpAST.swift
@@ -52,6 +52,9 @@ extension _ASTPrintable {
       if $0.isTrivia { return nil }
       return $0._dump()
     }.joined(separator: ",")
+    if sub.isEmpty {
+      return "\(_dumpBase)"
+    }
     return "\(_dumpBase)(\(sub))"
   }
 }
@@ -287,7 +290,11 @@ extension AST.Quantification: _ASTPrintable {
 
 extension AST.CustomCharacterClass: _ASTNode {
   public var _dumpBase: String {
-    "customCharacterClass(\(members))"
+    // Exclude trivia for now, as we don't want it to appear when performing
+    // comparisons of dumped output in tests.
+    // TODO: We should eventually have some way of filtering out trivia for
+    // tests, so that it can appear in regular dumps.
+    return "customCharacterClass(\(strippingTriviaShallow.members))"
   }
 }
 
@@ -298,6 +305,7 @@ extension AST.CustomCharacterClass.Member: _ASTPrintable {
     case .atom(let a): return "\(a)"
     case .range(let r): return "\(r)"
     case .quote(let q): return "\(q)"
+    case .trivia(let t): return "\(t)"
     case .setOperation(let lhs, let op, let rhs):
       return "op \(lhs) \(op.value) \(rhs)"
     }

--- a/Sources/_MatchingEngine/Regex/Printing/PrintAsCanonical.swift
+++ b/Sources/_MatchingEngine/Regex/Printing/PrintAsCanonical.swift
@@ -91,9 +91,7 @@ extension PrettyPrinter {
       output(q._canonicalBase)
 
     case let .trivia(t):
-      // TODO: We might want to output comments...
-      _ = t
-      output("")
+      output(t._canonicalBase)
 
     case let .atom(a):
       output(a._canonicalBase)
@@ -135,6 +133,8 @@ extension PrettyPrinter {
       output(a._canonicalBase)
     case .quote(let q):
       output(q._canonicalBase)
+    case .trivia(let t):
+      output(t._canonicalBase)
     case .setOperation:
       output("/* TODO: set operation \(self) */")
     }
@@ -314,4 +314,11 @@ extension AST.GlobalMatchingOption.Kind {
 
 extension AST.GlobalMatchingOption {
   var _canonicalBase: String { "(*\(kind._canonicalBase))"}
+}
+
+extension AST.Trivia {
+  var _canonicalBase: String {
+    // TODO: We might want to output comments...
+    ""
+  }
 }

--- a/Sources/_MatchingEngine/Regex/Printing/PrintAsPattern.swift
+++ b/Sources/_MatchingEngine/Regex/Printing/PrintAsPattern.swift
@@ -180,6 +180,9 @@ extension PrettyPrinter {
       }
     case .quote(let q):
       print("// TODO: quote \(q.literal._quoted) in custom character classes (should we split it?)")
+    case .trivia(let t):
+      // TODO: We might want to output comments...
+      _ = t
     case .setOperation:
       print("// TODO: Set operation: \(member)")
     }

--- a/Sources/_StringProcessing/ASTBuilder.swift
+++ b/Sources/_StringProcessing/ASTBuilder.swift
@@ -242,51 +242,51 @@ func quant(
   _ child: AST.Node
 ) -> AST.Node {
   .quantification(.init(
-    .init(faking: amount), .init(faking: kind), child, .fake))
+    .init(faking: amount), .init(faking: kind), child, .fake, trivia: []))
 }
 func zeroOrMore(
   _ kind: AST.Quantification.Kind = .eager,
-  _ child: AST.Node
+  of child: AST.Node
 ) -> AST.Node {
   quant(.zeroOrMore, kind, child)
 }
 func zeroOrOne(
   _ kind: AST.Quantification.Kind = .eager,
-  _ child: AST.Node
+  of child: AST.Node
 ) -> AST.Node {
   quant(.zeroOrOne, kind, child)
 }
 func oneOrMore(
   _ kind: AST.Quantification.Kind = .eager,
-  _ child: AST.Node
+  of child: AST.Node
 ) -> AST.Node {
   quant(.oneOrMore, kind, child)
 }
 func exactly(
-  _ kind: AST.Quantification.Kind = .eager,
   _ i: Int,
-  _ child: AST.Node
+  _ kind: AST.Quantification.Kind = .eager,
+  of child: AST.Node
 ) -> AST.Node {
   quant(.exactly(.init(faking: i)), kind, child)
 }
 func nOrMore(
-  _ kind: AST.Quantification.Kind = .eager,
   _ i: Int,
-  _ child: AST.Node
+  _ kind: AST.Quantification.Kind = .eager,
+  of child: AST.Node
 ) -> AST.Node {
   quant(.nOrMore(.init(faking: i)), kind, child)
 }
 func upToN(
-  _ kind: AST.Quantification.Kind = .eager,
   _ i: Int,
-  _ child: AST.Node
+  _ kind: AST.Quantification.Kind = .eager,
+  of child: AST.Node
 ) -> AST.Node {
   quant(.upToN(.init(faking: i)), kind, child)
 }
 func quantRange(
-  _ kind: AST.Quantification.Kind = .eager,
   _ r: ClosedRange<Int>,
-  _ child: AST.Node
+  _ kind: AST.Quantification.Kind = .eager,
+  of child: AST.Node
 ) -> AST.Node {
   let lower = AST.Located(faking: r.lowerBound)
   let upper = AST.Located(faking: r.upperBound)

--- a/Sources/_StringProcessing/CharacterClass.swift
+++ b/Sources/_StringProcessing/CharacterClass.swift
@@ -420,6 +420,10 @@ extension AST.CustomCharacterClass {
           // Decompose quoted literal into literal characters.
           result += q.literal.map { .character($0) }
 
+        case .trivia:
+          // Not semantically important.
+          break
+
         case .setOperation(let lhs, let op, let rhs):
           // FIXME: CharacterClass wasn't designed for set operations with
           // multiple components in each operand, we should fix that. For now,

--- a/Sources/_StringProcessing/RegexDSL/DSL.swift
+++ b/Sources/_StringProcessing/RegexDSL/DSL.swift
@@ -67,7 +67,7 @@ public struct OneOrMore<Component: RegexProtocol>: RegexProtocolWithComponent {
 
   public init(component: Component) {
     self.regex = .init(ast:
-      oneOrMore(.eager, component.regex.ast.root)
+      oneOrMore(of: component.regex.ast.root)
     )
   }
 
@@ -93,7 +93,7 @@ public struct Repeat<
 
   public init(component: Component) {
     self.regex = .init(ast:
-      zeroOrMore(.eager, component.regex.ast.root))
+      zeroOrMore(of: component.regex.ast.root))
   }
 
   public init(@RegexBuilder _ content: () -> Component) {
@@ -116,7 +116,7 @@ public struct Optionally<Component: RegexProtocol>: RegexProtocolWithComponent {
 
   public init(component: Component) {
     self.regex = .init(ast:
-      zeroOrOne(.eager, component.regex.ast.root))
+      zeroOrOne(of: component.regex.ast.root))
   }
 
   public init(@RegexBuilder _ content: () -> Component) {

--- a/Tests/RegexTests/LexTests.swift
+++ b/Tests/RegexTests/LexTests.swift
@@ -22,7 +22,7 @@ func diagnose(
   file: StaticString = #file,
   line: UInt = #line
 ) {
-  var src = Source(input, syntax)
+  var src = Source(input)
   do {
     try f(&src)
     XCTFail("""

--- a/Tests/RegexTests/ParseTests.swift
+++ b/Tests/RegexTests/ParseTests.swift
@@ -201,7 +201,7 @@ extension RegexTests {
       "abc", concat("a", "b", "c"))
     parseTest(
       #"abc\+d*"#,
-      concat("a", "b", "c", "+", zeroOrMore(.eager, "d")))
+      concat("a", "b", "c", "+", zeroOrMore(of: "d")))
     parseTest(
       "a(b)", concat("a", capture("b")),
       captures: .atom())
@@ -211,31 +211,31 @@ extension RegexTests {
         concat(
           "a", "b", "c",
           oneOrMore(
-            .eager, nonCapture(concat("d", "e"))),
-          "f", "g", "h", zeroOrMore(.eager, "i"), "k"),
+            of: nonCapture(concat("d", "e"))),
+          "f", "g", "h", zeroOrMore(of: "i"), "k"),
         "j"))
     parseTest(
       "a(?:b|c)?d",
       concat("a", zeroOrOne(
-        .eager, nonCapture(alt("b", "c"))), "d"))
+        of: nonCapture(alt("b", "c"))), "d"))
     parseTest(
       "a?b??c+d+?e*f*?",
       concat(
-        zeroOrOne(.eager, "a"), zeroOrOne(.reluctant, "b"),
-        oneOrMore(.eager, "c"), oneOrMore(.reluctant, "d"),
-        zeroOrMore(.eager, "e"), zeroOrMore(.reluctant, "f")))
+        zeroOrOne(of: "a"), zeroOrOne(.reluctant, of: "b"),
+        oneOrMore(of: "c"), oneOrMore(.reluctant, of: "d"),
+        zeroOrMore(of: "e"), zeroOrMore(.reluctant, of: "f")))
 
     parseTest(
       "(.)*(.*)",
       concat(
-        zeroOrMore(.eager, capture(atom(.any))),
-        capture(zeroOrMore(.eager, atom(.any)))),
+        zeroOrMore(of: capture(atom(.any))),
+        capture(zeroOrMore(of: atom(.any)))),
       captures: .tuple([.array(.atom()), .atom()]))
     parseTest(
       "((.))*((.)?)",
       concat(
-        zeroOrMore(.eager, capture(capture(atom(.any)))),
-        capture(zeroOrOne(.eager, capture(atom(.any))))),
+        zeroOrMore(of: capture(capture(atom(.any)))),
+        capture(zeroOrOne(of: capture(atom(.any))))),
       captures: .tuple([
         .array(.atom()), .array(.atom()), .atom(), .optional(.atom())
       ]))
@@ -247,7 +247,7 @@ extension RegexTests {
 
     parseTest(
       "a|b?c",
-      alt("a", concat(zeroOrOne(.eager, "b"), "c")))
+      alt("a", concat(zeroOrOne(of: "b"), "c")))
     parseTest(
       "(a|b)c",
       concat(capture(alt("a", "b")), "c"),
@@ -419,7 +419,7 @@ extension RegexTests {
 
     parseTest(
       #"[a[bc]de&&[^bc]\d]+"#,
-      oneOrMore(.eager, charClass(
+      oneOrMore(of: charClass(
         .setOperation(
           ["a", charClass("b", "c"), "d", "e"],
           .init(faking: .intersection),
@@ -448,13 +448,13 @@ extension RegexTests {
     parseTest(
       "a&&b", concat("a", "&", "&", "b"))
     parseTest(
-      "&?", zeroOrOne(.eager, "&"))
+      "&?", zeroOrOne(of: "&"))
     parseTest(
-      "&&?", concat("&", zeroOrOne(.eager, "&")))
+      "&&?", concat("&", zeroOrOne(of: "&")))
     parseTest(
-      "--+", concat("-", oneOrMore(.eager, "-")))
+      "--+", concat("-", oneOrMore(of: "-")))
     parseTest(
-      "~~*", concat("~", zeroOrMore(.eager, "~")))
+      "~~*", concat("~", zeroOrMore(of: "~")))
 
     // MARK: Quotes
 
@@ -496,25 +496,25 @@ extension RegexTests {
 
     parseTest(
       #"a{1,2}"#,
-      quantRange(.eager, 1...2, "a"))
+      quantRange(1...2, of: "a"))
     parseTest(
       #"a{,2}"#,
-      upToN(.eager, 2, "a"))
+      upToN(2, of: "a"))
     parseTest(
       #"a{2,}"#,
-      nOrMore(.eager, 2, "a"))
+      nOrMore(2, of: "a"))
     parseTest(
       #"a{1}"#,
-      exactly(.eager, 1, "a"))
+      exactly(1, of: "a"))
     parseTest(
       #"a{1,2}?"#,
-      quantRange(.reluctant, 1...2, "a"))
+      quantRange(1...2, .reluctant, of: "a"))
     parseTest(
       #"a{0}"#,
-      exactly(.eager, 0, "a"))
+      exactly(0, of: "a"))
     parseTest(
       #"a{0,0}"#,
-      quantRange(.eager, 0...0, "a"))
+      quantRange(0...0, of: "a"))
 
     // Make sure ranges get treated as literal if invalid.
     parseTest("{", "{")
@@ -524,16 +524,16 @@ extension RegexTests {
     parseTest("{,6", concat("{", ",", "6"))
     parseTest("{6", concat("{", "6"))
     parseTest("{6,", concat("{", "6", ","))
-    parseTest("{+", oneOrMore(.eager, "{"))
-    parseTest("{6,+", concat("{", "6", oneOrMore(.eager, ",")))
+    parseTest("{+", oneOrMore(of: "{"))
+    parseTest("{6,+", concat("{", "6", oneOrMore(of: ",")))
     parseTest("x{", concat("x", "{"))
     parseTest("x{}", concat("x", "{", "}"))
     parseTest("x{,}", concat("x", "{", ",", "}"))
     parseTest("x{,6", concat("x", "{", ",", "6"))
     parseTest("x{6", concat("x", "{", "6"))
     parseTest("x{6,", concat("x", "{", "6", ","))
-    parseTest("x{+", concat("x", oneOrMore(.eager, "{")))
-    parseTest("x{6,+", concat("x", "{", "6", oneOrMore(.eager, ",")))
+    parseTest("x{+", concat("x", oneOrMore(of: "{")))
+    parseTest("x{6,+", concat("x", "{", "6", oneOrMore(of: ",")))
 
     // TODO: We should emit a diagnostic for this.
     parseTest("x{3, 5}", concat("x", "{", "3", ",", " ", "5", "}"))
@@ -915,14 +915,11 @@ extension RegexTests {
 
     parseTest(#"\N{abc}"#, atom(.namedCharacter("abc")))
     parseTest(#"[\N{abc}]"#, charClass(atom_m(.namedCharacter("abc"))))
-    parseTest(
-      #"\N{abc}+"#,
-      oneOrMore(.eager,
-                atom(.namedCharacter("abc"))))
+    parseTest(#"\N{abc}+"#, oneOrMore(of: atom(.namedCharacter("abc"))))
     parseTest(
       #"\N {2}"#,
-      concat(atom(.escaped(.notNewline)),
-             exactly(.eager, 2, " ")))
+      concat(atom(.escaped(.notNewline)), exactly(2, of: " "))
+    )
 
     parseTest(#"\N{AA}"#, atom(.namedCharacter("AA")))
     parseTest(#"\N{U+AA}"#, scalar("\u{AA}"))
@@ -945,7 +942,7 @@ extension RegexTests {
     parseTest(#"[\p{C}]"#, charClass(prop_m(.generalCategory(.other))))
     parseTest(
       #"\p{C}+"#,
-      oneOrMore(.eager, prop(.generalCategory(.other))))
+      oneOrMore(of: prop(.generalCategory(.other))))
 
     parseTest(#"\p{Lx}"#, prop(.other(key: nil, value: "Lx")))
     parseTest(#"\p{gcL}"#, prop(.other(key: nil, value: "gcL")))
@@ -1064,7 +1061,7 @@ extension RegexTests {
       captures: .atom(name: "a1")
     )
 
-    parseTest(#"(?(1))?"#, zeroOrOne(.eager, conditional(
+    parseTest(#"(?(1))?"#, zeroOrOne(of: conditional(
       .groupMatched(ref(1)), trueBranch: empty(), falseBranch: empty())))
 
     parseTest(#"(?(R)a|b)"#, conditional(
@@ -1108,9 +1105,9 @@ extension RegexTests {
 
     parseTest(#"(?((a)?(b))(a)+|b)"#, conditional(
       groupCondition(.capture, concat(
-        zeroOrOne(.eager, capture("a")), capture("b")
+        zeroOrOne(of: capture("a")), capture("b")
       )),
-      trueBranch: oneOrMore(.eager, capture("a")),
+      trueBranch: oneOrMore(of: capture("a")),
       falseBranch: "b"
     ), captures: .tuple([
       .atom(), .optional(.atom()), .atom(), .optional(.array(.atom()))
@@ -1118,9 +1115,9 @@ extension RegexTests {
 
     parseTest(#"(?(?:(a)?(b))(a)+|b)"#, conditional(
       groupCondition(.nonCapture, concat(
-        zeroOrOne(.eager, capture("a")), capture("b")
+        zeroOrOne(of: capture("a")), capture("b")
       )),
-      trueBranch: oneOrMore(.eager, capture("a")),
+      trueBranch: oneOrMore(of: capture("a")),
       falseBranch: "b"
     ), captures: .tuple([
       .optional(.atom()), .atom(), .optional(.array(.atom()))
@@ -1190,10 +1187,10 @@ extension RegexTests {
 
     // MARK: Backtracking directives
 
-    parseTest("(*ACCEPT)?", zeroOrOne(.eager, backtrackingDirective(.accept)))
+    parseTest("(*ACCEPT)?", zeroOrOne(of: backtrackingDirective(.accept)))
     parseTest(
       "(*ACCEPT:a)??",
-      zeroOrOne(.reluctant, backtrackingDirective(.accept, name: "a"))
+      zeroOrOne(.reluctant, of: backtrackingDirective(.accept, name: "a"))
     )
     parseTest("(*:a)", backtrackingDirective(.mark, name: "a"))
     parseTest("(*MARK:a)", backtrackingDirective(.mark, name: "a"))
@@ -1208,17 +1205,17 @@ extension RegexTests {
 
     parseTest("(?~)", absentRepeater(empty()))
     parseTest("(?~abc)", absentRepeater(concat("a", "b", "c")))
-    parseTest("(?~a+)", absentRepeater(oneOrMore(.eager, "a")))
+    parseTest("(?~a+)", absentRepeater(oneOrMore(of: "a")))
     parseTest("(?~~)", absentRepeater("~"))
     parseTest("(?~a|b|c)", absentRepeater(alt("a", "b", "c")))
     parseTest("(?~(a))", absentRepeater(capture("a")), captures: .empty)
-    parseTest("(?~)*", zeroOrMore(.eager, absentRepeater(empty())))
+    parseTest("(?~)*", zeroOrMore(of: absentRepeater(empty())))
 
     parseTest("(?~|abc)", absentStopper(concat("a", "b", "c")))
-    parseTest("(?~|a+)", absentStopper(oneOrMore(.eager, "a")))
+    parseTest("(?~|a+)", absentStopper(oneOrMore(of: "a")))
     parseTest("(?~|~)", absentStopper("~"))
     parseTest("(?~|(a))", absentStopper(capture("a")), captures: .empty)
-    parseTest("(?~|a){2}", exactly(.eager, 2, absentStopper("a")))
+    parseTest("(?~|a){2}", exactly(2, of: absentStopper("a")))
 
     parseTest("(?~|a|b)", absentExpression("a", "b"))
     parseTest("(?~|~|~)", absentExpression("~", "~"))
@@ -1227,13 +1224,13 @@ extension RegexTests {
     parseTest("(?~|(a)|(?:(b)|c))", absentExpression(
       capture("a"), nonCapture(alt(capture("b"), "c"))
     ), captures: .optional(.atom()))
-    parseTest("(?~|a|b)?", zeroOrOne(.eager, absentExpression("a", "b")))
+    parseTest("(?~|a|b)?", zeroOrOne(of: absentExpression("a", "b")))
 
     parseTest("(?~|)", absentRangeClear())
 
     // TODO: It's not really clear what this means, but Oniguruma parses it...
     // Maybe we should diagnose it?
-    parseTest("(?~|)+", oneOrMore(.eager, absentRangeClear()))
+    parseTest("(?~|)+", oneOrMore(of: absentRangeClear()))
 
     // MARK: Global matching options
 
@@ -1372,19 +1369,19 @@ extension RegexTests {
       "(?x)a *",
       changeMatchingOptions(
         matchingOptions(adding: .extended), isIsolated: true,
-        zeroOrMore(.eager, "a"))
+        zeroOrMore(of: "a"))
     )
     parseTest(
       "(?x)a + ?",
       changeMatchingOptions(
         matchingOptions(adding: .extended), isIsolated: true,
-        oneOrMore(.reluctant, "a"))
+        oneOrMore(.reluctant, of: "a"))
     )
     parseTest(
       "(?x)a {2,4}",
       changeMatchingOptions(
         matchingOptions(adding: .extended), isIsolated: true,
-        quantRange(.eager, 2 ... 4, "a"))
+        quantRange(2 ... 4, of: "a"))
     )
 
     // PCRE states that whitespace won't be ignored within a range.
@@ -1424,7 +1421,7 @@ extension RegexTests {
 
     // Non-semantic whitespace between quantifier characters for consistency
     // with PCRE.
-    parseWithDelimitersTest("'|a * ?|'", zeroOrMore(.reluctant, "a"))
+    parseWithDelimitersTest("'|a * ?|'", zeroOrMore(.reluctant, of: "a"))
 
     // End-of-line comments aren't enabled by default in experimental syntax.
     parseWithDelimitersTest("'|#abc|'", concat("#", "a", "b", "c"))

--- a/Tests/RegexTests/SyntaxOptionsTests.swift
+++ b/Tests/RegexTests/SyntaxOptionsTests.swift
@@ -15,7 +15,7 @@ import XCTest
 
 
 private let dplus = oneOrMore(
-  .eager, atom(.escaped(.decimalDigit)))
+  of: atom(.escaped(.decimalDigit)))
 private let dotAST = concat(
   dplus, ".", dplus, ".", dplus, ".", dplus)
 private let dotASTQuoted = concat(
@@ -61,34 +61,34 @@ extension RegexTests {
   func testExperimentalRanges() {
     parseTest(
       #"a{1,2}"#,
-      quantRange(.eager, 1...2, "a"))
+      quantRange(1...2, of: "a"))
     parseTest(
       #"a{1...2}"#,
-      quantRange(.eager, 1...2, "a"),
+      quantRange(1...2, of: "a"),
       syntax: .experimentalRanges)
     parseTest(
       #"a{1..<3}"#,
-      quantRange(.eager, 1...2, "a"),
+      quantRange(1...2, of: "a"),
       syntax: .experimentalRanges)
 
     parseTest(
       #"a{,2}"#,
-      upToN(.eager, 2, "a"))
+      upToN(2, of: "a"))
     parseTest(
       #"a{...2}"#,
-      upToN(.eager, 2, "a"),
+      upToN(2, of: "a"),
       syntax: .experimental)
     parseTest(
       #"a{..<3}"#,
-      upToN(.eager, 2, "a"),
+      upToN(2, of: "a"),
       syntax: .experimental)
 
     parseTest(
       #"a{1,}"#,
-      nOrMore(.eager, 1, "a"))
+      nOrMore(1, of: "a"))
     parseTest(
       #"a{1...}"#,
-      nOrMore(.eager, 1, "a"),
+      nOrMore(1, of: "a"),
       syntax: .experimental)
   }
 


### PR DESCRIPTION
This is based on top of #133, only the last 3 commits are relevant.

---

Parse extended syntax which can be enabled with the `(?x)` and `(?xx)` options. This enables non-semantic whitespace both inside and outside custom character classes, and allows end-of-line `# abc` comment syntax.