### PR TITLE
Add DSL support for backreferences.

### DIFF
--- a/Sources/VariadicsGenerator/VariadicsGenerator.swift
+++ b/Sources/VariadicsGenerator/VariadicsGenerator.swift
@@ -538,52 +538,65 @@ struct VariadicsGenerator: ParsableCommand {
     output("""
       // MARK: - Non-builder capture arity \(arity)
 
-      public func capture<\(genericParams)>(_ component: R) -> \(regexTypeName)<\(newMatchType(newCaptureType: "W"))> \(whereClause) {
-        .init(node: .group(.capture, component.regex.root))
+      public func capture<\(genericParams)>(
+        _ component: R, as reference: Reference? = nil
+      ) -> \(regexTypeName)<\(newMatchType(newCaptureType: "W"))> \(whereClause) {
+        .init(node: .group(.capture, component.regex.root, reference?.id))
       }
 
       public func capture<\(genericParams), NewCapture>(
-        _ component: R, transform: @escaping (Substring) -> NewCapture
+        _ component: R,
+        as reference: Reference? = nil,
+        transform: @escaping (Substring) -> NewCapture
       ) -> \(regexTypeName)<\(newMatchType(newCaptureType: "NewCapture"))> \(whereClause) {
         .init(node: .groupTransform(
           .capture,
           component.regex.root,
           CaptureTransform(resultType: NewCapture.self) {
             transform($0) as Any
-          }))
+          },
+          reference?.id))
       }
 
       public func tryCapture<\(genericParams), NewCapture>(
-        _ component: R, transform: @escaping (Substring) throws -> NewCapture
+        _ component: R,
+        as reference: Reference? = nil,
+        transform: @escaping (Substring) throws -> NewCapture
       ) -> \(regexTypeName)<\(newMatchType(newCaptureType: "NewCapture"))> \(whereClause) {
         .init(node: .groupTransform(
           .capture,
           component.regex.root,
           CaptureTransform(resultType: NewCapture.self) {
             try transform($0) as Any
-          }))
+          },
+          reference?.id))
       }
 
       public func tryCapture<\(genericParams), NewCapture>(
-        _ component: R, transform: @escaping (Substring) -> NewCapture?
+        _ component: R,
+        as reference: Reference? = nil,
+        transform: @escaping (Substring) -> NewCapture?
       ) -> \(regexTypeName)<\(newMatchType(newCaptureType: "NewCapture"))> \(whereClause) {
         .init(node: .groupTransform(
           .capture,
           component.regex.root,
           CaptureTransform(resultType: NewCapture.self) {
             transform($0) as Any?
-          }))
+          },
+          reference?.id))
       }
 
       // MARK: - Builder capture arity \(arity)
 
       public func capture<\(genericParams)>(
+        as reference: Reference? = nil,
         @RegexBuilder _ component: () -> R
       ) -> \(regexTypeName)<\(newMatchType(newCaptureType: "W"))> \(whereClause) {
-        .init(node: .group(.capture, component().regex.root))
+        .init(node: .group(.capture, component().regex.root, reference?.id))
       }
 
       public func capture<\(genericParams), NewCapture>(
+        as reference: Reference? = nil,
         @RegexBuilder _ component: () -> R,
         transform: @escaping (Substring) -> NewCapture
       ) -> \(regexTypeName)<\(newMatchType(newCaptureType: "NewCapture"))> \(whereClause) {
@@ -592,10 +605,12 @@ struct VariadicsGenerator: ParsableCommand {
           component().regex.root,
           CaptureTransform(resultType: NewCapture.self) {
             transform($0) as Any
-          }))
+          },
+          reference?.id))
       }
 
       public func tryCapture<\(genericParams), NewCapture>(
+        as reference: Reference? = nil,
         @RegexBuilder _ component: () -> R,
         transform: @escaping (Substring) throws -> NewCapture
       ) -> \(regexTypeName)<\(newMatchType(newCaptureType: "NewCapture"))> \(whereClause) {
@@ -604,10 +619,12 @@ struct VariadicsGenerator: ParsableCommand {
           component().regex.root,
           CaptureTransform(resultType: NewCapture.self) {
             try transform($0) as Any
-          }))
+          },
+          reference?.id))
       }
 
       public func tryCapture<\(genericParams), NewCapture>(
+        as reference: Reference? = nil,
         @RegexBuilder _ component: () -> R,
         transform: @escaping (Substring) -> NewCapture?
       ) -> \(regexTypeName)<\(newMatchType(newCaptureType: "NewCapture"))> \(whereClause) {
@@ -616,7 +633,8 @@ struct VariadicsGenerator: ParsableCommand {
           component().regex.root,
           CaptureTransform(resultType: NewCapture.self) {
             transform($0) as Any?
-          }))
+          },
+          reference?.id))
       }
 
       """)

--- a/Sources/_StringProcessing/ByteCodeGen.swift
+++ b/Sources/_StringProcessing/ByteCodeGen.swift
@@ -31,6 +31,9 @@ extension Compiler.ByteCodeGen {
     case let .backreference(ref):
       try emitBackreference(ref)
 
+    case let .symbolicReference(id):
+      builder.buildUnresolvedReference(id: id)
+
     case let .unconverted(astAtom):
       if let consumer = try astAtom.generateConsumer(options) {
         builder.buildConsume(by: consumer)
@@ -293,8 +296,14 @@ extension Compiler.ByteCodeGen {
   }
 
   mutating func emitGroup(
-    _ kind: AST.Group.Kind, _ child: DSLTree.Node
+    _ kind: AST.Group.Kind,
+    _ child: DSLTree.Node,
+    _ referenceID: Reference.ID?
   ) throws -> CaptureRegister? {
+    guard kind.isCapturing || referenceID == nil else {
+      throw Unreachable("Reference ID shouldn't exist for non-capturing groups")
+    }
+
     options.beginScope()
     defer { options.endScope() }
 
@@ -303,7 +312,7 @@ extension Compiler.ByteCodeGen {
     //
     // FIXME: Unify with .groupTransform
     if kind.isCapturing, case let .matcher(_, m) = child {
-      let cap = builder.makeCapture()
+      let cap = builder.makeCapture(id: referenceID)
       emitMatcher(m, into: cap)
       return cap
     }
@@ -319,7 +328,7 @@ extension Compiler.ByteCodeGen {
       throw Unreachable("TODO: reason")
 
     case .capture, .namedCapture:
-      let cap = builder.makeCapture()
+      let cap = builder.makeCapture(id: referenceID)
       builder.buildBeginCapture(cap)
       try emitNode(child)
       builder.buildEndCapture(cap)
@@ -552,8 +561,8 @@ extension Compiler.ByteCodeGen {
         try emitConcatenationComponent(child)
       }
 
-    case let .group(kind, child):
-      _ = try emitGroup(kind, child)
+    case let .group(kind, child, referenceID):
+      _ = try emitGroup(kind, child, referenceID)
 
     case .conditional:
       throw Unsupported("Conditionals")
@@ -592,8 +601,8 @@ extension Compiler.ByteCodeGen {
     case let .convertedRegexLiteral(n, _):
       try emitNode(n)
 
-    case let .groupTransform(kind, child, t):
-      guard let cap = try emitGroup(kind, child) else {
+    case let .groupTransform(kind, child, t, referenceID):
+      guard let cap = try emitGroup(kind, child, referenceID) else {
         assertionFailure("""
           What does it mean to not have a capture to transform?
           """)

--- a/Sources/_StringProcessing/Compiler.swift
+++ b/Sources/_StringProcessing/Compiler.swift
@@ -43,3 +43,15 @@ public func _compileRegex(
   return Executor(program: program)
 }
 
+// An error produced when compiling a regular expression.
+public enum RegexCompilationError: Error, CustomStringConvertible {
+  // TODO: Source location?
+  case uncapturedReference
+
+  public var description: String {
+    switch self {
+    case .uncapturedReference:
+      return "Found a reference used before it captured any match."
+    }
+  }
+}

--- a/Sources/_StringProcessing/ConsumerInterface.swift
+++ b/Sources/_StringProcessing/ConsumerInterface.swift
@@ -93,6 +93,10 @@ extension DSLTree.Atom {
       // TODO: Should we handle?
       return nil
 
+    case .symbolicReference:
+      // TODO: Should we handle?
+      return nil
+
     case let .unconverted(a):
       return try a.generateConsumer(opts)
     }

--- a/Sources/_StringProcessing/PrintAsPattern.swift
+++ b/Sources/_StringProcessing/PrintAsPattern.swift
@@ -87,9 +87,10 @@ extension PrettyPrinter {
         }
       }
 
-    case let .group(kind, child):
+    case let .group(kind, child, referenceID):
       let kind = kind._patternBase
-      printBlock("Group(\(kind))") { printer in
+      let refIDString = referenceID.map { ", referenceID: \($0)" } ?? ""
+      printBlock("Group(\(kind)\(refIDString)") { printer in
         printer.printAsPattern(convertedFromAST: child)
       }
 
@@ -123,7 +124,9 @@ extension PrettyPrinter {
       case .assertion:
         print("/* TODO: assertions */")
       case .backreference:
-        print("/* TODO: backreferences */")
+        print("/* TOOD: backreferences */")
+      case .symbolicReference:
+        print("/* TOOD: symbolic references */")
       }
 
     case .trivia:

--- a/Sources/_StringProcessing/RegexDSL/DSL.swift
+++ b/Sources/_StringProcessing/RegexDSL/DSL.swift
@@ -184,3 +184,25 @@ public func choiceOf<R: RegexProtocol>(
 ) -> R {
   builder()
 }
+
+// MARK: - Backreference
+
+public struct Reference: RegexProtocol {
+  // FIXME: Public for prototypes.
+  public struct ID: Hashable, Equatable {
+    private static var counter: Int = 0
+    var base: Int
+    init() {
+      base = ID.counter
+      ID.counter += 1
+    }
+  }
+
+  let id = ID()
+  
+  public init() {}
+
+  public var regex: Regex<Substring> {
+    .init(node: .atom(.symbolicReference(id)))
+  }
+}

--- a/Sources/_StringProcessing/RegexDSL/DSLTree.swift
+++ b/Sources/_StringProcessing/RegexDSL/DSLTree.swift
@@ -30,7 +30,7 @@ extension DSLTree {
     case concatenation([Node])
 
     /// (...)
-    case group(AST.Group.Kind, Node)
+    case group(AST.Group.Kind, Node, Reference.ID? = nil)
 
     /// (?(cond) true-branch | false-branch)
     ///
@@ -81,7 +81,8 @@ extension DSLTree {
     case groupTransform(
       AST.Group.Kind,
       Node,
-      CaptureTransform)
+      CaptureTransform,
+      Reference.ID? = nil)
 
     case consumer(_ConsumerInterface)
 
@@ -119,6 +120,7 @@ extension DSLTree {
 
     case assertion(AST.Atom.AssertionKind)
     case backreference(AST.Reference)
+    case symbolicReference(Reference.ID)
 
     case unconverted(AST.Atom)
   }
@@ -162,8 +164,8 @@ extension DSLTree.Node {
       // Treat this transparently
       return n.children
 
-    case let .group(_, n):             return [n]
-    case let .groupTransform(_, n, _): return [n]
+    case let .group(_, n, _):             return [n]
+    case let .groupTransform(_, n, _, _): return [n]
     case let .quantification(_, _, n): return [n]
 
     case let .conditional(_, t, f): return [t,f]
@@ -224,8 +226,8 @@ extension DSLTree {
 extension DSLTree.Node {
   var hasCapture: Bool {
     switch self {
-    case let .group(k, _) where k.isCapturing,
-         let .groupTransform(k, _, _) where k.isCapturing:
+    case let .group(k, _, _) where k.isCapturing,
+         let .groupTransform(k, _, _, _) where k.isCapturing:
       return true
     case let .convertedRegexLiteral(n, re):
       assert(n.hasCapture == re.hasCapture)
@@ -257,14 +259,14 @@ extension DSLTree.Node {
     case let .concatenation(children):
       return constructor.concatenating(children)
 
-    case let .group(kind, child):
+    case let .group(kind, child, _):
       if let type = child.matcherCaptureType {
         return constructor.grouping(
           child, as: kind, withType: type)
       }
       return constructor.grouping(child, as: kind)
 
-    case let .groupTransform(kind, child, transform):
+    case let .groupTransform(kind, child, transform, _):
       return constructor.grouping(
         child, as: kind, withTransform: transform)
 

--- a/Sources/_StringProcessing/RegexDSL/Variadics.swift
+++ b/Sources/_StringProcessing/RegexDSL/Variadics.swift
@@ -2265,52 +2265,65 @@ extension AlternationBuilder {
 }
 // MARK: - Non-builder capture arity 0
 
-public func capture<R: RegexProtocol, W>(_ component: R) -> Regex<(Substring, W)> where R.Match == W {
-  .init(node: .group(.capture, component.regex.root))
+public func capture<R: RegexProtocol, W>(
+  _ component: R, as reference: Reference? = nil
+) -> Regex<(Substring, W)> where R.Match == W {
+  .init(node: .group(.capture, component.regex.root, reference?.id))
 }
 
 public func capture<R: RegexProtocol, W, NewCapture>(
-  _ component: R, transform: @escaping (Substring) -> NewCapture
+  _ component: R,
+  as reference: Reference? = nil,
+  transform: @escaping (Substring) -> NewCapture
 ) -> Regex<(Substring, NewCapture)> where R.Match == W {
   .init(node: .groupTransform(
     .capture,
     component.regex.root,
     CaptureTransform(resultType: NewCapture.self) {
       transform($0) as Any
-    }))
+    },
+    reference?.id))
 }
 
 public func tryCapture<R: RegexProtocol, W, NewCapture>(
-  _ component: R, transform: @escaping (Substring) throws -> NewCapture
+  _ component: R,
+  as reference: Reference? = nil,
+  transform: @escaping (Substring) throws -> NewCapture
 ) -> Regex<(Substring, NewCapture)> where R.Match == W {
   .init(node: .groupTransform(
     .capture,
     component.regex.root,
     CaptureTransform(resultType: NewCapture.self) {
       try transform($0) as Any
-    }))
+    },
+    reference?.id))
 }
 
 public func tryCapture<R: RegexProtocol, W, NewCapture>(
-  _ component: R, transform: @escaping (Substring) -> NewCapture?
+  _ component: R,
+  as reference: Reference? = nil,
+  transform: @escaping (Substring) -> NewCapture?
 ) -> Regex<(Substring, NewCapture)> where R.Match == W {
   .init(node: .groupTransform(
     .capture,
     component.regex.root,
     CaptureTransform(resultType: NewCapture.self) {
       transform($0) as Any?
-    }))
+    },
+    reference?.id))
 }
 
 // MARK: - Builder capture arity 0
 
 public func capture<R: RegexProtocol, W>(
+  as reference: Reference? = nil,
   @RegexBuilder _ component: () -> R
 ) -> Regex<(Substring, W)> where R.Match == W {
-  .init(node: .group(.capture, component().regex.root))
+  .init(node: .group(.capture, component().regex.root, reference?.id))
 }
 
 public func capture<R: RegexProtocol, W, NewCapture>(
+  as reference: Reference? = nil,
   @RegexBuilder _ component: () -> R,
   transform: @escaping (Substring) -> NewCapture
 ) -> Regex<(Substring, NewCapture)> where R.Match == W {
@@ -2319,10 +2332,12 @@ public func capture<R: RegexProtocol, W, NewCapture>(
     component().regex.root,
     CaptureTransform(resultType: NewCapture.self) {
       transform($0) as Any
-    }))
+    },
+    reference?.id))
 }
 
 public func tryCapture<R: RegexProtocol, W, NewCapture>(
+  as reference: Reference? = nil,
   @RegexBuilder _ component: () -> R,
   transform: @escaping (Substring) throws -> NewCapture
 ) -> Regex<(Substring, NewCapture)> where R.Match == W {
@@ -2331,10 +2346,12 @@ public func tryCapture<R: RegexProtocol, W, NewCapture>(
     component().regex.root,
     CaptureTransform(resultType: NewCapture.self) {
       try transform($0) as Any
-    }))
+    },
+    reference?.id))
 }
 
 public func tryCapture<R: RegexProtocol, W, NewCapture>(
+  as reference: Reference? = nil,
   @RegexBuilder _ component: () -> R,
   transform: @escaping (Substring) -> NewCapture?
 ) -> Regex<(Substring, NewCapture)> where R.Match == W {
@@ -2343,56 +2360,70 @@ public func tryCapture<R: RegexProtocol, W, NewCapture>(
     component().regex.root,
     CaptureTransform(resultType: NewCapture.self) {
       transform($0) as Any?
-    }))
+    },
+    reference?.id))
 }
 // MARK: - Non-builder capture arity 1
 
