### PR TITLE
Drop arrays and unzip tuples for quantified captures.

### DIFF
--- a/Sources/VariadicsGenerator/VariadicsGenerator.swift
+++ b/Sources/VariadicsGenerator/VariadicsGenerator.swift
@@ -294,8 +294,8 @@ struct VariadicsGenerator: ParsableCommand {
     var operatorName: String {
       switch self {
       case .zeroOrOne: return ".?"
-      case .zeroOrMore: return ".+"
-      case .oneOrMore: return ".*"
+      case .zeroOrMore: return ".*"
+      case .oneOrMore: return ".+"
       }
     }
 
@@ -320,16 +320,16 @@ struct VariadicsGenerator: ParsableCommand {
       result += "Component: \(regexProtocolName)"
       return result
     }()
-    let captures = (0..<arity).map { "C\($0)" }.joined(separator: ", ")
-    let capturesTupled = arity == 1 ? captures : "(\(captures))"
+    let captures = (0..<arity).map { "C\($0)" }
+    let capturesJoined = captures.joined(separator: ", ")
     let whereClause: String = arity == 0 ? "" :
-      "where Component.Match == (W, \(captures))"
+      "where Component.Match == (W, \(capturesJoined))"
     let quantifiedCaptures: String = {
       switch kind {
-      case .zeroOrOne:
-        return "\(capturesTupled)?"
-      case .zeroOrMore, .oneOrMore:
-        return "[\(capturesTupled)]"
+      case .zeroOrOne, .zeroOrMore:
+        return captures.map { "\($0)?" }.joined(separator: ", ")
+      case .oneOrMore:
+        return capturesJoined
       }
     }()
     let matchType = arity == 0 ? baseMatchTypeName : "(\(baseMatchTypeName), \(quantifiedCaptures))"

--- a/Sources/_MatchingEngine/Regex/Parse/CaptureStructure.swift
+++ b/Sources/_MatchingEngine/Regex/Parse/CaptureStructure.swift
@@ -46,7 +46,6 @@ extension CaptureStructure.Constructor {
   public mutating func alternating<C: Collection>(
     _ children: C
   ) -> CaptureStructure where C.Element: _TreeNode {
-//    assert(children.count > 1)
     return children.map {
       $0._captureStructure(&self)
     }.reduce(.empty, +)
@@ -113,17 +112,15 @@ extension CaptureStructure.Constructor {
     }
     let branchCaptures = trueBranch._captureStructure(&self) +
                          falseBranch._captureStructure(&self)
-    return captures + branchCaptures.map(
-      CaptureStructure.optional)
+    return captures + branchCaptures.map(CaptureStructure.optional)
   }
 
   public mutating func quantifying<T: _TreeNode>(
     _ child: T, amount: AST.Quantification.Amount
   ) -> CaptureStructure {
-    return child._captureStructure(&self).map(
-      amount == .zeroOrOne
-        ? CaptureStructure.optional
-        : CaptureStructure.array)
+    let result = child._captureStructure(&self)
+    return amount.bounds.atLeast == 0
+      ? result.map(CaptureStructure.optional) : result
   }
 
   // TODO: Will need to adjust for DSLTree support, and

--- a/Sources/_StringProcessing/RegexDSL/Variadics.swift
+++ b/Sources/_StringProcessing/RegexDSL/Variadics.swift
@@ -517,7 +517,7 @@ public func zeroOrMore<Component: RegexProtocol>(
 }
 
 @_disfavoredOverload
-public postfix func .+<Component: RegexProtocol>(
+public postfix func .*<Component: RegexProtocol>(
   _ component: Component
 ) -> Regex<Substring>  {
   .init(node: .quantification(.zeroOrMore, .eager, component.regex.root))
@@ -541,7 +541,7 @@ public func oneOrMore<Component: RegexProtocol>(
 }
 
 @_disfavoredOverload
-public postfix func .*<Component: RegexProtocol>(
+public postfix func .+<Component: RegexProtocol>(
   _ component: Component
 ) -> Regex<Substring>  {
   .init(node: .quantification(.oneOrMore, .eager, component.regex.root))
@@ -582,7 +582,7 @@ extension RegexBuilder {
 public func zeroOrMore<W, C0, Component: RegexProtocol>(
   _ component: Component,
   _ behavior: QuantificationBehavior = .eagerly
-) -> Regex<(Substring, [C0])> where Component.Match == (W, C0) {
+) -> Regex<(Substring, C0?)> where Component.Match == (W, C0) {
   .init(node: .quantification(.zeroOrMore, behavior.astKind, component.regex.root))
 }
 
@@ -590,14 +590,14 @@ public func zeroOrMore<W, C0, Component: RegexProtocol>(
 public func zeroOrMore<W, C0, Component: RegexProtocol>(
   _ behavior: QuantificationBehavior = .eagerly,
   @RegexBuilder _ component: () -> Component
-) -> Regex<(Substring, [C0])> where Component.Match == (W, C0) {
+) -> Regex<(Substring, C0?)> where Component.Match == (W, C0) {
   .init(node: .quantification(.zeroOrMore, behavior.astKind, component().regex.root))
 }
 
 
-public postfix func .+<W, C0, Component: RegexProtocol>(
+public postfix func .*<W, C0, Component: RegexProtocol>(
   _ component: Component
-) -> Regex<(Substring, [C0])> where Component.Match == (W, C0) {
+) -> Regex<(Substring, C0?)> where Component.Match == (W, C0) {
   .init(node: .quantification(.zeroOrMore, .eager, component.regex.root))
 }
 
@@ -606,7 +606,7 @@ public postfix func .+<W, C0, Component: RegexProtocol>(
 public func oneOrMore<W, C0, Component: RegexProtocol>(
   _ component: Component,
   _ behavior: QuantificationBehavior = .eagerly
-) -> Regex<(Substring, [C0])> where Component.Match == (W, C0) {
+) -> Regex<(Substring, C0)> where Component.Match == (W, C0) {
   .init(node: .quantification(.oneOrMore, behavior.astKind, component.regex.root))
 }
 
@@ -614,14 +614,14 @@ public func oneOrMore<W, C0, Component: RegexProtocol>(
 public func oneOrMore<W, C0, Component: RegexProtocol>(
   _ behavior: QuantificationBehavior = .eagerly,
   @RegexBuilder _ component: () -> Component
-) -> Regex<(Substring, [C0])> where Component.Match == (W, C0) {
+) -> Regex<(Substring, C0)> where Component.Match == (W, C0) {
   .init(node: .quantification(.oneOrMore, behavior.astKind, component().regex.root))
 }
 
 
-public postfix func .*<W, C0, Component: RegexProtocol>(
+public postfix func .+<W, C0, Component: RegexProtocol>(
   _ component: Component
-) -> Regex<(Substring, [C0])> where Component.Match == (W, C0) {
+) -> Regex<(Substring, C0)> where Component.Match == (W, C0) {
   .init(node: .quantification(.oneOrMore, .eager, component.regex.root))
 }
 
@@ -630,7 +630,7 @@ public postfix func .*<W, C0, Component: RegexProtocol>(
 public func optionally<W, C0, C1, Component: RegexProtocol>(
   _ component: Component,
   _ behavior: QuantificationBehavior = .eagerly
-) -> Regex<(Substring, (C0, C1)?)> where Component.Match == (W, C0, C1) {
+) -> Regex<(Substring, C0?, C1?)> where Component.Match == (W, C0, C1) {
   .init(node: .quantification(.zeroOrOne, behavior.astKind, component.regex.root))
 }
 
@@ -638,21 +638,21 @@ public func optionally<W, C0, C1, Component: RegexProtocol>(
 public func optionally<W, C0, C1, Component: RegexProtocol>(
   _ behavior: QuantificationBehavior = .eagerly,
   @RegexBuilder _ component: () -> Component
-) -> Regex<(Substring, (C0, C1)?)> where Component.Match == (W, C0, C1) {
+) -> Regex<(Substring, C0?, C1?)> where Component.Match == (W, C0, C1) {
   .init(node: .quantification(.zeroOrOne, behavior.astKind, component().regex.root))
 }
 
 
 public postfix func .?<W, C0, C1, Component: RegexProtocol>(
   _ component: Component
-) -> Regex<(Substring, (C0, C1)?)> where Component.Match == (W, C0, C1) {
+) -> Regex<(Substring, C0?, C1?)> where Component.Match == (W, C0, C1) {
   .init(node: .quantification(.zeroOrOne, .eager, component.regex.root))
 }
 
 extension RegexBuilder {
   public static func buildLimitedAvailability<W, C0, C1, Component: RegexProtocol>(
     _ component: Component
-  ) -> Regex<(Substring, (C0, C1)?)> where Component.Match == (W, C0, C1) {
+  ) -> Regex<(Substring, C0?, C1?)> where Component.Match == (W, C0, C1) {
     .init(node: .quantification(.zeroOrOne, .eager, component.regex.root))
   }
 }
@@ -660,7 +660,7 @@ extension RegexBuilder {
 public func zeroOrMore<W, C0, C1, Component: RegexProtocol>(
   _ component: Component,
   _ behavior: QuantificationBehavior = .eagerly
-) -> Regex<(Substring, [(C0, C1)])> where Component.Match == (W, C0, C1) {
+) -> Regex<(Substring, C0?, C1?)> where Component.Match == (W, C0, C1) {
   .init(node: .quantification(.zeroOrMore, behavior.astKind, component.regex.root))
 }
 
@@ -668,14 +668,14 @@ public func zeroOrMore<W, C0, C1, Component: RegexProtocol>(
 public func zeroOrMore<W, C0, C1, Component: RegexProtocol>(
   _ behavior: QuantificationBehavior = .eagerly,
   @RegexBuilder _ component: () -> Component
-) -> Regex<(Substring, [(C0, C1)])> where Component.Match == (W, C0, C1) {
+) -> Regex<(Substring, C0?, C1?)> where Component.Match == (W, C0, C1) {
   .init(node: .quantification(.zeroOrMore, behavior.astKind, component().regex.root))
 }
 
 
-public postfix func .+<W, C0, C1, Component: RegexProtocol>(
+public postfix func .*<W, C0, C1, Component: RegexProtocol>(
   _ component: Component
-) -> Regex<(Substring, [(C0, C1)])> where Component.Match == (W, C0, C1) {
+) -> Regex<(Substring, C0?, C1?)> where Component.Match == (W, C0, C1) {
   .init(node: .quantification(.zeroOrMore, .eager, component.regex.root))
 }
 
@@ -684,7 +684,7 @@ public postfix func .+<W, C0, C1, Component: RegexProtocol>(
 public func oneOrMore<W, C0, C1, Component: RegexProtocol>(
   _ component: Component,
   _ behavior: QuantificationBehavior = .eagerly
-) -> Regex<(Substring, [(C0, C1)])> where Component.Match == (W, C0, C1) {
+) -> Regex<(Substring, C0, C1)> where Component.Match == (W, C0, C1) {
   .init(node: .quantification(.oneOrMore, behavior.astKind, component.regex.root))
 }
 
@@ -692,14 +692,14 @@ public func oneOrMore<W, C0, C1, Component: RegexProtocol>(
 public func oneOrMore<W, C0, C1, Component: RegexProtocol>(
   _ behavior: QuantificationBehavior = .eagerly,
   @RegexBuilder _ component: () -> Component
-) -> Regex<(Substring, [(C0, C1)])> where Component.Match == (W, C0, C1) {
+) -> Regex<(Substring, C0, C1)> where Component.Match == (W, C0, C1) {
   .init(node: .quantification(.oneOrMore, behavior.astKind, component().regex.root))
 }
 
 
-public postfix func .*<W, C0, C1, Component: RegexProtocol>(
+public postfix func .+<W, C0, C1, Component: RegexProtocol>(
   _ component: Component
-) -> Regex<(Substring, [(C0, C1)])> where Component.Match == (W, C0, C1) {
+) -> Regex<(Substring, C0, C1)> where Component.Match == (W, C0, C1) {
   .init(node: .quantification(.oneOrMore, .eager, component.regex.root))
 }
 
@@ -708,7 +708,7 @@ public postfix func .*<W, C0, C1, Component: RegexProtocol>(
 public func optionally<W, C0, C1, C2, Component: RegexProtocol>(
   _ component: Component,
   _ behavior: QuantificationBehavior = .eagerly
-) -> Regex<(Substring, (C0, C1, C2)?)> where Component.Match == (W, C0, C1, C2) {
+) -> Regex<(Substring, C0?, C1?, C2?)> where Component.Match == (W, C0, C1, C2) {
   .init(node: .quantification(.zeroOrOne, behavior.astKind, component.regex.root))
 }
 
@@ -716,21 +716,21 @@ public func optionally<W, C0, C1, C2, Component: RegexProtocol>(
 public func optionally<W, C0, C1, C2, Component: RegexProtocol>(
   _ behavior: QuantificationBehavior = .eagerly,
   @RegexBuilder _ component: () -> Component
-) -> Regex<(Substring, (C0, C1, C2)?)> where Component.Match == (W, C0, C1, C2) {
+) -> Regex<(Substring, C0?, C1?, C2?)> where Component.Match == (W, C0, C1, C2) {
   .init(node: .quantification(.zeroOrOne, behavior.astKind, component().regex.root))
 }
 
 
 public postfix func .?<W, C0, C1, C2, Component: RegexProtocol>(
   _ component: Component
-) -> Regex<(Substring, (C0, C1, C2)?)> where Component.Match == (W, C0, C1, C2) {
+) -> Regex<(Substring, C0?, C1?, C2?)> where Component.Match == (W, C0, C1, C2) {
   .init(node: .quantification(.zeroOrOne, .eager, component.regex.root))
 }
 
 extension RegexBuilder {
   public static func buildLimitedAvailability<W, C0, C1, C2, Component: RegexProtocol>(
     _ component: Component
-  ) -> Regex<(Substring, (C0, C1, C2)?)> where Component.Match == (W, C0, C1, C2) {
+  ) -> Regex<(Substring, C0?, C1?, C2?)> where Component.Match == (W, C0, C1, C2) {
     .init(node: .quantification(.zeroOrOne, .eager, component.regex.root))
   }
 }
@@ -738,7 +738,7 @@ extension RegexBuilder {
 public func zeroOrMore<W, C0, C1, C2, Component: RegexProtocol>(
   _ component: Component,
   _ behavior: QuantificationBehavior = .eagerly
-) -> Regex<(Substring, [(C0, C1, C2)])> where Component.Match == (W, C0, C1, C2) {
+) -> Regex<(Substring, C0?, C1?, C2?)> where Component.Match == (W, C0, C1, C2) {
   .init(node: .quantification(.zeroOrMore, behavior.astKind, component.regex.root))
 }
 
@@ -746,14 +746,14 @@ public func zeroOrMore<W, C0, C1, C2, Component: RegexProtocol>(
 public func zeroOrMore<W, C0, C1, C2, Component: RegexProtocol>(
   _ behavior: QuantificationBehavior = .eagerly,
   @RegexBuilder _ component: () -> Component
-) -> Regex<(Substring, [(C0, C1, C2)])> where Component.Match == (W, C0, C1, C2) {
+) -> Regex<(Substring, C0?, C1?, C2?)> where Component.Match == (W, C0, C1, C2) {
   .init(node: .quantification(.zeroOrMore, behavior.astKind, component().regex.root))
 }
 
 
-public postfix func .+<W, C0, C1, C2, Component: RegexProtocol>(
+public postfix func .*<W, C0, C1, C2, Component: RegexProtocol>(
   _ component: Component
-) -> Regex<(Substring, [(C0, C1, C2)])> where Component.Match == (W, C0, C1, C2) {
+) -> Regex<(Substring, C0?, C1?, C2?)> where Component.Match == (W, C0, C1, C2) {
   .init(node: .quantification(.zeroOrMore, .eager, component.regex.root))
 }
 
@@ -762,7 +762,7 @@ public postfix func .+<W, C0, C1, C2, Component: RegexProtocol>(
 public func oneOrMore<W, C0, C1, C2, Component: RegexProtocol>(
   _ component: Component,
   _ behavior: QuantificationBehavior = .eagerly
-) -> Regex<(Substring, [(C0, C1, C2)])> where Component.Match == (W, C0, C1, C2) {
+) -> Regex<(Substring, C0, C1, C2)> where Component.Match == (W, C0, C1, C2) {
   .init(node: .quantification(.oneOrMore, behavior.astKind, component.regex.root))
 }
 
@@ -770,14 +770,14 @@ public func oneOrMore<W, C0, C1, C2, Component: RegexProtocol>(
 public func oneOrMore<W, C0, C1, C2, Component: RegexProtocol>(
   _ behavior: QuantificationBehavior = .eagerly,
   @RegexBuilder _ component: () -> Component
-) -> Regex<(Substring, [(C0, C1, C2)])> where Component.Match == (W, C0, C1, C2) {
+) -> Regex<(Substring, C0, C1, C2)> where Component.Match == (W, C0, C1, C2) {
   .init(node: .quantification(.oneOrMore, behavior.astKind, component().regex.root))
 }
 
 
-public postfix func .*<W, C0, C1, C2, Component: RegexProtocol>(
+public postfix func .+<W, C0, C1, C2, Component: RegexProtocol>(
   _ component: Component
-) -> Regex<(Substring, [(C0, C1, C2)])> where Component.Match == (W, C0, C1, C2) {
+) -> Regex<(Substring, C0, C1, C2)> where Component.Match == (W, C0, C1, C2) {
   .init(node: .quantification(.oneOrMore, .eager, component.regex.root))
 }
 
@@ -786,7 +786,7 @@ public postfix func .*<W, C0, C1, C2, Component: RegexProtocol>(
 public func optionally<W, C0, C1, C2, C3, Component: RegexProtocol>(
   _ component: Component,
   _ behavior: QuantificationBehavior = .eagerly
-) -> Regex<(Substring, (C0, C1, C2, C3)?)> where Component.Match == (W, C0, C1, C2, C3) {
+) -> Regex<(Substring, C0?, C1?, C2?, C3?)> where Component.Match == (W, C0, C1, C2, C3) {
   .init(node: .quantification(.zeroOrOne, behavior.astKind, component.regex.root))
 }
 
@@ -794,21 +794,21 @@ public func optionally<W, C0, C1, C2, C3, Component: RegexProtocol>(
 public func optionally<W, C0, C1, C2, C3, Component: RegexProtocol>(
   _ behavior: QuantificationBehavior = .eagerly,
   @RegexBuilder _ component: () -> Component
-) -> Regex<(Substring, (C0, C1, C2, C3)?)> where Component.Match == (W, C0, C1, C2, C3) {
+) -> Regex<(Substring, C0?, C1?, C2?, C3?)> where Component.Match == (W, C0, C1, C2, C3) {
   .init(node: .quantification(.zeroOrOne, behavior.astKind, component().regex.root))
 }
 
 
 public postfix func .?<W, C0, C1, C2, C3, Component: RegexProtocol>(
   _ component: Component
-) -> Regex<(Substring, (C0, C1, C2, C3)?)> where Component.Match == (W, C0, C1, C2, C3) {
+) -> Regex<(Substring, C0?, C1?, C2?, C3?)> where Component.Match == (W, C0, C1, C2, C3) {
   .init(node: .quantification(.zeroOrOne, .eager, component.regex.root))
 }
 
 extension RegexBuilder {
   public static func buildLimitedAvailability<W, C0, C1, C2, C3, Component: RegexProtocol>(
     _ component: Component
-  ) -> Regex<(Substring, (C0, C1, C2, C3)?)> where Component.Match == (W, C0, C1, C2, C3) {
+  ) -> Regex<(Substring, C0?, C1?, C2?, C3?)> where Component.Match == (W, C0, C1, C2, C3) {
     .init(node: .quantification(.zeroOrOne, .eager, component.regex.root))
   }
 }
@@ -816,7 +816,7 @@ extension RegexBuilder {
 public func zeroOrMore<W, C0, C1, C2, C3, Component: RegexProtocol>(
   _ component: Component,
   _ behavior: QuantificationBehavior = .eagerly
-) -> Regex<(Substring, [(C0, C1, C2, C3)])> where Component.Match == (W, C0, C1, C2, C3) {
+) -> Regex<(Substring, C0?, C1?, C2?, C3?)> where Component.Match == (W, C0, C1, C2, C3) {
   .init(node: .quantification(.zeroOrMore, behavior.astKind, component.regex.root))
 }
 
@@ -824,14 +824,14 @@ public func zeroOrMore<W, C0, C1, C2, C3, Component: RegexProtocol>(
 public func zeroOrMore<W, C0, C1, C2, C3, Component: RegexProtocol>(
   _ behavior: QuantificationBehavior = .eagerly,
   @RegexBuilder _ component: () -> Component
-) -> Regex<(Substring, [(C0, C1, C2, C3)])> where Component.Match == (W, C0, C1, C2, C3) {
+) -> Regex<(Substring, C0?, C1?, C2?, C3?)> where Component.Match == (W, C0, C1, C2, C3) {
   .init(node: .quantification(.zeroOrMore, behavior.astKind, component().regex.root))
 }
 
 
-public postfix func .+<W, C0, C1, C2, C3, Component: RegexProtocol>(
+public postfix func .*<W, C0, C1, C2, C3, Component: RegexProtocol>(
   _ component: Component
-) -> Regex<(Substring, [(C0, C1, C2, C3)])> where Component.Match == (W, C0, C1, C2, C3) {
+) -> Regex<(Substring, C0?, C1?, C2?, C3?)> where Component.Match == (W, C0, C1, C2, C3) {
   .init(node: .quantification(.zeroOrMore, .eager, component.regex.root))
 }
 
@@ -840,7 +840,7 @@ public postfix func .+<W, C0, C1, C2, C3, Component: RegexProtocol>(
 public func oneOrMore<W, C0, C1, C2, C3, Component: RegexProtocol>(
   _ component: Component,
   _ behavior: QuantificationBehavior = .eagerly
-) -> Regex<(Substring, [(C0, C1, C2, C3)])> where Component.Match == (W, C0, C1, C2, C3) {
+) -> Regex<(Substring, C0, C1, C2, C3)> where Component.Match == (W, C0, C1, C2, C3) {
   .init(node: .quantification(.oneOrMore, behavior.astKind, component.regex.root))
 }
 
@@ -848,14 +848,14 @@ public func oneOrMore<W, C0, C1, C2, C3, Component: RegexProtocol>(
 public func oneOrMore<W, C0, C1, C2, C3, Component: RegexProtocol>(
   _ behavior: QuantificationBehavior = .eagerly,
   @RegexBuilder _ component: () -> Component
-) -> Regex<(Substring, [(C0, C1, C2, C3)])> where Component.Match == (W, C0, C1, C2, C3) {
+) -> Regex<(Substring, C0, C1, C2, C3)> where Component.Match == (W, C0, C1, C2, C3) {
   .init(node: .quantification(.oneOrMore, behavior.astKind, component().regex.root))
 }
 
 
-public postfix func .*<W, C0, C1, C2, C3, Component: RegexProtocol>(
+public postfix func .+<W, C0, C1, C2, C3, Component: RegexProtocol>(
   _ component: Component
-) -> Regex<(Substring, [(C0, C1, C2, C3)])> where Component.Match == (W, C0, C1, C2, C3) {
+) -> Regex<(Substring, C0, C1, C2, C3)> where Component.Match == (W, C0, C1, C2, C3) {
   .init(node: .quantification(.oneOrMore, .eager, component.regex.root))
 }
 
@@ -864,7 +864,7 @@ public postfix func .*<W, C0, C1, C2, C3, Component: RegexProtocol>(
 public func optionally<W, C0, C1, C2, C3, C4, Component: RegexProtocol>(
   _ component: Component,
   _ behavior: QuantificationBehavior = .eagerly
-) -> Regex<(Substring, (C0, C1, C2, C3, C4)?)> where Component.Match == (W, C0, C1, C2, C3, C4) {
+) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?)> where Component.Match == (W, C0, C1, C2, C3, C4) {
   .init(node: .quantification(.zeroOrOne, behavior.astKind, component.regex.root))
 }
 
@@ -872,21 +872,21 @@ public func optionally<W, C0, C1, C2, C3, C4, Component: RegexProtocol>(
 public func optionally<W, C0, C1, C2, C3, C4, Component: RegexProtocol>(
   _ behavior: QuantificationBehavior = .eagerly,
   @RegexBuilder _ component: () -> Component
-) -> Regex<(Substring, (C0, C1, C2, C3, C4)?)> where Component.Match == (W, C0, C1, C2, C3, C4) {
+) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?)> where Component.Match == (W, C0, C1, C2, C3, C4) {
   .init(node: .quantification(.zeroOrOne, behavior.astKind, component().regex.root))
 }
 
 
 public postfix func .?<W, C0, C1, C2, C3, C4, Component: RegexProtocol>(
   _ component: Component
-) -> Regex<(Substring, (C0, C1, C2, C3, C4)?)> where Component.Match == (W, C0, C1, C2, C3, C4) {
+) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?)> where Component.Match == (W, C0, C1, C2, C3, C4) {
   .init(node: .quantification(.zeroOrOne, .eager, component.regex.root))
 }
 
 extension RegexBuilder {
   public static func buildLimitedAvailability<W, C0, C1, C2, C3, C4, Component: RegexProtocol>(
     _ component: Component
-  ) -> Regex<(Substring, (C0, C1, C2, C3, C4)?)> where Component.Match == (W, C0, C1, C2, C3, C4) {
+  ) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?)> where Component.Match == (W, C0, C1, C2, C3, C4) {
     .init(node: .quantification(.zeroOrOne, .eager, component.regex.root))
   }
 }
@@ -894,7 +894,7 @@ extension RegexBuilder {
 public func zeroOrMore<W, C0, C1, C2, C3, C4, Component: RegexProtocol>(
   _ component: Component,
   _ behavior: QuantificationBehavior = .eagerly
-) -> Regex<(Substring, [(C0, C1, C2, C3, C4)])> where Component.Match == (W, C0, C1, C2, C3, C4) {
+) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?)> where Component.Match == (W, C0, C1, C2, C3, C4) {
   .init(node: .quantification(.zeroOrMore, behavior.astKind, component.regex.root))
 }
 
@@ -902,14 +902,14 @@ public func zeroOrMore<W, C0, C1, C2, C3, C4, Component: RegexProtocol>(
 public func zeroOrMore<W, C0, C1, C2, C3, C4, Component: RegexProtocol>(
   _ behavior: QuantificationBehavior = .eagerly,
   @RegexBuilder _ component: () -> Component
-) -> Regex<(Substring, [(C0, C1, C2, C3, C4)])> where Component.Match == (W, C0, C1, C2, C3, C4) {
+) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?)> where Component.Match == (W, C0, C1, C2, C3, C4) {
   .init(node: .quantification(.zeroOrMore, behavior.astKind, component().regex.root))
 }
 
 
-public postfix func .+<W, C0, C1, C2, C3, C4, Component: RegexProtocol>(
+public postfix func .*<W, C0, C1, C2, C3, C4, Component: RegexProtocol>(
   _ component: Component
-) -> Regex<(Substring, [(C0, C1, C2, C3, C4)])> where Component.Match == (W, C0, C1, C2, C3, C4) {
+) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?)> where Component.Match == (W, C0, C1, C2, C3, C4) {
   .init(node: .quantification(.zeroOrMore, .eager, component.regex.root))
 }
 
@@ -918,7 +918,7 @@ public postfix func .+<W, C0, C1, C2, C3, C4, Component: RegexProtocol>(
 public func oneOrMore<W, C0, C1, C2, C3, C4, Component: RegexProtocol>(
   _ component: Component,
   _ behavior: QuantificationBehavior = .eagerly
-) -> Regex<(Substring, [(C0, C1, C2, C3, C4)])> where Component.Match == (W, C0, C1, C2, C3, C4) {
+) -> Regex<(Substring, C0, C1, C2, C3, C4)> where Component.Match == (W, C0, C1, C2, C3, C4) {
   .init(node: .quantification(.oneOrMore, behavior.astKind, component.regex.root))
 }
 
@@ -926,14 +926,14 @@ public func oneOrMore<W, C0, C1, C2, C3, C4, Component: RegexProtocol>(
 public func oneOrMore<W, C0, C1, C2, C3, C4, Component: RegexProtocol>(
   _ behavior: QuantificationBehavior = .eagerly,
   @RegexBuilder _ component: () -> Component
-) -> Regex<(Substring, [(C0, C1, C2, C3, C4)])> where Component.Match == (W, C0, C1, C2, C3, C4) {
+) -> Regex<(Substring, C0, C1, C2, C3, C4)> where Component.Match == (W, C0, C1, C2, C3, C4) {
   .init(node: .quantification(.oneOrMore, behavior.astKind, component().regex.root))
 }
 
 
-public postfix func .*<W, C0, C1, C2, C3, C4, Component: RegexProtocol>(
+public postfix func .+<W, C0, C1, C2, C3, C4, Component: RegexProtocol>(
   _ component: Component
-) -> Regex<(Substring, [(C0, C1, C2, C3, C4)])> where Component.Match == (W, C0, C1, C2, C3, C4) {
+) -> Regex<(Substring, C0, C1, C2, C3, C4)> where Component.Match == (W, C0, C1, C2, C3, C4) {
   .init(node: .quantification(.oneOrMore, .eager, component.regex.root))
 }
 
@@ -942,7 +942,7 @@ public postfix func .*<W, C0, C1, C2, C3, C4, Component: RegexProtocol>(
 public func optionally<W, C0, C1, C2, C3, C4, C5, Component: RegexProtocol>(
   _ component: Component,
   _ behavior: QuantificationBehavior = .eagerly
-) -> Regex<(Substring, (C0, C1, C2, C3, C4, C5)?)> where Component.Match == (W, C0, C1, C2, C3, C4, C5) {
+) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?)> where Component.Match == (W, C0, C1, C2, C3, C4, C5) {
   .init(node: .quantification(.zeroOrOne, behavior.astKind, component.regex.root))
 }
 
@@ -950,21 +950,21 @@ public func optionally<W, C0, C1, C2, C3, C4, C5, Component: RegexProtocol>(
 public func optionally<W, C0, C1, C2, C3, C4, C5, Component: RegexProtocol>(
   _ behavior: QuantificationBehavior = .eagerly,
   @RegexBuilder _ component: () -> Component
-) -> Regex<(Substring, (C0, C1, C2, C3, C4, C5)?)> where Component.Match == (W, C0, C1, C2, C3, C4, C5) {
+) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?)> where Component.Match == (W, C0, C1, C2, C3, C4, C5) {
   .init(node: .quantification(.zeroOrOne, behavior.astKind, component().regex.root))
 }
 
 
 public postfix func .?<W, C0, C1, C2, C3, C4, C5, Component: RegexProtocol>(
   _ component: Component
-) -> Regex<(Substring, (C0, C1, C2, C3, C4, C5)?)> where Component.Match == (W, C0, C1, C2, C3, C4, C5) {
+) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?)> where Component.Match == (W, C0, C1, C2, C3, C4, C5) {
   .init(node: .quantification(.zeroOrOne, .eager, component.regex.root))
 }
 
 extension RegexBuilder {
   public static func buildLimitedAvailability<W, C0, C1, C2, C3, C4, C5, Component: RegexProtocol>(
     _ component: Component
-  ) -> Regex<(Substring, (C0, C1, C2, C3, C4, C5)?)> where Component.Match == (W, C0, C1, C2, C3, C4, C5) {
+  ) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?)> where Component.Match == (W, C0, C1, C2, C3, C4, C5) {
     .init(node: .quantification(.zeroOrOne, .eager, component.regex.root))
   }
 }
@@ -972,7 +972,7 @@ extension RegexBuilder {
 public func zeroOrMore<W, C0, C1, C2, C3, C4, C5, Component: RegexProtocol>(
   _ component: Component,
   _ behavior: QuantificationBehavior = .eagerly
-) -> Regex<(Substring, [(C0, C1, C2, C3, C4, C5)])> where Component.Match == (W, C0, C1, C2, C3, C4, C5) {
+) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?)> where Component.Match == (W, C0, C1, C2, C3, C4, C5) {
   .init(node: .quantification(.zeroOrMore, behavior.astKind, component.regex.root))
 }
 
@@ -980,14 +980,14 @@ public func zeroOrMore<W, C0, C1, C2, C3, C4, C5, Component: RegexProtocol>(
 public func zeroOrMore<W, C0, C1, C2, C3, C4, C5, Component: RegexProtocol>(
   _ behavior: QuantificationBehavior = .eagerly,
   @RegexBuilder _ component: () -> Component
-) -> Regex<(Substring, [(C0, C1, C2, C3, C4, C5)])> where Component.Match == (W, C0, C1, C2, C3, C4, C5) {
+) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?)> where Component.Match == (W, C0, C1, C2, C3, C4, C5) {
   .init(node: .quantification(.zeroOrMore, behavior.astKind, component().regex.root))
 }
 
 
-public postfix func .+<W, C0, C1, C2, C3, C4, C5, Component: RegexProtocol>(
+public postfix func .*<W, C0, C1, C2, C3, C4, C5, Component: RegexProtocol>(
   _ component: Component
-) -> Regex<(Substring, [(C0, C1, C2, C3, C4, C5)])> where Component.Match == (W, C0, C1, C2, C3, C4, C5) {
+) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?)> where Component.Match == (W, C0, C1, C2, C3, C4, C5) {
   .init(node: .quantification(.zeroOrMore, .eager, component.regex.root))
 }
 
@@ -996,7 +996,7 @@ public postfix func .+<W, C0, C1, C2, C3, C4, C5, Component: RegexProtocol>(
 public func oneOrMore<W, C0, C1, C2, C3, C4, C5, Component: RegexProtocol>(
   _ component: Component,
   _ behavior: QuantificationBehavior = .eagerly
-) -> Regex<(Substring, [(C0, C1, C2, C3, C4, C5)])> where Component.Match == (W, C0, C1, C2, C3, C4, C5) {
+) -> Regex<(Substring, C0, C1, C2, C3, C4, C5)> where Component.Match == (W, C0, C1, C2, C3, C4, C5) {
   .init(node: .quantification(.oneOrMore, behavior.astKind, component.regex.root))
 }
 
@@ -1004,14 +1004,14 @@ public func oneOrMore<W, C0, C1, C2, C3, C4, C5, Component: RegexProtocol>(
 public func oneOrMore<W, C0, C1, C2, C3, C4, C5, Component: RegexProtocol>(
   _ behavior: QuantificationBehavior = .eagerly,
   @RegexBuilder _ component: () -> Component
-) -> Regex<(Substring, [(C0, C1, C2, C3, C4, C5)])> where Component.Match == (W, C0, C1, C2, C3, C4, C5) {
+) -> Regex<(Substring, C0, C1, C2, C3, C4, C5)> where Component.Match == (W, C0, C1, C2, C3, C4, C5) {
   .init(node: .quantification(.oneOrMore, behavior.astKind, component().regex.root))
 }
 
 
-public postfix func .*<W, C0, C1, C2, C3, C4, C5, Component: RegexProtocol>(
+public postfix func .+<W, C0, C1, C2, C3, C4, C5, Component: RegexProtocol>(
   _ component: Component
-) -> Regex<(Substring, [(C0, C1, C2, C3, C4, C5)])> where Component.Match == (W, C0, C1, C2, C3, C4, C5) {
+) -> Regex<(Substring, C0, C1, C2, C3, C4, C5)> where Component.Match == (W, C0, C1, C2, C3, C4, C5) {
   .init(node: .quantification(.oneOrMore, .eager, component.regex.root))
 }
 
@@ -1020,7 +1020,7 @@ public postfix func .*<W, C0, C1, C2, C3, C4, C5, Component: RegexProtocol>(
 public func optionally<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexProtocol>(
   _ component: Component,
   _ behavior: QuantificationBehavior = .eagerly
-) -> Regex<(Substring, (C0, C1, C2, C3, C4, C5, C6)?)> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6) {
+) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?)> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6) {
   .init(node: .quantification(.zeroOrOne, behavior.astKind, component.regex.root))
 }
 
@@ -1028,21 +1028,21 @@ public func optionally<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexProtocol>(
 public func optionally<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexProtocol>(
   _ behavior: QuantificationBehavior = .eagerly,
   @RegexBuilder _ component: () -> Component
-) -> Regex<(Substring, (C0, C1, C2, C3, C4, C5, C6)?)> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6) {
+) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?)> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6) {
   .init(node: .quantification(.zeroOrOne, behavior.astKind, component().regex.root))
 }
 
 
 public postfix func .?<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexProtocol>(
   _ component: Component
-) -> Regex<(Substring, (C0, C1, C2, C3, C4, C5, C6)?)> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6) {
+) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?)> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6) {
   .init(node: .quantification(.zeroOrOne, .eager, component.regex.root))
 }
 
 extension RegexBuilder {
   public static func buildLimitedAvailability<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexProtocol>(
     _ component: Component
-  ) -> Regex<(Substring, (C0, C1, C2, C3, C4, C5, C6)?)> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6) {
+  ) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?)> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6) {
     .init(node: .quantification(.zeroOrOne, .eager, component.regex.root))
   }
 }
@@ -1050,7 +1050,7 @@ extension RegexBuilder {
 public func zeroOrMore<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexProtocol>(
   _ component: Component,
   _ behavior: QuantificationBehavior = .eagerly
-) -> Regex<(Substring, [(C0, C1, C2, C3, C4, C5, C6)])> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6) {
+) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?)> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6) {
   .init(node: .quantification(.zeroOrMore, behavior.astKind, component.regex.root))
 }
 
@@ -1058,14 +1058,14 @@ public func zeroOrMore<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexProtocol>(
 public func zeroOrMore<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexProtocol>(
   _ behavior: QuantificationBehavior = .eagerly,
   @RegexBuilder _ component: () -> Component
-) -> Regex<(Substring, [(C0, C1, C2, C3, C4, C5, C6)])> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6) {
+) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?)> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6) {
   .init(node: .quantification(.zeroOrMore, behavior.astKind, component().regex.root))
 }
 
 
-public postfix func .+<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexProtocol>(
+public postfix func .*<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexProtocol>(
   _ component: Component
-) -> Regex<(Substring, [(C0, C1, C2, C3, C4, C5, C6)])> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6) {
+) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?)> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6) {
   .init(node: .quantification(.zeroOrMore, .eager, component.regex.root))
 }
 
@@ -1074,7 +1074,7 @@ public postfix func .+<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexProtocol>(
 public func oneOrMore<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexProtocol>(
   _ component: Component,
   _ behavior: QuantificationBehavior = .eagerly
-) -> Regex<(Substring, [(C0, C1, C2, C3, C4, C5, C6)])> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6) {
+) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6)> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6) {
   .init(node: .quantification(.oneOrMore, behavior.astKind, component.regex.root))
 }
 
@@ -1082,14 +1082,14 @@ public func oneOrMore<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexProtocol>(
 public func oneOrMore<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexProtocol>(
   _ behavior: QuantificationBehavior = .eagerly,
   @RegexBuilder _ component: () -> Component
-) -> Regex<(Substring, [(C0, C1, C2, C3, C4, C5, C6)])> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6) {
+) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6)> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6) {
   .init(node: .quantification(.oneOrMore, behavior.astKind, component().regex.root))
 }
 
 
-public postfix func .*<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexProtocol>(
+public postfix func .+<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexProtocol>(
   _ component: Component
-) -> Regex<(Substring, [(C0, C1, C2, C3, C4, C5, C6)])> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6) {
+) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6)> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6) {
   .init(node: .quantification(.oneOrMore, .eager, component.regex.root))
 }
 
@@ -1098,7 +1098,7 @@ public postfix func .*<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexProtocol>(
 public func optionally<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexProtocol>(
   _ component: Component,
   _ behavior: QuantificationBehavior = .eagerly
-) -> Regex<(Substring, (C0, C1, C2, C3, C4, C5, C6, C7)?)> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
+) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?)> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
   .init(node: .quantification(.zeroOrOne, behavior.astKind, component.regex.root))
 }
 
@@ -1106,21 +1106,21 @@ public func optionally<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexProtoc
 public func optionally<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexProtocol>(
   _ behavior: QuantificationBehavior = .eagerly,
   @RegexBuilder _ component: () -> Component
-) -> Regex<(Substring, (C0, C1, C2, C3, C4, C5, C6, C7)?)> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
+) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?)> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
   .init(node: .quantification(.zeroOrOne, behavior.astKind, component().regex.root))
 }
 
 
 public postfix func .?<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexProtocol>(
   _ component: Component
-) -> Regex<(Substring, (C0, C1, C2, C3, C4, C5, C6, C7)?)> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
+) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?)> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
   .init(node: .quantification(.zeroOrOne, .eager, component.regex.root))
 }
 
 extension RegexBuilder {
   public static func buildLimitedAvailability<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexProtocol>(
     _ component: Component
-  ) -> Regex<(Substring, (C0, C1, C2, C3, C4, C5, C6, C7)?)> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
+  ) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?)> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
     .init(node: .quantification(.zeroOrOne, .eager, component.regex.root))
   }
 }
@@ -1128,7 +1128,7 @@ extension RegexBuilder {
 public func zeroOrMore<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexProtocol>(
   _ component: Component,
   _ behavior: QuantificationBehavior = .eagerly
-) -> Regex<(Substring, [(C0, C1, C2, C3, C4, C5, C6, C7)])> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
+) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?)> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
   .init(node: .quantification(.zeroOrMore, behavior.astKind, component.regex.root))
 }
 
@@ -1136,14 +1136,14 @@ public func zeroOrMore<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexProtoc
 public func zeroOrMore<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexProtocol>(
   _ behavior: QuantificationBehavior = .eagerly,
   @RegexBuilder _ component: () -> Component
-) -> Regex<(Substring, [(C0, C1, C2, C3, C4, C5, C6, C7)])> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
+) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?)> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
   .init(node: .quantification(.zeroOrMore, behavior.astKind, component().regex.root))
 }
 
 
