### PR TITLE
Conform `Substring` to `RegexProtocol`

### DIFF
--- a/Sources/_StringProcessing/RegexDSL/DSL.swift
+++ b/Sources/_StringProcessing/RegexDSL/DSL.swift
@@ -22,6 +22,15 @@ extension String: RegexProtocol {
   }
 }
 
+extension Substring: RegexProtocol {
+  public typealias Match = Substring
+
+  public var regex: Regex<Match> {
+    let atoms = self.map { atom(.char($0)) }
+    return .init(ast: concat(atoms))
+  }
+}
+
 extension Character: RegexProtocol {
   public typealias Match = Substring
 


### PR DESCRIPTION
Currently `String` conforms but `Substring` doesn't. I don't see a reason `Substring` shouldn't be usable in a DSL builder block, so adding this conformance.