-public func capture<R: RegexProtocol, W, C0>(_ component: R) -> Regex<(Substring, W, C0)> where R.Match == (W, C0) {
-  .init(node: .group(.capture, component.regex.root))
+public func capture<R: RegexProtocol, W, C0>(
+  _ component: R, as reference: Reference? = nil
+) -> Regex<(Substring, W, C0)> where R.Match == (W, C0) {
+  .init(node: .group(.capture, component.regex.root, reference?.id))
 }
 
 public func capture<R: RegexProtocol, W, C0, NewCapture>(
-  _ component: R, transform: @escaping (Substring) -> NewCapture
+  _ component: R,
+  as reference: Reference? = nil,
+  transform: @escaping (Substring) -> NewCapture
 ) -> Regex<(Substring, NewCapture, C0)> where R.Match == (W, C0) {
   .init(node: .groupTransform(
     .capture,
     component.regex.root,
     CaptureTransform(resultType: NewCapture.self) {
       transform($0) as Any
-    }))
+    },
+    reference?.id))
 }
 
 public func tryCapture<R: RegexProtocol, W, C0, NewCapture>(
-  _ component: R, transform: @escaping (Substring) throws -> NewCapture
+  _ component: R,
+  as reference: Reference? = nil,
+  transform: @escaping (Substring) throws -> NewCapture
 ) -> Regex<(Substring, NewCapture, C0)> where R.Match == (W, C0) {
   .init(node: .groupTransform(
     .capture,
     component.regex.root,
     CaptureTransform(resultType: NewCapture.self) {
       try transform($0) as Any
-    }))
+    },
+    reference?.id))
 }
 
 public func tryCapture<R: RegexProtocol, W, C0, NewCapture>(
-  _ component: R, transform: @escaping (Substring) -> NewCapture?
+  _ component: R,
+  as reference: Reference? = nil,
+  transform: @escaping (Substring) -> NewCapture?
 ) -> Regex<(Substring, NewCapture, C0)> where R.Match == (W, C0) {
   .init(node: .groupTransform(
     .capture,
     component.regex.root,
     CaptureTransform(resultType: NewCapture.self) {
       transform($0) as Any?
-    }))
+    },
+    reference?.id))
 }
 
 // MARK: - Builder capture arity 1
 
 public func capture<R: RegexProtocol, W, C0>(
+  as reference: Reference? = nil,
   @RegexBuilder _ component: () -> R
 ) -> Regex<(Substring, W, C0)> where R.Match == (W, C0) {
-  .init(node: .group(.capture, component().regex.root))
+  .init(node: .group(.capture, component().regex.root, reference?.id))
 }
 
 public func capture<R: RegexProtocol, W, C0, NewCapture>(
+  as reference: Reference? = nil,
   @RegexBuilder _ component: () -> R,
   transform: @escaping (Substring) -> NewCapture
 ) -> Regex<(Substring, NewCapture, C0)> where R.Match == (W, C0) {
@@ -2401,10 +2432,12 @@ public func capture<R: RegexProtocol, W, C0, NewCapture>(
     component().regex.root,
     CaptureTransform(resultType: NewCapture.self) {
       transform($0) as Any
-    }))
+    },
+    reference?.id))
 }
 
 public func tryCapture<R: RegexProtocol, W, C0, NewCapture>(
+  as reference: Reference? = nil,
   @RegexBuilder _ component: () -> R,
   transform: @escaping (Substring) throws -> NewCapture
 ) -> Regex<(Substring, NewCapture, C0)> where R.Match == (W, C0) {
@@ -2413,10 +2446,12 @@ public func tryCapture<R: RegexProtocol, W, C0, NewCapture>(
     component().regex.root,
     CaptureTransform(resultType: NewCapture.self) {
       try transform($0) as Any
-    }))
+    },
+    reference?.id))
 }
 
 public func tryCapture<R: RegexProtocol, W, C0, NewCapture>(
+  as reference: Reference? = nil,
   @RegexBuilder _ component: () -> R,
   transform: @escaping (Substring) -> NewCapture?
 ) -> Regex<(Substring, NewCapture, C0)> where R.Match == (W, C0) {
@@ -2425,56 +2460,70 @@ public func tryCapture<R: RegexProtocol, W, C0, NewCapture>(
     component().regex.root,
     CaptureTransform(resultType: NewCapture.self) {
       transform($0) as Any?
-    }))
+    },
+    reference?.id))
 }
 // MARK: - Non-builder capture arity 2
 
