### PR TITLE
DSL minor renaming: `choiceOf` and `zeroOrMore`.

### DIFF
--- a/Sources/Exercises/Participants/RegexParticipant.swift
+++ b/Sources/Exercises/Participants/RegexParticipant.swift
@@ -89,7 +89,7 @@ private func graphemeBreakPropertyData(
     ";"
     oneOrMore(.whitespace)
     tryCapture(oneOrMore(.word)) { Unicode.GraphemeBreakProperty($0) }
-    many(.any)
+    zeroOrMore(.any)
   }.map {
     let (_, lower, upper, property) = $0.match
     return GraphemeBreakEntry(lower...(upper ?? lower), property)

--- a/Sources/VariadicsGenerator/VariadicsGenerator.swift
+++ b/Sources/VariadicsGenerator/VariadicsGenerator.swift
@@ -288,7 +288,7 @@ struct VariadicsGenerator: ParsableCommand {
 
   enum QuantifierKind: String, CaseIterable {
     case zeroOrOne = "optionally"
-    case zeroOrMore = "many"
+    case zeroOrMore = "zeroOrMore"
     case oneOrMore = "oneOrMore"
 
     var operatorName: String {

--- a/Sources/_StringProcessing/RegexDSL/DSL.swift
+++ b/Sources/_StringProcessing/RegexDSL/DSL.swift
@@ -179,7 +179,7 @@ public struct AlternationBuilder {
   }
 }
 
-public func oneOf<R: RegexProtocol>(
+public func choiceOf<R: RegexProtocol>(
   @AlternationBuilder builder: () -> R
 ) -> R {
   builder()

--- a/Sources/_StringProcessing/RegexDSL/Variadics.swift
+++ b/Sources/_StringProcessing/RegexDSL/Variadics.swift
@@ -501,7 +501,7 @@ extension RegexBuilder {
   }
 }
 @_disfavoredOverload
-public func many<Component: RegexProtocol>(
+public func zeroOrMore<Component: RegexProtocol>(
   _ component: Component,
   _ behavior: QuantificationBehavior = .eagerly
 ) -> Regex<Substring>  {
@@ -509,7 +509,7 @@ public func many<Component: RegexProtocol>(
 }
 
 @_disfavoredOverload
-public func many<Component: RegexProtocol>(
+public func zeroOrMore<Component: RegexProtocol>(
   _ behavior: QuantificationBehavior = .eagerly,
   @RegexBuilder _ component: () -> Component
 ) -> Regex<Substring>  {
@@ -579,7 +579,7 @@ extension RegexBuilder {
   }
 }
 
-public func many<W, C0, Component: RegexProtocol>(
+public func zeroOrMore<W, C0, Component: RegexProtocol>(
   _ component: Component,
   _ behavior: QuantificationBehavior = .eagerly
 ) -> Regex<(Substring, [C0])> where Component.Match == (W, C0) {
@@ -587,7 +587,7 @@ public func many<W, C0, Component: RegexProtocol>(
 }
 
 
-public func many<W, C0, Component: RegexProtocol>(
+public func zeroOrMore<W, C0, Component: RegexProtocol>(
   _ behavior: QuantificationBehavior = .eagerly,
   @RegexBuilder _ component: () -> Component
 ) -> Regex<(Substring, [C0])> where Component.Match == (W, C0) {
@@ -657,7 +657,7 @@ extension RegexBuilder {
   }
 }
 
-public func many<W, C0, C1, Component: RegexProtocol>(
+public func zeroOrMore<W, C0, C1, Component: RegexProtocol>(
   _ component: Component,
   _ behavior: QuantificationBehavior = .eagerly
 ) -> Regex<(Substring, [(C0, C1)])> where Component.Match == (W, C0, C1) {
@@ -665,7 +665,7 @@ public func many<W, C0, C1, Component: RegexProtocol>(
 }
 
 
-public func many<W, C0, C1, Component: RegexProtocol>(
+public func zeroOrMore<W, C0, C1, Component: RegexProtocol>(
   _ behavior: QuantificationBehavior = .eagerly,
   @RegexBuilder _ component: () -> Component
 ) -> Regex<(Substring, [(C0, C1)])> where Component.Match == (W, C0, C1) {
@@ -735,7 +735,7 @@ extension RegexBuilder {
   }
 }
 
-public func many<W, C0, C1, C2, Component: RegexProtocol>(
+public func zeroOrMore<W, C0, C1, C2, Component: RegexProtocol>(
   _ component: Component,
   _ behavior: QuantificationBehavior = .eagerly
 ) -> Regex<(Substring, [(C0, C1, C2)])> where Component.Match == (W, C0, C1, C2) {
@@ -743,7 +743,7 @@ public func many<W, C0, C1, C2, Component: RegexProtocol>(
 }
 
 
-public func many<W, C0, C1, C2, Component: RegexProtocol>(
+public func zeroOrMore<W, C0, C1, C2, Component: RegexProtocol>(
   _ behavior: QuantificationBehavior = .eagerly,
   @RegexBuilder _ component: () -> Component
 ) -> Regex<(Substring, [(C0, C1, C2)])> where Component.Match == (W, C0, C1, C2) {
@@ -813,7 +813,7 @@ extension RegexBuilder {
   }
 }
 
-public func many<W, C0, C1, C2, C3, Component: RegexProtocol>(
+public func zeroOrMore<W, C0, C1, C2, C3, Component: RegexProtocol>(
   _ component: Component,
   _ behavior: QuantificationBehavior = .eagerly
 ) -> Regex<(Substring, [(C0, C1, C2, C3)])> where Component.Match == (W, C0, C1, C2, C3) {
@@ -821,7 +821,7 @@ public func many<W, C0, C1, C2, C3, Component: RegexProtocol>(
 }
 
 
-public func many<W, C0, C1, C2, C3, Component: RegexProtocol>(
+public func zeroOrMore<W, C0, C1, C2, C3, Component: RegexProtocol>(
   _ behavior: QuantificationBehavior = .eagerly,
   @RegexBuilder _ component: () -> Component
 ) -> Regex<(Substring, [(C0, C1, C2, C3)])> where Component.Match == (W, C0, C1, C2, C3) {
@@ -891,7 +891,7 @@ extension RegexBuilder {
   }
 }
 
-public func many<W, C0, C1, C2, C3, C4, Component: RegexProtocol>(
+public func zeroOrMore<W, C0, C1, C2, C3, C4, Component: RegexProtocol>(
   _ component: Component,
   _ behavior: QuantificationBehavior = .eagerly
 ) -> Regex<(Substring, [(C0, C1, C2, C3, C4)])> where Component.Match == (W, C0, C1, C2, C3, C4) {
@@ -899,7 +899,7 @@ public func many<W, C0, C1, C2, C3, C4, Component: RegexProtocol>(
 }
 
 
-public func many<W, C0, C1, C2, C3, C4, Component: RegexProtocol>(
+public func zeroOrMore<W, C0, C1, C2, C3, C4, Component: RegexProtocol>(
   _ behavior: QuantificationBehavior = .eagerly,
   @RegexBuilder _ component: () -> Component
 ) -> Regex<(Substring, [(C0, C1, C2, C3, C4)])> where Component.Match == (W, C0, C1, C2, C3, C4) {
@@ -969,7 +969,7 @@ extension RegexBuilder {
   }
 }
 
-public func many<W, C0, C1, C2, C3, C4, C5, Component: RegexProtocol>(
+public func zeroOrMore<W, C0, C1, C2, C3, C4, C5, Component: RegexProtocol>(
   _ component: Component,
   _ behavior: QuantificationBehavior = .eagerly
 ) -> Regex<(Substring, [(C0, C1, C2, C3, C4, C5)])> where Component.Match == (W, C0, C1, C2, C3, C4, C5) {
@@ -977,7 +977,7 @@ public func many<W, C0, C1, C2, C3, C4, C5, Component: RegexProtocol>(
 }
 
 
-public func many<W, C0, C1, C2, C3, C4, C5, Component: RegexProtocol>(
+public func zeroOrMore<W, C0, C1, C2, C3, C4, C5, Component: RegexProtocol>(
   _ behavior: QuantificationBehavior = .eagerly,
   @RegexBuilder _ component: () -> Component
 ) -> Regex<(Substring, [(C0, C1, C2, C3, C4, C5)])> where Component.Match == (W, C0, C1, C2, C3, C4, C5) {
@@ -1047,7 +1047,7 @@ extension RegexBuilder {
   }
 }
 
-public func many<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexProtocol>(
+public func zeroOrMore<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexProtocol>(
   _ component: Component,
   _ behavior: QuantificationBehavior = .eagerly
 ) -> Regex<(Substring, [(C0, C1, C2, C3, C4, C5, C6)])> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6) {
@@ -1055,7 +1055,7 @@ public func many<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexProtocol>(
 }
 
 
-public func many<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexProtocol>(
+public func zeroOrMore<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexProtocol>(
   _ behavior: QuantificationBehavior = .eagerly,
   @RegexBuilder _ component: () -> Component
 ) -> Regex<(Substring, [(C0, C1, C2, C3, C4, C5, C6)])> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6) {
@@ -1125,7 +1125,7 @@ extension RegexBuilder {
   }
 }
 
-public func many<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexProtocol>(
+public func zeroOrMore<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexProtocol>(
   _ component: Component,
   _ behavior: QuantificationBehavior = .eagerly
 ) -> Regex<(Substring, [(C0, C1, C2, C3, C4, C5, C6, C7)])> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
@@ -1133,7 +1133,7 @@ public func many<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexProtocol>(
 }
 
 
-public func many<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexProtocol>(
+public func zeroOrMore<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexProtocol>(
   _ behavior: QuantificationBehavior = .eagerly,
   @RegexBuilder _ component: () -> Component
 ) -> Regex<(Substring, [(C0, C1, C2, C3, C4, C5, C6, C7)])> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
@@ -1203,7 +1203,7 @@ extension RegexBuilder {
   }
 }
 
-public func many<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexProtocol>(
+public func zeroOrMore<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexProtocol>(
   _ component: Component,
   _ behavior: QuantificationBehavior = .eagerly
 ) -> Regex<(Substring, [(C0, C1, C2, C3, C4, C5, C6, C7, C8)])> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
@@ -1211,7 +1211,7 @@ public func many<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexProtocol
 }
 
 
-public func many<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexProtocol>(
+public func zeroOrMore<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexProtocol>(
   _ behavior: QuantificationBehavior = .eagerly,
   @RegexBuilder _ component: () -> Component
 ) -> Regex<(Substring, [(C0, C1, C2, C3, C4, C5, C6, C7, C8)])> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {

--- a/Tests/RegexTests/RegexDSLTests.swift
+++ b/Tests/RegexTests/RegexDSLTests.swift
@@ -67,14 +67,14 @@ class RegexDSLTests: XCTestCase {
 
   func testAlternation() throws {
     do {
-      let regex = oneOf {
+      let regex = choiceOf {
         "aaa"
       }
       XCTAssertTrue("aaa".match(regex)?.match == "aaa")
       XCTAssertNil("aab".match(regex)?.match)
     }
     do {
-      let regex = oneOf {
+      let regex = choiceOf {
         "aaa"
         "bbb"
         "ccc"
@@ -88,7 +88,7 @@ class RegexDSLTests: XCTestCase {
       let regex = Regex {
         "ab"
         capture {
-          oneOf {
+          choiceOf {
             "c"
             "def"
           }
@@ -98,7 +98,7 @@ class RegexDSLTests: XCTestCase {
         try XCTUnwrap("abc".match(regex)?.match) == ("abc", ["c"]))
     }
     do {
-      let regex = oneOf {
+      let regex = choiceOf {
         "aaa"
         "bbb"
         "ccc"
@@ -109,7 +109,7 @@ class RegexDSLTests: XCTestCase {
       XCTAssertTrue("ccc".match(regex)?.match == "ccc")
     }
     do {
-      let regex = oneOf {
+      let regex = choiceOf {
         capture("aaa")
       }
       XCTAssertTrue(
@@ -117,7 +117,7 @@ class RegexDSLTests: XCTestCase {
       XCTAssertNil("aab".match(regex)?.match)
     }
     do {
-      let regex = oneOf {
+      let regex = choiceOf {
         capture("aaa")
         capture("bbb")
         capture("ccc")
@@ -139,11 +139,11 @@ class RegexDSLTests: XCTestCase {
     {
       "a".+
       capture(oneOrMore(Character("b"))) // Substring
-      capture(many("c")) // Substring
+      capture(zeroOrMore("c")) // Substring
       capture(.hexDigit).* // [Substring]
       "e".?
       capture("t" | "k") // Substring
-      oneOf { capture("k"); capture("j") } // (Substring?, Substring?)
+      choiceOf { capture("k"); capture("j") } // (Substring?, Substring?)
     }
   }
   
@@ -189,7 +189,7 @@ class RegexDSLTests: XCTestCase {
       "a".+
       oneOrMore {
         capture(oneOrMore("b"))
-        capture(many("c"))
+        capture(zeroOrMore("c"))
         capture("d").*
         "e".?
       }
@@ -201,7 +201,7 @@ class RegexDSLTests: XCTestCase {
     // straight out of the quantifier (without being wrapped in a builder), is
     // able to produce a regex whose `Match` type does not contain any sort of
     // void.
-    let regex = many(.digit)
+    let regex = zeroOrMore(.digit)
     // Assert the inferred capture type.
     let _: Substring.Type = type(of: regex).Match.self
     let input = "123123"
@@ -236,7 +236,7 @@ class RegexDSLTests: XCTestCase {
       optionally {
         capture(oneOrMore(.digit)) { Int($0)! }
       }
-      many {
+      zeroOrMore {
         oneOrMore(.whitespace)
         capture(oneOrMore(.word)) { Word($0)! }
       }
@@ -266,7 +266,7 @@ class RegexDSLTests: XCTestCase {
       "a".+
       capture {
         tryCapture("b") { Int($0) }
-        many {
+        zeroOrMore {
           tryCapture("c") { Double($0) }
         }
         "e".?
@@ -279,7 +279,7 @@ class RegexDSLTests: XCTestCase {
       capture {
         oneOrMore {
           capture(oneOrMore("b"))
-          capture(many("c"))
+          capture(zeroOrMore("c"))
           capture("d").*
           "e".?
         }
@@ -292,7 +292,7 @@ class RegexDSLTests: XCTestCase {
 
   func testUnicodeScalarPostProcessing() throws {
     let spaces = Regex {
-      many {
+      zeroOrMore {
         .whitespace
       }
     }
@@ -320,7 +320,7 @@ class RegexDSLTests: XCTestCase {
         }
       }
 
-      many {
+      zeroOrMore {
         .any
       }
     }
@@ -354,7 +354,7 @@ class RegexDSLTests: XCTestCase {
       ";"
       oneOrMore(.whitespace)
       capture(oneOrMore(.word))
-      many(.any)
+      zeroOrMore(.any)
     } // Regex<(Substring, Unicode.Scalar?, Unicode.Scalar??, Substring)>
     do {
       // Assert the inferred capture type.
@@ -389,7 +389,7 @@ class RegexDSLTests: XCTestCase {
       ";"
       oneOrMore(.whitespace)
       capture(oneOrMore(.word))
-      many(.any)
+      zeroOrMore(.any)
     } // Regex<(Substring, Unicode.Scalar, Unicode.Scalar?, Substring)>
     do {
       // Assert the inferred capture type.


### PR DESCRIPTION
While there are further improvements to be explored, to reduce confusion we rename `oneOf` to `choiceOf` and `many` to `zeroOrMore`.