### PR TITLE
Diagnose quantifiers without operands

### DIFF
--- a/Sources/_MatchingEngine/Regex/Parse/Diagnostics.swift
+++ b/Sources/_MatchingEngine/Regex/Parse/Diagnostics.swift
@@ -43,6 +43,7 @@ enum ParseError: Error, Hashable {
   case cannotReferToWholePattern
 
   case notQuantifiable
+  case quantifierRequiresOperand(String)
 
   case backtrackingDirectiveMustHaveName(String)
 
@@ -110,6 +111,8 @@ extension ParseError: CustomStringConvertible {
       return "cannot refer to whole pattern here"
     case .notQuantifiable:
       return "expression is not quantifiable"
+    case .quantifierRequiresOperand(let q):
+      return "quantifier '\(q)' must appear after expression"
     case .backtrackingDirectiveMustHaveName(let b):
       return "backtracking directive '\(b)' must include name"
     case let .tooManyBranchesInConditional(i):

--- a/Sources/_MatchingEngine/Regex/Parse/LexicalAnalysis.swift
+++ b/Sources/_MatchingEngine/Regex/Parse/LexicalAnalysis.swift
@@ -1774,6 +1774,13 @@ extension Source {
         return try src.expectGroupLikeAtom()
       }
 
+      // A quantifier here is invalid.
+      if !customCC,
+         let q = try src.recordLoc({ try $0.lexQuantifier(context: context) }) {
+        throw ParseError.quantifierRequiresOperand(
+          String(src[q.location.range]))
+      }
+
       let char = src.eat()
       switch char {
       case ")", "|":

--- a/Tests/RegexTests/ParseTests.swift
+++ b/Tests/RegexTests/ParseTests.swift
@@ -415,6 +415,9 @@ extension RegexTests {
     parseTest("[[:AL_NUM:]]", charClass(posixProp_m(.posix(.alnum))))
     parseTest("[[:script=Greek:]]", charClass(posixProp_m(.script(.greek))))
 
+    parseTest("[*]", charClass("*"))
+    parseTest("[{0}]", charClass("{", "0", "}"))
+
     // MARK: Operators
 
     parseTest(
@@ -494,6 +497,9 @@ extension RegexTests {
 
     // MARK: Quantification
 
+    parseTest("a*", zeroOrMore(of: "a"))
+    parseTest(" +", oneOrMore(of: " "))
+
     parseTest(
       #"a{1,2}"#,
       quantRange(1...2, of: "a"))
@@ -537,6 +543,8 @@ extension RegexTests {
 
     // TODO: We should emit a diagnostic for this.
     parseTest("x{3, 5}", concat("x", "{", "3", ",", " ", "5", "}"))
+    parseTest("{3, 5}", concat("{", "3", ",", " ", "5", "}"))
+    parseTest("{3 }", concat("{", "3", " ", "}"))
 
     // MARK: Groups
 
@@ -1741,6 +1749,15 @@ extension RegexTests {
     diagnosticTest(#"(?'a-b-c')"#, .expected("'"))
 
     diagnosticTest("(?x)(? : )", .unknownGroupKind("? "))
+
+    // MARK: Quantifiers
+
+    diagnosticTest("*", .quantifierRequiresOperand("*"))
+    diagnosticTest("+", .quantifierRequiresOperand("+"))
+    diagnosticTest("?", .quantifierRequiresOperand("?"))
+    diagnosticTest("*?", .quantifierRequiresOperand("*?"))
+    diagnosticTest("{5}", .quantifierRequiresOperand("{5}"))
+    diagnosticTest("{1,3}", .quantifierRequiresOperand("{1,3}"))
 
     // MARK: Matching options
 


### PR DESCRIPTION
Avoid treating such cases as literal.