-public func capture<R: RegexProtocol, W, C0, C1>(_ component: R) -> Regex<(Substring, W, C0, C1)> where R.Match == (W, C0, C1) {
-  .init(node: .group(.capture, component.regex.root))
+public func capture<R: RegexProtocol, W, C0, C1>(
+  _ component: R, as reference: Reference? = nil
+) -> Regex<(Substring, W, C0, C1)> where R.Match == (W, C0, C1) {
+  .init(node: .group(.capture, component.regex.root, reference?.id))
 }
 
 public func capture<R: RegexProtocol, W, C0, C1, NewCapture>(
-  _ component: R, transform: @escaping (Substring) -> NewCapture
+  _ component: R,
+  as reference: Reference? = nil,
+  transform: @escaping (Substring) -> NewCapture
 ) -> Regex<(Substring, NewCapture, C0, C1)> where R.Match == (W, C0, C1) {
   .init(node: .groupTransform(
     .capture,
     component.regex.root,
     CaptureTransform(resultType: NewCapture.self) {
       transform($0) as Any
-    }))
+    },
+    reference?.id))
 }
 
 public func tryCapture<R: RegexProtocol, W, C0, C1, NewCapture>(
-  _ component: R, transform: @escaping (Substring) throws -> NewCapture
+  _ component: R,
+  as reference: Reference? = nil,
+  transform: @escaping (Substring) throws -> NewCapture
 ) -> Regex<(Substring, NewCapture, C0, C1)> where R.Match == (W, C0, C1) {
   .init(node: .groupTransform(
     .capture,
     component.regex.root,
     CaptureTransform(resultType: NewCapture.self) {
       try transform($0) as Any
-    }))
+    },
+    reference?.id))
 }
 
 public func tryCapture<R: RegexProtocol, W, C0, C1, NewCapture>(
-  _ component: R, transform: @escaping (Substring) -> NewCapture?
+  _ component: R,
+  as reference: Reference? = nil,
+  transform: @escaping (Substring) -> NewCapture?
 ) -> Regex<(Substring, NewCapture, C0, C1)> where R.Match == (W, C0, C1) {
   .init(node: .groupTransform(
     .capture,
     component.regex.root,
     CaptureTransform(resultType: NewCapture.self) {
       transform($0) as Any?
-    }))
+    },
+    reference?.id))
 }
 
 // MARK: - Builder capture arity 2
 
 public func capture<R: RegexProtocol, W, C0, C1>(
+  as reference: Reference? = nil,
   @RegexBuilder _ component: () -> R
 ) -> Regex<(Substring, W, C0, C1)> where R.Match == (W, C0, C1) {
-  .init(node: .group(.capture, component().regex.root))
+  .init(node: .group(.capture, component().regex.root, reference?.id))
 }
 
 public func capture<R: RegexProtocol, W, C0, C1, NewCapture>(
+  as reference: Reference? = nil,
   @RegexBuilder _ component: () -> R,
   transform: @escaping (Substring) -> NewCapture
 ) -> Regex<(Substring, NewCapture, C0, C1)> where R.Match == (W, C0, C1) {
@@ -2483,10 +2532,12 @@ public func capture<R: RegexProtocol, W, C0, C1, NewCapture>(
     component().regex.root,
     CaptureTransform(resultType: NewCapture.self) {
       transform($0) as Any
-    }))
+    },
+    reference?.id))
 }
 
 public func tryCapture<R: RegexProtocol, W, C0, C1, NewCapture>(
+  as reference: Reference? = nil,
   @RegexBuilder _ component: () -> R,
   transform: @escaping (Substring) throws -> NewCapture
 ) -> Regex<(Substring, NewCapture, C0, C1)> where R.Match == (W, C0, C1) {
@@ -2495,10 +2546,12 @@ public func tryCapture<R: RegexProtocol, W, C0, C1, NewCapture>(
     component().regex.root,
     CaptureTransform(resultType: NewCapture.self) {
       try transform($0) as Any
-    }))
+    },
+    reference?.id))
 }
 
 public func tryCapture<R: RegexProtocol, W, C0, C1, NewCapture>(
+  as reference: Reference? = nil,
   @RegexBuilder _ component: () -> R,
   transform: @escaping (Substring) -> NewCapture?
 ) -> Regex<(Substring, NewCapture, C0, C1)> where R.Match == (W, C0, C1) {
@@ -2507,56 +2560,70 @@ public func tryCapture<R: RegexProtocol, W, C0, C1, NewCapture>(
     component().regex.root,
     CaptureTransform(resultType: NewCapture.self) {
       transform($0) as Any?
-    }))
+    },
+    reference?.id))
 }
 // MARK: - Non-builder capture arity 3
 