-public postfix func .+<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexProtocol>(
+public postfix func .*<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexProtocol>(
   _ component: Component
-) -> Regex<(Substring, [(C0, C1, C2, C3, C4, C5, C6, C7)])> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
+) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?)> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
   .init(node: .quantification(.zeroOrMore, .eager, component.regex.root))
 }
 
@@ -1152,7 +1152,7 @@ public postfix func .+<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexProtoc
 public func oneOrMore<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexProtocol>(
   _ component: Component,
   _ behavior: QuantificationBehavior = .eagerly
-) -> Regex<(Substring, [(C0, C1, C2, C3, C4, C5, C6, C7)])> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
+) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7)> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
   .init(node: .quantification(.oneOrMore, behavior.astKind, component.regex.root))
 }
 
@@ -1160,14 +1160,14 @@ public func oneOrMore<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexProtoco
 public func oneOrMore<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexProtocol>(
   _ behavior: QuantificationBehavior = .eagerly,
   @RegexBuilder _ component: () -> Component
-) -> Regex<(Substring, [(C0, C1, C2, C3, C4, C5, C6, C7)])> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
+) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7)> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
   .init(node: .quantification(.oneOrMore, behavior.astKind, component().regex.root))
 }
 
 
-public postfix func .*<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexProtocol>(
+public postfix func .+<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexProtocol>(
   _ component: Component
-) -> Regex<(Substring, [(C0, C1, C2, C3, C4, C5, C6, C7)])> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
+) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7)> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
   .init(node: .quantification(.oneOrMore, .eager, component.regex.root))
 }
 
