### PR TITLE
Change script property default to use Script Extension

### DIFF
--- a/Sources/_MatchingEngine/Regex/Parse/CharacterPropertyClassification.swift
+++ b/Sources/_MatchingEngine/Regex/Parse/CharacterPropertyClassification.swift
@@ -381,7 +381,7 @@ extension Source {
       return .generalCategory(cat)
     }
     if let script = classifyScriptProperty(value) {
-      return .script(script)
+      return .scriptExtension(script)
     }
     if let posix = classifyPOSIX(value) {
       return .posix(posix)

--- a/Tests/RegexTests/MatchTests.swift
+++ b/Tests/RegexTests/MatchTests.swift
@@ -695,6 +695,7 @@ extension RegexTests {
     firstMatchTest(#"\p{ISBAMUM}"#, input: "123ꚠꚡꚢxyz", match: "ꚠ")
     firstMatchTest(#"\p{Script=Unknown}"#, input: "\u{10FFFF}", match: "\u{10FFFF}")
     firstMatchTest(#"\p{scx=Gujr}"#, input: "\u{a839}", match: "\u{a839}")
+    firstMatchTest(#"\p{Gujr}"#, input: "\u{a839}", match: "\u{a839}")
 
     firstMatchTest(#"\p{alpha}"#, input: "123abcXYZ", match: "a")
     firstMatchTest(#"\P{alpha}"#, input: "123abcXYZ", match: "1")

--- a/Tests/RegexTests/ParseTests.swift
+++ b/Tests/RegexTests/ParseTests.swift
@@ -1003,13 +1003,13 @@ extension RegexTests {
 
     parseTest(#"\p{sc=grek}"#, prop(.script(.greek)))
     parseTest(#"\p{sc=isGreek}"#, prop(.script(.greek)))
-    parseTest(#"\p{Greek}"#, prop(.script(.greek)))
-    parseTest(#"\p{isGreek}"#, prop(.script(.greek)))
+    parseTest(#"\p{Greek}"#, prop(.scriptExtension(.greek)))
+    parseTest(#"\p{isGreek}"#, prop(.scriptExtension(.greek)))
     parseTest(#"\P{Script=Latn}"#, prop(.script(.latin), inverted: true))
     parseTest(#"\p{script=zzzz}"#, prop(.script(.unknown)))
     parseTest(#"\p{ISscript=iszzzz}"#, prop(.script(.unknown)))
     parseTest(#"\p{scx=bamum}"#, prop(.scriptExtension(.bamum)))
-    parseTest(#"\p{ISBAMUM}"#, prop(.script(.bamum)))
+    parseTest(#"\p{ISBAMUM}"#, prop(.scriptExtension(.bamum)))
 
     parseTest(#"\p{alpha}"#, prop(.binary(.alphabetic)))
     parseTest(#"\p{DEP}"#, prop(.binary(.deprecated)))


### PR DESCRIPTION
Change the default script property behavior for an unqualified value e.g `\p{Greek}` from `\p{Script=Greek}` to `\p{Script_Extension=Greek}`. This is arguably the more intuitive behavior, and matches what Perl does.