-public func capture<R: RegexProtocol, W, C0, C1, C2>(_ component: R) -> Regex<(Substring, W, C0, C1, C2)> where R.Match == (W, C0, C1, C2) {
-  .init(node: .group(.capture, component.regex.root))
+public func capture<R: RegexProtocol, W, C0, C1, C2>(
+  _ component: R, as reference: Reference? = nil
+) -> Regex<(Substring, W, C0, C1, C2)> where R.Match == (W, C0, C1, C2) {
+  .init(node: .group(.capture, component.regex.root, reference?.id))
 }
 
 public func capture<R: RegexProtocol, W, C0, C1, C2, NewCapture>(
-  _ component: R, transform: @escaping (Substring) -> NewCapture
+  _ component: R,
+  as reference: Reference? = nil,
+  transform: @escaping (Substring) -> NewCapture
 ) -> Regex<(Substring, NewCapture, C0, C1, C2)> where R.Match == (W, C0, C1, C2) {
   .init(node: .groupTransform(
     .capture,
     component.regex.root,
     CaptureTransform(resultType: NewCapture.self) {
       transform($0) as Any
-    }))
+    },
+    reference?.id))
 }
 
 public func tryCapture<R: RegexProtocol, W, C0, C1, C2, NewCapture>(
-  _ component: R, transform: @escaping (Substring) throws -> NewCapture
+  _ component: R,
+  as reference: Reference? = nil,
+  transform: @escaping (Substring) throws -> NewCapture
 ) -> Regex<(Substring, NewCapture, C0, C1, C2)> where R.Match == (W, C0, C1, C2) {
   .init(node: .groupTransform(
     .capture,
     component.regex.root,
     CaptureTransform(resultType: NewCapture.self) {
       try transform($0) as Any
-    }))
+    },
+    reference?.id))
 }
 
 public func tryCapture<R: RegexProtocol, W, C0, C1, C2, NewCapture>(
-  _ component: R, transform: @escaping (Substring) -> NewCapture?
+  _ component: R,
+  as reference: Reference? = nil,
+  transform: @escaping (Substring) -> NewCapture?
 ) -> Regex<(Substring, NewCapture, C0, C1, C2)> where R.Match == (W, C0, C1, C2) {
   .init(node: .groupTransform(
     .capture,
     component.regex.root,
     CaptureTransform(resultType: NewCapture.self) {
       transform($0) as Any?
-    }))
+    },
+    reference?.id))
 }
 
 // MARK: - Builder capture arity 3
 
 public func capture<R: RegexProtocol, W, C0, C1, C2>(
+  as reference: Reference? = nil,
   @RegexBuilder _ component: () -> R
 ) -> Regex<(Substring, W, C0, C1, C2)> where R.Match == (W, C0, C1, C2) {
-  .init(node: .group(.capture, component().regex.root))
+  .init(node: .group(.capture, component().regex.root, reference?.id))
 }
 
 public func capture<R: RegexProtocol, W, C0, C1, C2, NewCapture>(
+  as reference: Reference? = nil,
   @RegexBuilder _ component: () -> R,
   transform: @escaping (Substring) -> NewCapture
 ) -> Regex<(Substring, NewCapture, C0, C1, C2)> where R.Match == (W, C0, C1, C2) {
@@ -2565,10 +2632,12 @@ public func capture<R: RegexProtocol, W, C0, C1, C2, NewCapture>(
     component().regex.root,
     CaptureTransform(resultType: NewCapture.self) {
       transform($0) as Any
-    }))
+    },
+    reference?.id))
 }
 
 public func tryCapture<R: RegexProtocol, W, C0, C1, C2, NewCapture>(
+  as reference: Reference? = nil,
   @RegexBuilder _ component: () -> R,
   transform: @escaping (Substring) throws -> NewCapture
 ) -> Regex<(Substring, NewCapture, C0, C1, C2)> where R.Match == (W, C0, C1, C2) {
@@ -2577,10 +2646,12 @@ public func tryCapture<R: RegexProtocol, W, C0, C1, C2, NewCapture>(
     component().regex.root,
     CaptureTransform(resultType: NewCapture.self) {
       try transform($0) as Any
-    }))
+    },
+    reference?.id))
 }
 
 public func tryCapture<R: RegexProtocol, W, C0, C1, C2, NewCapture>(
+  as reference: Reference? = nil,
   @RegexBuilder _ component: () -> R,
   transform: @escaping (Substring) -> NewCapture?
 ) -> Regex<(Substring, NewCapture, C0, C1, C2)> where R.Match == (W, C0, C1, C2) {
@@ -2589,56 +2660,70 @@ public func tryCapture<R: RegexProtocol, W, C0, C1, C2, NewCapture>(
     component().regex.root,
     CaptureTransform(resultType: NewCapture.self) {
       transform($0) as Any?
-    }))
+    },
+    reference?.id))
 }
 // MARK: - Non-builder capture arity 4
 
