### PR TITLE
Cleanups and pretty printing

### DIFF
--- a/Sources/PatternConverter/PatternConverter.swift
+++ b/Sources/PatternConverter/PatternConverter.swift
@@ -30,6 +30,12 @@ struct PatternConverter: ParsableCommand {
   @Flag(help: "Whether to show canonical regex literal")
   var showCanonical: Bool = false
 
+  @Flag(help: "Whether to show capture structure")
+  var showCaptureStructure: Bool = false
+
+  @Flag(help: "Whether to skip result builder DSL")
+  var skipDSL: Bool = false
+
   @Option(help: "Limit (from top-down) the conversion levels")
   var topDownConversionLimit: Int?
 
@@ -65,12 +71,21 @@ struct PatternConverter: ParsableCommand {
       print()
     }
 
+    if showCaptureStructure {
+      print("Capture structure:")
+      print()
+      print(ast.captureStructure)
+      print()
+    }
+
     print()
-    let render = ast.renderAsBuilderDSL(
-      maxTopDownLevels: topDownConversionLimit,
-      minBottomUpLevels: bottomUpConversionLimit
-    )
-    print(render)
+    if !skipDSL {
+      let render = ast.renderAsBuilderDSL(
+        maxTopDownLevels: topDownConversionLimit,
+        minBottomUpLevels: bottomUpConversionLimit
+      )
+      print(render)
+    }
 
     return
   }

--- a/Sources/_MatchingEngine/Regex/Parse/CaptureStructure.swift
+++ b/Sources/_MatchingEngine/Regex/Parse/CaptureStructure.swift
@@ -400,3 +400,39 @@ extension CaptureStructure {
     self = currentScope.count == 1 ? currentScope[0] : .tuple(currentScope)
   }
 }
+
+extension CaptureStructure: CustomStringConvertible {
+  public var description: String {
+    var printer = PrettyPrinter()
+    _print(&printer)
+    return printer.finish()
+  }
+
+  private func _print(_ printer: inout PrettyPrinter) {
+    switch self {
+    case let .atom(name, type):
+      let name = name ?? "<unnamed>"
+      let type = type == nil ? "<untyped>"
+                             : String(describing: type)
+      printer.print("Atom(\(name): \(type))")
+
+    case let .array(c):
+      printer.printBlock("Array") { printer in
+        c._print(&printer)
+      }
+
+    case let .optional(c):
+      printer.printBlock("Optional") { printer in
+        c._print(&printer)
+      }
+
+    case let .tuple(cs):
+      printer.printBlock("Tuple") { printer in
+        for c in cs {
+          c._print(&printer)
+        }
+      }
+
+    }
+  }
+}

--- a/Sources/_MatchingEngine/Regex/Parse/LexicalAnalysis.swift
+++ b/Sources/_MatchingEngine/Regex/Parse/LexicalAnalysis.swift
@@ -1022,7 +1022,7 @@ extension Source {
 
   /// Attempt to lex the start of a group conditional.
   ///
-  ///     GroupConditionalStart -> '(?' GroupStart
+  ///     GroupCondStart -> '(?' GroupStart
   ///
   mutating func lexGroupConditionalStart(
     context: ParsingContext

--- a/Sources/_StringProcessing/Legacy/RECode.swift
+++ b/Sources/_StringProcessing/Legacy/RECode.swift
@@ -75,11 +75,11 @@ extension RECode {
     case captureSome
 
     /// Replace top-level captures with a single `Capture.optional(nil)`.
-    case captureNil(childType: AnyCaptureType)
+    case captureNil(childType: AnyType)
 
     /// Form a `Capture.array(...)` from top-level captures, and use it to replace the top-level
     /// captures.
-    case captureArray(childType: AnyCaptureType)
+    case captureArray(childType: AnyType)
 
     var isAccept: Bool {
       switch self {
@@ -132,11 +132,11 @@ extension RECode.Instruction {
   static func label(_ i: Int) -> Self { .label(LabelId(i)) }
 
   static func captureNil(childType: Any.Type) -> Self {
-    .captureNil(childType: AnyCaptureType(childType))
+    .captureNil(childType: AnyType(childType))
   }
 
   static func captureArray(childType: Any.Type) -> Self {
-    .captureArray(childType: AnyCaptureType(childType))
+    .captureArray(childType: AnyType(childType))
   }
 }
 

--- a/Sources/_StringProcessing/Legacy/VirtualMachine.swift
+++ b/Sources/_StringProcessing/Legacy/VirtualMachine.swift
@@ -129,7 +129,7 @@ extension RECode {
       topLevelCaptures = top
     }
 
-    mutating func captureNil(childType: AnyCaptureType) {
+    mutating func captureNil(childType: AnyType) {
       topLevelCaptures = [.none(childType: childType)]
     }
 
@@ -137,7 +137,7 @@ extension RECode {
       topLevelCaptures = [.some(.tupleOrAtom(topLevelCaptures))]
     }
 
-    mutating func captureArray(childType: AnyCaptureType) {
+    mutating func captureArray(childType: AnyType) {
       topLevelCaptures = [.array(topLevelCaptures, childType: childType)]
     }
 


### PR DESCRIPTION
Has some cleanups, and pretty-printing for CaptureStructure hooked up to command line tools:

```
swift run PatternConverter --show-capture-structure  '([0-9A-F]+)(?:\.\.([0-9A-F]+))?\s+;\s+(\w+)' --skip-dsl
Capture structure:

Tuple {
  Atom(_: _)
  Optional {
    Atom(_: _)
  }
  Atom(_: _)
}

```