@@ -1176,7 +1176,7 @@ public postfix func .*<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexProtoc
 public func optionally<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexProtocol>(
   _ component: Component,
   _ behavior: QuantificationBehavior = .eagerly
-) -> Regex<(Substring, (C0, C1, C2, C3, C4, C5, C6, C7, C8)?)> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
+) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?)> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
   .init(node: .quantification(.zeroOrOne, behavior.astKind, component.regex.root))
 }
 
@@ -1184,21 +1184,21 @@ public func optionally<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexPr
 public func optionally<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexProtocol>(
   _ behavior: QuantificationBehavior = .eagerly,
   @RegexBuilder _ component: () -> Component
-) -> Regex<(Substring, (C0, C1, C2, C3, C4, C5, C6, C7, C8)?)> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
+) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?)> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
   .init(node: .quantification(.zeroOrOne, behavior.astKind, component().regex.root))
 }
 
 
 public postfix func .?<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexProtocol>(
   _ component: Component
-) -> Regex<(Substring, (C0, C1, C2, C3, C4, C5, C6, C7, C8)?)> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
+) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?)> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
   .init(node: .quantification(.zeroOrOne, .eager, component.regex.root))
 }
 
 extension RegexBuilder {
   public static func buildLimitedAvailability<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexProtocol>(
     _ component: Component
-  ) -> Regex<(Substring, (C0, C1, C2, C3, C4, C5, C6, C7, C8)?)> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
+  ) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?)> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
     .init(node: .quantification(.zeroOrOne, .eager, component.regex.root))
   }
 }