-public func capture<R: RegexProtocol, W, C0, C1, C2, C3>(_ component: R) -> Regex<(Substring, W, C0, C1, C2, C3)> where R.Match == (W, C0, C1, C2, C3) {
-  .init(node: .group(.capture, component.regex.root))
+public func capture<R: RegexProtocol, W, C0, C1, C2, C3>(
+  _ component: R, as reference: Reference? = nil
+) -> Regex<(Substring, W, C0, C1, C2, C3)> where R.Match == (W, C0, C1, C2, C3) {
+  .init(node: .group(.capture, component.regex.root, reference?.id))
 }
 
 public func capture<R: RegexProtocol, W, C0, C1, C2, C3, NewCapture>(
-  _ component: R, transform: @escaping (Substring) -> NewCapture
+  _ component: R,
+  as reference: Reference? = nil,
+  transform: @escaping (Substring) -> NewCapture
 ) -> Regex<(Substring, NewCapture, C0, C1, C2, C3)> where R.Match == (W, C0, C1, C2, C3) {
   .init(node: .groupTransform(
     .capture,
     component.regex.root,
     CaptureTransform(resultType: NewCapture.self) {
       transform($0) as Any
-    }))
+    },
+    reference?.id))
 }
 
 public func tryCapture<R: RegexProtocol, W, C0, C1, C2, C3, NewCapture>(
-  _ component: R, transform: @escaping (Substring) throws -> NewCapture
+  _ component: R,
+  as reference: Reference? = nil,
+  transform: @escaping (Substring) throws -> NewCapture
 ) -> Regex<(Substring, NewCapture, C0, C1, C2, C3)> where R.Match == (W, C0, C1, C2, C3) {
   .init(node: .groupTransform(
     .capture,
     component.regex.root,
     CaptureTransform(resultType: NewCapture.self) {
       try transform($0) as Any
-    }))
+    },
+    reference?.id))
 }
 
 public func tryCapture<R: RegexProtocol, W, C0, C1, C2, C3, NewCapture>(
-  _ component: R, transform: @escaping (Substring) -> NewCapture?
+  _ component: R,
+  as reference: Reference? = nil,
+  transform: @escaping (Substring) -> NewCapture?
 ) -> Regex<(Substring, NewCapture, C0, C1, C2, C3)> where R.Match == (W, C0, C1, C2, C3) {
   .init(node: .groupTransform(
     .capture,
     component.regex.root,
     CaptureTransform(resultType: NewCapture.self) {
       transform($0) as Any?
-    }))
+    },
+    reference?.id))
 }
 
 // MARK: - Builder capture arity 4
 
 public func capture<R: RegexProtocol, W, C0, C1, C2, C3>(
+  as reference: Reference? = nil,
   @RegexBuilder _ component: () -> R
 ) -> Regex<(Substring, W, C0, C1, C2, C3)> where R.Match == (W, C0, C1, C2, C3) {
-  .init(node: .group(.capture, component().regex.root))
+  .init(node: .group(.capture, component().regex.root, reference?.id))
 }
 
 public func capture<R: RegexProtocol, W, C0, C1, C2, C3, NewCapture>(
+  as reference: Reference? = nil,
   @RegexBuilder _ component: () -> R,
   transform: @escaping (Substring) -> NewCapture
 ) -> Regex<(Substring, NewCapture, C0, C1, C2, C3)> where R.Match == (W, C0, C1, C2, C3) {
@@ -2647,10 +2732,12 @@ public func capture<R: RegexProtocol, W, C0, C1, C2, C3, NewCapture>(
     component().regex.root,
     CaptureTransform(resultType: NewCapture.self) {
       transform($0) as Any
-    }))
+    },
+    reference?.id))
 }
 
 public func tryCapture<R: RegexProtocol, W, C0, C1, C2, C3, NewCapture>(
+  as reference: Reference? = nil,
   @RegexBuilder _ component: () -> R,
   transform: @escaping (Substring) throws -> NewCapture
 ) -> Regex<(Substring, NewCapture, C0, C1, C2, C3)> where R.Match == (W, C0, C1, C2, C3) {
@@ -2659,10 +2746,12 @@ public func tryCapture<R: RegexProtocol, W, C0, C1, C2, C3, NewCapture>(
     component().regex.root,
     CaptureTransform(resultType: NewCapture.self) {
       try transform($0) as Any
-    }))
+    },
+    reference?.id))
 }
 
 public func tryCapture<R: RegexProtocol, W, C0, C1, C2, C3, NewCapture>(
+  as reference: Reference? = nil,
   @RegexBuilder _ component: () -> R,
   transform: @escaping (Substring) -> NewCapture?
 ) -> Regex<(Substring, NewCapture, C0, C1, C2, C3)> where R.Match == (W, C0, C1, C2, C3) {
@@ -2671,56 +2760,70 @@ public func tryCapture<R: RegexProtocol, W, C0, C1, C2, C3, NewCapture>(
     component().regex.root,
     CaptureTransform(resultType: NewCapture.self) {
       transform($0) as Any?
-    }))
+    },
+    reference?.id))
 }
 // MARK: - Non-builder capture arity 5
 
