### PR TITLE
Add `repeatMatch` functions to DSL

### DIFF
--- a/Sources/VariadicsGenerator/VariadicsGenerator.swift
+++ b/Sources/VariadicsGenerator/VariadicsGenerator.swift
@@ -391,33 +391,33 @@ struct VariadicsGenerator: ParsableCommand {
   
   func emitRepeating(arity: Int) {
     assert(arity >= 0)
-    // `repeating(..<5)` has the same generic semantics as zeroOrMore
+    // `repeatMatch(..<5)` has the same generic semantics as zeroOrMore
     let rangeParams = QuantifierParameters(kind: .zeroOrMore, arity: arity)
-    // `repeating(exactly:)` has the same generic semantics as oneOrMore
+    // `repeatMatch(count:)` has the same generic semantics as oneOrMore
     let exactlyParams = QuantifierParameters(kind: .zeroOrMore, arity: arity)
     output("""
       \(arity == 0 ? "@_disfavoredOverload" : "")
-      public func repeating<\(exactlyParams.genericParams)>(
+      public func repeatMatch<\(exactlyParams.genericParams)>(
         _ component: Component,
-        exactly count: Int
+        count: Int
       ) -> \(regexTypeName)<\(exactlyParams.matchType)> \(exactlyParams.whereClause) {
         assert(count > 0, "Must specify a positive count")
-        // TODO: Emit a warning about `repeating(exactly: 0)` or `repeating(exactly: 1)`
+        // TODO: Emit a warning about `repeatMatch(count: 0)` or `repeatMatch(count: 1)`
         return Regex(node: .quantification(.exactly(.init(faking: count)), .eager, component.regex.root))
       }
 
       \(arity == 0 ? "@_disfavoredOverload" : "")
-      public func repeating<\(exactlyParams.genericParams)>(
-        exactly count: Int,
+      public func repeatMatch<\(exactlyParams.genericParams)>(
+        count: Int,
         @RegexBuilder _ component: () -> Component
       ) -> \(regexTypeName)<\(exactlyParams.matchType)> \(exactlyParams.whereClause) {
         assert(count > 0, "Must specify a positive count")
-        // TODO: Emit a warning about `repeating(exactly: 0)` or `repeating(exactly: 1)`
+        // TODO: Emit a warning about `repeatMatch(count: 0)` or `repeatMatch(count: 1)`
         return Regex(node: .quantification(.exactly(.init(faking: count)), .eager, component().regex.root))
       }
       
       \(arity == 0 ? "@_disfavoredOverload" : "")
-      public func repeating<\(rangeParams.genericParams), R: RangeExpression>(
+      public func repeatMatch<\(rangeParams.genericParams), R: RangeExpression>(
         _ component: Component,
         _ expression: R,
         _ behavior: QuantificationBehavior = .eagerly
@@ -427,7 +427,7 @@ struct VariadicsGenerator: ParsableCommand {
       }
 
       \(arity == 0 ? "@_disfavoredOverload" : "")
-      public func repeating<\(rangeParams.genericParams), R: RangeExpression>(
+      public func repeatMatch<\(rangeParams.genericParams), R: RangeExpression>(
         _ expression: R,
         _ behavior: QuantificationBehavior = .eagerly,
         @RegexBuilder _ component: () -> Component

--- a/Sources/_StringProcessing/RegexDSL/DSL.swift
+++ b/Sources/_StringProcessing/RegexDSL/DSL.swift
@@ -145,6 +145,34 @@ postfix operator .?
 postfix operator .*
 postfix operator .+
 
+/// Generates a DSLTree node for a repeated range of the given DSLTree node.
+/// Individual public API functions are in the generated Variadics.swift file.
+internal func _repeatingNode(
+  _ range: Range<Int>,
+  _ behavior: QuantificationBehavior,
+  _ node: DSLTree.Node
+) -> DSLTree.Node {
+  // TODO: Throw these as errors
+  assert(range.lowerBound >= 0, "Cannot specify a negative lower bound")
+  assert(!range.isEmpty, "Cannot specify an empty range")
+  
+  switch (range.lowerBound, range.upperBound) {
+  case (0, Int.max): // 0...
+    return .quantification(.zeroOrMore, behavior.astKind, node)
+  case (1, Int.max): // 1...
+    return .quantification(.oneOrMore, behavior.astKind, node)
+  case _ where range.count == 1: // ..<1 or ...0 or any range with count == 1
+    // Note: `behavior` is ignored in this case
+    return .quantification(.exactly(.init(faking: range.lowerBound)), .eager, node)
+  case (0, _): // 0..<n or 0...n or ..<n or ...n
+    return .quantification(.upToN(.init(faking: range.upperBound)), behavior.astKind, node)
+  case (_, Int.max): // n...
+    return .quantification(.nOrMore(.init(faking: range.lowerBound)), behavior.astKind, node)
+  default: // any other range
+    return .quantification(.range(.init(faking: range.lowerBound), .init(faking: range.upperBound)), behavior.astKind, node)
+  }
+}
+
 // MARK: Alternation
 
 // TODO: Variadic generics

--- a/Sources/_StringProcessing/RegexDSL/Variadics.swift
+++ b/Sources/_StringProcessing/RegexDSL/Variadics.swift
@@ -548,6 +548,45 @@ public postfix func .*<Component: RegexProtocol>(
 }
 
 
+@_disfavoredOverload
+public func repeating<Component: RegexProtocol>(
+  _ component: Component,
+  exactly count: Int
+) -> Regex<Substring>  {
+  assert(count > 0, "Must specify a positive count")
+  // TODO: Emit a warning about `repeating(exactly: 0)` or `repeating(exactly: 1)`
+  return Regex(node: .quantification(.exactly(.init(faking: count)), .eager, component.regex.root))
+}
+
+@_disfavoredOverload
+public func repeating<Component: RegexProtocol>(
+  exactly count: Int,
+  @RegexBuilder _ component: () -> Component
+) -> Regex<Substring>  {
+  assert(count > 0, "Must specify a positive count")
+  // TODO: Emit a warning about `repeating(exactly: 0)` or `repeating(exactly: 1)`
+  return Regex(node: .quantification(.exactly(.init(faking: count)), .eager, component().regex.root))
+}
+
+@_disfavoredOverload
+public func repeating<Component: RegexProtocol, R: RangeExpression>(
+  _ component: Component,
+  _ expression: R,
+  _ behavior: QuantificationBehavior = .eagerly
+) -> Regex<Substring> where R.Bound == Int {
+  .init(node:
+    _repeatingNode(expression.relative(to: 0..<Int.max), behavior, component.regex.root))
+}
+
+@_disfavoredOverload
+public func repeating<Component: RegexProtocol, R: RangeExpression>(
+  _ expression: R,
+  _ behavior: QuantificationBehavior = .eagerly,
+  @RegexBuilder _ component: () -> Component
+) -> Regex<Substring> where R.Bound == Int {
+  .init(node:
+    _repeatingNode(expression.relative(to: 0..<Int.max), behavior, component().regex.root))
+}
 
 public func optionally<W, C0, Component: RegexProtocol>(
   _ component: Component,
@@ -627,6 +666,45 @@ public postfix func .*<W, C0, Component: RegexProtocol>(
 
 
 
+public func repeating<W, C0, Component: RegexProtocol>(
+  _ component: Component,
+  exactly count: Int
+) -> Regex<(Substring, [C0])> where Component.Match == (W, C0) {
+  assert(count > 0, "Must specify a positive count")
+  // TODO: Emit a warning about `repeating(exactly: 0)` or `repeating(exactly: 1)`
+  return Regex(node: .quantification(.exactly(.init(faking: count)), .eager, component.regex.root))
+}
+
+
+public func repeating<W, C0, Component: RegexProtocol>(
+  exactly count: Int,
+  @RegexBuilder _ component: () -> Component
+) -> Regex<(Substring, [C0])> where Component.Match == (W, C0) {
+  assert(count > 0, "Must specify a positive count")
+  // TODO: Emit a warning about `repeating(exactly: 0)` or `repeating(exactly: 1)`
+  return Regex(node: .quantification(.exactly(.init(faking: count)), .eager, component().regex.root))
+}
+
+
+public func repeating<W, C0, Component: RegexProtocol, R: RangeExpression>(
+  _ component: Component,
+  _ expression: R,
+  _ behavior: QuantificationBehavior = .eagerly
+) -> Regex<(Substring, [C0])> where Component.Match == (W, C0), R.Bound == Int {
+  .init(node:
+    _repeatingNode(expression.relative(to: 0..<Int.max), behavior, component.regex.root))
+}
+
+
+public func repeating<W, C0, Component: RegexProtocol, R: RangeExpression>(
+  _ expression: R,
+  _ behavior: QuantificationBehavior = .eagerly,
+  @RegexBuilder _ component: () -> Component
+) -> Regex<(Substring, [C0])> where Component.Match == (W, C0), R.Bound == Int {
+  .init(node:
+    _repeatingNode(expression.relative(to: 0..<Int.max), behavior, component().regex.root))
+}
+
 public func optionally<W, C0, C1, Component: RegexProtocol>(
   _ component: Component,
   _ behavior: QuantificationBehavior = .eagerly
@@ -704,6 +782,45 @@ public postfix func .*<W, C0, C1, Component: RegexProtocol>(
 }
 
 
+
+public func repeating<W, C0, C1, Component: RegexProtocol>(
+  _ component: Component,
+  exactly count: Int
+) -> Regex<(Substring, [(C0, C1)])> where Component.Match == (W, C0, C1) {
+  assert(count > 0, "Must specify a positive count")
+  // TODO: Emit a warning about `repeating(exactly: 0)` or `repeating(exactly: 1)`
+  return Regex(node: .quantification(.exactly(.init(faking: count)), .eager, component.regex.root))
+}
+
+
+public func repeating<W, C0, C1, Component: RegexProtocol>(
+  exactly count: Int,
+  @RegexBuilder _ component: () -> Component
+) -> Regex<(Substring, [(C0, C1)])> where Component.Match == (W, C0, C1) {
+  assert(count > 0, "Must specify a positive count")
+  // TODO: Emit a warning about `repeating(exactly: 0)` or `repeating(exactly: 1)`
+  return Regex(node: .quantification(.exactly(.init(faking: count)), .eager, component().regex.root))
+}
+
+
+public func repeating<W, C0, C1, Component: RegexProtocol, R: RangeExpression>(
+  _ component: Component,
+  _ expression: R,
+  _ behavior: QuantificationBehavior = .eagerly
+) -> Regex<(Substring, [(C0, C1)])> where Component.Match == (W, C0, C1), R.Bound == Int {
+  .init(node:
+    _repeatingNode(expression.relative(to: 0..<Int.max), behavior, component.regex.root))
+}
+
+
+public func repeating<W, C0, C1, Component: RegexProtocol, R: RangeExpression>(
+  _ expression: R,
+  _ behavior: QuantificationBehavior = .eagerly,
+  @RegexBuilder _ component: () -> Component
+) -> Regex<(Substring, [(C0, C1)])> where Component.Match == (W, C0, C1), R.Bound == Int {
+  .init(node:
+    _repeatingNode(expression.relative(to: 0..<Int.max), behavior, component().regex.root))
+}
 
 public func optionally<W, C0, C1, C2, Component: RegexProtocol>(
   _ component: Component,
@@ -783,6 +900,45 @@ public postfix func .*<W, C0, C1, C2, Component: RegexProtocol>(
 
 
 
+public func repeating<W, C0, C1, C2, Component: RegexProtocol>(
+  _ component: Component,
+  exactly count: Int
+) -> Regex<(Substring, [(C0, C1, C2)])> where Component.Match == (W, C0, C1, C2) {
+  assert(count > 0, "Must specify a positive count")
+  // TODO: Emit a warning about `repeating(exactly: 0)` or `repeating(exactly: 1)`
+  return Regex(node: .quantification(.exactly(.init(faking: count)), .eager, component.regex.root))
+}
+
+
+public func repeating<W, C0, C1, C2, Component: RegexProtocol>(
+  exactly count: Int,
+  @RegexBuilder _ component: () -> Component
+) -> Regex<(Substring, [(C0, C1, C2)])> where Component.Match == (W, C0, C1, C2) {
+  assert(count > 0, "Must specify a positive count")
+  // TODO: Emit a warning about `repeating(exactly: 0)` or `repeating(exactly: 1)`
+  return Regex(node: .quantification(.exactly(.init(faking: count)), .eager, component().regex.root))
+}
+
+
+public func repeating<W, C0, C1, C2, Component: RegexProtocol, R: RangeExpression>(
+  _ component: Component,
+  _ expression: R,
+  _ behavior: QuantificationBehavior = .eagerly
+) -> Regex<(Substring, [(C0, C1, C2)])> where Component.Match == (W, C0, C1, C2), R.Bound == Int {
+  .init(node:
+    _repeatingNode(expression.relative(to: 0..<Int.max), behavior, component.regex.root))
+}
+
+
+public func repeating<W, C0, C1, C2, Component: RegexProtocol, R: RangeExpression>(
+  _ expression: R,
+  _ behavior: QuantificationBehavior = .eagerly,
+  @RegexBuilder _ component: () -> Component
+) -> Regex<(Substring, [(C0, C1, C2)])> where Component.Match == (W, C0, C1, C2), R.Bound == Int {
+  .init(node:
+    _repeatingNode(expression.relative(to: 0..<Int.max), behavior, component().regex.root))
+}
+
 public func optionally<W, C0, C1, C2, C3, Component: RegexProtocol>(
   _ component: Component,
   _ behavior: QuantificationBehavior = .eagerly
@@ -860,6 +1016,45 @@ public postfix func .*<W, C0, C1, C2, C3, Component: RegexProtocol>(
 }
 
 
+
+public func repeating<W, C0, C1, C2, C3, Component: RegexProtocol>(
+  _ component: Component,
+  exactly count: Int
+) -> Regex<(Substring, [(C0, C1, C2, C3)])> where Component.Match == (W, C0, C1, C2, C3) {
+  assert(count > 0, "Must specify a positive count")
+  // TODO: Emit a warning about `repeating(exactly: 0)` or `repeating(exactly: 1)`
+  return Regex(node: .quantification(.exactly(.init(faking: count)), .eager, component.regex.root))
+}
+
+
+public func repeating<W, C0, C1, C2, C3, Component: RegexProtocol>(
+  exactly count: Int,
+  @RegexBuilder _ component: () -> Component
+) -> Regex<(Substring, [(C0, C1, C2, C3)])> where Component.Match == (W, C0, C1, C2, C3) {
+  assert(count > 0, "Must specify a positive count")
+  // TODO: Emit a warning about `repeating(exactly: 0)` or `repeating(exactly: 1)`
+  return Regex(node: .quantification(.exactly(.init(faking: count)), .eager, component().regex.root))
+}
+
+
+public func repeating<W, C0, C1, C2, C3, Component: RegexProtocol, R: RangeExpression>(
+  _ component: Component,
+  _ expression: R,
+  _ behavior: QuantificationBehavior = .eagerly
+) -> Regex<(Substring, [(C0, C1, C2, C3)])> where Component.Match == (W, C0, C1, C2, C3), R.Bound == Int {
+  .init(node:
+    _repeatingNode(expression.relative(to: 0..<Int.max), behavior, component.regex.root))
+}
+
+
+public func repeating<W, C0, C1, C2, C3, Component: RegexProtocol, R: RangeExpression>(
+  _ expression: R,
+  _ behavior: QuantificationBehavior = .eagerly,
+  @RegexBuilder _ component: () -> Component
+) -> Regex<(Substring, [(C0, C1, C2, C3)])> where Component.Match == (W, C0, C1, C2, C3), R.Bound == Int {
+  .init(node:
+    _repeatingNode(expression.relative(to: 0..<Int.max), behavior, component().regex.root))
+}
 
 public func optionally<W, C0, C1, C2, C3, C4, Component: RegexProtocol>(
   _ component: Component,
@@ -939,6 +1134,45 @@ public postfix func .*<W, C0, C1, C2, C3, C4, Component: RegexProtocol>(
 
 
 
+public func repeating<W, C0, C1, C2, C3, C4, Component: RegexProtocol>(
+  _ component: Component,
+  exactly count: Int
+) -> Regex<(Substring, [(C0, C1, C2, C3, C4)])> where Component.Match == (W, C0, C1, C2, C3, C4) {
+  assert(count > 0, "Must specify a positive count")
+  // TODO: Emit a warning about `repeating(exactly: 0)` or `repeating(exactly: 1)`
+  return Regex(node: .quantification(.exactly(.init(faking: count)), .eager, component.regex.root))
+}
+
+
+public func repeating<W, C0, C1, C2, C3, C4, Component: RegexProtocol>(
+  exactly count: Int,
+  @RegexBuilder _ component: () -> Component
+) -> Regex<(Substring, [(C0, C1, C2, C3, C4)])> where Component.Match == (W, C0, C1, C2, C3, C4) {
+  assert(count > 0, "Must specify a positive count")
+  // TODO: Emit a warning about `repeating(exactly: 0)` or `repeating(exactly: 1)`
+  return Regex(node: .quantification(.exactly(.init(faking: count)), .eager, component().regex.root))
+}
+
+
+public func repeating<W, C0, C1, C2, C3, C4, Component: RegexProtocol, R: RangeExpression>(
+  _ component: Component,
+  _ expression: R,
+  _ behavior: QuantificationBehavior = .eagerly
+) -> Regex<(Substring, [(C0, C1, C2, C3, C4)])> where Component.Match == (W, C0, C1, C2, C3, C4), R.Bound == Int {
+  .init(node:
+    _repeatingNode(expression.relative(to: 0..<Int.max), behavior, component.regex.root))
+}
+
+
+public func repeating<W, C0, C1, C2, C3, C4, Component: RegexProtocol, R: RangeExpression>(
+  _ expression: R,
+  _ behavior: QuantificationBehavior = .eagerly,
+  @RegexBuilder _ component: () -> Component
+) -> Regex<(Substring, [(C0, C1, C2, C3, C4)])> where Component.Match == (W, C0, C1, C2, C3, C4), R.Bound == Int {
+  .init(node:
+    _repeatingNode(expression.relative(to: 0..<Int.max), behavior, component().regex.root))
+}
+
 public func optionally<W, C0, C1, C2, C3, C4, C5, Component: RegexProtocol>(
   _ component: Component,
   _ behavior: QuantificationBehavior = .eagerly
@@ -1016,6 +1250,45 @@ public postfix func .*<W, C0, C1, C2, C3, C4, C5, Component: RegexProtocol>(
 }
 
 
+
+public func repeating<W, C0, C1, C2, C3, C4, C5, Component: RegexProtocol>(
+  _ component: Component,
+  exactly count: Int
+) -> Regex<(Substring, [(C0, C1, C2, C3, C4, C5)])> where Component.Match == (W, C0, C1, C2, C3, C4, C5) {
+  assert(count > 0, "Must specify a positive count")
+  // TODO: Emit a warning about `repeating(exactly: 0)` or `repeating(exactly: 1)`
+  return Regex(node: .quantification(.exactly(.init(faking: count)), .eager, component.regex.root))
+}
+
+
+public func repeating<W, C0, C1, C2, C3, C4, C5, Component: RegexProtocol>(
+  exactly count: Int,
+  @RegexBuilder _ component: () -> Component
+) -> Regex<(Substring, [(C0, C1, C2, C3, C4, C5)])> where Component.Match == (W, C0, C1, C2, C3, C4, C5) {
+  assert(count > 0, "Must specify a positive count")
+  // TODO: Emit a warning about `repeating(exactly: 0)` or `repeating(exactly: 1)`
+  return Regex(node: .quantification(.exactly(.init(faking: count)), .eager, component().regex.root))
+}
+
+
+public func repeating<W, C0, C1, C2, C3, C4, C5, Component: RegexProtocol, R: RangeExpression>(
+  _ component: Component,
+  _ expression: R,
+  _ behavior: QuantificationBehavior = .eagerly
+) -> Regex<(Substring, [(C0, C1, C2, C3, C4, C5)])> where Component.Match == (W, C0, C1, C2, C3, C4, C5), R.Bound == Int {
+  .init(node:
+    _repeatingNode(expression.relative(to: 0..<Int.max), behavior, component.regex.root))
+}
+
+
+public func repeating<W, C0, C1, C2, C3, C4, C5, Component: RegexProtocol, R: RangeExpression>(
+  _ expression: R,
+  _ behavior: QuantificationBehavior = .eagerly,
+  @RegexBuilder _ component: () -> Component
+) -> Regex<(Substring, [(C0, C1, C2, C3, C4, C5)])> where Component.Match == (W, C0, C1, C2, C3, C4, C5), R.Bound == Int {
+  .init(node:
+    _repeatingNode(expression.relative(to: 0..<Int.max), behavior, component().regex.root))
+}
 
 public func optionally<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexProtocol>(
   _ component: Component,
@@ -1095,6 +1368,45 @@ public postfix func .*<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexProtocol>(
 
 
 
+public func repeating<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexProtocol>(
+  _ component: Component,
+  exactly count: Int
+) -> Regex<(Substring, [(C0, C1, C2, C3, C4, C5, C6)])> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6) {
+  assert(count > 0, "Must specify a positive count")
+  // TODO: Emit a warning about `repeating(exactly: 0)` or `repeating(exactly: 1)`
+  return Regex(node: .quantification(.exactly(.init(faking: count)), .eager, component.regex.root))
+}
+
+
+public func repeating<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexProtocol>(
+  exactly count: Int,
+  @RegexBuilder _ component: () -> Component
+) -> Regex<(Substring, [(C0, C1, C2, C3, C4, C5, C6)])> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6) {
+  assert(count > 0, "Must specify a positive count")
+  // TODO: Emit a warning about `repeating(exactly: 0)` or `repeating(exactly: 1)`
+  return Regex(node: .quantification(.exactly(.init(faking: count)), .eager, component().regex.root))
+}
+
+
+public func repeating<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexProtocol, R: RangeExpression>(
+  _ component: Component,
+  _ expression: R,
+  _ behavior: QuantificationBehavior = .eagerly
+) -> Regex<(Substring, [(C0, C1, C2, C3, C4, C5, C6)])> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6), R.Bound == Int {
+  .init(node:
+    _repeatingNode(expression.relative(to: 0..<Int.max), behavior, component.regex.root))
+}
+
+
+public func repeating<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexProtocol, R: RangeExpression>(
+  _ expression: R,
+  _ behavior: QuantificationBehavior = .eagerly,
+  @RegexBuilder _ component: () -> Component
+) -> Regex<(Substring, [(C0, C1, C2, C3, C4, C5, C6)])> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6), R.Bound == Int {
+  .init(node:
+    _repeatingNode(expression.relative(to: 0..<Int.max), behavior, component().regex.root))
+}
+
 public func optionally<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexProtocol>(
   _ component: Component,
   _ behavior: QuantificationBehavior = .eagerly
@@ -1173,6 +1485,45 @@ public postfix func .*<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexProtoc
 
 
 
+public func repeating<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexProtocol>(
+  _ component: Component,
+  exactly count: Int
+) -> Regex<(Substring, [(C0, C1, C2, C3, C4, C5, C6, C7)])> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
+  assert(count > 0, "Must specify a positive count")
+  // TODO: Emit a warning about `repeating(exactly: 0)` or `repeating(exactly: 1)`
+  return Regex(node: .quantification(.exactly(.init(faking: count)), .eager, component.regex.root))
+}
+
+
+public func repeating<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexProtocol>(
+  exactly count: Int,
+  @RegexBuilder _ component: () -> Component
+) -> Regex<(Substring, [(C0, C1, C2, C3, C4, C5, C6, C7)])> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
+  assert(count > 0, "Must specify a positive count")
+  // TODO: Emit a warning about `repeating(exactly: 0)` or `repeating(exactly: 1)`
+  return Regex(node: .quantification(.exactly(.init(faking: count)), .eager, component().regex.root))
+}
+
+
+public func repeating<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexProtocol, R: RangeExpression>(
+  _ component: Component,
+  _ expression: R,
+  _ behavior: QuantificationBehavior = .eagerly
+) -> Regex<(Substring, [(C0, C1, C2, C3, C4, C5, C6, C7)])> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7), R.Bound == Int {
+  .init(node:
+    _repeatingNode(expression.relative(to: 0..<Int.max), behavior, component.regex.root))
+}
+
+
+public func repeating<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexProtocol, R: RangeExpression>(
+  _ expression: R,
+  _ behavior: QuantificationBehavior = .eagerly,
+  @RegexBuilder _ component: () -> Component
+) -> Regex<(Substring, [(C0, C1, C2, C3, C4, C5, C6, C7)])> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7), R.Bound == Int {
+  .init(node:
+    _repeatingNode(expression.relative(to: 0..<Int.max), behavior, component().regex.root))
+}
+
 public func optionally<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexProtocol>(
   _ component: Component,
   _ behavior: QuantificationBehavior = .eagerly
@@ -1250,6 +1601,45 @@ public postfix func .*<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexPr
 }
 
 
+
+public func repeating<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexProtocol>(
+  _ component: Component,
+  exactly count: Int
+) -> Regex<(Substring, [(C0, C1, C2, C3, C4, C5, C6, C7, C8)])> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
+  assert(count > 0, "Must specify a positive count")
+  // TODO: Emit a warning about `repeating(exactly: 0)` or `repeating(exactly: 1)`
+  return Regex(node: .quantification(.exactly(.init(faking: count)), .eager, component.regex.root))
+}
+
+
+public func repeating<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexProtocol>(
+  exactly count: Int,
+  @RegexBuilder _ component: () -> Component
+) -> Regex<(Substring, [(C0, C1, C2, C3, C4, C5, C6, C7, C8)])> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
+  assert(count > 0, "Must specify a positive count")
+  // TODO: Emit a warning about `repeating(exactly: 0)` or `repeating(exactly: 1)`
+  return Regex(node: .quantification(.exactly(.init(faking: count)), .eager, component().regex.root))
+}
+
+
+public func repeating<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexProtocol, R: RangeExpression>(
+  _ component: Component,
+  _ expression: R,
+  _ behavior: QuantificationBehavior = .eagerly
+) -> Regex<(Substring, [(C0, C1, C2, C3, C4, C5, C6, C7, C8)])> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8), R.Bound == Int {
+  .init(node:
+    _repeatingNode(expression.relative(to: 0..<Int.max), behavior, component.regex.root))
+}
+
+
+public func repeating<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexProtocol, R: RangeExpression>(
+  _ expression: R,
+  _ behavior: QuantificationBehavior = .eagerly,
+  @RegexBuilder _ component: () -> Component
+) -> Regex<(Substring, [(C0, C1, C2, C3, C4, C5, C6, C7, C8)])> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8), R.Bound == Int {
+  .init(node:
+    _repeatingNode(expression.relative(to: 0..<Int.max), behavior, component().regex.root))
+}
 extension AlternationBuilder {
   public static func buildBlock<R0, R1>(
     combining next: R1, into combined: R0

--- a/Sources/_StringProcessing/RegexDSL/Variadics.swift
+++ b/Sources/_StringProcessing/RegexDSL/Variadics.swift
@@ -549,27 +549,27 @@ public postfix func .*<Component: RegexProtocol>(
 
 
 @_disfavoredOverload
-public func repeating<Component: RegexProtocol>(
+public func repeatMatch<Component: RegexProtocol>(
   _ component: Component,
-  exactly count: Int
+  count: Int
 ) -> Regex<Substring>  {
   assert(count > 0, "Must specify a positive count")
-  // TODO: Emit a warning about `repeating(exactly: 0)` or `repeating(exactly: 1)`
+  // TODO: Emit a warning about `repeatMatch(count: 0)` or `repeatMatch(count: 1)`
   return Regex(node: .quantification(.exactly(.init(faking: count)), .eager, component.regex.root))
 }
 
 @_disfavoredOverload
-public func repeating<Component: RegexProtocol>(
-  exactly count: Int,
+public func repeatMatch<Component: RegexProtocol>(
+  count: Int,
   @RegexBuilder _ component: () -> Component
 ) -> Regex<Substring>  {
   assert(count > 0, "Must specify a positive count")
-  // TODO: Emit a warning about `repeating(exactly: 0)` or `repeating(exactly: 1)`
+  // TODO: Emit a warning about `repeatMatch(count: 0)` or `repeatMatch(count: 1)`
   return Regex(node: .quantification(.exactly(.init(faking: count)), .eager, component().regex.root))
 }
 
 @_disfavoredOverload
-public func repeating<Component: RegexProtocol, R: RangeExpression>(
+public func repeatMatch<Component: RegexProtocol, R: RangeExpression>(
   _ component: Component,
   _ expression: R,
   _ behavior: QuantificationBehavior = .eagerly
@@ -579,7 +579,7 @@ public func repeating<Component: RegexProtocol, R: RangeExpression>(
 }
 
 @_disfavoredOverload
-public func repeating<Component: RegexProtocol, R: RangeExpression>(
+public func repeatMatch<Component: RegexProtocol, R: RangeExpression>(
   _ expression: R,
   _ behavior: QuantificationBehavior = .eagerly,
   @RegexBuilder _ component: () -> Component
@@ -666,27 +666,27 @@ public postfix func .*<W, C0, Component: RegexProtocol>(
 
 
 
-public func repeating<W, C0, Component: RegexProtocol>(
+public func repeatMatch<W, C0, Component: RegexProtocol>(
   _ component: Component,
-  exactly count: Int
+  count: Int
 ) -> Regex<(Substring, [C0])> where Component.Match == (W, C0) {
   assert(count > 0, "Must specify a positive count")
-  // TODO: Emit a warning about `repeating(exactly: 0)` or `repeating(exactly: 1)`
+  // TODO: Emit a warning about `repeatMatch(count: 0)` or `repeatMatch(count: 1)`
   return Regex(node: .quantification(.exactly(.init(faking: count)), .eager, component.regex.root))
 }
 
 
-public func repeating<W, C0, Component: RegexProtocol>(
-  exactly count: Int,
+public func repeatMatch<W, C0, Component: RegexProtocol>(
+  count: Int,
   @RegexBuilder _ component: () -> Component
 ) -> Regex<(Substring, [C0])> where Component.Match == (W, C0) {
   assert(count > 0, "Must specify a positive count")
-  // TODO: Emit a warning about `repeating(exactly: 0)` or `repeating(exactly: 1)`
+  // TODO: Emit a warning about `repeatMatch(count: 0)` or `repeatMatch(count: 1)`
   return Regex(node: .quantification(.exactly(.init(faking: count)), .eager, component().regex.root))
 }
 
 
-public func repeating<W, C0, Component: RegexProtocol, R: RangeExpression>(
+public func repeatMatch<W, C0, Component: RegexProtocol, R: RangeExpression>(
   _ component: Component,
   _ expression: R,
   _ behavior: QuantificationBehavior = .eagerly
@@ -696,7 +696,7 @@ public func repeating<W, C0, Component: RegexProtocol, R: RangeExpression>(
 }
 
 
-public func repeating<W, C0, Component: RegexProtocol, R: RangeExpression>(
+public func repeatMatch<W, C0, Component: RegexProtocol, R: RangeExpression>(
   _ expression: R,
   _ behavior: QuantificationBehavior = .eagerly,
   @RegexBuilder _ component: () -> Component
@@ -783,27 +783,27 @@ public postfix func .*<W, C0, C1, Component: RegexProtocol>(
 
 
 
-public func repeating<W, C0, C1, Component: RegexProtocol>(
+public func repeatMatch<W, C0, C1, Component: RegexProtocol>(
   _ component: Component,
-  exactly count: Int
+  count: Int
 ) -> Regex<(Substring, [(C0, C1)])> where Component.Match == (W, C0, C1) {
   assert(count > 0, "Must specify a positive count")
-  // TODO: Emit a warning about `repeating(exactly: 0)` or `repeating(exactly: 1)`
+  // TODO: Emit a warning about `repeatMatch(count: 0)` or `repeatMatch(count: 1)`
   return Regex(node: .quantification(.exactly(.init(faking: count)), .eager, component.regex.root))
 }
 
 
-public func repeating<W, C0, C1, Component: RegexProtocol>(
-  exactly count: Int,
+public func repeatMatch<W, C0, C1, Component: RegexProtocol>(
+  count: Int,
   @RegexBuilder _ component: () -> Component
 ) -> Regex<(Substring, [(C0, C1)])> where Component.Match == (W, C0, C1) {
   assert(count > 0, "Must specify a positive count")
-  // TODO: Emit a warning about `repeating(exactly: 0)` or `repeating(exactly: 1)`
+  // TODO: Emit a warning about `repeatMatch(count: 0)` or `repeatMatch(count: 1)`
   return Regex(node: .quantification(.exactly(.init(faking: count)), .eager, component().regex.root))
 }
 
 
-public func repeating<W, C0, C1, Component: RegexProtocol, R: RangeExpression>(
+public func repeatMatch<W, C0, C1, Component: RegexProtocol, R: RangeExpression>(
   _ component: Component,
   _ expression: R,
   _ behavior: QuantificationBehavior = .eagerly
@@ -813,7 +813,7 @@ public func repeating<W, C0, C1, Component: RegexProtocol, R: RangeExpression>(
 }
 
 
-public func repeating<W, C0, C1, Component: RegexProtocol, R: RangeExpression>(
+public func repeatMatch<W, C0, C1, Component: RegexProtocol, R: RangeExpression>(
   _ expression: R,
   _ behavior: QuantificationBehavior = .eagerly,
   @RegexBuilder _ component: () -> Component
@@ -900,27 +900,27 @@ public postfix func .*<W, C0, C1, C2, Component: RegexProtocol>(
 
 
 
-public func repeating<W, C0, C1, C2, Component: RegexProtocol>(
+public func repeatMatch<W, C0, C1, C2, Component: RegexProtocol>(
   _ component: Component,
-  exactly count: Int
+  count: Int
 ) -> Regex<(Substring, [(C0, C1, C2)])> where Component.Match == (W, C0, C1, C2) {
   assert(count > 0, "Must specify a positive count")
-  // TODO: Emit a warning about `repeating(exactly: 0)` or `repeating(exactly: 1)`
+  // TODO: Emit a warning about `repeatMatch(count: 0)` or `repeatMatch(count: 1)`
   return Regex(node: .quantification(.exactly(.init(faking: count)), .eager, component.regex.root))
 }
 
 
-public func repeating<W, C0, C1, C2, Component: RegexProtocol>(
-  exactly count: Int,
+public func repeatMatch<W, C0, C1, C2, Component: RegexProtocol>(
+  count: Int,
   @RegexBuilder _ component: () -> Component
 ) -> Regex<(Substring, [(C0, C1, C2)])> where Component.Match == (W, C0, C1, C2) {
   assert(count > 0, "Must specify a positive count")
-  // TODO: Emit a warning about `repeating(exactly: 0)` or `repeating(exactly: 1)`
+  // TODO: Emit a warning about `repeatMatch(count: 0)` or `repeatMatch(count: 1)`
   return Regex(node: .quantification(.exactly(.init(faking: count)), .eager, component().regex.root))
 }
 
 
-public func repeating<W, C0, C1, C2, Component: RegexProtocol, R: RangeExpression>(
+public func repeatMatch<W, C0, C1, C2, Component: RegexProtocol, R: RangeExpression>(
   _ component: Component,
   _ expression: R,
   _ behavior: QuantificationBehavior = .eagerly
@@ -930,7 +930,7 @@ public func repeating<W, C0, C1, C2, Component: RegexProtocol, R: RangeExpressio
 }
 
 
-public func repeating<W, C0, C1, C2, Component: RegexProtocol, R: RangeExpression>(
+public func repeatMatch<W, C0, C1, C2, Component: RegexProtocol, R: RangeExpression>(
   _ expression: R,
   _ behavior: QuantificationBehavior = .eagerly,
   @RegexBuilder _ component: () -> Component
@@ -1017,27 +1017,27 @@ public postfix func .*<W, C0, C1, C2, C3, Component: RegexProtocol>(
 
 
 
-public func repeating<W, C0, C1, C2, C3, Component: RegexProtocol>(
+public func repeatMatch<W, C0, C1, C2, C3, Component: RegexProtocol>(
   _ component: Component,
-  exactly count: Int
+  count: Int
 ) -> Regex<(Substring, [(C0, C1, C2, C3)])> where Component.Match == (W, C0, C1, C2, C3) {
   assert(count > 0, "Must specify a positive count")
-  // TODO: Emit a warning about `repeating(exactly: 0)` or `repeating(exactly: 1)`
+  // TODO: Emit a warning about `repeatMatch(count: 0)` or `repeatMatch(count: 1)`
   return Regex(node: .quantification(.exactly(.init(faking: count)), .eager, component.regex.root))
 }
 
 
-public func repeating<W, C0, C1, C2, C3, Component: RegexProtocol>(
-  exactly count: Int,
+public func repeatMatch<W, C0, C1, C2, C3, Component: RegexProtocol>(
+  count: Int,
   @RegexBuilder _ component: () -> Component
 ) -> Regex<(Substring, [(C0, C1, C2, C3)])> where Component.Match == (W, C0, C1, C2, C3) {
   assert(count > 0, "Must specify a positive count")
-  // TODO: Emit a warning about `repeating(exactly: 0)` or `repeating(exactly: 1)`
+  // TODO: Emit a warning about `repeatMatch(count: 0)` or `repeatMatch(count: 1)`
   return Regex(node: .quantification(.exactly(.init(faking: count)), .eager, component().regex.root))
 }
 
 
-public func repeating<W, C0, C1, C2, C3, Component: RegexProtocol, R: RangeExpression>(
+public func repeatMatch<W, C0, C1, C2, C3, Component: RegexProtocol, R: RangeExpression>(
   _ component: Component,
   _ expression: R,
   _ behavior: QuantificationBehavior = .eagerly
@@ -1047,7 +1047,7 @@ public func repeating<W, C0, C1, C2, C3, Component: RegexProtocol, R: RangeExpre
 }
 
 
-public func repeating<W, C0, C1, C2, C3, Component: RegexProtocol, R: RangeExpression>(
+public func repeatMatch<W, C0, C1, C2, C3, Component: RegexProtocol, R: RangeExpression>(
   _ expression: R,
   _ behavior: QuantificationBehavior = .eagerly,
   @RegexBuilder _ component: () -> Component
@@ -1134,27 +1134,27 @@ public postfix func .*<W, C0, C1, C2, C3, C4, Component: RegexProtocol>(
 
 
 
-public func repeating<W, C0, C1, C2, C3, C4, Component: RegexProtocol>(
+public func repeatMatch<W, C0, C1, C2, C3, C4, Component: RegexProtocol>(
   _ component: Component,
-  exactly count: Int
+  count: Int
 ) -> Regex<(Substring, [(C0, C1, C2, C3, C4)])> where Component.Match == (W, C0, C1, C2, C3, C4) {
   assert(count > 0, "Must specify a positive count")
-  // TODO: Emit a warning about `repeating(exactly: 0)` or `repeating(exactly: 1)`
+  // TODO: Emit a warning about `repeatMatch(count: 0)` or `repeatMatch(count: 1)`
   return Regex(node: .quantification(.exactly(.init(faking: count)), .eager, component.regex.root))
 }
 
 
-public func repeating<W, C0, C1, C2, C3, C4, Component: RegexProtocol>(
-  exactly count: Int,
+public func repeatMatch<W, C0, C1, C2, C3, C4, Component: RegexProtocol>(
+  count: Int,
   @RegexBuilder _ component: () -> Component
 ) -> Regex<(Substring, [(C0, C1, C2, C3, C4)])> where Component.Match == (W, C0, C1, C2, C3, C4) {
   assert(count > 0, "Must specify a positive count")
-  // TODO: Emit a warning about `repeating(exactly: 0)` or `repeating(exactly: 1)`
+  // TODO: Emit a warning about `repeatMatch(count: 0)` or `repeatMatch(count: 1)`
   return Regex(node: .quantification(.exactly(.init(faking: count)), .eager, component().regex.root))
 }
 
 
-public func repeating<W, C0, C1, C2, C3, C4, Component: RegexProtocol, R: RangeExpression>(
+public func repeatMatch<W, C0, C1, C2, C3, C4, Component: RegexProtocol, R: RangeExpression>(
   _ component: Component,
   _ expression: R,
   _ behavior: QuantificationBehavior = .eagerly
@@ -1164,7 +1164,7 @@ public func repeating<W, C0, C1, C2, C3, C4, Component: RegexProtocol, R: RangeE
 }
 
 
-public func repeating<W, C0, C1, C2, C3, C4, Component: RegexProtocol, R: RangeExpression>(
+public func repeatMatch<W, C0, C1, C2, C3, C4, Component: RegexProtocol, R: RangeExpression>(
   _ expression: R,
   _ behavior: QuantificationBehavior = .eagerly,
   @RegexBuilder _ component: () -> Component
@@ -1251,27 +1251,27 @@ public postfix func .*<W, C0, C1, C2, C3, C4, C5, Component: RegexProtocol>(
 
 
 
-public func repeating<W, C0, C1, C2, C3, C4, C5, Component: RegexProtocol>(
+public func repeatMatch<W, C0, C1, C2, C3, C4, C5, Component: RegexProtocol>(
   _ component: Component,
-  exactly count: Int
+  count: Int
 ) -> Regex<(Substring, [(C0, C1, C2, C3, C4, C5)])> where Component.Match == (W, C0, C1, C2, C3, C4, C5) {
   assert(count > 0, "Must specify a positive count")
-  // TODO: Emit a warning about `repeating(exactly: 0)` or `repeating(exactly: 1)`
+  // TODO: Emit a warning about `repeatMatch(count: 0)` or `repeatMatch(count: 1)`
   return Regex(node: .quantification(.exactly(.init(faking: count)), .eager, component.regex.root))
 }
 
 
-public func repeating<W, C0, C1, C2, C3, C4, C5, Component: RegexProtocol>(
-  exactly count: Int,
+public func repeatMatch<W, C0, C1, C2, C3, C4, C5, Component: RegexProtocol>(
+  count: Int,
   @RegexBuilder _ component: () -> Component
 ) -> Regex<(Substring, [(C0, C1, C2, C3, C4, C5)])> where Component.Match == (W, C0, C1, C2, C3, C4, C5) {
   assert(count > 0, "Must specify a positive count")
-  // TODO: Emit a warning about `repeating(exactly: 0)` or `repeating(exactly: 1)`
+  // TODO: Emit a warning about `repeatMatch(count: 0)` or `repeatMatch(count: 1)`
   return Regex(node: .quantification(.exactly(.init(faking: count)), .eager, component().regex.root))
 }
 
 
-public func repeating<W, C0, C1, C2, C3, C4, C5, Component: RegexProtocol, R: RangeExpression>(
+public func repeatMatch<W, C0, C1, C2, C3, C4, C5, Component: RegexProtocol, R: RangeExpression>(
   _ component: Component,
   _ expression: R,
   _ behavior: QuantificationBehavior = .eagerly
@@ -1281,7 +1281,7 @@ public func repeating<W, C0, C1, C2, C3, C4, C5, Component: RegexProtocol, R: Ra
 }
 
 
-public func repeating<W, C0, C1, C2, C3, C4, C5, Component: RegexProtocol, R: RangeExpression>(
+public func repeatMatch<W, C0, C1, C2, C3, C4, C5, Component: RegexProtocol, R: RangeExpression>(
   _ expression: R,
   _ behavior: QuantificationBehavior = .eagerly,
   @RegexBuilder _ component: () -> Component
@@ -1368,27 +1368,27 @@ public postfix func .*<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexProtocol>(
 
 
 
-public func repeating<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexProtocol>(
+public func repeatMatch<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexProtocol>(
   _ component: Component,
-  exactly count: Int
+  count: Int
 ) -> Regex<(Substring, [(C0, C1, C2, C3, C4, C5, C6)])> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6) {
   assert(count > 0, "Must specify a positive count")
-  // TODO: Emit a warning about `repeating(exactly: 0)` or `repeating(exactly: 1)`
+  // TODO: Emit a warning about `repeatMatch(count: 0)` or `repeatMatch(count: 1)`
   return Regex(node: .quantification(.exactly(.init(faking: count)), .eager, component.regex.root))
 }
 
 
-public func repeating<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexProtocol>(
-  exactly count: Int,
+public func repeatMatch<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexProtocol>(
+  count: Int,
   @RegexBuilder _ component: () -> Component
 ) -> Regex<(Substring, [(C0, C1, C2, C3, C4, C5, C6)])> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6) {
   assert(count > 0, "Must specify a positive count")
-  // TODO: Emit a warning about `repeating(exactly: 0)` or `repeating(exactly: 1)`
+  // TODO: Emit a warning about `repeatMatch(count: 0)` or `repeatMatch(count: 1)`
   return Regex(node: .quantification(.exactly(.init(faking: count)), .eager, component().regex.root))
 }
 
 
-public func repeating<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexProtocol, R: RangeExpression>(
+public func repeatMatch<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexProtocol, R: RangeExpression>(
   _ component: Component,
   _ expression: R,
   _ behavior: QuantificationBehavior = .eagerly
@@ -1398,7 +1398,7 @@ public func repeating<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexProtocol, R
 }
 
 
-public func repeating<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexProtocol, R: RangeExpression>(
+public func repeatMatch<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexProtocol, R: RangeExpression>(
   _ expression: R,
   _ behavior: QuantificationBehavior = .eagerly,
   @RegexBuilder _ component: () -> Component
@@ -1485,27 +1485,27 @@ public postfix func .*<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexProtoc
 
 
 
-public func repeating<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexProtocol>(
+public func repeatMatch<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexProtocol>(
   _ component: Component,
-  exactly count: Int
+  count: Int
 ) -> Regex<(Substring, [(C0, C1, C2, C3, C4, C5, C6, C7)])> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
   assert(count > 0, "Must specify a positive count")
-  // TODO: Emit a warning about `repeating(exactly: 0)` or `repeating(exactly: 1)`
+  // TODO: Emit a warning about `repeatMatch(count: 0)` or `repeatMatch(count: 1)`
   return Regex(node: .quantification(.exactly(.init(faking: count)), .eager, component.regex.root))
 }
 
 
-public func repeating<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexProtocol>(
-  exactly count: Int,
+public func repeatMatch<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexProtocol>(
+  count: Int,
   @RegexBuilder _ component: () -> Component
 ) -> Regex<(Substring, [(C0, C1, C2, C3, C4, C5, C6, C7)])> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
   assert(count > 0, "Must specify a positive count")
-  // TODO: Emit a warning about `repeating(exactly: 0)` or `repeating(exactly: 1)`
+  // TODO: Emit a warning about `repeatMatch(count: 0)` or `repeatMatch(count: 1)`
   return Regex(node: .quantification(.exactly(.init(faking: count)), .eager, component().regex.root))
 }
 
 
-public func repeating<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexProtocol, R: RangeExpression>(
+public func repeatMatch<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexProtocol, R: RangeExpression>(
   _ component: Component,
   _ expression: R,
   _ behavior: QuantificationBehavior = .eagerly
@@ -1515,7 +1515,7 @@ public func repeating<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexProtoco
 }
 
 
-public func repeating<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexProtocol, R: RangeExpression>(
+public func repeatMatch<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexProtocol, R: RangeExpression>(
   _ expression: R,
   _ behavior: QuantificationBehavior = .eagerly,
   @RegexBuilder _ component: () -> Component
@@ -1602,27 +1602,27 @@ public postfix func .*<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexPr
 
 
 
-public func repeating<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexProtocol>(
+public func repeatMatch<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexProtocol>(
   _ component: Component,
-  exactly count: Int
+  count: Int
 ) -> Regex<(Substring, [(C0, C1, C2, C3, C4, C5, C6, C7, C8)])> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
   assert(count > 0, "Must specify a positive count")
-  // TODO: Emit a warning about `repeating(exactly: 0)` or `repeating(exactly: 1)`
+  // TODO: Emit a warning about `repeatMatch(count: 0)` or `repeatMatch(count: 1)`
   return Regex(node: .quantification(.exactly(.init(faking: count)), .eager, component.regex.root))
 }
 
 
-public func repeating<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexProtocol>(
-  exactly count: Int,
+public func repeatMatch<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexProtocol>(
+  count: Int,
   @RegexBuilder _ component: () -> Component
 ) -> Regex<(Substring, [(C0, C1, C2, C3, C4, C5, C6, C7, C8)])> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
   assert(count > 0, "Must specify a positive count")
-  // TODO: Emit a warning about `repeating(exactly: 0)` or `repeating(exactly: 1)`
+  // TODO: Emit a warning about `repeatMatch(count: 0)` or `repeatMatch(count: 1)`
   return Regex(node: .quantification(.exactly(.init(faking: count)), .eager, component().regex.root))
 }
 
 
-public func repeating<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexProtocol, R: RangeExpression>(
+public func repeatMatch<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexProtocol, R: RangeExpression>(
   _ component: Component,
   _ expression: R,
   _ behavior: QuantificationBehavior = .eagerly
@@ -1632,7 +1632,7 @@ public func repeating<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexPro
 }
 
 
-public func repeating<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexProtocol, R: RangeExpression>(
+public func repeatMatch<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexProtocol, R: RangeExpression>(
   _ expression: R,
   _ behavior: QuantificationBehavior = .eagerly,
   @RegexBuilder _ component: () -> Component

--- a/Tests/RegexTests/RegexDSLTests.swift
+++ b/Tests/RegexTests/RegexDSLTests.swift
@@ -184,8 +184,8 @@ class RegexDSLTests: XCTestCase {
       ("abc1def2", "abc1def2"),
       captureType: Substring.self, ==)
     {
-      oneOrMore {
-        repeating(exactly: 3) {
+      repeatMatch(2...) {
+        repeatMatch(count: 3) {
           CharacterClass.word
         }
         CharacterClass.digit
@@ -202,12 +202,12 @@ class RegexDSLTests: XCTestCase {
       ("aaabbbcccdddeee", "aaabbbcccdddeee"),
       captureType: Substring.self, ==)
     {
-      repeating(exactly: 3) { "a" }
-      repeating(1...) { "b" }
-      repeating(2...5) { "c" }
-      repeating(..<5) { "d" }
-      repeating(2...) { "e" }
-      repeating(0...) { "f" }
+      repeatMatch(count: 3) { "a" }
+      repeatMatch(1...) { "b" }
+      repeatMatch(2...5) { "c" }
+      repeatMatch(..<5) { "d" }
+      repeatMatch(2...) { "e" }
+      repeatMatch(0...) { "f" }
     }
   }
 

--- a/Tests/RegexTests/RegexDSLTests.swift
+++ b/Tests/RegexTests/RegexDSLTests.swift
@@ -179,6 +179,36 @@ class RegexDSLTests: XCTestCase {
         capture(.digit)
       }
     }
+    
+    try _testDSLCaptures(
+      ("abc1def2", "abc1def2"),
+      captureType: Substring.self, ==)
+    {
+      oneOrMore {
+        repeating(exactly: 3) {
+          CharacterClass.word
+        }
+        CharacterClass.digit
+      }
+    }
+    
+    try _testDSLCaptures(
+      ("aaabbbcccdddeeefff", "aaabbbcccdddeeefff"),
+      ("aaaabbbcccdddeeefff", nil),
+      ("aaacccdddeeefff", nil),
+      ("aaabbbcccccccdddeeefff", nil),
+      ("aaabbbcccddddddeeefff", nil),
+      ("aaabbbcccdddefff", nil),
+      ("aaabbbcccdddeee", "aaabbbcccdddeee"),
+      captureType: Substring.self, ==)
+    {
+      repeating(exactly: 3) { "a" }
+      repeating(1...) { "b" }
+      repeating(2...5) { "c" }
+      repeating(..<5) { "d" }
+      repeating(2...) { "e" }
+      repeating(0...) { "f" }
+    }
   }
 
   func testNestedGroups() throws {


### PR DESCRIPTION
These allow you to spell literal expressions like `a{3,}` or `a{2,5}` when using the DSL. I've gone with the `repeatMatch` name to align a bit with `repeatElement` in the stdlib, and because `repeating(...)` sounds too much to my ear like you have to repeat the matched text, not repeat the match, if that makes sense.

Usage:

```swift
let regex = Regex {
    repeatMatch(2...) {
        repeatMatch(CharacterClass.word, count: 3)
        CharacterClass.digit
    }
}
"abc1".matches(regex)        // false
"abc1def2".matches(regex)    // true
"abc1defg2".matches(regex)   // false
```