@@ -1206,7 +1206,7 @@ extension RegexBuilder {
 public func zeroOrMore<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexProtocol>(
   _ component: Component,
   _ behavior: QuantificationBehavior = .eagerly
-) -> Regex<(Substring, [(C0, C1, C2, C3, C4, C5, C6, C7, C8)])> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
+) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?)> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
   .init(node: .quantification(.zeroOrMore, behavior.astKind, component.regex.root))
 }
 
@@ -1214,14 +1214,14 @@ public func zeroOrMore<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexPr
 public func zeroOrMore<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexProtocol>(
   _ behavior: QuantificationBehavior = .eagerly,
   @RegexBuilder _ component: () -> Component
-) -> Regex<(Substring, [(C0, C1, C2, C3, C4, C5, C6, C7, C8)])> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
+) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?)> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
   .init(node: .quantification(.zeroOrMore, behavior.astKind, component().regex.root))
 }
 
 
-public postfix func .+<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexProtocol>(
+public postfix func .*<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexProtocol>(
   _ component: Component
-) -> Regex<(Substring, [(C0, C1, C2, C3, C4, C5, C6, C7, C8)])> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
+) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?)> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
   .init(node: .quantification(.zeroOrMore, .eager, component.regex.root))
 }
 
@@ -1230,7 +1230,7 @@ public postfix func .+<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexPr
 public func oneOrMore<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexProtocol>(
   _ component: Component,
   _ behavior: QuantificationBehavior = .eagerly
-) -> Regex<(Substring, [(C0, C1, C2, C3, C4, C5, C6, C7, C8)])> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
+) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8)> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
   .init(node: .quantification(.oneOrMore, behavior.astKind, component.regex.root))
 }
 