-public func capture<R: RegexProtocol, W, C0, C1, C2, C3, C4>(_ component: R) -> Regex<(Substring, W, C0, C1, C2, C3, C4)> where R.Match == (W, C0, C1, C2, C3, C4) {
-  .init(node: .group(.capture, component.regex.root))
+public func capture<R: RegexProtocol, W, C0, C1, C2, C3, C4>(
+  _ component: R, as reference: Reference? = nil
+) -> Regex<(Substring, W, C0, C1, C2, C3, C4)> where R.Match == (W, C0, C1, C2, C3, C4) {
+  .init(node: .group(.capture, component.regex.root, reference?.id))
 }
 
 public func capture<R: RegexProtocol, W, C0, C1, C2, C3, C4, NewCapture>(
-  _ component: R, transform: @escaping (Substring) -> NewCapture
+  _ component: R,
+  as reference: Reference? = nil,
+  transform: @escaping (Substring) -> NewCapture
 ) -> Regex<(Substring, NewCapture, C0, C1, C2, C3, C4)> where R.Match == (W, C0, C1, C2, C3, C4) {
   .init(node: .groupTransform(
     .capture,
     component.regex.root,
     CaptureTransform(resultType: NewCapture.self) {
       transform($0) as Any
-    }))
+    },
+    reference?.id))
 }
 
 public func tryCapture<R: RegexProtocol, W, C0, C1, C2, C3, C4, NewCapture>(
-  _ component: R, transform: @escaping (Substring) throws -> NewCapture
+  _ component: R,
+  as reference: Reference? = nil,
+  transform: @escaping (Substring) throws -> NewCapture
 ) -> Regex<(Substring, NewCapture, C0, C1, C2, C3, C4)> where R.Match == (W, C0, C1, C2, C3, C4) {
   .init(node: .groupTransform(
     .capture,
     component.regex.root,
     CaptureTransform(resultType: NewCapture.self) {
       try transform($0) as Any
-    }))
+    },
+    reference?.id))
 }
 
 public func tryCapture<R: RegexProtocol, W, C0, C1, C2, C3, C4, NewCapture>(
-  _ component: R, transform: @escaping (Substring) -> NewCapture?
+  _ component: R,
+  as reference: Reference? = nil,
+  transform: @escaping (Substring) -> NewCapture?
 ) -> Regex<(Substring, NewCapture, C0, C1, C2, C3, C4)> where R.Match == (W, C0, C1, C2, C3, C4) {
   .init(node: .groupTransform(
     .capture,
     component.regex.root,
     CaptureTransform(resultType: NewCapture.self) {
       transform($0) as Any?
-    }))
+    },
+    reference?.id))
 }
 
 // MARK: - Builder capture arity 5
 
 public func capture<R: RegexProtocol, W, C0, C1, C2, C3, C4>(
+  as reference: Reference? = nil,
   @RegexBuilder _ component: () -> R
 ) -> Regex<(Substring, W, C0, C1, C2, C3, C4)> where R.Match == (W, C0, C1, C2, C3, C4) {
-  .init(node: .group(.capture, component().regex.root))
+  .init(node: .group(.capture, component().regex.root, reference?.id))
 }
 
 public func capture<R: RegexProtocol, W, C0, C1, C2, C3, C4, NewCapture>(
+  as reference: Reference? = nil,
   @RegexBuilder _ component: () -> R,
   transform: @escaping (Substring) -> NewCapture
 ) -> Regex<(Substring, NewCapture, C0, C1, C2, C3, C4)> where R.Match == (W, C0, C1, C2, C3, C4) {
@@ -2729,10 +2832,12 @@ public func capture<R: RegexProtocol, W, C0, C1, C2, C3, C4, NewCapture>(
     component().regex.root,
     CaptureTransform(resultType: NewCapture.self) {
       transform($0) as Any
-    }))
+    },
+    reference?.id))
 }
 
 public func tryCapture<R: RegexProtocol, W, C0, C1, C2, C3, C4, NewCapture>(
+  as reference: Reference? = nil,
   @RegexBuilder _ component: () -> R,
   transform: @escaping (Substring) throws -> NewCapture
 ) -> Regex<(Substring, NewCapture, C0, C1, C2, C3, C4)> where R.Match == (W, C0, C1, C2, C3, C4) {
@@ -2741,10 +2846,12 @@ public func tryCapture<R: RegexProtocol, W, C0, C1, C2, C3, C4, NewCapture>(
     component().regex.root,
     CaptureTransform(resultType: NewCapture.self) {
       try transform($0) as Any
-    }))
+    },
+    reference?.id))
 }
 
 public func tryCapture<R: RegexProtocol, W, C0, C1, C2, C3, C4, NewCapture>(
+  as reference: Reference? = nil,
   @RegexBuilder _ component: () -> R,
   transform: @escaping (Substring) -> NewCapture?
 ) -> Regex<(Substring, NewCapture, C0, C1, C2, C3, C4)> where R.Match == (W, C0, C1, C2, C3, C4) {
@@ -2753,56 +2860,70 @@ public func tryCapture<R: RegexProtocol, W, C0, C1, C2, C3, C4, NewCapture>(
     component().regex.root,
     CaptureTransform(resultType: NewCapture.self) {
       transform($0) as Any?
-    }))
+    },
+    reference?.id))
 }
 // MARK: - Non-builder capture arity 6
 
-public func capture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5>(_ component: R) -> Regex<(Substring, W, C0, C1, C2, C3, C4, C5)> where R.Match == (W, C0, C1, C2, C3, C4, C5) {
-  .init(node: .group(.capture, component.regex.root))
+public func capture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5>(
+  _ component: R, as reference: Reference? = nil
+) -> Regex<(Substring, W, C0, C1, C2, C3, C4, C5)> where R.Match == (W, C0, C1, C2, C3, C4, C5) {
+  .init(node: .group(.capture, component.regex.root, reference?.id))
 }
 
 public func capture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5, NewCapture>(
-  _ component: R, transform: @escaping (Substring) -> NewCapture
+  _ component: R,
+  as reference: Reference? = nil,
+  transform: @escaping (Substring) -> NewCapture
 ) -> Regex<(Substring, NewCapture, C0, C1, C2, C3, C4, C5)> where R.Match == (W, C0, C1, C2, C3, C4, C5) {
   .init(node: .groupTransform(
     .capture,
     component.regex.root,
     CaptureTransform(resultType: NewCapture.self) {
       transform($0) as Any
-    }))
+    },
+    reference?.id))
 }
 
 public func tryCapture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5, NewCapture>(
-  _ component: R, transform: @escaping (Substring) throws -> NewCapture
+  _ component: R,
+  as reference: Reference? = nil,
+  transform: @escaping (Substring) throws -> NewCapture
 ) -> Regex<(Substring, NewCapture, C0, C1, C2, C3, C4, C5)> where R.Match == (W, C0, C1, C2, C3, C4, C5) {
   .init(node: .groupTransform(
     .capture,
     component.regex.root,
     CaptureTransform(resultType: NewCapture.self) {
       try transform($0) as Any
-    }))
+    },
+    reference?.id))
 }
 
 public func tryCapture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5, NewCapture>(
-  _ component: R, transform: @escaping (Substring) -> NewCapture?
+  _ component: R,
+  as reference: Reference? = nil,
+  transform: @escaping (Substring) -> NewCapture?
 ) -> Regex<(Substring, NewCapture, C0, C1, C2, C3, C4, C5)> where R.Match == (W, C0, C1, C2, C3, C4, C5) {
   .init(node: .groupTransform(
     .capture,
     component.regex.root,
     CaptureTransform(resultType: NewCapture.self) {
       transform($0) as Any?
-    }))
+    },
+    reference?.id))
 }
 
 // MARK: - Builder capture arity 6
 
 public func capture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5>(
+  as reference: Reference? = nil,
   @RegexBuilder _ component: () -> R
 ) -> Regex<(Substring, W, C0, C1, C2, C3, C4, C5)> where R.Match == (W, C0, C1, C2, C3, C4, C5) {
-  .init(node: .group(.capture, component().regex.root))
+  .init(node: .group(.capture, component().regex.root, reference?.id))
 }
 
 public func capture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5, NewCapture>(
+  as reference: Reference? = nil,
   @RegexBuilder _ component: () -> R,
   transform: @escaping (Substring) -> NewCapture
 ) -> Regex<(Substring, NewCapture, C0, C1, C2, C3, C4, C5)> where R.Match == (W, C0, C1, C2, C3, C4, C5) {
@@ -2811,10 +2932,12 @@ public func capture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5, NewCapture>(
     component().regex.root,
     CaptureTransform(resultType: NewCapture.self) {
       transform($0) as Any
-    }))
+    },
+    reference?.id))
 }
 
 public func tryCapture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5, NewCapture>(
+  as reference: Reference? = nil,
   @RegexBuilder _ component: () -> R,
   transform: @escaping (Substring) throws -> NewCapture
 ) -> Regex<(Substring, NewCapture, C0, C1, C2, C3, C4, C5)> where R.Match == (W, C0, C1, C2, C3, C4, C5) {
@@ -2823,10 +2946,12 @@ public func tryCapture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5, NewCapture>(
     component().regex.root,
     CaptureTransform(resultType: NewCapture.self) {
       try transform($0) as Any
-    }))
+    },
+    reference?.id))
 }
 
 public func tryCapture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5, NewCapture>(
+  as reference: Reference? = nil,
   @RegexBuilder _ component: () -> R,
   transform: @escaping (Substring) -> NewCapture?
 ) -> Regex<(Substring, NewCapture, C0, C1, C2, C3, C4, C5)> where R.Match == (W, C0, C1, C2, C3, C4, C5) {
@@ -2835,56 +2960,70 @@ public func tryCapture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5, NewCapture>(
     component().regex.root,
     CaptureTransform(resultType: NewCapture.self) {
       transform($0) as Any?
-    }))
+    },
+    reference?.id))
 }
 // MARK: - Non-builder capture arity 7
 
