### PR TITLE
Allow `.0` when `RegexMatch` has a non-tuple `Match`.

### DIFF
--- a/Sources/_StringProcessing/RegexDSL/Match.swift
+++ b/Sources/_StringProcessing/RegexDSL/Match.swift
@@ -17,6 +17,14 @@ public struct RegexMatch<Match> {
   public subscript<T>(dynamicMember keyPath: KeyPath<Match, T>) -> T {
     match[keyPath: keyPath]
   }
+
+  // Allows `.0` when `Match` is not a tuple.
+  @_disfavoredOverload
+  public subscript(
+    dynamicMember keyPath: KeyPath<(Match, _doNotUse: ()), Match>
+  ) -> Match {
+    match
+  }
 }
 
 extension RegexProtocol {

--- a/Tests/RegexTests/RegexDSLTests.swift
+++ b/Tests/RegexTests/RegexDSLTests.swift
@@ -65,6 +65,11 @@ class RegexDSLTests: XCTestCase {
     }
   }
 
+  func testMatchResultDotZeroWithoutCapture() throws {
+    let match = try XCTUnwrap("aaa".match { oneOrMore { "a" } })
+    XCTAssertEqual(match.0, "aaa")
+  }
+
   func testAlternation() throws {
     do {
       let regex = choiceOf {


### PR DESCRIPTION
This is a hacky way of allowing the match result of a non-capturing regex to have a `.0` member.