@@ -1238,14 +1238,14 @@ public func oneOrMore<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexPro
 public func oneOrMore<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexProtocol>(
   _ behavior: QuantificationBehavior = .eagerly,
   @RegexBuilder _ component: () -> Component
-) -> Regex<(Substring, [(C0, C1, C2, C3, C4, C5, C6, C7, C8)])> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
+) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8)> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
   .init(node: .quantification(.oneOrMore, behavior.astKind, component().regex.root))
 }
 
 
-public postfix func .*<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexProtocol>(
+public postfix func .+<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexProtocol>(
   _ component: Component
-) -> Regex<(Substring, [(C0, C1, C2, C3, C4, C5, C6, C7, C8)])> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
+) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8)> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
   .init(node: .quantification(.oneOrMore, .eager, component.regex.root))
 }
 

--- a/Tests/RegexTests/AlgorithmsTests.swift
+++ b/Tests/RegexTests/AlgorithmsTests.swift
@@ -146,12 +146,13 @@ class RegexConsumerTests: XCTestCase {
       input: "9+16, 0+3, 5+5, 99+1",
       result: "25, 3, 10, 100",
       { match in "\(match.result.1 + match.result.2)" })
-    
-    replaceTest(
-      oneOrMore { int; "," },
-      input: "3,5,8,0, 1,0,2,-5,x8,8,",
-      result: "16 3-5x16",
-      { match in "\(match.result.1.reduce(0, +))" })
+
+    // TODO: Need to support capture history
+    // replaceTest(
+    //   oneOrMore { int; "," },
+    //   input: "3,5,8,0, 1,0,2,-5,x8,8,",
+    //   result: "16 3-5x16",
+    //   { match in "\(match.result.1.reduce(0, +))" })
     
     replaceTest(
       Regex { int; "x"; int; optionally { "x"; int } },

--- a/Tests/RegexTests/ParseTests.swift
+++ b/Tests/RegexTests/ParseTests.swift
@@ -250,14 +250,14 @@ extension RegexTests {
       concat(
         zeroOrMore(of: capture(atom(.any))),
         capture(zeroOrMore(of: atom(.any)))),
-      captures: .tuple([.array(.atom()), .atom()]))
+      captures: .tuple([.optional(.atom()), .atom()]))
     parseTest(
       "((.))*((.)?)",
       concat(
         zeroOrMore(of: capture(capture(atom(.any)))),
         capture(zeroOrOne(of: capture(atom(.any))))),
       captures: .tuple([
-        .array(.atom()), .array(.atom()), .atom(), .optional(.atom())
+        .optional(.atom()), .optional(.atom()), .atom(), .optional(.atom())
       ]))
     parseTest(
       #"abc\d"#,
@@ -289,7 +289,7 @@ extension RegexTests {
       concat(quant(
         .zeroOrMore, .reluctant,
         nonCapture(capture(capture(alt("a", "b"))))), "c"),
-      captures: .tuple(.array(.atom()), .array(.atom())))
+      captures: .tuple(.optional(.atom()), .optional(.atom())))
     parseTest(
       "(a)|b|(c)d",
       alt(capture("a"), "b", concat(capture("c"), "d")),
@@ -1138,7 +1138,7 @@ extension RegexTests {
       trueBranch: oneOrMore(of: capture("a")),
       falseBranch: "b"
     ), captures: .tuple([
-      .atom(), .optional(.atom()), .atom(), .optional(.array(.atom()))
+      .atom(), .optional(.atom()), .atom(), .optional(.atom())
     ]))
 
     parseTest(#"(?(?:(a)?(b))(a)+|b)"#, conditional(
@@ -1148,7 +1148,7 @@ extension RegexTests {
       trueBranch: oneOrMore(of: capture("a")),
       falseBranch: "b"
     ), captures: .tuple([
-      .optional(.atom()), .atom(), .optional(.array(.atom()))
+      .optional(.atom()), .atom(), .optional(.atom())
     ]))
 
     parseTest(#"(?<xxx>y)(?(xxx)a|b)"#, concat(

--- a/Tests/RegexTests/RegexDSLTests.swift
+++ b/Tests/RegexTests/RegexDSLTests.swift
@@ -95,7 +95,7 @@ class RegexDSLTests: XCTestCase {
         }.+
       }
       XCTAssertTrue(
-        try XCTUnwrap("abc".match(regex)?.match) == ("abc", ["c"]))
+        try XCTUnwrap("abc".match(regex)?.match) == ("abc", "c"))
     }
     do {
       let regex = choiceOf {
@@ -134,8 +134,8 @@ class RegexDSLTests: XCTestCase {
 
   func testCombinators() throws {
     try _testDSLCaptures(
-      ("aaaabccccdddkj", ("aaaabccccdddkj", "b", "cccc", ["d", "d", "d"], "k", nil, "j")),
-      captureType: (Substring, Substring, Substring, [Substring], Substring, Substring?, Substring?).self, ==)
+      ("aaaabccccdddkj", ("aaaabccccdddkj", "b", "cccc", "d", "k", nil, "j")),
+      captureType: (Substring, Substring, Substring, Substring, Substring, Substring?, Substring?).self, ==)
     {
       "a".+
       capture(oneOrMore(Character("b"))) // Substring
@@ -149,8 +149,8 @@ class RegexDSLTests: XCTestCase {
   
   func testQuantificationBehavior() throws {
     try _testDSLCaptures(
-      ("abc1def2", ("abc1def2", ["2"])),
-      captureType: (Substring, [Substring]).self, ==)
+      ("abc1def2", ("abc1def2", "2")),
+      captureType: (Substring, Substring).self, ==)
     {
       oneOrMore {
         oneOrMore(.word)
@@ -159,8 +159,8 @@ class RegexDSLTests: XCTestCase {
     }
 
     try _testDSLCaptures(
-      ("abc1def2", ("abc1def2", ["1", "2"])),
-      captureType: (Substring, [Substring]).self, ==)
+      ("abc1def2", ("abc1def2", "2")),
+      captureType: (Substring, Substring).self, ==)
     {
       oneOrMore {
         oneOrMore(.word, .reluctantly)
@@ -169,8 +169,8 @@ class RegexDSLTests: XCTestCase {
     }
 
     try _testDSLCaptures(
-      ("abc1def2", ("abc1def2", ["1", "2"])),
-      captureType: (Substring, [Substring]).self, ==)
+      ("abc1def2", ("abc1def2", "2")),
+      captureType: (Substring, Substring).self, ==)
     {
       oneOrMore {
         oneOrMore(.reluctantly) {
@@ -233,9 +233,9 @@ class RegexDSLTests: XCTestCase {
       }
     }
     try _testDSLCaptures(
-      ("aaa 123 apple orange apple", ("aaa 123 apple orange apple", 123, [.apple, .orange, .apple])),
-      ("aaa     ", ("aaa     ", nil, [])),
-      captureType: (Substring, Int?, [Word]).self, ==)
+      ("aaa 123 apple orange apple", ("aaa 123 apple orange apple", 123, .apple)),
+      ("aaa     ", ("aaa     ", nil, nil)),
+      captureType: (Substring, Int?, Word?).self, ==)
     {
       "a".+
       oneOrMore(.whitespace)
@@ -266,7 +266,7 @@ class RegexDSLTests: XCTestCase {
         "e".?
       }
     }
-    let _: (Substring, Substring, [Int]).Type
+    let _: (Substring, Substring, Int?).Type
       = type(of: regex2).Match.self
     let regex3 = Regex {
       "a".+
@@ -278,7 +278,7 @@ class RegexDSLTests: XCTestCase {
         "e".?
       }
     }
-    let _: (Substring, Substring, Int, [Double]).Type
+    let _: (Substring, Substring, Int, Double?).Type
       = type(of: regex3).Match.self
     let regex4 = Regex {
       "a".+
@@ -292,7 +292,7 @@ class RegexDSLTests: XCTestCase {
       }
     }
     let _: (
-      Substring, Substring, [(Substring, Substring, [Substring])]).Type
+      Substring, Substring, Substring, Substring, Substring?).Type
       = type(of: regex4).Match.self
   }
 


### PR DESCRIPTION
To bridge the typing gap between regex literals and regex builder, this patch introduces the following changes:

1. Repeating quantifiers no longer produce an array capture. Instead, produce an optional capture when the lower bound is `0`, otherwise an atom capture. After matching, this capture corresponds to the last occurrence in the match. A history-saving quantifier variant will be introduced at a later time.
2. Applying a quantifier on a tuple-capturing regex will map quantification onto every tuple element, resulting in a tuple of quantified captures (unzipped).

-----

```swift
let literal = /a((b)(b)+)*(c)+(d)?/
//           0 ^~~~~~~~~~~~~~~~
//            1 ^~~~~~
//             2 ^~~
//                3 ^~~
//                   4 ^~~
//                       5 ^~~
// => Regex<(Substring, Substring?, Substring?, Substring?, Substring, Substring?)>

// Equivalent regex using regex builder:
let dsl = Regex { // 0
  "a"
  zeroOrMore {
    capture { // 1
      capture { // 2
        "b"
      }
      oneOrMore {
        capture { // 3
          "b"
        }
      }
    }
  }
  oneOrMore {
    capture { // 4
      "c"
    }
  }
  optionally {
    capture { // 5
      "d"
    }
  }
}

// => Regex<(Substring, Substring?, Substring?, Substring?, Substring, Substring?)>
```