-public func capture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5, C6>(_ component: R) -> Regex<(Substring, W, C0, C1, C2, C3, C4, C5, C6)> where R.Match == (W, C0, C1, C2, C3, C4, C5, C6) {
-  .init(node: .group(.capture, component.regex.root))
+public func capture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5, C6>(
+  _ component: R, as reference: Reference? = nil
+) -> Regex<(Substring, W, C0, C1, C2, C3, C4, C5, C6)> where R.Match == (W, C0, C1, C2, C3, C4, C5, C6) {
+  .init(node: .group(.capture, component.regex.root, reference?.id))
 }
 
 public func capture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5, C6, NewCapture>(
-  _ component: R, transform: @escaping (Substring) -> NewCapture
+  _ component: R,
+  as reference: Reference? = nil,
+  transform: @escaping (Substring) -> NewCapture
 ) -> Regex<(Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6)> where R.Match == (W, C0, C1, C2, C3, C4, C5, C6) {
   .init(node: .groupTransform(
     .capture,
     component.regex.root,
     CaptureTransform(resultType: NewCapture.self) {
       transform($0) as Any
-    }))
+    },
+    reference?.id))
 }
 
 public func tryCapture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5, C6, NewCapture>(
-  _ component: R, transform: @escaping (Substring) throws -> NewCapture
+  _ component: R,
+  as reference: Reference? = nil,
+  transform: @escaping (Substring) throws -> NewCapture
 ) -> Regex<(Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6)> where R.Match == (W, C0, C1, C2, C3, C4, C5, C6) {
   .init(node: .groupTransform(
     .capture,
     component.regex.root,
     CaptureTransform(resultType: NewCapture.self) {
       try transform($0) as Any
-    }))
+    },
+    reference?.id))
 }
 
 public func tryCapture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5, C6, NewCapture>(
-  _ component: R, transform: @escaping (Substring) -> NewCapture?
+  _ component: R,
+  as reference: Reference? = nil,
+  transform: @escaping (Substring) -> NewCapture?
 ) -> Regex<(Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6)> where R.Match == (W, C0, C1, C2, C3, C4, C5, C6) {
   .init(node: .groupTransform(
     .capture,
     component.regex.root,
     CaptureTransform(resultType: NewCapture.self) {
       transform($0) as Any?
-    }))
+    },
+    reference?.id))
 }
 
 // MARK: - Builder capture arity 7
 
 public func capture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5, C6>(
+  as reference: Reference? = nil,
   @RegexBuilder _ component: () -> R
 ) -> Regex<(Substring, W, C0, C1, C2, C3, C4, C5, C6)> where R.Match == (W, C0, C1, C2, C3, C4, C5, C6) {
-  .init(node: .group(.capture, component().regex.root))
+  .init(node: .group(.capture, component().regex.root, reference?.id))
 }
 
 public func capture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5, C6, NewCapture>(
+  as reference: Reference? = nil,
   @RegexBuilder _ component: () -> R,
   transform: @escaping (Substring) -> NewCapture
 ) -> Regex<(Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6)> where R.Match == (W, C0, C1, C2, C3, C4, C5, C6) {
@@ -2893,10 +3032,12 @@ public func capture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5, C6, NewCapture>
     component().regex.root,
     CaptureTransform(resultType: NewCapture.self) {
       transform($0) as Any
-    }))
+    },
+    reference?.id))
 }
 
 public func tryCapture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5, C6, NewCapture>(
+  as reference: Reference? = nil,
   @RegexBuilder _ component: () -> R,
   transform: @escaping (Substring) throws -> NewCapture
 ) -> Regex<(Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6)> where R.Match == (W, C0, C1, C2, C3, C4, C5, C6) {
@@ -2905,10 +3046,12 @@ public func tryCapture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5, C6, NewCaptu
     component().regex.root,
     CaptureTransform(resultType: NewCapture.self) {
       try transform($0) as Any
-    }))
+    },
+    reference?.id))
 }
 
 public func tryCapture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5, C6, NewCapture>(
+  as reference: Reference? = nil,
   @RegexBuilder _ component: () -> R,
   transform: @escaping (Substring) -> NewCapture?
 ) -> Regex<(Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6)> where R.Match == (W, C0, C1, C2, C3, C4, C5, C6) {
@@ -2917,56 +3060,70 @@ public func tryCapture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5, C6, NewCaptu
     component().regex.root,
     CaptureTransform(resultType: NewCapture.self) {
       transform($0) as Any?
-    }))
+    },
+    reference?.id))
 }
 // MARK: - Non-builder capture arity 8
 
-public func capture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5, C6, C7>(_ component: R) -> Regex<(Substring, W, C0, C1, C2, C3, C4, C5, C6, C7)> where R.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
-  .init(node: .group(.capture, component.regex.root))
+public func capture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5, C6, C7>(
+  _ component: R, as reference: Reference? = nil
+) -> Regex<(Substring, W, C0, C1, C2, C3, C4, C5, C6, C7)> where R.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
+  .init(node: .group(.capture, component.regex.root, reference?.id))
 }
 
 public func capture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5, C6, C7, NewCapture>(
-  _ component: R, transform: @escaping (Substring) -> NewCapture
+  _ component: R,
+  as reference: Reference? = nil,
+  transform: @escaping (Substring) -> NewCapture
 ) -> Regex<(Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6, C7)> where R.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
   .init(node: .groupTransform(
     .capture,
     component.regex.root,
     CaptureTransform(resultType: NewCapture.self) {
       transform($0) as Any
-    }))
+    },
+    reference?.id))
 }
 
 public func tryCapture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5, C6, C7, NewCapture>(
-  _ component: R, transform: @escaping (Substring) throws -> NewCapture
+  _ component: R,
+  as reference: Reference? = nil,
+  transform: @escaping (Substring) throws -> NewCapture
 ) -> Regex<(Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6, C7)> where R.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
   .init(node: .groupTransform(
     .capture,
     component.regex.root,
     CaptureTransform(resultType: NewCapture.self) {
       try transform($0) as Any
-    }))
+    },
+    reference?.id))
 }
 
 public func tryCapture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5, C6, C7, NewCapture>(
-  _ component: R, transform: @escaping (Substring) -> NewCapture?
+  _ component: R,
+  as reference: Reference? = nil,
+  transform: @escaping (Substring) -> NewCapture?
 ) -> Regex<(Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6, C7)> where R.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
   .init(node: .groupTransform(
     .capture,
     component.regex.root,
     CaptureTransform(resultType: NewCapture.self) {
       transform($0) as Any?
-    }))
+    },
+    reference?.id))
 }
 
 // MARK: - Builder capture arity 8
 
 public func capture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5, C6, C7>(
+  as reference: Reference? = nil,
   @RegexBuilder _ component: () -> R
 ) -> Regex<(Substring, W, C0, C1, C2, C3, C4, C5, C6, C7)> where R.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
