### PR TITLE
Option APIs for RegexProtocol

### DIFF
--- a/Sources/_MatchingEngine/Regex/AST/MatchingOptions.swift
+++ b/Sources/_MatchingEngine/Regex/AST/MatchingOptions.swift
@@ -110,6 +110,16 @@ extension AST {
   }
 }
 
+extension AST.MatchingOptionSequence {
+  public init(adding: [AST.MatchingOption]) {
+    self.init(caretLoc: nil, adding: adding, minusLoc: nil, removing: [])
+  }
+
+  public init(removing: [AST.MatchingOption]) {
+    self.init(caretLoc: nil, adding: [], minusLoc: nil, removing: removing)
+  }
+}
+
 extension AST.MatchingOption: _ASTPrintable {
   public var _dumpBase: String { "\(kind)" }
 }

--- a/Sources/_StringProcessing/RegexDSL/Options.swift
+++ b/Sources/_StringProcessing/RegexDSL/Options.swift
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2021-2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+import _MatchingEngine
+
+extension RegexProtocol {
+  public func caseSensitive(_ isCaseSensitive: Bool) -> Regex<Match> {
+    // The API is "case sensitive = true or false", so as to avoid the
+    // double negatives inherent in setting "case insensitive" to a Boolean
+    // value. The internal version of this option, on the other hand, is
+    // `.caseInsensitive`, derived from the `(?i)` regex literal option.
+    let sequence = isCaseSensitive
+      ? AST.MatchingOptionSequence(removing: [.init(.caseInsensitive, location: .fake)])
+      : AST.MatchingOptionSequence(adding: [.init(.caseInsensitive, location: .fake)])
+    return Regex(node: .group(.changeMatchingOptions(sequence, isIsolated: false), regex.root))
+  }
+}
+


### PR DESCRIPTION
This adds an API to any conforming type that lets the user control whether a match uses case sensitive comparison from within a DSL declaration. Applying modifiers like this has the opposite precedence as a regex literal, where the nearest option setter has precedence.

For example, these two regex declarations are equivalent:

```swift
let regexDSL = Regex {
    oneOrMore {
        "a"
    }
    .caseSensitive(true)
    .caseSensitive(false)
}

let regexLiteral = #/(?-i)(?i)a+/#
```

Note: This requires #168.
Note 2: More options TK once we're okay with this approach.