### PR TITLE
Store integer registers in SavePoint

### DIFF
--- a/Sources/_StringProcessing/Engine/Backtracking.swift
+++ b/Sources/_StringProcessing/Engine/Backtracking.swift
@@ -29,13 +29,18 @@ extension Processor {
     // perhaps current start)
     var captureEnds: [_StoredCapture]
 
+    // The int registers store values that can be relevant to
+    // backtracking, such as the number of trips in a quantification.
+    var intRegisters: [Int]
+
     var destructure: (
       pc: InstructionAddress,
       pos: Position?,
       stackEnd: CallStackAddress,
-      captureEnds: [_StoredCapture]
+      captureEnds: [_StoredCapture],
+      intRegisters: [Int]
     ) {
-      (pc, pos, stackEnd, captureEnds)
+      (pc, pos, stackEnd, captureEnds, intRegisters)
     }
   }
 
@@ -47,7 +52,8 @@ extension Processor {
       pc: pc,
       pos: addressOnly ? nil : currentPosition,
       stackEnd: .init(callStack.count),
-      captureEnds: storedCaptures)
+      captureEnds: storedCaptures,
+      intRegisters: registers.ints)
   }
 }
 

--- a/Sources/_StringProcessing/Engine/Processor.swift
+++ b/Sources/_StringProcessing/Engine/Processor.swift
@@ -163,7 +163,7 @@ extension Processor {
   }
 
   mutating func signalFailure() {
-    guard let (pc, pos, stackEnd, capEnds) =
+    guard let (pc, pos, stackEnd, capEnds, intRegisters) =
             savePoints.popLast()?.destructure
     else {
       state = .fail
@@ -175,7 +175,8 @@ extension Processor {
     controller.pc = pc
     currentPosition = pos ?? currentPosition
     callStack.removeLast(callStack.count - stackEnd.rawValue)
-      storedCaptures = capEnds
+    storedCaptures = capEnds
+    registers.ints = intRegisters
   }
 
   mutating func tryAccept() {

--- a/Tests/RegexTests/MatchTests.swift
+++ b/Tests/RegexTests/MatchTests.swift
@@ -316,6 +316,10 @@ extension RegexTests {
       #"xa{0}y"#, input: "123aaaxyz", match: "xy")
     firstMatchTest(
       #"xa{0,0}y"#, input: "123aaaxyz", match: "xy")
+    firstMatchTest(
+      #"(a|a){2}a"#, input: "123aaaxyz", match: "aaa")
+    firstMatchTest(
+      #"(a|a){3}a"#, input: "123aaaxyz", match: nil)
 
     firstMatchTest("a.*", input: "dcba", match: "a")
 


### PR DESCRIPTION
Without saving the int registers, quantifications can't accurately keep track of their loop count when backtracking, so some patterns were incorrectly matching.

For example, `/(a|a){3}a/` incorrectly matched against `"aaaxyz"`, because after failing to match the final `a` against the `"x"`, the engine backtracked to the second alternation without resetting the number of times the quantification had been satisfied.