### PR TITLE
Tweak a few generic signatures to work around a bug in the Requirement Machine

### DIFF
--- a/Sources/_StringProcessing/Algorithms/Algorithms/Replace.swift
+++ b/Sources/_StringProcessing/Algorithms/Algorithms/Replace.swift
@@ -154,7 +154,7 @@ extension RangeReplaceableCollection where SubSequence == Substring {
     with replacement: Replacement,
     subrange: Range<Index>,
     maxReplacements: Int = .max
-  ) -> Self where Replacement.Element == Element {
+  ) -> Self where Replacement.Element == Character {
     replacing(
       RegexConsumer(regex),
       with: replacement,
@@ -166,7 +166,7 @@ extension RangeReplaceableCollection where SubSequence == Substring {
     _ regex: R,
     with replacement: Replacement,
     maxReplacements: Int = .max
-  ) -> Self where Replacement.Element == Element {
+  ) -> Self where Replacement.Element == Character {
     replacing(
       regex,
       with: replacement,
@@ -178,7 +178,7 @@ extension RangeReplaceableCollection where SubSequence == Substring {
     _ regex: R,
     with replacement: Replacement,
     maxReplacements: Int = .max
-  ) where Replacement.Element == Element {
+  ) where Replacement.Element == Character {
     self = replacing(
       regex,
       with: replacement,

--- a/Sources/_StringProcessing/Algorithms/Matching/MatchReplace.swift
+++ b/Sources/_StringProcessing/Algorithms/Matching/MatchReplace.swift
@@ -80,7 +80,7 @@ extension RangeReplaceableCollection where SubSequence == Substring {
     with replacement: (_MatchResult<RegexConsumer<R, Substring>>) throws -> Replacement,
     subrange: Range<Index>,
     maxReplacements: Int = .max
-  ) rethrows -> Self where Replacement.Element == Element {
+  ) rethrows -> Self where Replacement.Element == Character {
     try replacing(
       RegexConsumer(regex),
       with: replacement,
@@ -92,7 +92,7 @@ extension RangeReplaceableCollection where SubSequence == Substring {
     _ regex: R,
     with replacement: (_MatchResult<RegexConsumer<R, Substring>>) throws -> Replacement,
     maxReplacements: Int = .max
-  ) rethrows -> Self where Replacement.Element == Element {
+  ) rethrows -> Self where Replacement.Element == Character {
     try replacing(
       regex,
       with: replacement,
@@ -104,7 +104,7 @@ extension RangeReplaceableCollection where SubSequence == Substring {
     _ regex: R,
     with replacement: (_MatchResult<RegexConsumer<R, Substring>>) throws -> Replacement,
     maxReplacements: Int = .max
-  ) rethrows where Replacement.Element == Element {
+  ) rethrows where Replacement.Element == Character {
     self = try replacing(
       regex,
       with: replacement,


### PR DESCRIPTION
Here is the reduced test case:

    func foo<C : Collection, R : Sequence>(_: C, _: R) where C.SubSequence == Substring, C.Element == R.Element {}

The Requirement Machine produces a valid but different minimization than the GenericSignatureBuilder for this signature, which flags the assert since right now we run both and compare the results:

    error: compile command failed due to signal 6 (use -v to see invocation)
    RequirementMachine generic signature minimization is broken:
    RequirementMachine says:      <C, R where C : Collection, R : Sequence, C.[Sequence]Element == R.[Sequence]Element, C.[Collection]SubSequence == Substring>
    GenericSignatureBuilder says: <C, R where C : Collection, R : Sequence, C.[Collection]SubSequence == Substring, R.[Sequence]Element == Character>


Radar tracking the fix: rdar://problem/89791117