-  .init(node: .group(.capture, component().regex.root))
+  .init(node: .group(.capture, component().regex.root, reference?.id))
 }
 
 public func capture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5, C6, C7, NewCapture>(
+  as reference: Reference? = nil,
   @RegexBuilder _ component: () -> R,
   transform: @escaping (Substring) -> NewCapture
 ) -> Regex<(Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6, C7)> where R.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
@@ -2975,10 +3132,12 @@ public func capture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5, C6, C7, NewCapt
     component().regex.root,
     CaptureTransform(resultType: NewCapture.self) {
       transform($0) as Any
-    }))
+    },
+    reference?.id))
 }
 
 public func tryCapture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5, C6, C7, NewCapture>(
+  as reference: Reference? = nil,
   @RegexBuilder _ component: () -> R,
   transform: @escaping (Substring) throws -> NewCapture
 ) -> Regex<(Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6, C7)> where R.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
@@ -2987,10 +3146,12 @@ public func tryCapture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5, C6, C7, NewC
     component().regex.root,
     CaptureTransform(resultType: NewCapture.self) {
       try transform($0) as Any
-    }))
+    },
+    reference?.id))
 }
 
 public func tryCapture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5, C6, C7, NewCapture>(
+  as reference: Reference? = nil,
   @RegexBuilder _ component: () -> R,
   transform: @escaping (Substring) -> NewCapture?
 ) -> Regex<(Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6, C7)> where R.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
@@ -2999,56 +3160,70 @@ public func tryCapture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5, C6, C7, NewC
     component().regex.root,
     CaptureTransform(resultType: NewCapture.self) {
       transform($0) as Any?
-    }))
+    },
+    reference?.id))
 }
 // MARK: - Non-builder capture arity 9
 
-public func capture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5, C6, C7, C8>(_ component: R) -> Regex<(Substring, W, C0, C1, C2, C3, C4, C5, C6, C7, C8)> where R.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
-  .init(node: .group(.capture, component.regex.root))
+public func capture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5, C6, C7, C8>(
+  _ component: R, as reference: Reference? = nil
+) -> Regex<(Substring, W, C0, C1, C2, C3, C4, C5, C6, C7, C8)> where R.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
+  .init(node: .group(.capture, component.regex.root, reference?.id))
 }
 
 public func capture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5, C6, C7, C8, NewCapture>(
-  _ component: R, transform: @escaping (Substring) -> NewCapture
+  _ component: R,
+  as reference: Reference? = nil,
+  transform: @escaping (Substring) -> NewCapture
 ) -> Regex<(Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6, C7, C8)> where R.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
   .init(node: .groupTransform(
     .capture,
     component.regex.root,
     CaptureTransform(resultType: NewCapture.self) {
       transform($0) as Any
-    }))
+    },
+    reference?.id))
 }
 
 public func tryCapture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5, C6, C7, C8, NewCapture>(
-  _ component: R, transform: @escaping (Substring) throws -> NewCapture
+  _ component: R,
+  as reference: Reference? = nil,
+  transform: @escaping (Substring) throws -> NewCapture
 ) -> Regex<(Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6, C7, C8)> where R.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
   .init(node: .groupTransform(
     .capture,
     component.regex.root,
     CaptureTransform(resultType: NewCapture.self) {
       try transform($0) as Any
-    }))
+    },
+    reference?.id))
 }
 
 public func tryCapture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5, C6, C7, C8, NewCapture>(
-  _ component: R, transform: @escaping (Substring) -> NewCapture?
+  _ component: R,
+  as reference: Reference? = nil,
+  transform: @escaping (Substring) -> NewCapture?
 ) -> Regex<(Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6, C7, C8)> where R.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
   .init(node: .groupTransform(
     .capture,
     component.regex.root,
     CaptureTransform(resultType: NewCapture.self) {
       transform($0) as Any?
-    }))
+    },
+    reference?.id))
 }
 
 // MARK: - Builder capture arity 9
 
 public func capture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5, C6, C7, C8>(
+  as reference: Reference? = nil,
   @RegexBuilder _ component: () -> R
 ) -> Regex<(Substring, W, C0, C1, C2, C3, C4, C5, C6, C7, C8)> where R.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
-  .init(node: .group(.capture, component().regex.root))
+  .init(node: .group(.capture, component().regex.root, reference?.id))
 }
 
 public func capture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5, C6, C7, C8, NewCapture>(
+  as reference: Reference? = nil,
   @RegexBuilder _ component: () -> R,
   transform: @escaping (Substring) -> NewCapture
 ) -> Regex<(Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6, C7, C8)> where R.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
@@ -3057,10 +3232,12 @@ public func capture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5, C6, C7, C8, New
     component().regex.root,
     CaptureTransform(resultType: NewCapture.self) {
       transform($0) as Any
-    }))
+    },
+    reference?.id))
 }
 
 public func tryCapture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5, C6, C7, C8, NewCapture>(
+  as reference: Reference? = nil,
   @RegexBuilder _ component: () -> R,
   transform: @escaping (Substring) throws -> NewCapture
 ) -> Regex<(Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6, C7, C8)> where R.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
@@ -3069,10 +3246,12 @@ public func tryCapture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5, C6, C7, C8, 
     component().regex.root,
     CaptureTransform(resultType: NewCapture.self) {
       try transform($0) as Any
-    }))
+    },
+    reference?.id))
 }
 
 public func tryCapture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5, C6, C7, C8, NewCapture>(
+  as reference: Reference? = nil,
   @RegexBuilder _ component: () -> R,
   transform: @escaping (Substring) -> NewCapture?
 ) -> Regex<(Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6, C7, C8)> where R.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
@@ -3081,7 +3260,8 @@ public func tryCapture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5, C6, C7, C8, 
     component().regex.root,
     CaptureTransform(resultType: NewCapture.self) {
       transform($0) as Any?
-    }))
+    },
+    reference?.id))
 }
 
 


### PR DESCRIPTION
Allow `capture` and `tryCapture` to assign the captured value to a `Reference`, which can be used as a regex later in the scope.

`Reference` initialization creates a unique identifier. The compiler converts the identifier to an absolute backreference offset.

-----

Example:

```swift
let regex = Regex {
  let a = Reference()
  let b = Reference()
  capture("abc", as: a)
  capture("def", as: b)
  a
  capture(b)
}
```