### PR TITLE
Add the CustomRegexComponent protocol

### DIFF
--- a/Sources/_StringProcessing/Engine/MEProgram.swift
+++ b/Sources/_StringProcessing/Engine/MEProgram.swift
@@ -18,7 +18,7 @@ public struct MEProgram<Input: Collection> where Input.Element: Equatable {
   public typealias TransformFunction =
     (Input, Range<Input.Index>) -> Any?
   public typealias MatcherFunction =
-    (Input, Range<Input.Index>) -> (Input.Index, Any)?
+    (Input, Input.Index, Range<Input.Index>) -> (Input.Index, Any)?
 
   var instructions: InstructionList<Instruction>
 

--- a/Sources/_StringProcessing/Engine/Processor.swift
+++ b/Sources/_StringProcessing/Engine/Processor.swift
@@ -362,7 +362,7 @@ extension Processor {
       let (matcherReg, valReg) = payload.pairedMatcherValue
       let matcher = registers[matcherReg]
       guard let (nextIdx, val) = matcher(
-        input, currentPosition..<bounds.upperBound
+        input, currentPosition, bounds
       ) else {
         signalFailure()
         return

--- a/Sources/_StringProcessing/RegexDSL/DSLConsumers.swift
+++ b/Sources/_StringProcessing/RegexDSL/DSLConsumers.swift
@@ -9,24 +9,18 @@
 //
 //===----------------------------------------------------------------------===//
 
-extension MatchingCollectionConsumer where Consumed == String {
+public protocol CustomRegexComponent: RegexProtocol {
+  func match(
+    _ input: String,
+    startingAt index: String.Index,
+    in bounds: Range<String.Index>
+  ) -> (upperBound: String.Index, match: Match)?
+}
+
+extension CustomRegexComponent {
   public var regex: Regex<Match> {
-    Regex(node: .matcher(.init(Match.self)) {
-      self.matchingConsuming($0, in: $1)
-    })
+    Regex(node: .matcher(.init(Match.self), { input, index, bounds in
+      match(input, startingAt: index, in: bounds)
+    }))
   }
 }
-
-extension CollectionConsumer where Consumed == String {
-  public var regex: Regex<Void> {
-    Regex(node: .consumer {
-      self.consuming($0, in: $1)
-    })
-  }
-}
-
-// TODO: How can/should the DSL choose between them? Need to
-// know whether value is captured or not. Should this be
-// done via how we declare API or should this be part of
-// compilation / DSLTree logic?
-

--- a/Sources/_StringProcessing/RegexDSL/DSLTree.swift
+++ b/Sources/_StringProcessing/RegexDSL/DSLTree.swift
@@ -132,7 +132,7 @@ typealias _ConsumerInterface = (
 // Type producing consume
 // TODO: better name
 typealias _MatcherInterface = (
-  String, Range<String.Index>
+  String, String.Index, Range<String.Index>
 ) -> (String.Index, Any)?
 
 // Character-set (post grapheme segmentation)

--- a/Tests/RegexTests/CustomTests.swift
+++ b/Tests/RegexTests/CustomTests.swift
@@ -2,28 +2,21 @@ import _StringProcessing
 import XCTest
 
 // A nibbler processes a single character from a string
-private protocol Nibbler:
-  MatchingCollectionConsumer, RegexProtocol
-where Consumed == String {
+private protocol Nibbler: CustomRegexComponent {
   func nibble(_: Character) -> Match?
 }
 
 extension Nibbler {
   // Default implementation, just feed the character in
-  func matchingConsuming(
-    _ consumed: Consumed,
-    in range: Range<Consumed.Index>
-  ) -> (upperBound: Consumed.Index, match: Match)? {
-    guard !range.isEmpty else {
-      // FIXME: Do we have a full story here?
+  func match(
+    _ input: String,
+    startingAt index: String.Index,
+    in bounds: Range<String.Index>
+  ) -> (upperBound: String.Index, match: Match)? {
+    guard index != bounds.upperBound, let res = nibble(input[index]) else {
       return nil
     }
-    let idx = range.lowerBound
-
-    guard let res = nibble(consumed[idx]) else {
-      return nil
-    }
-    return (consumed.index(after: idx), res)
+    return (input.index(after: index), res)
   }
 }
 


### PR DESCRIPTION
Adds the `CustomRegexComponent` protocol that inherits from `RegexProtocol`, and modifies `_MatcherInterface` to also take an index that is separate from the given index range.