### PR TITLE
Rename `RegexProtocol` to `RegexComponent` and `RegexBuilder` to `RegexComponentBuilder`.

### DIFF
--- a/Sources/Exercises/Participants/RegexParticipant.swift
+++ b/Sources/Exercises/Participants/RegexParticipant.swift
@@ -58,7 +58,7 @@ private func extractFromCaptures(
 }
 
 @inline(__always) // get rid of generic please
-private func graphemeBreakPropertyData<RP: RegexProtocol>(
+private func graphemeBreakPropertyData<RP: RegexComponent>(
   forLine line: String,
   using regex: RP
 ) -> GraphemeBreakEntry? where RP.Match == (Substring, Substring, Substring?, Substring) {

--- a/Sources/Prototypes/TourOfTypes/Literal.swift
+++ b/Sources/Prototypes/TourOfTypes/Literal.swift
@@ -55,16 +55,16 @@ enum SemanticsLevel {
 }
 
 /// Conformers can be ran as a regex / pattern
-protocol RegexProtocol {
+protocol RegexComponent {
   var level: SemanticsLevel? { get }
 }
 
 /// Provide the option to encode semantic level statically
 protocol RegexLiteralProtocol: ExpressibleByRegexLiteral {
-  associatedtype ScalarSemanticRegex: RegexProtocol
-  associatedtype GraphemeSemanticRegex: RegexProtocol
-  associatedtype POSIXSemanticRegex: RegexProtocol
-  associatedtype UnspecifiedSemanticRegex: RegexProtocol = RegexLiteral
+  associatedtype ScalarSemanticRegex: RegexComponent
+  associatedtype GraphemeSemanticRegex: RegexComponent
+  associatedtype POSIXSemanticRegex: RegexComponent
+  associatedtype UnspecifiedSemanticRegex: RegexComponent = RegexLiteral
 
   var scalarSemantic: ScalarSemanticRegex { get }
   var graphemeSemantic: GraphemeSemanticRegex { get }
@@ -84,16 +84,16 @@ struct StaticSemanticRegexLiteral: RegexLiteralProtocol {
    */
 
   /// A regex that has statically  bound its semantic level
-  struct ScalarSemanticRegex: RegexProtocol {
+  struct ScalarSemanticRegex: RegexComponent {
     var level: SemanticsLevel? { .scalar }
   }
-  struct GraphemeSemanticRegex: RegexProtocol {
+  struct GraphemeSemanticRegex: RegexComponent {
     var level: SemanticsLevel? { .graphemeCluster }
   }
-  struct POSIXSemanticRegex: RegexProtocol {
+  struct POSIXSemanticRegex: RegexComponent {
     var level: SemanticsLevel? { .posix }
   }
-  struct UnspecifiedSemanticRegex: RegexProtocol {
+  struct UnspecifiedSemanticRegex: RegexComponent {
     var level: SemanticsLevel? { nil }
   }
 
@@ -132,9 +132,9 @@ struct RegexLiteral: ExpressibleByRegexLiteral {
   }
 }
 
-extension RegexLiteral: RegexProtocol, RegexLiteralProtocol {
+extension RegexLiteral: RegexComponent, RegexLiteralProtocol {
   /// A regex that has finally bound its semantic level (dynamically)
-  struct BoundSemantic: RegexProtocol {
+  struct BoundSemantic: RegexComponent {
     var _level: SemanticsLevel // Bound semantic level
     var level: SemanticsLevel? { _level }
   }

--- a/Sources/_StringProcessing/Algorithms/Algorithms/Contains.swift
+++ b/Sources/_StringProcessing/Algorithms/Algorithms/Contains.swift
@@ -40,7 +40,7 @@ extension BidirectionalCollection where Element: Comparable {
 // MARK: Regex algorithms
 
 extension BidirectionalCollection where SubSequence == Substring {
-  public func contains<R: RegexProtocol>(_ regex: R) -> Bool {
+  public func contains<R: RegexComponent>(_ regex: R) -> Bool {
     contains(RegexConsumer(regex))
   }
 }

--- a/Sources/_StringProcessing/Algorithms/Algorithms/FirstRange.swift
+++ b/Sources/_StringProcessing/Algorithms/Algorithms/FirstRange.swift
@@ -56,11 +56,11 @@ extension BidirectionalCollection where Element: Comparable {
 // MARK: Regex algorithms
 
 extension BidirectionalCollection where SubSequence == Substring {
-  public func firstRange<R: RegexProtocol>(of regex: R) -> Range<Index>? {
+  public func firstRange<R: RegexComponent>(of regex: R) -> Range<Index>? {
     firstRange(of: RegexConsumer(regex))
   }
   
-  public func lastRange<R: RegexProtocol>(of regex: R) -> Range<Index>? {
+  public func lastRange<R: RegexComponent>(of regex: R) -> Range<Index>? {
     lastRange(of: RegexConsumer(regex))
   }
 }

--- a/Sources/_StringProcessing/Algorithms/Algorithms/Ranges.swift
+++ b/Sources/_StringProcessing/Algorithms/Algorithms/Ranges.swift
@@ -216,13 +216,13 @@ extension BidirectionalCollection where Element: Comparable {
 // MARK: Regex algorithms
 
 extension BidirectionalCollection where SubSequence == Substring {
-  public func ranges<R: RegexProtocol>(
+  public func ranges<R: RegexComponent>(
     of regex: R
   ) -> RangesCollection<RegexConsumer<R, Self>> {
     ranges(of: RegexConsumer(regex))
   }
   
-  public func rangesFromBack<R: RegexProtocol>(
+  public func rangesFromBack<R: RegexComponent>(
     of regex: R
   ) -> ReversedRangesCollection<RegexConsumer<R, Self>> {
     rangesFromBack(of: RegexConsumer(regex))

--- a/Sources/_StringProcessing/Algorithms/Algorithms/Replace.swift
+++ b/Sources/_StringProcessing/Algorithms/Algorithms/Replace.swift
@@ -149,7 +149,7 @@ extension RangeReplaceableCollection
 // MARK: Regex algorithms
 
 extension RangeReplaceableCollection where SubSequence == Substring {
-  public func replacing<R: RegexProtocol, Replacement: Collection>(
+  public func replacing<R: RegexComponent, Replacement: Collection>(
     _ regex: R,
     with replacement: Replacement,
     subrange: Range<Index>,
@@ -162,7 +162,7 @@ extension RangeReplaceableCollection where SubSequence == Substring {
       maxReplacements: maxReplacements)
   }
   
-  public func replacing<R: RegexProtocol, Replacement: Collection>(
+  public func replacing<R: RegexComponent, Replacement: Collection>(
     _ regex: R,
     with replacement: Replacement,
     maxReplacements: Int = .max
@@ -174,7 +174,7 @@ extension RangeReplaceableCollection where SubSequence == Substring {
       maxReplacements: maxReplacements)
   }
   
-  public mutating func replace<R: RegexProtocol, Replacement: Collection>(
+  public mutating func replace<R: RegexComponent, Replacement: Collection>(
     _ regex: R,
     with replacement: Replacement,
     maxReplacements: Int = .max

--- a/Sources/_StringProcessing/Algorithms/Algorithms/Split.swift
+++ b/Sources/_StringProcessing/Algorithms/Algorithms/Split.swift
@@ -275,13 +275,13 @@ extension BidirectionalCollection where Element: Comparable {
 // MARK: Regex algorithms
 
 extension BidirectionalCollection where SubSequence == Substring {
-  public func split<R: RegexProtocol>(
+  public func split<R: RegexComponent>(
     by separator: R
   ) -> SplitCollection<RegexConsumer<R, Self>> {
     split(by: RegexConsumer(separator))
   }
   
-  public func splitFromBack<R: RegexProtocol>(
+  public func splitFromBack<R: RegexComponent>(
     by separator: R
   ) -> ReversedSplitCollection<RegexConsumer<R, Self>> {
     splitFromBack(by: RegexConsumer(separator))

--- a/Sources/_StringProcessing/Algorithms/Algorithms/StartsWith.swift
+++ b/Sources/_StringProcessing/Algorithms/Algorithms/StartsWith.swift
@@ -48,11 +48,11 @@ extension BidirectionalCollection where Element: Equatable {
 // MARK: Regex algorithms
 
 extension BidirectionalCollection where SubSequence == Substring {
-  public func starts<R: RegexProtocol>(with regex: R) -> Bool {
+  public func starts<R: RegexComponent>(with regex: R) -> Bool {
     starts(with: RegexConsumer(regex))
   }
   
-  public func ends<R: RegexProtocol>(with regex: R) -> Bool {
+  public func ends<R: RegexComponent>(with regex: R) -> Bool {
     ends(with: RegexConsumer(regex))
   }
 }

--- a/Sources/_StringProcessing/Algorithms/Algorithms/Trim.swift
+++ b/Sources/_StringProcessing/Algorithms/Algorithms/Trim.swift
@@ -257,15 +257,15 @@ extension RangeReplaceableCollection
 // MARK: Regex algorithms
 
 extension BidirectionalCollection where SubSequence == Substring {
-  public func trimmingPrefix<R: RegexProtocol>(_ regex: R) -> SubSequence {
+  public func trimmingPrefix<R: RegexComponent>(_ regex: R) -> SubSequence {
     trimmingPrefix(RegexConsumer(regex))
   }
   
-  public func trimmingSuffix<R: RegexProtocol>(_ regex: R) -> SubSequence {
+  public func trimmingSuffix<R: RegexComponent>(_ regex: R) -> SubSequence {
     trimmingSuffix(RegexConsumer(regex))
   }
   
-  public func trimming<R: RegexProtocol>(_ regex: R) -> SubSequence {
+  public func trimming<R: RegexComponent>(_ regex: R) -> SubSequence {
     trimming(RegexConsumer(regex))
   }
 }
@@ -273,15 +273,15 @@ extension BidirectionalCollection where SubSequence == Substring {
 extension RangeReplaceableCollection
   where Self: BidirectionalCollection, SubSequence == Substring
 {
-  public mutating func trimPrefix<R: RegexProtocol>(_ regex: R) {
+  public mutating func trimPrefix<R: RegexComponent>(_ regex: R) {
     trimPrefix(RegexConsumer(regex))
   }
   
-  public mutating func trimSuffix<R: RegexProtocol>(_ regex: R) {
+  public mutating func trimSuffix<R: RegexComponent>(_ regex: R) {
     trimSuffix(RegexConsumer(regex))
   }
   
-  public mutating func trim<R: RegexProtocol>(_ regex: R) {
+  public mutating func trim<R: RegexComponent>(_ regex: R) {
     let consumer = RegexConsumer<R, Self>(regex)
     trimPrefix(consumer)
     trimSuffix(consumer)
@@ -289,15 +289,15 @@ extension RangeReplaceableCollection
 }
 
 extension Substring {
-  public mutating func trimPrefix<R: RegexProtocol>(_ regex: R) {
+  public mutating func trimPrefix<R: RegexComponent>(_ regex: R) {
     trimPrefix(RegexConsumer(regex))
   }
   
-  public mutating func trimSuffix<R: RegexProtocol>(_ regex: R) {
+  public mutating func trimSuffix<R: RegexComponent>(_ regex: R) {
     trimSuffix(RegexConsumer(regex))
   }
   
-  public mutating func trim<R: RegexProtocol>(_ regex: R) {
+  public mutating func trim<R: RegexComponent>(_ regex: R) {
     let consumer = RegexConsumer<R, Self>(regex)
     trimPrefix(consumer)
     trimSuffix(consumer)

--- a/Sources/_StringProcessing/Algorithms/Consumers/RegexConsumer.swift
+++ b/Sources/_StringProcessing/Algorithms/Consumers/RegexConsumer.swift
@@ -10,7 +10,7 @@
 //===----------------------------------------------------------------------===//
 
 public struct RegexConsumer<
-  R: RegexProtocol, Consumed: BidirectionalCollection
+  R: RegexComponent, Consumed: BidirectionalCollection
 > where Consumed.SubSequence == Substring {
   // TODO: Should `Regex` itself implement these protocols?
   let regex: R

--- a/Sources/_StringProcessing/Algorithms/Matching/FirstMatch.swift
+++ b/Sources/_StringProcessing/Algorithms/Matching/FirstMatch.swift
@@ -38,13 +38,13 @@ extension BidirectionalCollection {
 // MARK: Regex algorithms
 
 extension BidirectionalCollection where SubSequence == Substring {
-  public func firstMatch<R: RegexProtocol>(
+  public func firstMatch<R: RegexComponent>(
     of regex: R
   ) -> _MatchResult<RegexConsumer<R, Self>>? {
     firstMatch(of: RegexConsumer(regex))
   }
   
-  public func lastMatch<R: RegexProtocol>(
+  public func lastMatch<R: RegexComponent>(
     of regex: R
   ) -> _BackwardMatchResult<RegexConsumer<R, Self>>? {
     lastMatch(of: RegexConsumer(regex))

--- a/Sources/_StringProcessing/Algorithms/Matching/MatchReplace.swift
+++ b/Sources/_StringProcessing/Algorithms/Matching/MatchReplace.swift
@@ -75,7 +75,7 @@ extension RangeReplaceableCollection {
 // MARK: Regex algorithms
 
 extension RangeReplaceableCollection where SubSequence == Substring {
-  public func replacing<R: RegexProtocol, Replacement: Collection>(
+  public func replacing<R: RegexComponent, Replacement: Collection>(
     _ regex: R,
     with replacement: (_MatchResult<RegexConsumer<R, Substring>>) throws -> Replacement,
     subrange: Range<Index>,
@@ -88,7 +88,7 @@ extension RangeReplaceableCollection where SubSequence == Substring {
       maxReplacements: maxReplacements)
   }
   
-  public func replacing<R: RegexProtocol, Replacement: Collection>(
+  public func replacing<R: RegexComponent, Replacement: Collection>(
     _ regex: R,
     with replacement: (_MatchResult<RegexConsumer<R, Substring>>) throws -> Replacement,
     maxReplacements: Int = .max
@@ -100,7 +100,7 @@ extension RangeReplaceableCollection where SubSequence == Substring {
       maxReplacements: maxReplacements)
   }
   
-  public mutating func replace<R: RegexProtocol, Replacement: Collection>(
+  public mutating func replace<R: RegexComponent, Replacement: Collection>(
     _ regex: R,
     with replacement: (_MatchResult<RegexConsumer<R, Substring>>) throws -> Replacement,
     maxReplacements: Int = .max

--- a/Sources/_StringProcessing/Algorithms/Matching/Matches.swift
+++ b/Sources/_StringProcessing/Algorithms/Matching/Matches.swift
@@ -184,13 +184,13 @@ extension BidirectionalCollection {
 // MARK: Regex algorithms
 
 extension BidirectionalCollection where SubSequence == Substring {
-  public func matches<R: RegexProtocol>(
+  public func matches<R: RegexComponent>(
     of regex: R
   ) -> MatchesCollection<RegexConsumer<R, Self>> {
     matches(of: RegexConsumer(regex))
   }
   
-  public func matchesFromBack<R: RegexProtocol>(
+  public func matchesFromBack<R: RegexComponent>(
     of regex: R
   ) -> ReversedMatchesCollection<RegexConsumer<R, Self>> {
     matchesFromBack(of: RegexConsumer(regex))

--- a/Sources/_StringProcessing/CharacterClass.swift
+++ b/Sources/_StringProcessing/CharacterClass.swift
@@ -178,7 +178,7 @@ public struct CharacterClass: Hashable {
   }
 }
 
-extension RegexProtocol where Self == CharacterClass {
+extension RegexComponent where Self == CharacterClass {
   public static var any: CharacterClass {
     .init(cc: .any, matchLevel: .graphemeCluster)
   }

--- a/Sources/_StringProcessing/RegexDSL/Anchor.swift
+++ b/Sources/_StringProcessing/RegexDSL/Anchor.swift
@@ -27,7 +27,7 @@ public struct Anchor {
   var isInverted: Bool = false
 }
 
-extension Anchor: RegexProtocol {
+extension Anchor: RegexComponent {
   var astAssertion: AST.Atom.AssertionKind {
     if !isInverted {
       switch kind {
@@ -106,14 +106,14 @@ extension Anchor {
   }
 }
 
-public func lookahead<R: RegexProtocol>(
+public func lookahead<R: RegexComponent>(
   negative: Bool = false,
-  @RegexBuilder _ content: () -> R
+  @RegexComponentBuilder _ content: () -> R
 ) -> Regex<R.Match> {
   Regex(node: .group(negative ? .negativeLookahead : .lookahead, content().regex.root))
 }
   
-public func lookahead<R: RegexProtocol>(
+public func lookahead<R: RegexComponent>(
   _ component: R,
   negative: Bool = false
 ) -> Regex<R.Match> {

--- a/Sources/_StringProcessing/RegexDSL/Builder.swift
+++ b/Sources/_StringProcessing/RegexDSL/Builder.swift
@@ -10,21 +10,21 @@
 //===----------------------------------------------------------------------===//
 
 @resultBuilder
-public enum RegexBuilder {
+public enum RegexComponentBuilder {
   @_disfavoredOverload
-  public static func buildBlock<R0: RegexProtocol>(_ r0: R0) -> R0 {
+  public static func buildBlock<R0: RegexComponent>(_ r0: R0) -> R0 {
     r0
   }
 
-  public static func buildExpression<R: RegexProtocol>(_ regex: R) -> R {
+  public static func buildExpression<R: RegexComponent>(_ regex: R) -> R {
     regex
   }
 
-  public static func buildEither<R: RegexProtocol>(first component: R) -> R {
+  public static func buildEither<R: RegexComponent>(first component: R) -> R {
     component
   }
 
-  public static func buildEither<R: RegexProtocol>(second component: R) -> R {
+  public static func buildEither<R: RegexComponent>(second component: R) -> R {
     component
   }
 }

--- a/Sources/_StringProcessing/RegexDSL/Core.swift
+++ b/Sources/_StringProcessing/RegexDSL/Core.swift
@@ -13,13 +13,13 @@ import _MatchingEngine
 
 
 /// A type that represents a regular expression.
-public protocol RegexProtocol {
+public protocol RegexComponent {
   associatedtype Match
   var regex: Regex<Match> { get }
 }
 
 /// A regular expression.
-public struct Regex<Match>: RegexProtocol {
+public struct Regex<Match>: RegexComponent {
   /// A program representation that caches any lowered representation for
   /// execution.
   internal class Program {
@@ -78,14 +78,14 @@ public struct Regex<Match>: RegexProtocol {
     self.init(ast: try! parseWithDelimiters(pattern))
   }
 
-  public init<Content: RegexProtocol>(
+  public init<Content: RegexComponent>(
     _ content: Content
   ) where Content.Match == Match {
     self = content.regex
   }
 
-  public init<Content: RegexProtocol>(
-    @RegexBuilder _ content: () -> Content
+  public init<Content: RegexComponent>(
+    @RegexComponentBuilder _ content: () -> Content
   ) where Content.Match == Match {
     self.init(content())
   }
@@ -96,7 +96,7 @@ public struct Regex<Match>: RegexProtocol {
 }
 
 
-public struct MockRegexLiteral<Match>: RegexProtocol {
+public struct MockRegexLiteral<Match>: RegexComponent {
   public typealias MatchValue = Substring
   public let regex: Regex<Match>
 

--- a/Sources/_StringProcessing/RegexDSL/DSL.swift
+++ b/Sources/_StringProcessing/RegexDSL/DSL.swift
@@ -13,7 +13,7 @@ import _MatchingEngine
 
 // MARK: - Primitives
 
-extension String: RegexProtocol {
+extension String: RegexComponent {
   public typealias Match = Substring
 
   public var regex: Regex<Match> {
@@ -21,7 +21,7 @@ extension String: RegexProtocol {
   }
 }
 
-extension Substring: RegexProtocol {
+extension Substring: RegexComponent {
   public typealias Match = Substring
 
   public var regex: Regex<Match> {
@@ -29,7 +29,7 @@ extension Substring: RegexProtocol {
   }
 }
 
-extension Character: RegexProtocol {
+extension Character: RegexComponent {
   public typealias Match = Substring
 
   public var regex: Regex<Match> {
@@ -37,7 +37,7 @@ extension Character: RegexProtocol {
   }
 }
 
-extension UnicodeScalar: RegexProtocol {
+extension UnicodeScalar: RegexComponent {
   public typealias Match = Substring
 
   public var regex: Regex<Match> {
@@ -45,7 +45,7 @@ extension UnicodeScalar: RegexProtocol {
   }
 }
 
-extension CharacterClass: RegexProtocol {
+extension CharacterClass: RegexComponent {
   public typealias Match = Substring
 
   public var regex: Regex<Match> {
@@ -63,7 +63,7 @@ extension CharacterClass: RegexProtocol {
 // Note: Concatenation overloads are currently gyb'd.
 
 // TODO: Variadic generics
-// struct Concatenation<W0, C0..., R0: RegexProtocol, W1, C1..., R1: RegexProtocol>
+// struct Concatenation<W0, C0..., R0: RegexComponent, W1, C1..., R1: RegexComponent>
 // where R0.Match == (W0, C0...), R1.Match == (W1, C1...)
 // {
 //   typealias Match = (Substring, C0..., C1...)
@@ -116,7 +116,7 @@ extension QuantificationBehavior {
 }
 
 // TODO: Variadic generics
-// struct _OneOrMore<W, C..., Component: RegexProtocol>
+// struct _OneOrMore<W, C..., Component: RegexComponent>
 // where R.Match == (W, C...)
 // {
 //   typealias Match = (Substring, [(C...)])
@@ -126,7 +126,7 @@ extension QuantificationBehavior {
 //   }
 // }
 //
-// struct _OneOrMoreNonCapturing<Component: RegexProtocol> {
+// struct _OneOrMoreNonCapturing<Component: RegexComponent> {
 //   typealias Match = Substring
 //   let regex: Regex<Match>
 //   init(_ component: Component) {
@@ -134,16 +134,16 @@ extension QuantificationBehavior {
 //   }
 // }
 //
-// func oneOrMore<W, C..., Component: RegexProtocol>(
+// func oneOrMore<W, C..., Component: RegexComponent>(
 //   _ component: Component
-// ) -> <R: RegexProtocol where R.Match == (Substring, [(C...)])> R {
+// ) -> <R: RegexComponent where R.Match == (Substring, [(C...)])> R {
 //   _OneOrMore(component)
 // }
 //
 // @_disfavoredOverload
-// func oneOrMore<Component: RegexProtocol>(
+// func oneOrMore<Component: RegexComponent>(
 //   _ component: Component
-// ) -> <R: RegexProtocol where R.Match == Substring> R {
+// ) -> <R: RegexComponent where R.Match == Substring> R {
 //   _OneOrMoreNonCapturing(component)
 // }
 
@@ -157,9 +157,9 @@ postfix operator .+
 // @resultBuilder
 // struct AlternationBuilder {
 //   @_disfavoredOverload
-//   func buildBlock<R: RegexProtocol>(_ regex: R) -> R
+//   func buildBlock<R: RegexComponent>(_ regex: R) -> R
 //   func buildBlock<
-//     R: RegexProtocol, W0, C0...
+//     R: RegexComponent, W0, C0...
 //   >(
 //     _ regex: R
 //   ) -> R where R.Match == (W, C...)
@@ -168,24 +168,24 @@ postfix operator .+
 @resultBuilder
 public struct AlternationBuilder {
   @_disfavoredOverload
-  public static func buildBlock<R: RegexProtocol>(_ regex: R) -> R {
+  public static func buildBlock<R: RegexComponent>(_ regex: R) -> R {
     regex
   }
 
-  public static func buildExpression<R: RegexProtocol>(_ regex: R) -> R {
+  public static func buildExpression<R: RegexComponent>(_ regex: R) -> R {
     regex
   }
 
-  public static func buildEither<R: RegexProtocol>(first component: R) -> R {
+  public static func buildEither<R: RegexComponent>(first component: R) -> R {
     component
   }
 
-  public static func buildEither<R: RegexProtocol>(second component: R) -> R {
+  public static func buildEither<R: RegexComponent>(second component: R) -> R {
     component
   }
 }
 
-public func choiceOf<R: RegexProtocol>(
+public func choiceOf<R: RegexComponent>(
   @AlternationBuilder builder: () -> R
 ) -> R {
   builder()
@@ -203,7 +203,7 @@ struct ReferenceID: Hashable, Equatable {
   }
 }
 
-public struct Reference<Capture>: RegexProtocol {
+public struct Reference<Capture>: RegexComponent {
   let id = ReferenceID()
   
   public init(_ captureType: Capture.Type = Capture.self) {}

--- a/Sources/_StringProcessing/RegexDSL/DSLConsumers.swift
+++ b/Sources/_StringProcessing/RegexDSL/DSLConsumers.swift
@@ -9,7 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-public protocol CustomRegexComponent: RegexProtocol {
+public protocol CustomRegexComponent: RegexComponent {
   func match(
     _ input: String,
     startingAt index: String.Index,

--- a/Sources/_StringProcessing/RegexDSL/Match.swift
+++ b/Sources/_StringProcessing/RegexDSL/Match.swift
@@ -63,7 +63,7 @@ public struct RegexMatch<Match> {
   }
 }
 
-extension RegexProtocol {
+extension RegexComponent {
   public func match(in input: String) -> RegexMatch<Match>? {
     _match(
       input, in: input.startIndex..<input.endIndex)
@@ -88,23 +88,23 @@ extension RegexProtocol {
 }
 
 extension String {
-  public func match<R: RegexProtocol>(_ regex: R) -> RegexMatch<R.Match>? {
+  public func match<R: RegexComponent>(_ regex: R) -> RegexMatch<R.Match>? {
     regex.match(in: self)
   }
 
-  public func match<R: RegexProtocol>(
-    @RegexBuilder _ content: () -> R
+  public func match<R: RegexComponent>(
+    @RegexComponentBuilder _ content: () -> R
   ) -> RegexMatch<R.Match>? {
     match(content())
   }
 }
 extension Substring {
-  public func match<R: RegexProtocol>(_ regex: R) -> RegexMatch<R.Match>? {
+  public func match<R: RegexComponent>(_ regex: R) -> RegexMatch<R.Match>? {
     regex.match(in: self)
   }
 
-  public func match<R: RegexProtocol>(
-    @RegexBuilder _ content: () -> R
+  public func match<R: RegexComponent>(
+    @RegexComponentBuilder _ content: () -> R
   ) -> RegexMatch<R.Match>? {
     match(content())
   }

--- a/Sources/_StringProcessing/RegexDSL/Options.swift
+++ b/Sources/_StringProcessing/RegexDSL/Options.swift
@@ -11,7 +11,7 @@
 
 import _MatchingEngine
 
-extension RegexProtocol {
+extension RegexComponent {
   public func caseSensitive(_ isCaseSensitive: Bool) -> Regex<Match> {
     // The API is "case sensitive = true or false", so as to avoid the
     // double negatives inherent in setting "case insensitive" to a Boolean

--- a/Sources/_StringProcessing/RegexDSL/Variadics.swift
+++ b/Sources/_StringProcessing/RegexDSL/Variadics.swift
@@ -13,456 +13,456 @@
 
 import _MatchingEngine
 
-extension RegexBuilder {
-  public static func buildBlock<W0, W1, C0, R0: RegexProtocol, R1: RegexProtocol>(
+extension RegexComponentBuilder {
+  public static func buildBlock<W0, W1, C0, R0: RegexComponent, R1: RegexComponent>(
     combining next: R1, into combined: R0
   ) -> Regex<(Substring, C0)>  where R0.Match == W0, R1.Match == (W1, C0) {
     .init(node: combined.regex.root.appending(next.regex.root))
   }
 }
-extension RegexBuilder {
-  public static func buildBlock<W0, W1, C0, C1, R0: RegexProtocol, R1: RegexProtocol>(
+extension RegexComponentBuilder {
+  public static func buildBlock<W0, W1, C0, C1, R0: RegexComponent, R1: RegexComponent>(
     combining next: R1, into combined: R0
   ) -> Regex<(Substring, C0, C1)>  where R0.Match == W0, R1.Match == (W1, C0, C1) {
     .init(node: combined.regex.root.appending(next.regex.root))
   }
 }
-extension RegexBuilder {
-  public static func buildBlock<W0, W1, C0, C1, C2, R0: RegexProtocol, R1: RegexProtocol>(
+extension RegexComponentBuilder {
+  public static func buildBlock<W0, W1, C0, C1, C2, R0: RegexComponent, R1: RegexComponent>(
     combining next: R1, into combined: R0
   ) -> Regex<(Substring, C0, C1, C2)>  where R0.Match == W0, R1.Match == (W1, C0, C1, C2) {
     .init(node: combined.regex.root.appending(next.regex.root))
   }
 }
-extension RegexBuilder {
-  public static func buildBlock<W0, W1, C0, C1, C2, C3, R0: RegexProtocol, R1: RegexProtocol>(
+extension RegexComponentBuilder {
+  public static func buildBlock<W0, W1, C0, C1, C2, C3, R0: RegexComponent, R1: RegexComponent>(
     combining next: R1, into combined: R0
   ) -> Regex<(Substring, C0, C1, C2, C3)>  where R0.Match == W0, R1.Match == (W1, C0, C1, C2, C3) {
     .init(node: combined.regex.root.appending(next.regex.root))
   }
 }
-extension RegexBuilder {
-  public static func buildBlock<W0, W1, C0, C1, C2, C3, C4, R0: RegexProtocol, R1: RegexProtocol>(
+extension RegexComponentBuilder {
+  public static func buildBlock<W0, W1, C0, C1, C2, C3, C4, R0: RegexComponent, R1: RegexComponent>(
     combining next: R1, into combined: R0
   ) -> Regex<(Substring, C0, C1, C2, C3, C4)>  where R0.Match == W0, R1.Match == (W1, C0, C1, C2, C3, C4) {
     .init(node: combined.regex.root.appending(next.regex.root))
   }
 }
-extension RegexBuilder {
-  public static func buildBlock<W0, W1, C0, C1, C2, C3, C4, C5, R0: RegexProtocol, R1: RegexProtocol>(
+extension RegexComponentBuilder {
+  public static func buildBlock<W0, W1, C0, C1, C2, C3, C4, C5, R0: RegexComponent, R1: RegexComponent>(
     combining next: R1, into combined: R0
   ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5)>  where R0.Match == W0, R1.Match == (W1, C0, C1, C2, C3, C4, C5) {
     .init(node: combined.regex.root.appending(next.regex.root))
   }
 }
-extension RegexBuilder {
-  public static func buildBlock<W0, W1, C0, C1, C2, C3, C4, C5, C6, R0: RegexProtocol, R1: RegexProtocol>(
+extension RegexComponentBuilder {
+  public static func buildBlock<W0, W1, C0, C1, C2, C3, C4, C5, C6, R0: RegexComponent, R1: RegexComponent>(
     combining next: R1, into combined: R0
   ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6)>  where R0.Match == W0, R1.Match == (W1, C0, C1, C2, C3, C4, C5, C6) {
     .init(node: combined.regex.root.appending(next.regex.root))
   }
 }
-extension RegexBuilder {
-  public static func buildBlock<W0, W1, C0, C1, C2, C3, C4, C5, C6, C7, R0: RegexProtocol, R1: RegexProtocol>(
+extension RegexComponentBuilder {
+  public static func buildBlock<W0, W1, C0, C1, C2, C3, C4, C5, C6, C7, R0: RegexComponent, R1: RegexComponent>(
     combining next: R1, into combined: R0
   ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7)>  where R0.Match == W0, R1.Match == (W1, C0, C1, C2, C3, C4, C5, C6, C7) {
     .init(node: combined.regex.root.appending(next.regex.root))
   }
 }
-extension RegexBuilder {
-  public static func buildBlock<W0, W1, C0, C1, C2, C3, C4, C5, C6, C7, C8, R0: RegexProtocol, R1: RegexProtocol>(
+extension RegexComponentBuilder {
+  public static func buildBlock<W0, W1, C0, C1, C2, C3, C4, C5, C6, C7, C8, R0: RegexComponent, R1: RegexComponent>(
     combining next: R1, into combined: R0
   ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8)>  where R0.Match == W0, R1.Match == (W1, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
     .init(node: combined.regex.root.appending(next.regex.root))
   }
 }
-extension RegexBuilder {
-  public static func buildBlock<W0, W1, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9, R0: RegexProtocol, R1: RegexProtocol>(
+extension RegexComponentBuilder {
+  public static func buildBlock<W0, W1, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9, R0: RegexComponent, R1: RegexComponent>(
     combining next: R1, into combined: R0
   ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9)>  where R0.Match == W0, R1.Match == (W1, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
     .init(node: combined.regex.root.appending(next.regex.root))
   }
 }
-extension RegexBuilder {
-  public static func buildBlock<W0, W1, C0, C1, R0: RegexProtocol, R1: RegexProtocol>(
+extension RegexComponentBuilder {
+  public static func buildBlock<W0, W1, C0, C1, R0: RegexComponent, R1: RegexComponent>(
     combining next: R1, into combined: R0
   ) -> Regex<(Substring, C0, C1)>  where R0.Match == (W0, C0), R1.Match == (W1, C1) {
     .init(node: combined.regex.root.appending(next.regex.root))
   }
 }
-extension RegexBuilder {
-  public static func buildBlock<W0, W1, C0, C1, C2, R0: RegexProtocol, R1: RegexProtocol>(
+extension RegexComponentBuilder {
+  public static func buildBlock<W0, W1, C0, C1, C2, R0: RegexComponent, R1: RegexComponent>(
     combining next: R1, into combined: R0
   ) -> Regex<(Substring, C0, C1, C2)>  where R0.Match == (W0, C0), R1.Match == (W1, C1, C2) {
     .init(node: combined.regex.root.appending(next.regex.root))
   }
 }
-extension RegexBuilder {
-  public static func buildBlock<W0, W1, C0, C1, C2, C3, R0: RegexProtocol, R1: RegexProtocol>(
+extension RegexComponentBuilder {
+  public static func buildBlock<W0, W1, C0, C1, C2, C3, R0: RegexComponent, R1: RegexComponent>(
     combining next: R1, into combined: R0
   ) -> Regex<(Substring, C0, C1, C2, C3)>  where R0.Match == (W0, C0), R1.Match == (W1, C1, C2, C3) {
     .init(node: combined.regex.root.appending(next.regex.root))
   }
 }
-extension RegexBuilder {
-  public static func buildBlock<W0, W1, C0, C1, C2, C3, C4, R0: RegexProtocol, R1: RegexProtocol>(
+extension RegexComponentBuilder {
+  public static func buildBlock<W0, W1, C0, C1, C2, C3, C4, R0: RegexComponent, R1: RegexComponent>(
     combining next: R1, into combined: R0
   ) -> Regex<(Substring, C0, C1, C2, C3, C4)>  where R0.Match == (W0, C0), R1.Match == (W1, C1, C2, C3, C4) {
     .init(node: combined.regex.root.appending(next.regex.root))
   }
 }
-extension RegexBuilder {
-  public static func buildBlock<W0, W1, C0, C1, C2, C3, C4, C5, R0: RegexProtocol, R1: RegexProtocol>(
+extension RegexComponentBuilder {
+  public static func buildBlock<W0, W1, C0, C1, C2, C3, C4, C5, R0: RegexComponent, R1: RegexComponent>(
     combining next: R1, into combined: R0
   ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5)>  where R0.Match == (W0, C0), R1.Match == (W1, C1, C2, C3, C4, C5) {
     .init(node: combined.regex.root.appending(next.regex.root))
   }
 }
-extension RegexBuilder {
-  public static func buildBlock<W0, W1, C0, C1, C2, C3, C4, C5, C6, R0: RegexProtocol, R1: RegexProtocol>(
+extension RegexComponentBuilder {
+  public static func buildBlock<W0, W1, C0, C1, C2, C3, C4, C5, C6, R0: RegexComponent, R1: RegexComponent>(
     combining next: R1, into combined: R0
   ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6)>  where R0.Match == (W0, C0), R1.Match == (W1, C1, C2, C3, C4, C5, C6) {
     .init(node: combined.regex.root.appending(next.regex.root))
   }
 }
-extension RegexBuilder {
-  public static func buildBlock<W0, W1, C0, C1, C2, C3, C4, C5, C6, C7, R0: RegexProtocol, R1: RegexProtocol>(
+extension RegexComponentBuilder {
+  public static func buildBlock<W0, W1, C0, C1, C2, C3, C4, C5, C6, C7, R0: RegexComponent, R1: RegexComponent>(
     combining next: R1, into combined: R0
   ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7)>  where R0.Match == (W0, C0), R1.Match == (W1, C1, C2, C3, C4, C5, C6, C7) {
     .init(node: combined.regex.root.appending(next.regex.root))
   }
 }
-extension RegexBuilder {
-  public static func buildBlock<W0, W1, C0, C1, C2, C3, C4, C5, C6, C7, C8, R0: RegexProtocol, R1: RegexProtocol>(
+extension RegexComponentBuilder {
+  public static func buildBlock<W0, W1, C0, C1, C2, C3, C4, C5, C6, C7, C8, R0: RegexComponent, R1: RegexComponent>(
     combining next: R1, into combined: R0
   ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8)>  where R0.Match == (W0, C0), R1.Match == (W1, C1, C2, C3, C4, C5, C6, C7, C8) {
     .init(node: combined.regex.root.appending(next.regex.root))
   }
 }
-extension RegexBuilder {
-  public static func buildBlock<W0, W1, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9, R0: RegexProtocol, R1: RegexProtocol>(
+extension RegexComponentBuilder {
+  public static func buildBlock<W0, W1, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9, R0: RegexComponent, R1: RegexComponent>(
     combining next: R1, into combined: R0
   ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9)>  where R0.Match == (W0, C0), R1.Match == (W1, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
     .init(node: combined.regex.root.appending(next.regex.root))
   }
 }
-extension RegexBuilder {
-  public static func buildBlock<W0, W1, C0, C1, C2, R0: RegexProtocol, R1: RegexProtocol>(
+extension RegexComponentBuilder {
+  public static func buildBlock<W0, W1, C0, C1, C2, R0: RegexComponent, R1: RegexComponent>(
     combining next: R1, into combined: R0
   ) -> Regex<(Substring, C0, C1, C2)>  where R0.Match == (W0, C0, C1), R1.Match == (W1, C2) {
     .init(node: combined.regex.root.appending(next.regex.root))
   }
 }
-extension RegexBuilder {
-  public static func buildBlock<W0, W1, C0, C1, C2, C3, R0: RegexProtocol, R1: RegexProtocol>(
+extension RegexComponentBuilder {
+  public static func buildBlock<W0, W1, C0, C1, C2, C3, R0: RegexComponent, R1: RegexComponent>(
     combining next: R1, into combined: R0
   ) -> Regex<(Substring, C0, C1, C2, C3)>  where R0.Match == (W0, C0, C1), R1.Match == (W1, C2, C3) {
     .init(node: combined.regex.root.appending(next.regex.root))
   }
 }
-extension RegexBuilder {
-  public static func buildBlock<W0, W1, C0, C1, C2, C3, C4, R0: RegexProtocol, R1: RegexProtocol>(
+extension RegexComponentBuilder {
+  public static func buildBlock<W0, W1, C0, C1, C2, C3, C4, R0: RegexComponent, R1: RegexComponent>(
     combining next: R1, into combined: R0
   ) -> Regex<(Substring, C0, C1, C2, C3, C4)>  where R0.Match == (W0, C0, C1), R1.Match == (W1, C2, C3, C4) {
     .init(node: combined.regex.root.appending(next.regex.root))
   }
 }
-extension RegexBuilder {
-  public static func buildBlock<W0, W1, C0, C1, C2, C3, C4, C5, R0: RegexProtocol, R1: RegexProtocol>(
+extension RegexComponentBuilder {
+  public static func buildBlock<W0, W1, C0, C1, C2, C3, C4, C5, R0: RegexComponent, R1: RegexComponent>(
     combining next: R1, into combined: R0
   ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5)>  where R0.Match == (W0, C0, C1), R1.Match == (W1, C2, C3, C4, C5) {
     .init(node: combined.regex.root.appending(next.regex.root))
   }
 }
-extension RegexBuilder {
-  public static func buildBlock<W0, W1, C0, C1, C2, C3, C4, C5, C6, R0: RegexProtocol, R1: RegexProtocol>(
+extension RegexComponentBuilder {
+  public static func buildBlock<W0, W1, C0, C1, C2, C3, C4, C5, C6, R0: RegexComponent, R1: RegexComponent>(
     combining next: R1, into combined: R0
   ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6)>  where R0.Match == (W0, C0, C1), R1.Match == (W1, C2, C3, C4, C5, C6) {
     .init(node: combined.regex.root.appending(next.regex.root))
   }
 }
-extension RegexBuilder {
-  public static func buildBlock<W0, W1, C0, C1, C2, C3, C4, C5, C6, C7, R0: RegexProtocol, R1: RegexProtocol>(
+extension RegexComponentBuilder {
+  public static func buildBlock<W0, W1, C0, C1, C2, C3, C4, C5, C6, C7, R0: RegexComponent, R1: RegexComponent>(
     combining next: R1, into combined: R0
   ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7)>  where R0.Match == (W0, C0, C1), R1.Match == (W1, C2, C3, C4, C5, C6, C7) {
     .init(node: combined.regex.root.appending(next.regex.root))
   }
 }
-extension RegexBuilder {
-  public static func buildBlock<W0, W1, C0, C1, C2, C3, C4, C5, C6, C7, C8, R0: RegexProtocol, R1: RegexProtocol>(
+extension RegexComponentBuilder {
+  public static func buildBlock<W0, W1, C0, C1, C2, C3, C4, C5, C6, C7, C8, R0: RegexComponent, R1: RegexComponent>(
     combining next: R1, into combined: R0
   ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8)>  where R0.Match == (W0, C0, C1), R1.Match == (W1, C2, C3, C4, C5, C6, C7, C8) {
     .init(node: combined.regex.root.appending(next.regex.root))
   }
 }
-extension RegexBuilder {
-  public static func buildBlock<W0, W1, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9, R0: RegexProtocol, R1: RegexProtocol>(
+extension RegexComponentBuilder {
+  public static func buildBlock<W0, W1, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9, R0: RegexComponent, R1: RegexComponent>(
     combining next: R1, into combined: R0
   ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9)>  where R0.Match == (W0, C0, C1), R1.Match == (W1, C2, C3, C4, C5, C6, C7, C8, C9) {
     .init(node: combined.regex.root.appending(next.regex.root))
   }
 }
-extension RegexBuilder {
-  public static func buildBlock<W0, W1, C0, C1, C2, C3, R0: RegexProtocol, R1: RegexProtocol>(
+extension RegexComponentBuilder {
+  public static func buildBlock<W0, W1, C0, C1, C2, C3, R0: RegexComponent, R1: RegexComponent>(
     combining next: R1, into combined: R0
   ) -> Regex<(Substring, C0, C1, C2, C3)>  where R0.Match == (W0, C0, C1, C2), R1.Match == (W1, C3) {
     .init(node: combined.regex.root.appending(next.regex.root))
   }
 }
-extension RegexBuilder {
-  public static func buildBlock<W0, W1, C0, C1, C2, C3, C4, R0: RegexProtocol, R1: RegexProtocol>(
+extension RegexComponentBuilder {
+  public static func buildBlock<W0, W1, C0, C1, C2, C3, C4, R0: RegexComponent, R1: RegexComponent>(
     combining next: R1, into combined: R0
   ) -> Regex<(Substring, C0, C1, C2, C3, C4)>  where R0.Match == (W0, C0, C1, C2), R1.Match == (W1, C3, C4) {
     .init(node: combined.regex.root.appending(next.regex.root))
   }
 }
-extension RegexBuilder {
-  public static func buildBlock<W0, W1, C0, C1, C2, C3, C4, C5, R0: RegexProtocol, R1: RegexProtocol>(
+extension RegexComponentBuilder {
+  public static func buildBlock<W0, W1, C0, C1, C2, C3, C4, C5, R0: RegexComponent, R1: RegexComponent>(
     combining next: R1, into combined: R0
   ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5)>  where R0.Match == (W0, C0, C1, C2), R1.Match == (W1, C3, C4, C5) {
     .init(node: combined.regex.root.appending(next.regex.root))
   }
 }
-extension RegexBuilder {
-  public static func buildBlock<W0, W1, C0, C1, C2, C3, C4, C5, C6, R0: RegexProtocol, R1: RegexProtocol>(
+extension RegexComponentBuilder {
+  public static func buildBlock<W0, W1, C0, C1, C2, C3, C4, C5, C6, R0: RegexComponent, R1: RegexComponent>(
     combining next: R1, into combined: R0
   ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6)>  where R0.Match == (W0, C0, C1, C2), R1.Match == (W1, C3, C4, C5, C6) {
     .init(node: combined.regex.root.appending(next.regex.root))
   }
 }
-extension RegexBuilder {
-  public static func buildBlock<W0, W1, C0, C1, C2, C3, C4, C5, C6, C7, R0: RegexProtocol, R1: RegexProtocol>(
+extension RegexComponentBuilder {
+  public static func buildBlock<W0, W1, C0, C1, C2, C3, C4, C5, C6, C7, R0: RegexComponent, R1: RegexComponent>(
     combining next: R1, into combined: R0
   ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7)>  where R0.Match == (W0, C0, C1, C2), R1.Match == (W1, C3, C4, C5, C6, C7) {
     .init(node: combined.regex.root.appending(next.regex.root))
   }
 }
-extension RegexBuilder {
-  public static func buildBlock<W0, W1, C0, C1, C2, C3, C4, C5, C6, C7, C8, R0: RegexProtocol, R1: RegexProtocol>(
+extension RegexComponentBuilder {
+  public static func buildBlock<W0, W1, C0, C1, C2, C3, C4, C5, C6, C7, C8, R0: RegexComponent, R1: RegexComponent>(
     combining next: R1, into combined: R0
   ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8)>  where R0.Match == (W0, C0, C1, C2), R1.Match == (W1, C3, C4, C5, C6, C7, C8) {
     .init(node: combined.regex.root.appending(next.regex.root))
   }
 }
-extension RegexBuilder {
-  public static func buildBlock<W0, W1, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9, R0: RegexProtocol, R1: RegexProtocol>(
+extension RegexComponentBuilder {
+  public static func buildBlock<W0, W1, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9, R0: RegexComponent, R1: RegexComponent>(
     combining next: R1, into combined: R0
   ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9)>  where R0.Match == (W0, C0, C1, C2), R1.Match == (W1, C3, C4, C5, C6, C7, C8, C9) {
     .init(node: combined.regex.root.appending(next.regex.root))
   }
 }
-extension RegexBuilder {
-  public static func buildBlock<W0, W1, C0, C1, C2, C3, C4, R0: RegexProtocol, R1: RegexProtocol>(
+extension RegexComponentBuilder {
+  public static func buildBlock<W0, W1, C0, C1, C2, C3, C4, R0: RegexComponent, R1: RegexComponent>(
     combining next: R1, into combined: R0
   ) -> Regex<(Substring, C0, C1, C2, C3, C4)>  where R0.Match == (W0, C0, C1, C2, C3), R1.Match == (W1, C4) {
     .init(node: combined.regex.root.appending(next.regex.root))
   }
 }
-extension RegexBuilder {
-  public static func buildBlock<W0, W1, C0, C1, C2, C3, C4, C5, R0: RegexProtocol, R1: RegexProtocol>(
+extension RegexComponentBuilder {
+  public static func buildBlock<W0, W1, C0, C1, C2, C3, C4, C5, R0: RegexComponent, R1: RegexComponent>(
     combining next: R1, into combined: R0
   ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5)>  where R0.Match == (W0, C0, C1, C2, C3), R1.Match == (W1, C4, C5) {
     .init(node: combined.regex.root.appending(next.regex.root))
   }
 }
-extension RegexBuilder {
-  public static func buildBlock<W0, W1, C0, C1, C2, C3, C4, C5, C6, R0: RegexProtocol, R1: RegexProtocol>(
+extension RegexComponentBuilder {
+  public static func buildBlock<W0, W1, C0, C1, C2, C3, C4, C5, C6, R0: RegexComponent, R1: RegexComponent>(
     combining next: R1, into combined: R0
   ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6)>  where R0.Match == (W0, C0, C1, C2, C3), R1.Match == (W1, C4, C5, C6) {
     .init(node: combined.regex.root.appending(next.regex.root))
   }
 }
-extension RegexBuilder {
-  public static func buildBlock<W0, W1, C0, C1, C2, C3, C4, C5, C6, C7, R0: RegexProtocol, R1: RegexProtocol>(
+extension RegexComponentBuilder {
+  public static func buildBlock<W0, W1, C0, C1, C2, C3, C4, C5, C6, C7, R0: RegexComponent, R1: RegexComponent>(
     combining next: R1, into combined: R0
   ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7)>  where R0.Match == (W0, C0, C1, C2, C3), R1.Match == (W1, C4, C5, C6, C7) {
     .init(node: combined.regex.root.appending(next.regex.root))
   }
 }
-extension RegexBuilder {
-  public static func buildBlock<W0, W1, C0, C1, C2, C3, C4, C5, C6, C7, C8, R0: RegexProtocol, R1: RegexProtocol>(
+extension RegexComponentBuilder {
+  public static func buildBlock<W0, W1, C0, C1, C2, C3, C4, C5, C6, C7, C8, R0: RegexComponent, R1: RegexComponent>(
     combining next: R1, into combined: R0
   ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8)>  where R0.Match == (W0, C0, C1, C2, C3), R1.Match == (W1, C4, C5, C6, C7, C8) {
     .init(node: combined.regex.root.appending(next.regex.root))
   }
 }
-extension RegexBuilder {
-  public static func buildBlock<W0, W1, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9, R0: RegexProtocol, R1: RegexProtocol>(
+extension RegexComponentBuilder {
+  public static func buildBlock<W0, W1, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9, R0: RegexComponent, R1: RegexComponent>(
     combining next: R1, into combined: R0
   ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9)>  where R0.Match == (W0, C0, C1, C2, C3), R1.Match == (W1, C4, C5, C6, C7, C8, C9) {
     .init(node: combined.regex.root.appending(next.regex.root))
   }
 }
-extension RegexBuilder {
-  public static func buildBlock<W0, W1, C0, C1, C2, C3, C4, C5, R0: RegexProtocol, R1: RegexProtocol>(
+extension RegexComponentBuilder {
+  public static func buildBlock<W0, W1, C0, C1, C2, C3, C4, C5, R0: RegexComponent, R1: RegexComponent>(
     combining next: R1, into combined: R0
   ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5)>  where R0.Match == (W0, C0, C1, C2, C3, C4), R1.Match == (W1, C5) {
     .init(node: combined.regex.root.appending(next.regex.root))
   }
 }
-extension RegexBuilder {
-  public static func buildBlock<W0, W1, C0, C1, C2, C3, C4, C5, C6, R0: RegexProtocol, R1: RegexProtocol>(
+extension RegexComponentBuilder {
+  public static func buildBlock<W0, W1, C0, C1, C2, C3, C4, C5, C6, R0: RegexComponent, R1: RegexComponent>(
     combining next: R1, into combined: R0
   ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6)>  where R0.Match == (W0, C0, C1, C2, C3, C4), R1.Match == (W1, C5, C6) {
     .init(node: combined.regex.root.appending(next.regex.root))
   }
 }
-extension RegexBuilder {
-  public static func buildBlock<W0, W1, C0, C1, C2, C3, C4, C5, C6, C7, R0: RegexProtocol, R1: RegexProtocol>(
+extension RegexComponentBuilder {
+  public static func buildBlock<W0, W1, C0, C1, C2, C3, C4, C5, C6, C7, R0: RegexComponent, R1: RegexComponent>(
     combining next: R1, into combined: R0
   ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7)>  where R0.Match == (W0, C0, C1, C2, C3, C4), R1.Match == (W1, C5, C6, C7) {
     .init(node: combined.regex.root.appending(next.regex.root))
   }
 }
-extension RegexBuilder {
-  public static func buildBlock<W0, W1, C0, C1, C2, C3, C4, C5, C6, C7, C8, R0: RegexProtocol, R1: RegexProtocol>(
+extension RegexComponentBuilder {
+  public static func buildBlock<W0, W1, C0, C1, C2, C3, C4, C5, C6, C7, C8, R0: RegexComponent, R1: RegexComponent>(
     combining next: R1, into combined: R0
   ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8)>  where R0.Match == (W0, C0, C1, C2, C3, C4), R1.Match == (W1, C5, C6, C7, C8) {
     .init(node: combined.regex.root.appending(next.regex.root))
   }
 }
-extension RegexBuilder {
-  public static func buildBlock<W0, W1, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9, R0: RegexProtocol, R1: RegexProtocol>(
+extension RegexComponentBuilder {
+  public static func buildBlock<W0, W1, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9, R0: RegexComponent, R1: RegexComponent>(
     combining next: R1, into combined: R0
   ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9)>  where R0.Match == (W0, C0, C1, C2, C3, C4), R1.Match == (W1, C5, C6, C7, C8, C9) {
     .init(node: combined.regex.root.appending(next.regex.root))
   }
 }
-extension RegexBuilder {
-  public static func buildBlock<W0, W1, C0, C1, C2, C3, C4, C5, C6, R0: RegexProtocol, R1: RegexProtocol>(
+extension RegexComponentBuilder {
+  public static func buildBlock<W0, W1, C0, C1, C2, C3, C4, C5, C6, R0: RegexComponent, R1: RegexComponent>(
     combining next: R1, into combined: R0
   ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6)>  where R0.Match == (W0, C0, C1, C2, C3, C4, C5), R1.Match == (W1, C6) {
     .init(node: combined.regex.root.appending(next.regex.root))
   }
 }
-extension RegexBuilder {
-  public static func buildBlock<W0, W1, C0, C1, C2, C3, C4, C5, C6, C7, R0: RegexProtocol, R1: RegexProtocol>(
+extension RegexComponentBuilder {
+  public static func buildBlock<W0, W1, C0, C1, C2, C3, C4, C5, C6, C7, R0: RegexComponent, R1: RegexComponent>(
     combining next: R1, into combined: R0
   ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7)>  where R0.Match == (W0, C0, C1, C2, C3, C4, C5), R1.Match == (W1, C6, C7) {
     .init(node: combined.regex.root.appending(next.regex.root))
   }
 }
-extension RegexBuilder {
-  public static func buildBlock<W0, W1, C0, C1, C2, C3, C4, C5, C6, C7, C8, R0: RegexProtocol, R1: RegexProtocol>(
+extension RegexComponentBuilder {
+  public static func buildBlock<W0, W1, C0, C1, C2, C3, C4, C5, C6, C7, C8, R0: RegexComponent, R1: RegexComponent>(
     combining next: R1, into combined: R0
   ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8)>  where R0.Match == (W0, C0, C1, C2, C3, C4, C5), R1.Match == (W1, C6, C7, C8) {
     .init(node: combined.regex.root.appending(next.regex.root))
   }
 }
-extension RegexBuilder {
-  public static func buildBlock<W0, W1, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9, R0: RegexProtocol, R1: RegexProtocol>(
+extension RegexComponentBuilder {
+  public static func buildBlock<W0, W1, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9, R0: RegexComponent, R1: RegexComponent>(
     combining next: R1, into combined: R0
   ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9)>  where R0.Match == (W0, C0, C1, C2, C3, C4, C5), R1.Match == (W1, C6, C7, C8, C9) {
     .init(node: combined.regex.root.appending(next.regex.root))
   }
 }
-extension RegexBuilder {
-  public static func buildBlock<W0, W1, C0, C1, C2, C3, C4, C5, C6, C7, R0: RegexProtocol, R1: RegexProtocol>(
+extension RegexComponentBuilder {
+  public static func buildBlock<W0, W1, C0, C1, C2, C3, C4, C5, C6, C7, R0: RegexComponent, R1: RegexComponent>(
     combining next: R1, into combined: R0
   ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7)>  where R0.Match == (W0, C0, C1, C2, C3, C4, C5, C6), R1.Match == (W1, C7) {
     .init(node: combined.regex.root.appending(next.regex.root))
   }
 }
-extension RegexBuilder {
-  public static func buildBlock<W0, W1, C0, C1, C2, C3, C4, C5, C6, C7, C8, R0: RegexProtocol, R1: RegexProtocol>(
+extension RegexComponentBuilder {
+  public static func buildBlock<W0, W1, C0, C1, C2, C3, C4, C5, C6, C7, C8, R0: RegexComponent, R1: RegexComponent>(
     combining next: R1, into combined: R0
   ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8)>  where R0.Match == (W0, C0, C1, C2, C3, C4, C5, C6), R1.Match == (W1, C7, C8) {
     .init(node: combined.regex.root.appending(next.regex.root))
   }
 }
-extension RegexBuilder {
-  public static func buildBlock<W0, W1, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9, R0: RegexProtocol, R1: RegexProtocol>(
+extension RegexComponentBuilder {
+  public static func buildBlock<W0, W1, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9, R0: RegexComponent, R1: RegexComponent>(
     combining next: R1, into combined: R0
   ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9)>  where R0.Match == (W0, C0, C1, C2, C3, C4, C5, C6), R1.Match == (W1, C7, C8, C9) {
     .init(node: combined.regex.root.appending(next.regex.root))
   }
 }
-extension RegexBuilder {
-  public static func buildBlock<W0, W1, C0, C1, C2, C3, C4, C5, C6, C7, C8, R0: RegexProtocol, R1: RegexProtocol>(
+extension RegexComponentBuilder {
+  public static func buildBlock<W0, W1, C0, C1, C2, C3, C4, C5, C6, C7, C8, R0: RegexComponent, R1: RegexComponent>(
     combining next: R1, into combined: R0
   ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8)>  where R0.Match == (W0, C0, C1, C2, C3, C4, C5, C6, C7), R1.Match == (W1, C8) {
     .init(node: combined.regex.root.appending(next.regex.root))
   }
 }
-extension RegexBuilder {
-  public static func buildBlock<W0, W1, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9, R0: RegexProtocol, R1: RegexProtocol>(
+extension RegexComponentBuilder {
+  public static func buildBlock<W0, W1, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9, R0: RegexComponent, R1: RegexComponent>(
     combining next: R1, into combined: R0
   ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9)>  where R0.Match == (W0, C0, C1, C2, C3, C4, C5, C6, C7), R1.Match == (W1, C8, C9) {
     .init(node: combined.regex.root.appending(next.regex.root))
   }
 }
-extension RegexBuilder {
-  public static func buildBlock<W0, W1, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9, R0: RegexProtocol, R1: RegexProtocol>(
+extension RegexComponentBuilder {
+  public static func buildBlock<W0, W1, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9, R0: RegexComponent, R1: RegexComponent>(
     combining next: R1, into combined: R0
   ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9)>  where R0.Match == (W0, C0, C1, C2, C3, C4, C5, C6, C7, C8), R1.Match == (W1, C9) {
     .init(node: combined.regex.root.appending(next.regex.root))
   }
 }
-extension RegexBuilder {
-  public static func buildBlock<W0, R0: RegexProtocol, R1: RegexProtocol>(
+extension RegexComponentBuilder {
+  public static func buildBlock<W0, R0: RegexComponent, R1: RegexComponent>(
     combining next: R1, into combined: R0
   ) -> Regex<Substring> where R0.Match == W0  {
     .init(node: combined.regex.root.appending(next.regex.root))
   }
 }
-extension RegexBuilder {
-  public static func buildBlock<W0, C0, R0: RegexProtocol, R1: RegexProtocol>(
+extension RegexComponentBuilder {
+  public static func buildBlock<W0, C0, R0: RegexComponent, R1: RegexComponent>(
     combining next: R1, into combined: R0
   ) -> Regex<(Substring, C0)> where R0.Match == (W0, C0)  {
     .init(node: combined.regex.root.appending(next.regex.root))
   }
 }
-extension RegexBuilder {
-  public static func buildBlock<W0, C0, C1, R0: RegexProtocol, R1: RegexProtocol>(
+extension RegexComponentBuilder {
+  public static func buildBlock<W0, C0, C1, R0: RegexComponent, R1: RegexComponent>(
     combining next: R1, into combined: R0
   ) -> Regex<(Substring, C0, C1)> where R0.Match == (W0, C0, C1)  {
     .init(node: combined.regex.root.appending(next.regex.root))
   }
 }
-extension RegexBuilder {
-  public static func buildBlock<W0, C0, C1, C2, R0: RegexProtocol, R1: RegexProtocol>(
+extension RegexComponentBuilder {
+  public static func buildBlock<W0, C0, C1, C2, R0: RegexComponent, R1: RegexComponent>(
     combining next: R1, into combined: R0
   ) -> Regex<(Substring, C0, C1, C2)> where R0.Match == (W0, C0, C1, C2)  {
     .init(node: combined.regex.root.appending(next.regex.root))
   }
 }
-extension RegexBuilder {
-  public static func buildBlock<W0, C0, C1, C2, C3, R0: RegexProtocol, R1: RegexProtocol>(
+extension RegexComponentBuilder {
+  public static func buildBlock<W0, C0, C1, C2, C3, R0: RegexComponent, R1: RegexComponent>(
     combining next: R1, into combined: R0
   ) -> Regex<(Substring, C0, C1, C2, C3)> where R0.Match == (W0, C0, C1, C2, C3)  {
     .init(node: combined.regex.root.appending(next.regex.root))
   }
 }
-extension RegexBuilder {
-  public static func buildBlock<W0, C0, C1, C2, C3, C4, R0: RegexProtocol, R1: RegexProtocol>(
+extension RegexComponentBuilder {
+  public static func buildBlock<W0, C0, C1, C2, C3, C4, R0: RegexComponent, R1: RegexComponent>(
     combining next: R1, into combined: R0
   ) -> Regex<(Substring, C0, C1, C2, C3, C4)> where R0.Match == (W0, C0, C1, C2, C3, C4)  {
     .init(node: combined.regex.root.appending(next.regex.root))
   }
 }
-extension RegexBuilder {
-  public static func buildBlock<W0, C0, C1, C2, C3, C4, C5, R0: RegexProtocol, R1: RegexProtocol>(
+extension RegexComponentBuilder {
+  public static func buildBlock<W0, C0, C1, C2, C3, C4, C5, R0: RegexComponent, R1: RegexComponent>(
     combining next: R1, into combined: R0
   ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5)> where R0.Match == (W0, C0, C1, C2, C3, C4, C5)  {
     .init(node: combined.regex.root.appending(next.regex.root))
   }
 }
-extension RegexBuilder {
-  public static func buildBlock<W0, C0, C1, C2, C3, C4, C5, C6, R0: RegexProtocol, R1: RegexProtocol>(
+extension RegexComponentBuilder {
+  public static func buildBlock<W0, C0, C1, C2, C3, C4, C5, C6, R0: RegexComponent, R1: RegexComponent>(
     combining next: R1, into combined: R0
   ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6)> where R0.Match == (W0, C0, C1, C2, C3, C4, C5, C6)  {
     .init(node: combined.regex.root.appending(next.regex.root))
   }
 }
-extension RegexBuilder {
-  public static func buildBlock<W0, C0, C1, C2, C3, C4, C5, C6, C7, R0: RegexProtocol, R1: RegexProtocol>(
+extension RegexComponentBuilder {
+  public static func buildBlock<W0, C0, C1, C2, C3, C4, C5, C6, C7, R0: RegexComponent, R1: RegexComponent>(
     combining next: R1, into combined: R0
   ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7)> where R0.Match == (W0, C0, C1, C2, C3, C4, C5, C6, C7)  {
     .init(node: combined.regex.root.appending(next.regex.root))
   }
 }
-extension RegexBuilder {
-  public static func buildBlock<W0, C0, C1, C2, C3, C4, C5, C6, C7, C8, R0: RegexProtocol, R1: RegexProtocol>(
+extension RegexComponentBuilder {
+  public static func buildBlock<W0, C0, C1, C2, C3, C4, C5, C6, C7, C8, R0: RegexComponent, R1: RegexComponent>(
     combining next: R1, into combined: R0
   ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8)> where R0.Match == (W0, C0, C1, C2, C3, C4, C5, C6, C7, C8)  {
     .init(node: combined.regex.root.appending(next.regex.root))
@@ -471,7 +471,7 @@ extension RegexBuilder {
 
 
 @_disfavoredOverload
-public func optionally<Component: RegexProtocol>(
+public func optionally<Component: RegexComponent>(
   _ component: Component,
   _ behavior: QuantificationBehavior = .eagerly
 ) -> Regex<Substring>  {
@@ -479,29 +479,29 @@ public func optionally<Component: RegexProtocol>(
 }
 
 @_disfavoredOverload
-public func optionally<Component: RegexProtocol>(
+public func optionally<Component: RegexComponent>(
   _ behavior: QuantificationBehavior = .eagerly,
-  @RegexBuilder _ component: () -> Component
+  @RegexComponentBuilder _ component: () -> Component
 ) -> Regex<Substring>  {
   .init(node: .quantification(.zeroOrOne, behavior.astKind, component().regex.root))
 }
 
 @_disfavoredOverload
-public postfix func .?<Component: RegexProtocol>(
+public postfix func .?<Component: RegexComponent>(
   _ component: Component
 ) -> Regex<Substring>  {
   .init(node: .quantification(.zeroOrOne, .eager, component.regex.root))
 }
 
-extension RegexBuilder {
-  public static func buildLimitedAvailability<Component: RegexProtocol>(
+extension RegexComponentBuilder {
+  public static func buildLimitedAvailability<Component: RegexComponent>(
     _ component: Component
   ) -> Regex<Substring>  {
     .init(node: .quantification(.zeroOrOne, .eager, component.regex.root))
   }
 }
 @_disfavoredOverload
-public func zeroOrMore<Component: RegexProtocol>(
+public func zeroOrMore<Component: RegexComponent>(
   _ component: Component,
   _ behavior: QuantificationBehavior = .eagerly
 ) -> Regex<Substring>  {
@@ -509,15 +509,15 @@ public func zeroOrMore<Component: RegexProtocol>(
 }
 
 @_disfavoredOverload
-public func zeroOrMore<Component: RegexProtocol>(
+public func zeroOrMore<Component: RegexComponent>(
   _ behavior: QuantificationBehavior = .eagerly,
-  @RegexBuilder _ component: () -> Component
+  @RegexComponentBuilder _ component: () -> Component
 ) -> Regex<Substring>  {
   .init(node: .quantification(.zeroOrMore, behavior.astKind, component().regex.root))
 }
 
 @_disfavoredOverload
-public postfix func .*<Component: RegexProtocol>(
+public postfix func .*<Component: RegexComponent>(
   _ component: Component
 ) -> Regex<Substring>  {
   .init(node: .quantification(.zeroOrMore, .eager, component.regex.root))
@@ -525,7 +525,7 @@ public postfix func .*<Component: RegexProtocol>(
 
 
 @_disfavoredOverload
-public func oneOrMore<Component: RegexProtocol>(
+public func oneOrMore<Component: RegexComponent>(
   _ component: Component,
   _ behavior: QuantificationBehavior = .eagerly
 ) -> Regex<Substring>  {
@@ -533,15 +533,15 @@ public func oneOrMore<Component: RegexProtocol>(
 }
 
 @_disfavoredOverload
-public func oneOrMore<Component: RegexProtocol>(
+public func oneOrMore<Component: RegexComponent>(
   _ behavior: QuantificationBehavior = .eagerly,
-  @RegexBuilder _ component: () -> Component
+  @RegexComponentBuilder _ component: () -> Component
 ) -> Regex<Substring>  {
   .init(node: .quantification(.oneOrMore, behavior.astKind, component().regex.root))
 }
 
 @_disfavoredOverload
-public postfix func .+<Component: RegexProtocol>(
+public postfix func .+<Component: RegexComponent>(
   _ component: Component
 ) -> Regex<Substring>  {
   .init(node: .quantification(.oneOrMore, .eager, component.regex.root))
@@ -549,7 +549,7 @@ public postfix func .+<Component: RegexProtocol>(
 
 
 @_disfavoredOverload
-public func repeating<Component: RegexProtocol>(
+public func repeating<Component: RegexComponent>(
   _ component: Component,
   count: Int
 ) -> Regex<Substring>  {
@@ -559,9 +559,9 @@ public func repeating<Component: RegexProtocol>(
 }
 
 @_disfavoredOverload
-public func repeating<Component: RegexProtocol>(
+public func repeating<Component: RegexComponent>(
   count: Int,
-  @RegexBuilder _ component: () -> Component
+  @RegexComponentBuilder _ component: () -> Component
 ) -> Regex<Substring>  {
   assert(count > 0, "Must specify a positive count")
   // TODO: Emit a warning about `repeatMatch(count: 0)` or `repeatMatch(count: 1)`
@@ -569,7 +569,7 @@ public func repeating<Component: RegexProtocol>(
 }
 
 @_disfavoredOverload
-public func repeating<Component: RegexProtocol, R: RangeExpression>(
+public func repeating<Component: RegexComponent, R: RangeExpression>(
   _ component: Component,
   _ expression: R,
   _ behavior: QuantificationBehavior = .eagerly
@@ -578,83 +578,83 @@ public func repeating<Component: RegexProtocol, R: RangeExpression>(
 }
 
 @_disfavoredOverload
-public func repeating<Component: RegexProtocol, R: RangeExpression>(
+public func repeating<Component: RegexComponent, R: RangeExpression>(
   _ expression: R,
   _ behavior: QuantificationBehavior = .eagerly,
-  @RegexBuilder _ component: () -> Component
+  @RegexComponentBuilder _ component: () -> Component
 ) -> Regex<Substring> where R.Bound == Int {
   .init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component().regex.root))
 }
-public func optionally<W, C0, Component: RegexProtocol>(
+public func optionally<W, C0, Component: RegexComponent>(
   _ component: Component,
   _ behavior: QuantificationBehavior = .eagerly
 ) -> Regex<(Substring, C0?)> where Component.Match == (W, C0) {
   .init(node: .quantification(.zeroOrOne, behavior.astKind, component.regex.root))
 }
 
-public func optionally<W, C0, Component: RegexProtocol>(
+public func optionally<W, C0, Component: RegexComponent>(
   _ behavior: QuantificationBehavior = .eagerly,
-  @RegexBuilder _ component: () -> Component
+  @RegexComponentBuilder _ component: () -> Component
 ) -> Regex<(Substring, C0?)> where Component.Match == (W, C0) {
   .init(node: .quantification(.zeroOrOne, behavior.astKind, component().regex.root))
 }
 
-public postfix func .?<W, C0, Component: RegexProtocol>(
+public postfix func .?<W, C0, Component: RegexComponent>(
   _ component: Component
 ) -> Regex<(Substring, C0?)> where Component.Match == (W, C0) {
   .init(node: .quantification(.zeroOrOne, .eager, component.regex.root))
 }
 
-extension RegexBuilder {
-  public static func buildLimitedAvailability<W, C0, Component: RegexProtocol>(
+extension RegexComponentBuilder {
+  public static func buildLimitedAvailability<W, C0, Component: RegexComponent>(
     _ component: Component
   ) -> Regex<(Substring, C0?)> where Component.Match == (W, C0) {
     .init(node: .quantification(.zeroOrOne, .eager, component.regex.root))
   }
 }
-public func zeroOrMore<W, C0, Component: RegexProtocol>(
+public func zeroOrMore<W, C0, Component: RegexComponent>(
   _ component: Component,
   _ behavior: QuantificationBehavior = .eagerly
 ) -> Regex<(Substring, C0?)> where Component.Match == (W, C0) {
   .init(node: .quantification(.zeroOrMore, behavior.astKind, component.regex.root))
 }
 
-public func zeroOrMore<W, C0, Component: RegexProtocol>(
+public func zeroOrMore<W, C0, Component: RegexComponent>(
   _ behavior: QuantificationBehavior = .eagerly,
-  @RegexBuilder _ component: () -> Component
+  @RegexComponentBuilder _ component: () -> Component
 ) -> Regex<(Substring, C0?)> where Component.Match == (W, C0) {
   .init(node: .quantification(.zeroOrMore, behavior.astKind, component().regex.root))
 }
 
-public postfix func .*<W, C0, Component: RegexProtocol>(
+public postfix func .*<W, C0, Component: RegexComponent>(
   _ component: Component
 ) -> Regex<(Substring, C0?)> where Component.Match == (W, C0) {
   .init(node: .quantification(.zeroOrMore, .eager, component.regex.root))
 }
 
 
-public func oneOrMore<W, C0, Component: RegexProtocol>(
+public func oneOrMore<W, C0, Component: RegexComponent>(
   _ component: Component,
   _ behavior: QuantificationBehavior = .eagerly
 ) -> Regex<(Substring, C0)> where Component.Match == (W, C0) {
   .init(node: .quantification(.oneOrMore, behavior.astKind, component.regex.root))
 }
 
-public func oneOrMore<W, C0, Component: RegexProtocol>(
+public func oneOrMore<W, C0, Component: RegexComponent>(
   _ behavior: QuantificationBehavior = .eagerly,
-  @RegexBuilder _ component: () -> Component
+  @RegexComponentBuilder _ component: () -> Component
 ) -> Regex<(Substring, C0)> where Component.Match == (W, C0) {
   .init(node: .quantification(.oneOrMore, behavior.astKind, component().regex.root))
 }
 
-public postfix func .+<W, C0, Component: RegexProtocol>(
+public postfix func .+<W, C0, Component: RegexComponent>(
   _ component: Component
 ) -> Regex<(Substring, C0)> where Component.Match == (W, C0) {
   .init(node: .quantification(.oneOrMore, .eager, component.regex.root))
 }
 
 
-public func repeating<W, C0, Component: RegexProtocol>(
+public func repeating<W, C0, Component: RegexComponent>(
   _ component: Component,
   count: Int
 ) -> Regex<(Substring, C0?)> where Component.Match == (W, C0) {
@@ -663,16 +663,16 @@ public func repeating<W, C0, Component: RegexProtocol>(
   return Regex(node: .quantification(.exactly(.init(faking: count)), .eager, component.regex.root))
 }
 
-public func repeating<W, C0, Component: RegexProtocol>(
+public func repeating<W, C0, Component: RegexComponent>(
   count: Int,
-  @RegexBuilder _ component: () -> Component
+  @RegexComponentBuilder _ component: () -> Component
 ) -> Regex<(Substring, C0?)> where Component.Match == (W, C0) {
   assert(count > 0, "Must specify a positive count")
   // TODO: Emit a warning about `repeatMatch(count: 0)` or `repeatMatch(count: 1)`
   return Regex(node: .quantification(.exactly(.init(faking: count)), .eager, component().regex.root))
 }
 
-public func repeating<W, C0, Component: RegexProtocol, R: RangeExpression>(
+public func repeating<W, C0, Component: RegexComponent, R: RangeExpression>(
   _ component: Component,
   _ expression: R,
   _ behavior: QuantificationBehavior = .eagerly
@@ -680,83 +680,83 @@ public func repeating<W, C0, Component: RegexProtocol, R: RangeExpression>(
   .init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component.regex.root))
 }
 
-public func repeating<W, C0, Component: RegexProtocol, R: RangeExpression>(
+public func repeating<W, C0, Component: RegexComponent, R: RangeExpression>(
   _ expression: R,
   _ behavior: QuantificationBehavior = .eagerly,
-  @RegexBuilder _ component: () -> Component
+  @RegexComponentBuilder _ component: () -> Component
 ) -> Regex<(Substring, C0?)> where Component.Match == (W, C0), R.Bound == Int {
   .init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component().regex.root))
 }
-public func optionally<W, C0, C1, Component: RegexProtocol>(
+public func optionally<W, C0, C1, Component: RegexComponent>(
   _ component: Component,
   _ behavior: QuantificationBehavior = .eagerly
 ) -> Regex<(Substring, C0?, C1?)> where Component.Match == (W, C0, C1) {
   .init(node: .quantification(.zeroOrOne, behavior.astKind, component.regex.root))
 }
 
-public func optionally<W, C0, C1, Component: RegexProtocol>(
+public func optionally<W, C0, C1, Component: RegexComponent>(
   _ behavior: QuantificationBehavior = .eagerly,
-  @RegexBuilder _ component: () -> Component
+  @RegexComponentBuilder _ component: () -> Component
 ) -> Regex<(Substring, C0?, C1?)> where Component.Match == (W, C0, C1) {
   .init(node: .quantification(.zeroOrOne, behavior.astKind, component().regex.root))
 }
 
-public postfix func .?<W, C0, C1, Component: RegexProtocol>(
+public postfix func .?<W, C0, C1, Component: RegexComponent>(
   _ component: Component
 ) -> Regex<(Substring, C0?, C1?)> where Component.Match == (W, C0, C1) {
   .init(node: .quantification(.zeroOrOne, .eager, component.regex.root))
 }
 
-extension RegexBuilder {
-  public static func buildLimitedAvailability<W, C0, C1, Component: RegexProtocol>(
+extension RegexComponentBuilder {
+  public static func buildLimitedAvailability<W, C0, C1, Component: RegexComponent>(
     _ component: Component
   ) -> Regex<(Substring, C0?, C1?)> where Component.Match == (W, C0, C1) {
     .init(node: .quantification(.zeroOrOne, .eager, component.regex.root))
   }
 }
-public func zeroOrMore<W, C0, C1, Component: RegexProtocol>(
+public func zeroOrMore<W, C0, C1, Component: RegexComponent>(
   _ component: Component,
   _ behavior: QuantificationBehavior = .eagerly
 ) -> Regex<(Substring, C0?, C1?)> where Component.Match == (W, C0, C1) {
   .init(node: .quantification(.zeroOrMore, behavior.astKind, component.regex.root))
 }
 
-public func zeroOrMore<W, C0, C1, Component: RegexProtocol>(
+public func zeroOrMore<W, C0, C1, Component: RegexComponent>(
   _ behavior: QuantificationBehavior = .eagerly,
-  @RegexBuilder _ component: () -> Component
+  @RegexComponentBuilder _ component: () -> Component
 ) -> Regex<(Substring, C0?, C1?)> where Component.Match == (W, C0, C1) {
   .init(node: .quantification(.zeroOrMore, behavior.astKind, component().regex.root))
 }
 
-public postfix func .*<W, C0, C1, Component: RegexProtocol>(
+public postfix func .*<W, C0, C1, Component: RegexComponent>(
   _ component: Component
 ) -> Regex<(Substring, C0?, C1?)> where Component.Match == (W, C0, C1) {
   .init(node: .quantification(.zeroOrMore, .eager, component.regex.root))
 }
 
 
-public func oneOrMore<W, C0, C1, Component: RegexProtocol>(
+public func oneOrMore<W, C0, C1, Component: RegexComponent>(
   _ component: Component,
   _ behavior: QuantificationBehavior = .eagerly
 ) -> Regex<(Substring, C0, C1)> where Component.Match == (W, C0, C1) {
   .init(node: .quantification(.oneOrMore, behavior.astKind, component.regex.root))
 }
 
-public func oneOrMore<W, C0, C1, Component: RegexProtocol>(
+public func oneOrMore<W, C0, C1, Component: RegexComponent>(
   _ behavior: QuantificationBehavior = .eagerly,
-  @RegexBuilder _ component: () -> Component
+  @RegexComponentBuilder _ component: () -> Component
 ) -> Regex<(Substring, C0, C1)> where Component.Match == (W, C0, C1) {
   .init(node: .quantification(.oneOrMore, behavior.astKind, component().regex.root))
 }
 
-public postfix func .+<W, C0, C1, Component: RegexProtocol>(
+public postfix func .+<W, C0, C1, Component: RegexComponent>(
   _ component: Component
 ) -> Regex<(Substring, C0, C1)> where Component.Match == (W, C0, C1) {
   .init(node: .quantification(.oneOrMore, .eager, component.regex.root))
 }
 
 
-public func repeating<W, C0, C1, Component: RegexProtocol>(
+public func repeating<W, C0, C1, Component: RegexComponent>(
   _ component: Component,
   count: Int
 ) -> Regex<(Substring, C0?, C1?)> where Component.Match == (W, C0, C1) {
@@ -765,16 +765,16 @@ public func repeating<W, C0, C1, Component: RegexProtocol>(
   return Regex(node: .quantification(.exactly(.init(faking: count)), .eager, component.regex.root))
 }
 
-public func repeating<W, C0, C1, Component: RegexProtocol>(
+public func repeating<W, C0, C1, Component: RegexComponent>(
   count: Int,
-  @RegexBuilder _ component: () -> Component
+  @RegexComponentBuilder _ component: () -> Component
 ) -> Regex<(Substring, C0?, C1?)> where Component.Match == (W, C0, C1) {
   assert(count > 0, "Must specify a positive count")
   // TODO: Emit a warning about `repeatMatch(count: 0)` or `repeatMatch(count: 1)`
   return Regex(node: .quantification(.exactly(.init(faking: count)), .eager, component().regex.root))
 }
 
-public func repeating<W, C0, C1, Component: RegexProtocol, R: RangeExpression>(
+public func repeating<W, C0, C1, Component: RegexComponent, R: RangeExpression>(
   _ component: Component,
   _ expression: R,
   _ behavior: QuantificationBehavior = .eagerly
@@ -782,83 +782,83 @@ public func repeating<W, C0, C1, Component: RegexProtocol, R: RangeExpression>(
   .init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component.regex.root))
 }
 
-public func repeating<W, C0, C1, Component: RegexProtocol, R: RangeExpression>(
+public func repeating<W, C0, C1, Component: RegexComponent, R: RangeExpression>(
   _ expression: R,
   _ behavior: QuantificationBehavior = .eagerly,
-  @RegexBuilder _ component: () -> Component
+  @RegexComponentBuilder _ component: () -> Component
 ) -> Regex<(Substring, C0?, C1?)> where Component.Match == (W, C0, C1), R.Bound == Int {
   .init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component().regex.root))
 }
-public func optionally<W, C0, C1, C2, Component: RegexProtocol>(
+public func optionally<W, C0, C1, C2, Component: RegexComponent>(
   _ component: Component,
   _ behavior: QuantificationBehavior = .eagerly
 ) -> Regex<(Substring, C0?, C1?, C2?)> where Component.Match == (W, C0, C1, C2) {
   .init(node: .quantification(.zeroOrOne, behavior.astKind, component.regex.root))
 }
 
-public func optionally<W, C0, C1, C2, Component: RegexProtocol>(
+public func optionally<W, C0, C1, C2, Component: RegexComponent>(
   _ behavior: QuantificationBehavior = .eagerly,
-  @RegexBuilder _ component: () -> Component
+  @RegexComponentBuilder _ component: () -> Component
 ) -> Regex<(Substring, C0?, C1?, C2?)> where Component.Match == (W, C0, C1, C2) {
   .init(node: .quantification(.zeroOrOne, behavior.astKind, component().regex.root))
 }
 
-public postfix func .?<W, C0, C1, C2, Component: RegexProtocol>(
+public postfix func .?<W, C0, C1, C2, Component: RegexComponent>(
   _ component: Component
 ) -> Regex<(Substring, C0?, C1?, C2?)> where Component.Match == (W, C0, C1, C2) {
   .init(node: .quantification(.zeroOrOne, .eager, component.regex.root))
 }
 
-extension RegexBuilder {
-  public static func buildLimitedAvailability<W, C0, C1, C2, Component: RegexProtocol>(
+extension RegexComponentBuilder {
+  public static func buildLimitedAvailability<W, C0, C1, C2, Component: RegexComponent>(
     _ component: Component
   ) -> Regex<(Substring, C0?, C1?, C2?)> where Component.Match == (W, C0, C1, C2) {
     .init(node: .quantification(.zeroOrOne, .eager, component.regex.root))
   }
 }
-public func zeroOrMore<W, C0, C1, C2, Component: RegexProtocol>(
+public func zeroOrMore<W, C0, C1, C2, Component: RegexComponent>(
   _ component: Component,
   _ behavior: QuantificationBehavior = .eagerly
 ) -> Regex<(Substring, C0?, C1?, C2?)> where Component.Match == (W, C0, C1, C2) {
   .init(node: .quantification(.zeroOrMore, behavior.astKind, component.regex.root))
 }
 
-public func zeroOrMore<W, C0, C1, C2, Component: RegexProtocol>(
+public func zeroOrMore<W, C0, C1, C2, Component: RegexComponent>(
   _ behavior: QuantificationBehavior = .eagerly,
-  @RegexBuilder _ component: () -> Component
+  @RegexComponentBuilder _ component: () -> Component
 ) -> Regex<(Substring, C0?, C1?, C2?)> where Component.Match == (W, C0, C1, C2) {
   .init(node: .quantification(.zeroOrMore, behavior.astKind, component().regex.root))
 }
 
-public postfix func .*<W, C0, C1, C2, Component: RegexProtocol>(
+public postfix func .*<W, C0, C1, C2, Component: RegexComponent>(
   _ component: Component
 ) -> Regex<(Substring, C0?, C1?, C2?)> where Component.Match == (W, C0, C1, C2) {
   .init(node: .quantification(.zeroOrMore, .eager, component.regex.root))
 }
 
 
-public func oneOrMore<W, C0, C1, C2, Component: RegexProtocol>(
+public func oneOrMore<W, C0, C1, C2, Component: RegexComponent>(
   _ component: Component,
   _ behavior: QuantificationBehavior = .eagerly
 ) -> Regex<(Substring, C0, C1, C2)> where Component.Match == (W, C0, C1, C2) {
   .init(node: .quantification(.oneOrMore, behavior.astKind, component.regex.root))
 }
 
-public func oneOrMore<W, C0, C1, C2, Component: RegexProtocol>(
+public func oneOrMore<W, C0, C1, C2, Component: RegexComponent>(
   _ behavior: QuantificationBehavior = .eagerly,
-  @RegexBuilder _ component: () -> Component
+  @RegexComponentBuilder _ component: () -> Component
 ) -> Regex<(Substring, C0, C1, C2)> where Component.Match == (W, C0, C1, C2) {
   .init(node: .quantification(.oneOrMore, behavior.astKind, component().regex.root))
 }
 
-public postfix func .+<W, C0, C1, C2, Component: RegexProtocol>(
+public postfix func .+<W, C0, C1, C2, Component: RegexComponent>(
   _ component: Component
 ) -> Regex<(Substring, C0, C1, C2)> where Component.Match == (W, C0, C1, C2) {
   .init(node: .quantification(.oneOrMore, .eager, component.regex.root))
 }
 
 
-public func repeating<W, C0, C1, C2, Component: RegexProtocol>(
+public func repeating<W, C0, C1, C2, Component: RegexComponent>(
   _ component: Component,
   count: Int
 ) -> Regex<(Substring, C0?, C1?, C2?)> where Component.Match == (W, C0, C1, C2) {
@@ -867,16 +867,16 @@ public func repeating<W, C0, C1, C2, Component: RegexProtocol>(
   return Regex(node: .quantification(.exactly(.init(faking: count)), .eager, component.regex.root))
 }
 
-public func repeating<W, C0, C1, C2, Component: RegexProtocol>(
+public func repeating<W, C0, C1, C2, Component: RegexComponent>(
   count: Int,
-  @RegexBuilder _ component: () -> Component
+  @RegexComponentBuilder _ component: () -> Component
 ) -> Regex<(Substring, C0?, C1?, C2?)> where Component.Match == (W, C0, C1, C2) {
   assert(count > 0, "Must specify a positive count")
   // TODO: Emit a warning about `repeatMatch(count: 0)` or `repeatMatch(count: 1)`
   return Regex(node: .quantification(.exactly(.init(faking: count)), .eager, component().regex.root))
 }
 
-public func repeating<W, C0, C1, C2, Component: RegexProtocol, R: RangeExpression>(
+public func repeating<W, C0, C1, C2, Component: RegexComponent, R: RangeExpression>(
   _ component: Component,
   _ expression: R,
   _ behavior: QuantificationBehavior = .eagerly
@@ -884,83 +884,83 @@ public func repeating<W, C0, C1, C2, Component: RegexProtocol, R: RangeExpressio
   .init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component.regex.root))
 }
 
-public func repeating<W, C0, C1, C2, Component: RegexProtocol, R: RangeExpression>(
+public func repeating<W, C0, C1, C2, Component: RegexComponent, R: RangeExpression>(
   _ expression: R,
   _ behavior: QuantificationBehavior = .eagerly,
-  @RegexBuilder _ component: () -> Component
+  @RegexComponentBuilder _ component: () -> Component
 ) -> Regex<(Substring, C0?, C1?, C2?)> where Component.Match == (W, C0, C1, C2), R.Bound == Int {
   .init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component().regex.root))
 }
-public func optionally<W, C0, C1, C2, C3, Component: RegexProtocol>(
+public func optionally<W, C0, C1, C2, C3, Component: RegexComponent>(
   _ component: Component,
   _ behavior: QuantificationBehavior = .eagerly
 ) -> Regex<(Substring, C0?, C1?, C2?, C3?)> where Component.Match == (W, C0, C1, C2, C3) {
   .init(node: .quantification(.zeroOrOne, behavior.astKind, component.regex.root))
 }
 
-public func optionally<W, C0, C1, C2, C3, Component: RegexProtocol>(
+public func optionally<W, C0, C1, C2, C3, Component: RegexComponent>(
   _ behavior: QuantificationBehavior = .eagerly,
-  @RegexBuilder _ component: () -> Component
+  @RegexComponentBuilder _ component: () -> Component
 ) -> Regex<(Substring, C0?, C1?, C2?, C3?)> where Component.Match == (W, C0, C1, C2, C3) {
   .init(node: .quantification(.zeroOrOne, behavior.astKind, component().regex.root))
 }
 
-public postfix func .?<W, C0, C1, C2, C3, Component: RegexProtocol>(
+public postfix func .?<W, C0, C1, C2, C3, Component: RegexComponent>(
   _ component: Component
 ) -> Regex<(Substring, C0?, C1?, C2?, C3?)> where Component.Match == (W, C0, C1, C2, C3) {
   .init(node: .quantification(.zeroOrOne, .eager, component.regex.root))
 }
 
-extension RegexBuilder {
-  public static func buildLimitedAvailability<W, C0, C1, C2, C3, Component: RegexProtocol>(
+extension RegexComponentBuilder {
+  public static func buildLimitedAvailability<W, C0, C1, C2, C3, Component: RegexComponent>(
     _ component: Component
   ) -> Regex<(Substring, C0?, C1?, C2?, C3?)> where Component.Match == (W, C0, C1, C2, C3) {
     .init(node: .quantification(.zeroOrOne, .eager, component.regex.root))
   }
 }
-public func zeroOrMore<W, C0, C1, C2, C3, Component: RegexProtocol>(
+public func zeroOrMore<W, C0, C1, C2, C3, Component: RegexComponent>(
   _ component: Component,
   _ behavior: QuantificationBehavior = .eagerly
 ) -> Regex<(Substring, C0?, C1?, C2?, C3?)> where Component.Match == (W, C0, C1, C2, C3) {
   .init(node: .quantification(.zeroOrMore, behavior.astKind, component.regex.root))
 }
 
-public func zeroOrMore<W, C0, C1, C2, C3, Component: RegexProtocol>(
+public func zeroOrMore<W, C0, C1, C2, C3, Component: RegexComponent>(
   _ behavior: QuantificationBehavior = .eagerly,
-  @RegexBuilder _ component: () -> Component
+  @RegexComponentBuilder _ component: () -> Component
 ) -> Regex<(Substring, C0?, C1?, C2?, C3?)> where Component.Match == (W, C0, C1, C2, C3) {
   .init(node: .quantification(.zeroOrMore, behavior.astKind, component().regex.root))
 }
 
-public postfix func .*<W, C0, C1, C2, C3, Component: RegexProtocol>(
+public postfix func .*<W, C0, C1, C2, C3, Component: RegexComponent>(
   _ component: Component
 ) -> Regex<(Substring, C0?, C1?, C2?, C3?)> where Component.Match == (W, C0, C1, C2, C3) {
   .init(node: .quantification(.zeroOrMore, .eager, component.regex.root))
 }
 
 
-public func oneOrMore<W, C0, C1, C2, C3, Component: RegexProtocol>(
+public func oneOrMore<W, C0, C1, C2, C3, Component: RegexComponent>(
   _ component: Component,
   _ behavior: QuantificationBehavior = .eagerly
 ) -> Regex<(Substring, C0, C1, C2, C3)> where Component.Match == (W, C0, C1, C2, C3) {
   .init(node: .quantification(.oneOrMore, behavior.astKind, component.regex.root))
 }
 
-public func oneOrMore<W, C0, C1, C2, C3, Component: RegexProtocol>(
+public func oneOrMore<W, C0, C1, C2, C3, Component: RegexComponent>(
   _ behavior: QuantificationBehavior = .eagerly,
-  @RegexBuilder _ component: () -> Component
+  @RegexComponentBuilder _ component: () -> Component
 ) -> Regex<(Substring, C0, C1, C2, C3)> where Component.Match == (W, C0, C1, C2, C3) {
   .init(node: .quantification(.oneOrMore, behavior.astKind, component().regex.root))
 }
 
-public postfix func .+<W, C0, C1, C2, C3, Component: RegexProtocol>(
+public postfix func .+<W, C0, C1, C2, C3, Component: RegexComponent>(
   _ component: Component
 ) -> Regex<(Substring, C0, C1, C2, C3)> where Component.Match == (W, C0, C1, C2, C3) {
   .init(node: .quantification(.oneOrMore, .eager, component.regex.root))
 }
 
 
-public func repeating<W, C0, C1, C2, C3, Component: RegexProtocol>(
+public func repeating<W, C0, C1, C2, C3, Component: RegexComponent>(
   _ component: Component,
   count: Int
 ) -> Regex<(Substring, C0?, C1?, C2?, C3?)> where Component.Match == (W, C0, C1, C2, C3) {
@@ -969,16 +969,16 @@ public func repeating<W, C0, C1, C2, C3, Component: RegexProtocol>(
   return Regex(node: .quantification(.exactly(.init(faking: count)), .eager, component.regex.root))
 }
 
-public func repeating<W, C0, C1, C2, C3, Component: RegexProtocol>(
+public func repeating<W, C0, C1, C2, C3, Component: RegexComponent>(
   count: Int,
-  @RegexBuilder _ component: () -> Component
+  @RegexComponentBuilder _ component: () -> Component
 ) -> Regex<(Substring, C0?, C1?, C2?, C3?)> where Component.Match == (W, C0, C1, C2, C3) {
   assert(count > 0, "Must specify a positive count")
   // TODO: Emit a warning about `repeatMatch(count: 0)` or `repeatMatch(count: 1)`
   return Regex(node: .quantification(.exactly(.init(faking: count)), .eager, component().regex.root))
 }
 
-public func repeating<W, C0, C1, C2, C3, Component: RegexProtocol, R: RangeExpression>(
+public func repeating<W, C0, C1, C2, C3, Component: RegexComponent, R: RangeExpression>(
   _ component: Component,
   _ expression: R,
   _ behavior: QuantificationBehavior = .eagerly
@@ -986,83 +986,83 @@ public func repeating<W, C0, C1, C2, C3, Component: RegexProtocol, R: RangeExpre
   .init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component.regex.root))
 }
 
-public func repeating<W, C0, C1, C2, C3, Component: RegexProtocol, R: RangeExpression>(
+public func repeating<W, C0, C1, C2, C3, Component: RegexComponent, R: RangeExpression>(
   _ expression: R,
   _ behavior: QuantificationBehavior = .eagerly,
-  @RegexBuilder _ component: () -> Component
+  @RegexComponentBuilder _ component: () -> Component
 ) -> Regex<(Substring, C0?, C1?, C2?, C3?)> where Component.Match == (W, C0, C1, C2, C3), R.Bound == Int {
   .init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component().regex.root))
 }
-public func optionally<W, C0, C1, C2, C3, C4, Component: RegexProtocol>(
+public func optionally<W, C0, C1, C2, C3, C4, Component: RegexComponent>(
   _ component: Component,
   _ behavior: QuantificationBehavior = .eagerly
 ) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?)> where Component.Match == (W, C0, C1, C2, C3, C4) {
   .init(node: .quantification(.zeroOrOne, behavior.astKind, component.regex.root))
 }
 
-public func optionally<W, C0, C1, C2, C3, C4, Component: RegexProtocol>(
+public func optionally<W, C0, C1, C2, C3, C4, Component: RegexComponent>(
   _ behavior: QuantificationBehavior = .eagerly,
-  @RegexBuilder _ component: () -> Component
+  @RegexComponentBuilder _ component: () -> Component
 ) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?)> where Component.Match == (W, C0, C1, C2, C3, C4) {
   .init(node: .quantification(.zeroOrOne, behavior.astKind, component().regex.root))
 }
 
-public postfix func .?<W, C0, C1, C2, C3, C4, Component: RegexProtocol>(
+public postfix func .?<W, C0, C1, C2, C3, C4, Component: RegexComponent>(
   _ component: Component
 ) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?)> where Component.Match == (W, C0, C1, C2, C3, C4) {
   .init(node: .quantification(.zeroOrOne, .eager, component.regex.root))
 }
 
-extension RegexBuilder {
-  public static func buildLimitedAvailability<W, C0, C1, C2, C3, C4, Component: RegexProtocol>(
+extension RegexComponentBuilder {
+  public static func buildLimitedAvailability<W, C0, C1, C2, C3, C4, Component: RegexComponent>(
     _ component: Component
   ) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?)> where Component.Match == (W, C0, C1, C2, C3, C4) {
     .init(node: .quantification(.zeroOrOne, .eager, component.regex.root))
   }
 }
-public func zeroOrMore<W, C0, C1, C2, C3, C4, Component: RegexProtocol>(
+public func zeroOrMore<W, C0, C1, C2, C3, C4, Component: RegexComponent>(
   _ component: Component,
   _ behavior: QuantificationBehavior = .eagerly
 ) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?)> where Component.Match == (W, C0, C1, C2, C3, C4) {
   .init(node: .quantification(.zeroOrMore, behavior.astKind, component.regex.root))
 }
 
-public func zeroOrMore<W, C0, C1, C2, C3, C4, Component: RegexProtocol>(
+public func zeroOrMore<W, C0, C1, C2, C3, C4, Component: RegexComponent>(
   _ behavior: QuantificationBehavior = .eagerly,
-  @RegexBuilder _ component: () -> Component
+  @RegexComponentBuilder _ component: () -> Component
 ) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?)> where Component.Match == (W, C0, C1, C2, C3, C4) {
   .init(node: .quantification(.zeroOrMore, behavior.astKind, component().regex.root))
 }
 
-public postfix func .*<W, C0, C1, C2, C3, C4, Component: RegexProtocol>(
+public postfix func .*<W, C0, C1, C2, C3, C4, Component: RegexComponent>(
   _ component: Component
 ) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?)> where Component.Match == (W, C0, C1, C2, C3, C4) {
   .init(node: .quantification(.zeroOrMore, .eager, component.regex.root))
 }
 
 
-public func oneOrMore<W, C0, C1, C2, C3, C4, Component: RegexProtocol>(
+public func oneOrMore<W, C0, C1, C2, C3, C4, Component: RegexComponent>(
   _ component: Component,
   _ behavior: QuantificationBehavior = .eagerly
 ) -> Regex<(Substring, C0, C1, C2, C3, C4)> where Component.Match == (W, C0, C1, C2, C3, C4) {
   .init(node: .quantification(.oneOrMore, behavior.astKind, component.regex.root))
 }
 
-public func oneOrMore<W, C0, C1, C2, C3, C4, Component: RegexProtocol>(
+public func oneOrMore<W, C0, C1, C2, C3, C4, Component: RegexComponent>(
   _ behavior: QuantificationBehavior = .eagerly,
-  @RegexBuilder _ component: () -> Component
+  @RegexComponentBuilder _ component: () -> Component
 ) -> Regex<(Substring, C0, C1, C2, C3, C4)> where Component.Match == (W, C0, C1, C2, C3, C4) {
   .init(node: .quantification(.oneOrMore, behavior.astKind, component().regex.root))
 }
 
-public postfix func .+<W, C0, C1, C2, C3, C4, Component: RegexProtocol>(
+public postfix func .+<W, C0, C1, C2, C3, C4, Component: RegexComponent>(
   _ component: Component
 ) -> Regex<(Substring, C0, C1, C2, C3, C4)> where Component.Match == (W, C0, C1, C2, C3, C4) {
   .init(node: .quantification(.oneOrMore, .eager, component.regex.root))
 }
 
 
-public func repeating<W, C0, C1, C2, C3, C4, Component: RegexProtocol>(
+public func repeating<W, C0, C1, C2, C3, C4, Component: RegexComponent>(
   _ component: Component,
   count: Int
 ) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?)> where Component.Match == (W, C0, C1, C2, C3, C4) {
@@ -1071,16 +1071,16 @@ public func repeating<W, C0, C1, C2, C3, C4, Component: RegexProtocol>(
   return Regex(node: .quantification(.exactly(.init(faking: count)), .eager, component.regex.root))
 }
 
-public func repeating<W, C0, C1, C2, C3, C4, Component: RegexProtocol>(
+public func repeating<W, C0, C1, C2, C3, C4, Component: RegexComponent>(
   count: Int,
-  @RegexBuilder _ component: () -> Component
+  @RegexComponentBuilder _ component: () -> Component
 ) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?)> where Component.Match == (W, C0, C1, C2, C3, C4) {
   assert(count > 0, "Must specify a positive count")
   // TODO: Emit a warning about `repeatMatch(count: 0)` or `repeatMatch(count: 1)`
   return Regex(node: .quantification(.exactly(.init(faking: count)), .eager, component().regex.root))
 }
 
-public func repeating<W, C0, C1, C2, C3, C4, Component: RegexProtocol, R: RangeExpression>(
+public func repeating<W, C0, C1, C2, C3, C4, Component: RegexComponent, R: RangeExpression>(
   _ component: Component,
   _ expression: R,
   _ behavior: QuantificationBehavior = .eagerly
@@ -1088,83 +1088,83 @@ public func repeating<W, C0, C1, C2, C3, C4, Component: RegexProtocol, R: RangeE
   .init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component.regex.root))
 }
 
-public func repeating<W, C0, C1, C2, C3, C4, Component: RegexProtocol, R: RangeExpression>(
+public func repeating<W, C0, C1, C2, C3, C4, Component: RegexComponent, R: RangeExpression>(
   _ expression: R,
   _ behavior: QuantificationBehavior = .eagerly,
-  @RegexBuilder _ component: () -> Component
+  @RegexComponentBuilder _ component: () -> Component
 ) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?)> where Component.Match == (W, C0, C1, C2, C3, C4), R.Bound == Int {
   .init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component().regex.root))
 }
-public func optionally<W, C0, C1, C2, C3, C4, C5, Component: RegexProtocol>(
+public func optionally<W, C0, C1, C2, C3, C4, C5, Component: RegexComponent>(
   _ component: Component,
   _ behavior: QuantificationBehavior = .eagerly
 ) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?)> where Component.Match == (W, C0, C1, C2, C3, C4, C5) {
   .init(node: .quantification(.zeroOrOne, behavior.astKind, component.regex.root))
 }
 
-public func optionally<W, C0, C1, C2, C3, C4, C5, Component: RegexProtocol>(
+public func optionally<W, C0, C1, C2, C3, C4, C5, Component: RegexComponent>(
   _ behavior: QuantificationBehavior = .eagerly,
-  @RegexBuilder _ component: () -> Component
+  @RegexComponentBuilder _ component: () -> Component
 ) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?)> where Component.Match == (W, C0, C1, C2, C3, C4, C5) {
   .init(node: .quantification(.zeroOrOne, behavior.astKind, component().regex.root))
 }
 
-public postfix func .?<W, C0, C1, C2, C3, C4, C5, Component: RegexProtocol>(
+public postfix func .?<W, C0, C1, C2, C3, C4, C5, Component: RegexComponent>(
   _ component: Component
 ) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?)> where Component.Match == (W, C0, C1, C2, C3, C4, C5) {
   .init(node: .quantification(.zeroOrOne, .eager, component.regex.root))
 }
 
-extension RegexBuilder {
-  public static func buildLimitedAvailability<W, C0, C1, C2, C3, C4, C5, Component: RegexProtocol>(
+extension RegexComponentBuilder {
+  public static func buildLimitedAvailability<W, C0, C1, C2, C3, C4, C5, Component: RegexComponent>(
     _ component: Component
   ) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?)> where Component.Match == (W, C0, C1, C2, C3, C4, C5) {
     .init(node: .quantification(.zeroOrOne, .eager, component.regex.root))
   }
 }
-public func zeroOrMore<W, C0, C1, C2, C3, C4, C5, Component: RegexProtocol>(
+public func zeroOrMore<W, C0, C1, C2, C3, C4, C5, Component: RegexComponent>(
   _ component: Component,
   _ behavior: QuantificationBehavior = .eagerly
 ) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?)> where Component.Match == (W, C0, C1, C2, C3, C4, C5) {
   .init(node: .quantification(.zeroOrMore, behavior.astKind, component.regex.root))
 }
 
-public func zeroOrMore<W, C0, C1, C2, C3, C4, C5, Component: RegexProtocol>(
+public func zeroOrMore<W, C0, C1, C2, C3, C4, C5, Component: RegexComponent>(
   _ behavior: QuantificationBehavior = .eagerly,
-  @RegexBuilder _ component: () -> Component
+  @RegexComponentBuilder _ component: () -> Component
 ) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?)> where Component.Match == (W, C0, C1, C2, C3, C4, C5) {
   .init(node: .quantification(.zeroOrMore, behavior.astKind, component().regex.root))
 }
 
-public postfix func .*<W, C0, C1, C2, C3, C4, C5, Component: RegexProtocol>(
+public postfix func .*<W, C0, C1, C2, C3, C4, C5, Component: RegexComponent>(
   _ component: Component
 ) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?)> where Component.Match == (W, C0, C1, C2, C3, C4, C5) {
   .init(node: .quantification(.zeroOrMore, .eager, component.regex.root))
 }
 
 
-public func oneOrMore<W, C0, C1, C2, C3, C4, C5, Component: RegexProtocol>(
+public func oneOrMore<W, C0, C1, C2, C3, C4, C5, Component: RegexComponent>(
   _ component: Component,
   _ behavior: QuantificationBehavior = .eagerly
 ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5)> where Component.Match == (W, C0, C1, C2, C3, C4, C5) {
   .init(node: .quantification(.oneOrMore, behavior.astKind, component.regex.root))
 }
 
-public func oneOrMore<W, C0, C1, C2, C3, C4, C5, Component: RegexProtocol>(
+public func oneOrMore<W, C0, C1, C2, C3, C4, C5, Component: RegexComponent>(
   _ behavior: QuantificationBehavior = .eagerly,
-  @RegexBuilder _ component: () -> Component
+  @RegexComponentBuilder _ component: () -> Component
 ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5)> where Component.Match == (W, C0, C1, C2, C3, C4, C5) {
   .init(node: .quantification(.oneOrMore, behavior.astKind, component().regex.root))
 }
 
-public postfix func .+<W, C0, C1, C2, C3, C4, C5, Component: RegexProtocol>(
+public postfix func .+<W, C0, C1, C2, C3, C4, C5, Component: RegexComponent>(
   _ component: Component
 ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5)> where Component.Match == (W, C0, C1, C2, C3, C4, C5) {
   .init(node: .quantification(.oneOrMore, .eager, component.regex.root))
 }
 
 
-public func repeating<W, C0, C1, C2, C3, C4, C5, Component: RegexProtocol>(
+public func repeating<W, C0, C1, C2, C3, C4, C5, Component: RegexComponent>(
   _ component: Component,
   count: Int
 ) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?)> where Component.Match == (W, C0, C1, C2, C3, C4, C5) {
@@ -1173,16 +1173,16 @@ public func repeating<W, C0, C1, C2, C3, C4, C5, Component: RegexProtocol>(
   return Regex(node: .quantification(.exactly(.init(faking: count)), .eager, component.regex.root))
 }
 
-public func repeating<W, C0, C1, C2, C3, C4, C5, Component: RegexProtocol>(
+public func repeating<W, C0, C1, C2, C3, C4, C5, Component: RegexComponent>(
   count: Int,
-  @RegexBuilder _ component: () -> Component
+  @RegexComponentBuilder _ component: () -> Component
 ) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?)> where Component.Match == (W, C0, C1, C2, C3, C4, C5) {
   assert(count > 0, "Must specify a positive count")
   // TODO: Emit a warning about `repeatMatch(count: 0)` or `repeatMatch(count: 1)`
   return Regex(node: .quantification(.exactly(.init(faking: count)), .eager, component().regex.root))
 }
 
-public func repeating<W, C0, C1, C2, C3, C4, C5, Component: RegexProtocol, R: RangeExpression>(
+public func repeating<W, C0, C1, C2, C3, C4, C5, Component: RegexComponent, R: RangeExpression>(
   _ component: Component,
   _ expression: R,
   _ behavior: QuantificationBehavior = .eagerly
@@ -1190,83 +1190,83 @@ public func repeating<W, C0, C1, C2, C3, C4, C5, Component: RegexProtocol, R: Ra
   .init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component.regex.root))
 }
 
-public func repeating<W, C0, C1, C2, C3, C4, C5, Component: RegexProtocol, R: RangeExpression>(
+public func repeating<W, C0, C1, C2, C3, C4, C5, Component: RegexComponent, R: RangeExpression>(
   _ expression: R,
   _ behavior: QuantificationBehavior = .eagerly,
-  @RegexBuilder _ component: () -> Component
+  @RegexComponentBuilder _ component: () -> Component
 ) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?)> where Component.Match == (W, C0, C1, C2, C3, C4, C5), R.Bound == Int {
   .init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component().regex.root))
 }
-public func optionally<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexProtocol>(
+public func optionally<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexComponent>(
   _ component: Component,
   _ behavior: QuantificationBehavior = .eagerly
 ) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?)> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6) {
   .init(node: .quantification(.zeroOrOne, behavior.astKind, component.regex.root))
 }
 
-public func optionally<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexProtocol>(
+public func optionally<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexComponent>(
   _ behavior: QuantificationBehavior = .eagerly,
-  @RegexBuilder _ component: () -> Component
+  @RegexComponentBuilder _ component: () -> Component
 ) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?)> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6) {
   .init(node: .quantification(.zeroOrOne, behavior.astKind, component().regex.root))
 }
 
-public postfix func .?<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexProtocol>(
+public postfix func .?<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexComponent>(
   _ component: Component
 ) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?)> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6) {
   .init(node: .quantification(.zeroOrOne, .eager, component.regex.root))
 }
 
-extension RegexBuilder {
-  public static func buildLimitedAvailability<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexProtocol>(
+extension RegexComponentBuilder {
+  public static func buildLimitedAvailability<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexComponent>(
     _ component: Component
   ) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?)> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6) {
     .init(node: .quantification(.zeroOrOne, .eager, component.regex.root))
   }
 }
-public func zeroOrMore<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexProtocol>(
+public func zeroOrMore<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexComponent>(
   _ component: Component,
   _ behavior: QuantificationBehavior = .eagerly
 ) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?)> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6) {
   .init(node: .quantification(.zeroOrMore, behavior.astKind, component.regex.root))
 }
 
-public func zeroOrMore<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexProtocol>(
+public func zeroOrMore<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexComponent>(
   _ behavior: QuantificationBehavior = .eagerly,
-  @RegexBuilder _ component: () -> Component
+  @RegexComponentBuilder _ component: () -> Component
 ) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?)> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6) {
   .init(node: .quantification(.zeroOrMore, behavior.astKind, component().regex.root))
 }
 
-public postfix func .*<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexProtocol>(
+public postfix func .*<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexComponent>(
   _ component: Component
 ) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?)> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6) {
   .init(node: .quantification(.zeroOrMore, .eager, component.regex.root))
 }
 
 
-public func oneOrMore<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexProtocol>(
+public func oneOrMore<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexComponent>(
   _ component: Component,
   _ behavior: QuantificationBehavior = .eagerly
 ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6)> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6) {
   .init(node: .quantification(.oneOrMore, behavior.astKind, component.regex.root))
 }
 
-public func oneOrMore<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexProtocol>(
+public func oneOrMore<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexComponent>(
   _ behavior: QuantificationBehavior = .eagerly,
-  @RegexBuilder _ component: () -> Component
+  @RegexComponentBuilder _ component: () -> Component
 ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6)> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6) {
   .init(node: .quantification(.oneOrMore, behavior.astKind, component().regex.root))
 }
 
-public postfix func .+<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexProtocol>(
+public postfix func .+<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexComponent>(
   _ component: Component
 ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6)> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6) {
   .init(node: .quantification(.oneOrMore, .eager, component.regex.root))
 }
 
 
-public func repeating<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexProtocol>(
+public func repeating<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexComponent>(
   _ component: Component,
   count: Int
 ) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?)> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6) {
@@ -1275,16 +1275,16 @@ public func repeating<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexProtocol>(
   return Regex(node: .quantification(.exactly(.init(faking: count)), .eager, component.regex.root))
 }
 
-public func repeating<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexProtocol>(
+public func repeating<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexComponent>(
   count: Int,
-  @RegexBuilder _ component: () -> Component
+  @RegexComponentBuilder _ component: () -> Component
 ) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?)> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6) {
   assert(count > 0, "Must specify a positive count")
   // TODO: Emit a warning about `repeatMatch(count: 0)` or `repeatMatch(count: 1)`
   return Regex(node: .quantification(.exactly(.init(faking: count)), .eager, component().regex.root))
 }
 
-public func repeating<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexProtocol, R: RangeExpression>(
+public func repeating<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexComponent, R: RangeExpression>(
   _ component: Component,
   _ expression: R,
   _ behavior: QuantificationBehavior = .eagerly
@@ -1292,83 +1292,83 @@ public func repeating<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexProtocol, R
   .init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component.regex.root))
 }
 
-public func repeating<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexProtocol, R: RangeExpression>(
+public func repeating<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexComponent, R: RangeExpression>(
   _ expression: R,
   _ behavior: QuantificationBehavior = .eagerly,
-  @RegexBuilder _ component: () -> Component
+  @RegexComponentBuilder _ component: () -> Component
 ) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?)> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6), R.Bound == Int {
   .init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component().regex.root))
 }
-public func optionally<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexProtocol>(
+public func optionally<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexComponent>(
   _ component: Component,
   _ behavior: QuantificationBehavior = .eagerly
 ) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?)> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
   .init(node: .quantification(.zeroOrOne, behavior.astKind, component.regex.root))
 }
 
-public func optionally<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexProtocol>(
+public func optionally<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexComponent>(
   _ behavior: QuantificationBehavior = .eagerly,
-  @RegexBuilder _ component: () -> Component
+  @RegexComponentBuilder _ component: () -> Component
 ) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?)> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
   .init(node: .quantification(.zeroOrOne, behavior.astKind, component().regex.root))
 }
 
-public postfix func .?<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexProtocol>(
+public postfix func .?<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexComponent>(
   _ component: Component
 ) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?)> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
   .init(node: .quantification(.zeroOrOne, .eager, component.regex.root))
 }
 
-extension RegexBuilder {
-  public static func buildLimitedAvailability<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexProtocol>(
+extension RegexComponentBuilder {
+  public static func buildLimitedAvailability<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexComponent>(
     _ component: Component
   ) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?)> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
     .init(node: .quantification(.zeroOrOne, .eager, component.regex.root))
   }
 }
-public func zeroOrMore<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexProtocol>(
+public func zeroOrMore<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexComponent>(
   _ component: Component,
   _ behavior: QuantificationBehavior = .eagerly
 ) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?)> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
   .init(node: .quantification(.zeroOrMore, behavior.astKind, component.regex.root))
 }
 
-public func zeroOrMore<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexProtocol>(
+public func zeroOrMore<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexComponent>(
   _ behavior: QuantificationBehavior = .eagerly,
-  @RegexBuilder _ component: () -> Component
+  @RegexComponentBuilder _ component: () -> Component
 ) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?)> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
   .init(node: .quantification(.zeroOrMore, behavior.astKind, component().regex.root))
 }
 
-public postfix func .*<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexProtocol>(
+public postfix func .*<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexComponent>(
   _ component: Component
 ) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?)> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
   .init(node: .quantification(.zeroOrMore, .eager, component.regex.root))
 }
 
 
-public func oneOrMore<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexProtocol>(
+public func oneOrMore<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexComponent>(
   _ component: Component,
   _ behavior: QuantificationBehavior = .eagerly
 ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7)> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
   .init(node: .quantification(.oneOrMore, behavior.astKind, component.regex.root))
 }
 
-public func oneOrMore<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexProtocol>(
+public func oneOrMore<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexComponent>(
   _ behavior: QuantificationBehavior = .eagerly,
-  @RegexBuilder _ component: () -> Component
+  @RegexComponentBuilder _ component: () -> Component
 ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7)> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
   .init(node: .quantification(.oneOrMore, behavior.astKind, component().regex.root))
 }
 
-public postfix func .+<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexProtocol>(
+public postfix func .+<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexComponent>(
   _ component: Component
 ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7)> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
   .init(node: .quantification(.oneOrMore, .eager, component.regex.root))
 }
 
 
-public func repeating<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexProtocol>(
+public func repeating<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexComponent>(
   _ component: Component,
   count: Int
 ) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?)> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
@@ -1377,16 +1377,16 @@ public func repeating<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexProtoco
   return Regex(node: .quantification(.exactly(.init(faking: count)), .eager, component.regex.root))
 }
 
-public func repeating<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexProtocol>(
+public func repeating<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexComponent>(
   count: Int,
-  @RegexBuilder _ component: () -> Component
+  @RegexComponentBuilder _ component: () -> Component
 ) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?)> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
   assert(count > 0, "Must specify a positive count")
   // TODO: Emit a warning about `repeatMatch(count: 0)` or `repeatMatch(count: 1)`
   return Regex(node: .quantification(.exactly(.init(faking: count)), .eager, component().regex.root))
 }
 
-public func repeating<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexProtocol, R: RangeExpression>(
+public func repeating<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexComponent, R: RangeExpression>(
   _ component: Component,
   _ expression: R,
   _ behavior: QuantificationBehavior = .eagerly
@@ -1394,83 +1394,83 @@ public func repeating<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexProtoco
   .init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component.regex.root))
 }
 
-public func repeating<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexProtocol, R: RangeExpression>(
+public func repeating<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexComponent, R: RangeExpression>(
   _ expression: R,
   _ behavior: QuantificationBehavior = .eagerly,
-  @RegexBuilder _ component: () -> Component
+  @RegexComponentBuilder _ component: () -> Component
 ) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?)> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7), R.Bound == Int {
   .init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component().regex.root))
 }
-public func optionally<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexProtocol>(
+public func optionally<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexComponent>(
   _ component: Component,
   _ behavior: QuantificationBehavior = .eagerly
 ) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?)> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
   .init(node: .quantification(.zeroOrOne, behavior.astKind, component.regex.root))
 }
 
-public func optionally<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexProtocol>(
+public func optionally<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexComponent>(
   _ behavior: QuantificationBehavior = .eagerly,
-  @RegexBuilder _ component: () -> Component
+  @RegexComponentBuilder _ component: () -> Component
 ) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?)> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
   .init(node: .quantification(.zeroOrOne, behavior.astKind, component().regex.root))
 }
 
-public postfix func .?<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexProtocol>(
+public postfix func .?<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexComponent>(
   _ component: Component
 ) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?)> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
   .init(node: .quantification(.zeroOrOne, .eager, component.regex.root))
 }
 
-extension RegexBuilder {
-  public static func buildLimitedAvailability<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexProtocol>(
+extension RegexComponentBuilder {
+  public static func buildLimitedAvailability<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexComponent>(
     _ component: Component
   ) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?)> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
     .init(node: .quantification(.zeroOrOne, .eager, component.regex.root))
   }
 }
-public func zeroOrMore<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexProtocol>(
+public func zeroOrMore<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexComponent>(
   _ component: Component,
   _ behavior: QuantificationBehavior = .eagerly
 ) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?)> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
   .init(node: .quantification(.zeroOrMore, behavior.astKind, component.regex.root))
 }
 
-public func zeroOrMore<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexProtocol>(
+public func zeroOrMore<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexComponent>(
   _ behavior: QuantificationBehavior = .eagerly,
-  @RegexBuilder _ component: () -> Component
+  @RegexComponentBuilder _ component: () -> Component
 ) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?)> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
   .init(node: .quantification(.zeroOrMore, behavior.astKind, component().regex.root))
 }
 
-public postfix func .*<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexProtocol>(
+public postfix func .*<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexComponent>(
   _ component: Component
 ) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?)> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
   .init(node: .quantification(.zeroOrMore, .eager, component.regex.root))
 }
 
 
-public func oneOrMore<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexProtocol>(
+public func oneOrMore<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexComponent>(
   _ component: Component,
   _ behavior: QuantificationBehavior = .eagerly
 ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8)> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
   .init(node: .quantification(.oneOrMore, behavior.astKind, component.regex.root))
 }
 
-public func oneOrMore<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexProtocol>(
+public func oneOrMore<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexComponent>(
   _ behavior: QuantificationBehavior = .eagerly,
-  @RegexBuilder _ component: () -> Component
+  @RegexComponentBuilder _ component: () -> Component
 ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8)> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
   .init(node: .quantification(.oneOrMore, behavior.astKind, component().regex.root))
 }
 
-public postfix func .+<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexProtocol>(
+public postfix func .+<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexComponent>(
   _ component: Component
 ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8)> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
   .init(node: .quantification(.oneOrMore, .eager, component.regex.root))
 }
 
 
-public func repeating<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexProtocol>(
+public func repeating<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexComponent>(
   _ component: Component,
   count: Int
 ) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?)> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
@@ -1479,16 +1479,16 @@ public func repeating<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexPro
   return Regex(node: .quantification(.exactly(.init(faking: count)), .eager, component.regex.root))
 }
 
-public func repeating<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexProtocol>(
+public func repeating<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexComponent>(
   count: Int,
-  @RegexBuilder _ component: () -> Component
+  @RegexComponentBuilder _ component: () -> Component
 ) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?)> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
   assert(count > 0, "Must specify a positive count")
   // TODO: Emit a warning about `repeatMatch(count: 0)` or `repeatMatch(count: 1)`
   return Regex(node: .quantification(.exactly(.init(faking: count)), .eager, component().regex.root))
 }
 
-public func repeating<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexProtocol, R: RangeExpression>(
+public func repeating<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexComponent, R: RangeExpression>(
   _ component: Component,
   _ expression: R,
   _ behavior: QuantificationBehavior = .eagerly
@@ -1496,788 +1496,788 @@ public func repeating<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexPro
   .init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component.regex.root))
 }
 
-public func repeating<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexProtocol, R: RangeExpression>(
+public func repeating<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexComponent, R: RangeExpression>(
   _ expression: R,
   _ behavior: QuantificationBehavior = .eagerly,
-  @RegexBuilder _ component: () -> Component
+  @RegexComponentBuilder _ component: () -> Component
 ) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?)> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8), R.Bound == Int {
   .init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component().regex.root))
 }
 extension AlternationBuilder {
   public static func buildBlock<R0, R1>(
     combining next: R1, into combined: R0
-  ) -> Regex<Substring> where R0: RegexProtocol, R1: RegexProtocol {
+  ) -> Regex<Substring> where R0: RegexComponent, R1: RegexComponent {
     .init(node: combined.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 
-public func | <R0, R1>(lhs: R0, rhs: R1) -> Regex<Substring> where R0: RegexProtocol, R1: RegexProtocol {
+public func | <R0, R1>(lhs: R0, rhs: R1) -> Regex<Substring> where R0: RegexComponent, R1: RegexComponent {
   .init(node: lhs.regex.root.appendingAlternationCase(rhs.regex.root))
 }
 extension AlternationBuilder {
   public static func buildBlock<R0, R1, W1, C0>(
     combining next: R1, into combined: R0
-  ) -> Regex<(Substring, C0?)> where R0: RegexProtocol, R1: RegexProtocol, R1.Match == (W1, C0) {
+  ) -> Regex<(Substring, C0?)> where R0: RegexComponent, R1: RegexComponent, R1.Match == (W1, C0) {
     .init(node: combined.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 
-public func | <R0, R1, W1, C0>(lhs: R0, rhs: R1) -> Regex<(Substring, C0?)> where R0: RegexProtocol, R1: RegexProtocol, R1.Match == (W1, C0) {
+public func | <R0, R1, W1, C0>(lhs: R0, rhs: R1) -> Regex<(Substring, C0?)> where R0: RegexComponent, R1: RegexComponent, R1.Match == (W1, C0) {
   .init(node: lhs.regex.root.appendingAlternationCase(rhs.regex.root))
 }
 extension AlternationBuilder {
   public static func buildBlock<R0, R1, W1, C0, C1>(
     combining next: R1, into combined: R0
-  ) -> Regex<(Substring, C0?, C1?)> where R0: RegexProtocol, R1: RegexProtocol, R1.Match == (W1, C0, C1) {
+  ) -> Regex<(Substring, C0?, C1?)> where R0: RegexComponent, R1: RegexComponent, R1.Match == (W1, C0, C1) {
     .init(node: combined.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 
-public func | <R0, R1, W1, C0, C1>(lhs: R0, rhs: R1) -> Regex<(Substring, C0?, C1?)> where R0: RegexProtocol, R1: RegexProtocol, R1.Match == (W1, C0, C1) {
+public func | <R0, R1, W1, C0, C1>(lhs: R0, rhs: R1) -> Regex<(Substring, C0?, C1?)> where R0: RegexComponent, R1: RegexComponent, R1.Match == (W1, C0, C1) {
   .init(node: lhs.regex.root.appendingAlternationCase(rhs.regex.root))
 }
 extension AlternationBuilder {
   public static func buildBlock<R0, R1, W1, C0, C1, C2>(
     combining next: R1, into combined: R0
-  ) -> Regex<(Substring, C0?, C1?, C2?)> where R0: RegexProtocol, R1: RegexProtocol, R1.Match == (W1, C0, C1, C2) {
+  ) -> Regex<(Substring, C0?, C1?, C2?)> where R0: RegexComponent, R1: RegexComponent, R1.Match == (W1, C0, C1, C2) {
     .init(node: combined.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 
-public func | <R0, R1, W1, C0, C1, C2>(lhs: R0, rhs: R1) -> Regex<(Substring, C0?, C1?, C2?)> where R0: RegexProtocol, R1: RegexProtocol, R1.Match == (W1, C0, C1, C2) {
+public func | <R0, R1, W1, C0, C1, C2>(lhs: R0, rhs: R1) -> Regex<(Substring, C0?, C1?, C2?)> where R0: RegexComponent, R1: RegexComponent, R1.Match == (W1, C0, C1, C2) {
   .init(node: lhs.regex.root.appendingAlternationCase(rhs.regex.root))
 }
 extension AlternationBuilder {
   public static func buildBlock<R0, R1, W1, C0, C1, C2, C3>(
     combining next: R1, into combined: R0
-  ) -> Regex<(Substring, C0?, C1?, C2?, C3?)> where R0: RegexProtocol, R1: RegexProtocol, R1.Match == (W1, C0, C1, C2, C3) {
+  ) -> Regex<(Substring, C0?, C1?, C2?, C3?)> where R0: RegexComponent, R1: RegexComponent, R1.Match == (W1, C0, C1, C2, C3) {
     .init(node: combined.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 
-public func | <R0, R1, W1, C0, C1, C2, C3>(lhs: R0, rhs: R1) -> Regex<(Substring, C0?, C1?, C2?, C3?)> where R0: RegexProtocol, R1: RegexProtocol, R1.Match == (W1, C0, C1, C2, C3) {
+public func | <R0, R1, W1, C0, C1, C2, C3>(lhs: R0, rhs: R1) -> Regex<(Substring, C0?, C1?, C2?, C3?)> where R0: RegexComponent, R1: RegexComponent, R1.Match == (W1, C0, C1, C2, C3) {
   .init(node: lhs.regex.root.appendingAlternationCase(rhs.regex.root))
 }
 extension AlternationBuilder {
   public static func buildBlock<R0, R1, W1, C0, C1, C2, C3, C4>(
     combining next: R1, into combined: R0
-  ) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?)> where R0: RegexProtocol, R1: RegexProtocol, R1.Match == (W1, C0, C1, C2, C3, C4) {
+  ) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?)> where R0: RegexComponent, R1: RegexComponent, R1.Match == (W1, C0, C1, C2, C3, C4) {
     .init(node: combined.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 
-public func | <R0, R1, W1, C0, C1, C2, C3, C4>(lhs: R0, rhs: R1) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?)> where R0: RegexProtocol, R1: RegexProtocol, R1.Match == (W1, C0, C1, C2, C3, C4) {
+public func | <R0, R1, W1, C0, C1, C2, C3, C4>(lhs: R0, rhs: R1) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?)> where R0: RegexComponent, R1: RegexComponent, R1.Match == (W1, C0, C1, C2, C3, C4) {
   .init(node: lhs.regex.root.appendingAlternationCase(rhs.regex.root))
 }
 extension AlternationBuilder {
   public static func buildBlock<R0, R1, W1, C0, C1, C2, C3, C4, C5>(
     combining next: R1, into combined: R0
-  ) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?)> where R0: RegexProtocol, R1: RegexProtocol, R1.Match == (W1, C0, C1, C2, C3, C4, C5) {
+  ) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?)> where R0: RegexComponent, R1: RegexComponent, R1.Match == (W1, C0, C1, C2, C3, C4, C5) {
     .init(node: combined.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 
-public func | <R0, R1, W1, C0, C1, C2, C3, C4, C5>(lhs: R0, rhs: R1) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?)> where R0: RegexProtocol, R1: RegexProtocol, R1.Match == (W1, C0, C1, C2, C3, C4, C5) {
+public func | <R0, R1, W1, C0, C1, C2, C3, C4, C5>(lhs: R0, rhs: R1) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?)> where R0: RegexComponent, R1: RegexComponent, R1.Match == (W1, C0, C1, C2, C3, C4, C5) {
   .init(node: lhs.regex.root.appendingAlternationCase(rhs.regex.root))
 }
 extension AlternationBuilder {
   public static func buildBlock<R0, R1, W1, C0, C1, C2, C3, C4, C5, C6>(
     combining next: R1, into combined: R0
-  ) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?)> where R0: RegexProtocol, R1: RegexProtocol, R1.Match == (W1, C0, C1, C2, C3, C4, C5, C6) {
+  ) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?)> where R0: RegexComponent, R1: RegexComponent, R1.Match == (W1, C0, C1, C2, C3, C4, C5, C6) {
     .init(node: combined.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 
-public func | <R0, R1, W1, C0, C1, C2, C3, C4, C5, C6>(lhs: R0, rhs: R1) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?)> where R0: RegexProtocol, R1: RegexProtocol, R1.Match == (W1, C0, C1, C2, C3, C4, C5, C6) {
+public func | <R0, R1, W1, C0, C1, C2, C3, C4, C5, C6>(lhs: R0, rhs: R1) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?)> where R0: RegexComponent, R1: RegexComponent, R1.Match == (W1, C0, C1, C2, C3, C4, C5, C6) {
   .init(node: lhs.regex.root.appendingAlternationCase(rhs.regex.root))
 }
 extension AlternationBuilder {
   public static func buildBlock<R0, R1, W1, C0, C1, C2, C3, C4, C5, C6, C7>(
     combining next: R1, into combined: R0
-  ) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?)> where R0: RegexProtocol, R1: RegexProtocol, R1.Match == (W1, C0, C1, C2, C3, C4, C5, C6, C7) {
+  ) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?)> where R0: RegexComponent, R1: RegexComponent, R1.Match == (W1, C0, C1, C2, C3, C4, C5, C6, C7) {
     .init(node: combined.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 
-public func | <R0, R1, W1, C0, C1, C2, C3, C4, C5, C6, C7>(lhs: R0, rhs: R1) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?)> where R0: RegexProtocol, R1: RegexProtocol, R1.Match == (W1, C0, C1, C2, C3, C4, C5, C6, C7) {
+public func | <R0, R1, W1, C0, C1, C2, C3, C4, C5, C6, C7>(lhs: R0, rhs: R1) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?)> where R0: RegexComponent, R1: RegexComponent, R1.Match == (W1, C0, C1, C2, C3, C4, C5, C6, C7) {
   .init(node: lhs.regex.root.appendingAlternationCase(rhs.regex.root))
 }
 extension AlternationBuilder {
   public static func buildBlock<R0, R1, W1, C0, C1, C2, C3, C4, C5, C6, C7, C8>(
     combining next: R1, into combined: R0
-  ) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?)> where R0: RegexProtocol, R1: RegexProtocol, R1.Match == (W1, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
+  ) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?)> where R0: RegexComponent, R1: RegexComponent, R1.Match == (W1, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
     .init(node: combined.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 
-public func | <R0, R1, W1, C0, C1, C2, C3, C4, C5, C6, C7, C8>(lhs: R0, rhs: R1) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?)> where R0: RegexProtocol, R1: RegexProtocol, R1.Match == (W1, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
+public func | <R0, R1, W1, C0, C1, C2, C3, C4, C5, C6, C7, C8>(lhs: R0, rhs: R1) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?)> where R0: RegexComponent, R1: RegexComponent, R1.Match == (W1, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
   .init(node: lhs.regex.root.appendingAlternationCase(rhs.regex.root))
 }
 extension AlternationBuilder {
   public static func buildBlock<R0, R1, W1, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9>(
     combining next: R1, into combined: R0
-  ) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?)> where R0: RegexProtocol, R1: RegexProtocol, R1.Match == (W1, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
+  ) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?)> where R0: RegexComponent, R1: RegexComponent, R1.Match == (W1, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
     .init(node: combined.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 
-public func | <R0, R1, W1, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9>(lhs: R0, rhs: R1) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?)> where R0: RegexProtocol, R1: RegexProtocol, R1.Match == (W1, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
+public func | <R0, R1, W1, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9>(lhs: R0, rhs: R1) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?)> where R0: RegexComponent, R1: RegexComponent, R1.Match == (W1, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
   .init(node: lhs.regex.root.appendingAlternationCase(rhs.regex.root))
 }
 extension AlternationBuilder {
   public static func buildBlock<R0, W0, C0, R1>(
     combining next: R1, into combined: R0
-  ) -> Regex<(Substring, C0)> where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0) {
+  ) -> Regex<(Substring, C0)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0) {
     .init(node: combined.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 
-public func | <R0, W0, C0, R1>(lhs: R0, rhs: R1) -> Regex<(Substring, C0)> where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0) {
+public func | <R0, W0, C0, R1>(lhs: R0, rhs: R1) -> Regex<(Substring, C0)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0) {
   .init(node: lhs.regex.root.appendingAlternationCase(rhs.regex.root))
 }
 extension AlternationBuilder {
   public static func buildBlock<R0, W0, C0, R1, W1, C1>(
     combining next: R1, into combined: R0
-  ) -> Regex<(Substring, C0, C1?)> where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0), R1.Match == (W1, C1) {
+  ) -> Regex<(Substring, C0, C1?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0), R1.Match == (W1, C1) {
     .init(node: combined.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 
-public func | <R0, W0, C0, R1, W1, C1>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1?)> where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0), R1.Match == (W1, C1) {
+public func | <R0, W0, C0, R1, W1, C1>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0), R1.Match == (W1, C1) {
   .init(node: lhs.regex.root.appendingAlternationCase(rhs.regex.root))
 }
 extension AlternationBuilder {
   public static func buildBlock<R0, W0, C0, R1, W1, C1, C2>(
     combining next: R1, into combined: R0
-  ) -> Regex<(Substring, C0, C1?, C2?)> where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0), R1.Match == (W1, C1, C2) {
+  ) -> Regex<(Substring, C0, C1?, C2?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0), R1.Match == (W1, C1, C2) {
     .init(node: combined.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 
-public func | <R0, W0, C0, R1, W1, C1, C2>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1?, C2?)> where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0), R1.Match == (W1, C1, C2) {
+public func | <R0, W0, C0, R1, W1, C1, C2>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1?, C2?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0), R1.Match == (W1, C1, C2) {
   .init(node: lhs.regex.root.appendingAlternationCase(rhs.regex.root))
 }
 extension AlternationBuilder {
   public static func buildBlock<R0, W0, C0, R1, W1, C1, C2, C3>(
     combining next: R1, into combined: R0
-  ) -> Regex<(Substring, C0, C1?, C2?, C3?)> where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0), R1.Match == (W1, C1, C2, C3) {
+  ) -> Regex<(Substring, C0, C1?, C2?, C3?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0), R1.Match == (W1, C1, C2, C3) {
     .init(node: combined.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 
-public func | <R0, W0, C0, R1, W1, C1, C2, C3>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1?, C2?, C3?)> where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0), R1.Match == (W1, C1, C2, C3) {
+public func | <R0, W0, C0, R1, W1, C1, C2, C3>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1?, C2?, C3?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0), R1.Match == (W1, C1, C2, C3) {
   .init(node: lhs.regex.root.appendingAlternationCase(rhs.regex.root))
 }
 extension AlternationBuilder {
   public static func buildBlock<R0, W0, C0, R1, W1, C1, C2, C3, C4>(
     combining next: R1, into combined: R0
-  ) -> Regex<(Substring, C0, C1?, C2?, C3?, C4?)> where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0), R1.Match == (W1, C1, C2, C3, C4) {
+  ) -> Regex<(Substring, C0, C1?, C2?, C3?, C4?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0), R1.Match == (W1, C1, C2, C3, C4) {
     .init(node: combined.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 
-public func | <R0, W0, C0, R1, W1, C1, C2, C3, C4>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1?, C2?, C3?, C4?)> where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0), R1.Match == (W1, C1, C2, C3, C4) {
+public func | <R0, W0, C0, R1, W1, C1, C2, C3, C4>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1?, C2?, C3?, C4?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0), R1.Match == (W1, C1, C2, C3, C4) {
   .init(node: lhs.regex.root.appendingAlternationCase(rhs.regex.root))
 }
 extension AlternationBuilder {
   public static func buildBlock<R0, W0, C0, R1, W1, C1, C2, C3, C4, C5>(
     combining next: R1, into combined: R0
-  ) -> Regex<(Substring, C0, C1?, C2?, C3?, C4?, C5?)> where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0), R1.Match == (W1, C1, C2, C3, C4, C5) {
+  ) -> Regex<(Substring, C0, C1?, C2?, C3?, C4?, C5?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0), R1.Match == (W1, C1, C2, C3, C4, C5) {
     .init(node: combined.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 
-public func | <R0, W0, C0, R1, W1, C1, C2, C3, C4, C5>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1?, C2?, C3?, C4?, C5?)> where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0), R1.Match == (W1, C1, C2, C3, C4, C5) {
+public func | <R0, W0, C0, R1, W1, C1, C2, C3, C4, C5>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1?, C2?, C3?, C4?, C5?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0), R1.Match == (W1, C1, C2, C3, C4, C5) {
   .init(node: lhs.regex.root.appendingAlternationCase(rhs.regex.root))
 }
 extension AlternationBuilder {
   public static func buildBlock<R0, W0, C0, R1, W1, C1, C2, C3, C4, C5, C6>(
     combining next: R1, into combined: R0
-  ) -> Regex<(Substring, C0, C1?, C2?, C3?, C4?, C5?, C6?)> where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0), R1.Match == (W1, C1, C2, C3, C4, C5, C6) {
+  ) -> Regex<(Substring, C0, C1?, C2?, C3?, C4?, C5?, C6?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0), R1.Match == (W1, C1, C2, C3, C4, C5, C6) {
     .init(node: combined.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 
-public func | <R0, W0, C0, R1, W1, C1, C2, C3, C4, C5, C6>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1?, C2?, C3?, C4?, C5?, C6?)> where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0), R1.Match == (W1, C1, C2, C3, C4, C5, C6) {
+public func | <R0, W0, C0, R1, W1, C1, C2, C3, C4, C5, C6>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1?, C2?, C3?, C4?, C5?, C6?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0), R1.Match == (W1, C1, C2, C3, C4, C5, C6) {
   .init(node: lhs.regex.root.appendingAlternationCase(rhs.regex.root))
 }
 extension AlternationBuilder {
   public static func buildBlock<R0, W0, C0, R1, W1, C1, C2, C3, C4, C5, C6, C7>(
     combining next: R1, into combined: R0
-  ) -> Regex<(Substring, C0, C1?, C2?, C3?, C4?, C5?, C6?, C7?)> where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0), R1.Match == (W1, C1, C2, C3, C4, C5, C6, C7) {
+  ) -> Regex<(Substring, C0, C1?, C2?, C3?, C4?, C5?, C6?, C7?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0), R1.Match == (W1, C1, C2, C3, C4, C5, C6, C7) {
     .init(node: combined.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 
-public func | <R0, W0, C0, R1, W1, C1, C2, C3, C4, C5, C6, C7>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1?, C2?, C3?, C4?, C5?, C6?, C7?)> where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0), R1.Match == (W1, C1, C2, C3, C4, C5, C6, C7) {
+public func | <R0, W0, C0, R1, W1, C1, C2, C3, C4, C5, C6, C7>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1?, C2?, C3?, C4?, C5?, C6?, C7?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0), R1.Match == (W1, C1, C2, C3, C4, C5, C6, C7) {
   .init(node: lhs.regex.root.appendingAlternationCase(rhs.regex.root))
 }
 extension AlternationBuilder {
   public static func buildBlock<R0, W0, C0, R1, W1, C1, C2, C3, C4, C5, C6, C7, C8>(
     combining next: R1, into combined: R0
-  ) -> Regex<(Substring, C0, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?)> where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0), R1.Match == (W1, C1, C2, C3, C4, C5, C6, C7, C8) {
+  ) -> Regex<(Substring, C0, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0), R1.Match == (W1, C1, C2, C3, C4, C5, C6, C7, C8) {
     .init(node: combined.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 
-public func | <R0, W0, C0, R1, W1, C1, C2, C3, C4, C5, C6, C7, C8>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?)> where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0), R1.Match == (W1, C1, C2, C3, C4, C5, C6, C7, C8) {
+public func | <R0, W0, C0, R1, W1, C1, C2, C3, C4, C5, C6, C7, C8>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0), R1.Match == (W1, C1, C2, C3, C4, C5, C6, C7, C8) {
   .init(node: lhs.regex.root.appendingAlternationCase(rhs.regex.root))
 }
 extension AlternationBuilder {
   public static func buildBlock<R0, W0, C0, R1, W1, C1, C2, C3, C4, C5, C6, C7, C8, C9>(
     combining next: R1, into combined: R0
-  ) -> Regex<(Substring, C0, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?)> where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0), R1.Match == (W1, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
+  ) -> Regex<(Substring, C0, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0), R1.Match == (W1, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
     .init(node: combined.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 
-public func | <R0, W0, C0, R1, W1, C1, C2, C3, C4, C5, C6, C7, C8, C9>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?)> where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0), R1.Match == (W1, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
+public func | <R0, W0, C0, R1, W1, C1, C2, C3, C4, C5, C6, C7, C8, C9>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0), R1.Match == (W1, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
   .init(node: lhs.regex.root.appendingAlternationCase(rhs.regex.root))
 }
 extension AlternationBuilder {
   public static func buildBlock<R0, W0, C0, C1, R1>(
     combining next: R1, into combined: R0
-  ) -> Regex<(Substring, C0, C1)> where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0, C1) {
+  ) -> Regex<(Substring, C0, C1)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1) {
     .init(node: combined.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 
-public func | <R0, W0, C0, C1, R1>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1)> where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0, C1) {
+public func | <R0, W0, C0, C1, R1>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1) {
   .init(node: lhs.regex.root.appendingAlternationCase(rhs.regex.root))
 }
 extension AlternationBuilder {
   public static func buildBlock<R0, W0, C0, C1, R1, W1, C2>(
     combining next: R1, into combined: R0
-  ) -> Regex<(Substring, C0, C1, C2?)> where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0, C1), R1.Match == (W1, C2) {
+  ) -> Regex<(Substring, C0, C1, C2?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1), R1.Match == (W1, C2) {
     .init(node: combined.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 
-public func | <R0, W0, C0, C1, R1, W1, C2>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1, C2?)> where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0, C1), R1.Match == (W1, C2) {
+public func | <R0, W0, C0, C1, R1, W1, C2>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1, C2?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1), R1.Match == (W1, C2) {
   .init(node: lhs.regex.root.appendingAlternationCase(rhs.regex.root))
 }
 extension AlternationBuilder {
   public static func buildBlock<R0, W0, C0, C1, R1, W1, C2, C3>(
     combining next: R1, into combined: R0
-  ) -> Regex<(Substring, C0, C1, C2?, C3?)> where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0, C1), R1.Match == (W1, C2, C3) {
+  ) -> Regex<(Substring, C0, C1, C2?, C3?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1), R1.Match == (W1, C2, C3) {
     .init(node: combined.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 
-public func | <R0, W0, C0, C1, R1, W1, C2, C3>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1, C2?, C3?)> where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0, C1), R1.Match == (W1, C2, C3) {
+public func | <R0, W0, C0, C1, R1, W1, C2, C3>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1, C2?, C3?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1), R1.Match == (W1, C2, C3) {
   .init(node: lhs.regex.root.appendingAlternationCase(rhs.regex.root))
 }
 extension AlternationBuilder {
   public static func buildBlock<R0, W0, C0, C1, R1, W1, C2, C3, C4>(
     combining next: R1, into combined: R0
-  ) -> Regex<(Substring, C0, C1, C2?, C3?, C4?)> where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0, C1), R1.Match == (W1, C2, C3, C4) {
+  ) -> Regex<(Substring, C0, C1, C2?, C3?, C4?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1), R1.Match == (W1, C2, C3, C4) {
     .init(node: combined.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 
-public func | <R0, W0, C0, C1, R1, W1, C2, C3, C4>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1, C2?, C3?, C4?)> where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0, C1), R1.Match == (W1, C2, C3, C4) {
+public func | <R0, W0, C0, C1, R1, W1, C2, C3, C4>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1, C2?, C3?, C4?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1), R1.Match == (W1, C2, C3, C4) {
   .init(node: lhs.regex.root.appendingAlternationCase(rhs.regex.root))
 }
 extension AlternationBuilder {
   public static func buildBlock<R0, W0, C0, C1, R1, W1, C2, C3, C4, C5>(
     combining next: R1, into combined: R0
-  ) -> Regex<(Substring, C0, C1, C2?, C3?, C4?, C5?)> where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0, C1), R1.Match == (W1, C2, C3, C4, C5) {
+  ) -> Regex<(Substring, C0, C1, C2?, C3?, C4?, C5?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1), R1.Match == (W1, C2, C3, C4, C5) {
     .init(node: combined.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 
-public func | <R0, W0, C0, C1, R1, W1, C2, C3, C4, C5>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1, C2?, C3?, C4?, C5?)> where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0, C1), R1.Match == (W1, C2, C3, C4, C5) {
+public func | <R0, W0, C0, C1, R1, W1, C2, C3, C4, C5>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1, C2?, C3?, C4?, C5?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1), R1.Match == (W1, C2, C3, C4, C5) {
   .init(node: lhs.regex.root.appendingAlternationCase(rhs.regex.root))
 }
 extension AlternationBuilder {
   public static func buildBlock<R0, W0, C0, C1, R1, W1, C2, C3, C4, C5, C6>(
     combining next: R1, into combined: R0
-  ) -> Regex<(Substring, C0, C1, C2?, C3?, C4?, C5?, C6?)> where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0, C1), R1.Match == (W1, C2, C3, C4, C5, C6) {
+  ) -> Regex<(Substring, C0, C1, C2?, C3?, C4?, C5?, C6?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1), R1.Match == (W1, C2, C3, C4, C5, C6) {
     .init(node: combined.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 
-public func | <R0, W0, C0, C1, R1, W1, C2, C3, C4, C5, C6>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1, C2?, C3?, C4?, C5?, C6?)> where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0, C1), R1.Match == (W1, C2, C3, C4, C5, C6) {
+public func | <R0, W0, C0, C1, R1, W1, C2, C3, C4, C5, C6>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1, C2?, C3?, C4?, C5?, C6?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1), R1.Match == (W1, C2, C3, C4, C5, C6) {
   .init(node: lhs.regex.root.appendingAlternationCase(rhs.regex.root))
 }
 extension AlternationBuilder {
   public static func buildBlock<R0, W0, C0, C1, R1, W1, C2, C3, C4, C5, C6, C7>(
     combining next: R1, into combined: R0
-  ) -> Regex<(Substring, C0, C1, C2?, C3?, C4?, C5?, C6?, C7?)> where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0, C1), R1.Match == (W1, C2, C3, C4, C5, C6, C7) {
+  ) -> Regex<(Substring, C0, C1, C2?, C3?, C4?, C5?, C6?, C7?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1), R1.Match == (W1, C2, C3, C4, C5, C6, C7) {
     .init(node: combined.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 
-public func | <R0, W0, C0, C1, R1, W1, C2, C3, C4, C5, C6, C7>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1, C2?, C3?, C4?, C5?, C6?, C7?)> where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0, C1), R1.Match == (W1, C2, C3, C4, C5, C6, C7) {
+public func | <R0, W0, C0, C1, R1, W1, C2, C3, C4, C5, C6, C7>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1, C2?, C3?, C4?, C5?, C6?, C7?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1), R1.Match == (W1, C2, C3, C4, C5, C6, C7) {
   .init(node: lhs.regex.root.appendingAlternationCase(rhs.regex.root))
 }
 extension AlternationBuilder {
   public static func buildBlock<R0, W0, C0, C1, R1, W1, C2, C3, C4, C5, C6, C7, C8>(
     combining next: R1, into combined: R0
-  ) -> Regex<(Substring, C0, C1, C2?, C3?, C4?, C5?, C6?, C7?, C8?)> where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0, C1), R1.Match == (W1, C2, C3, C4, C5, C6, C7, C8) {
+  ) -> Regex<(Substring, C0, C1, C2?, C3?, C4?, C5?, C6?, C7?, C8?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1), R1.Match == (W1, C2, C3, C4, C5, C6, C7, C8) {
     .init(node: combined.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 
-public func | <R0, W0, C0, C1, R1, W1, C2, C3, C4, C5, C6, C7, C8>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1, C2?, C3?, C4?, C5?, C6?, C7?, C8?)> where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0, C1), R1.Match == (W1, C2, C3, C4, C5, C6, C7, C8) {
+public func | <R0, W0, C0, C1, R1, W1, C2, C3, C4, C5, C6, C7, C8>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1, C2?, C3?, C4?, C5?, C6?, C7?, C8?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1), R1.Match == (W1, C2, C3, C4, C5, C6, C7, C8) {
   .init(node: lhs.regex.root.appendingAlternationCase(rhs.regex.root))
 }
 extension AlternationBuilder {
   public static func buildBlock<R0, W0, C0, C1, R1, W1, C2, C3, C4, C5, C6, C7, C8, C9>(
     combining next: R1, into combined: R0
-  ) -> Regex<(Substring, C0, C1, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?)> where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0, C1), R1.Match == (W1, C2, C3, C4, C5, C6, C7, C8, C9) {
+  ) -> Regex<(Substring, C0, C1, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1), R1.Match == (W1, C2, C3, C4, C5, C6, C7, C8, C9) {
     .init(node: combined.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 
-public func | <R0, W0, C0, C1, R1, W1, C2, C3, C4, C5, C6, C7, C8, C9>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?)> where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0, C1), R1.Match == (W1, C2, C3, C4, C5, C6, C7, C8, C9) {
+public func | <R0, W0, C0, C1, R1, W1, C2, C3, C4, C5, C6, C7, C8, C9>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1), R1.Match == (W1, C2, C3, C4, C5, C6, C7, C8, C9) {
   .init(node: lhs.regex.root.appendingAlternationCase(rhs.regex.root))
 }
 extension AlternationBuilder {
   public static func buildBlock<R0, W0, C0, C1, C2, R1>(
     combining next: R1, into combined: R0
-  ) -> Regex<(Substring, C0, C1, C2)> where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0, C1, C2) {
+  ) -> Regex<(Substring, C0, C1, C2)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2) {
     .init(node: combined.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 
-public func | <R0, W0, C0, C1, C2, R1>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1, C2)> where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0, C1, C2) {
+public func | <R0, W0, C0, C1, C2, R1>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1, C2)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2) {
   .init(node: lhs.regex.root.appendingAlternationCase(rhs.regex.root))
 }
 extension AlternationBuilder {
   public static func buildBlock<R0, W0, C0, C1, C2, R1, W1, C3>(
     combining next: R1, into combined: R0
-  ) -> Regex<(Substring, C0, C1, C2, C3?)> where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0, C1, C2), R1.Match == (W1, C3) {
+  ) -> Regex<(Substring, C0, C1, C2, C3?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2), R1.Match == (W1, C3) {
     .init(node: combined.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 
-public func | <R0, W0, C0, C1, C2, R1, W1, C3>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1, C2, C3?)> where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0, C1, C2), R1.Match == (W1, C3) {
+public func | <R0, W0, C0, C1, C2, R1, W1, C3>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1, C2, C3?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2), R1.Match == (W1, C3) {
   .init(node: lhs.regex.root.appendingAlternationCase(rhs.regex.root))
 }
 extension AlternationBuilder {
   public static func buildBlock<R0, W0, C0, C1, C2, R1, W1, C3, C4>(
     combining next: R1, into combined: R0
-  ) -> Regex<(Substring, C0, C1, C2, C3?, C4?)> where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0, C1, C2), R1.Match == (W1, C3, C4) {
+  ) -> Regex<(Substring, C0, C1, C2, C3?, C4?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2), R1.Match == (W1, C3, C4) {
     .init(node: combined.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 
-public func | <R0, W0, C0, C1, C2, R1, W1, C3, C4>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1, C2, C3?, C4?)> where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0, C1, C2), R1.Match == (W1, C3, C4) {
+public func | <R0, W0, C0, C1, C2, R1, W1, C3, C4>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1, C2, C3?, C4?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2), R1.Match == (W1, C3, C4) {
   .init(node: lhs.regex.root.appendingAlternationCase(rhs.regex.root))
 }
 extension AlternationBuilder {
   public static func buildBlock<R0, W0, C0, C1, C2, R1, W1, C3, C4, C5>(
     combining next: R1, into combined: R0
-  ) -> Regex<(Substring, C0, C1, C2, C3?, C4?, C5?)> where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0, C1, C2), R1.Match == (W1, C3, C4, C5) {
+  ) -> Regex<(Substring, C0, C1, C2, C3?, C4?, C5?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2), R1.Match == (W1, C3, C4, C5) {
     .init(node: combined.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 
-public func | <R0, W0, C0, C1, C2, R1, W1, C3, C4, C5>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1, C2, C3?, C4?, C5?)> where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0, C1, C2), R1.Match == (W1, C3, C4, C5) {
+public func | <R0, W0, C0, C1, C2, R1, W1, C3, C4, C5>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1, C2, C3?, C4?, C5?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2), R1.Match == (W1, C3, C4, C5) {
   .init(node: lhs.regex.root.appendingAlternationCase(rhs.regex.root))
 }
 extension AlternationBuilder {
   public static func buildBlock<R0, W0, C0, C1, C2, R1, W1, C3, C4, C5, C6>(
     combining next: R1, into combined: R0
-  ) -> Regex<(Substring, C0, C1, C2, C3?, C4?, C5?, C6?)> where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0, C1, C2), R1.Match == (W1, C3, C4, C5, C6) {
+  ) -> Regex<(Substring, C0, C1, C2, C3?, C4?, C5?, C6?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2), R1.Match == (W1, C3, C4, C5, C6) {
     .init(node: combined.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 
-public func | <R0, W0, C0, C1, C2, R1, W1, C3, C4, C5, C6>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1, C2, C3?, C4?, C5?, C6?)> where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0, C1, C2), R1.Match == (W1, C3, C4, C5, C6) {
+public func | <R0, W0, C0, C1, C2, R1, W1, C3, C4, C5, C6>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1, C2, C3?, C4?, C5?, C6?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2), R1.Match == (W1, C3, C4, C5, C6) {
   .init(node: lhs.regex.root.appendingAlternationCase(rhs.regex.root))
 }
 extension AlternationBuilder {
   public static func buildBlock<R0, W0, C0, C1, C2, R1, W1, C3, C4, C5, C6, C7>(
     combining next: R1, into combined: R0
-  ) -> Regex<(Substring, C0, C1, C2, C3?, C4?, C5?, C6?, C7?)> where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0, C1, C2), R1.Match == (W1, C3, C4, C5, C6, C7) {
+  ) -> Regex<(Substring, C0, C1, C2, C3?, C4?, C5?, C6?, C7?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2), R1.Match == (W1, C3, C4, C5, C6, C7) {
     .init(node: combined.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 
-public func | <R0, W0, C0, C1, C2, R1, W1, C3, C4, C5, C6, C7>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1, C2, C3?, C4?, C5?, C6?, C7?)> where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0, C1, C2), R1.Match == (W1, C3, C4, C5, C6, C7) {
+public func | <R0, W0, C0, C1, C2, R1, W1, C3, C4, C5, C6, C7>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1, C2, C3?, C4?, C5?, C6?, C7?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2), R1.Match == (W1, C3, C4, C5, C6, C7) {
   .init(node: lhs.regex.root.appendingAlternationCase(rhs.regex.root))
 }
 extension AlternationBuilder {
   public static func buildBlock<R0, W0, C0, C1, C2, R1, W1, C3, C4, C5, C6, C7, C8>(
     combining next: R1, into combined: R0
-  ) -> Regex<(Substring, C0, C1, C2, C3?, C4?, C5?, C6?, C7?, C8?)> where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0, C1, C2), R1.Match == (W1, C3, C4, C5, C6, C7, C8) {
+  ) -> Regex<(Substring, C0, C1, C2, C3?, C4?, C5?, C6?, C7?, C8?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2), R1.Match == (W1, C3, C4, C5, C6, C7, C8) {
     .init(node: combined.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 
-public func | <R0, W0, C0, C1, C2, R1, W1, C3, C4, C5, C6, C7, C8>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1, C2, C3?, C4?, C5?, C6?, C7?, C8?)> where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0, C1, C2), R1.Match == (W1, C3, C4, C5, C6, C7, C8) {
+public func | <R0, W0, C0, C1, C2, R1, W1, C3, C4, C5, C6, C7, C8>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1, C2, C3?, C4?, C5?, C6?, C7?, C8?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2), R1.Match == (W1, C3, C4, C5, C6, C7, C8) {
   .init(node: lhs.regex.root.appendingAlternationCase(rhs.regex.root))
 }
 extension AlternationBuilder {
   public static func buildBlock<R0, W0, C0, C1, C2, R1, W1, C3, C4, C5, C6, C7, C8, C9>(
     combining next: R1, into combined: R0
-  ) -> Regex<(Substring, C0, C1, C2, C3?, C4?, C5?, C6?, C7?, C8?, C9?)> where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0, C1, C2), R1.Match == (W1, C3, C4, C5, C6, C7, C8, C9) {
+  ) -> Regex<(Substring, C0, C1, C2, C3?, C4?, C5?, C6?, C7?, C8?, C9?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2), R1.Match == (W1, C3, C4, C5, C6, C7, C8, C9) {
     .init(node: combined.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 
-public func | <R0, W0, C0, C1, C2, R1, W1, C3, C4, C5, C6, C7, C8, C9>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1, C2, C3?, C4?, C5?, C6?, C7?, C8?, C9?)> where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0, C1, C2), R1.Match == (W1, C3, C4, C5, C6, C7, C8, C9) {
+public func | <R0, W0, C0, C1, C2, R1, W1, C3, C4, C5, C6, C7, C8, C9>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1, C2, C3?, C4?, C5?, C6?, C7?, C8?, C9?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2), R1.Match == (W1, C3, C4, C5, C6, C7, C8, C9) {
   .init(node: lhs.regex.root.appendingAlternationCase(rhs.regex.root))
 }
 extension AlternationBuilder {
   public static func buildBlock<R0, W0, C0, C1, C2, C3, R1>(
     combining next: R1, into combined: R0
-  ) -> Regex<(Substring, C0, C1, C2, C3)> where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0, C1, C2, C3) {
+  ) -> Regex<(Substring, C0, C1, C2, C3)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3) {
     .init(node: combined.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 
-public func | <R0, W0, C0, C1, C2, C3, R1>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1, C2, C3)> where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0, C1, C2, C3) {
+public func | <R0, W0, C0, C1, C2, C3, R1>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1, C2, C3)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3) {
   .init(node: lhs.regex.root.appendingAlternationCase(rhs.regex.root))
 }
 extension AlternationBuilder {
   public static func buildBlock<R0, W0, C0, C1, C2, C3, R1, W1, C4>(
     combining next: R1, into combined: R0
-  ) -> Regex<(Substring, C0, C1, C2, C3, C4?)> where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0, C1, C2, C3), R1.Match == (W1, C4) {
+  ) -> Regex<(Substring, C0, C1, C2, C3, C4?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3), R1.Match == (W1, C4) {
     .init(node: combined.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 
-public func | <R0, W0, C0, C1, C2, C3, R1, W1, C4>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1, C2, C3, C4?)> where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0, C1, C2, C3), R1.Match == (W1, C4) {
+public func | <R0, W0, C0, C1, C2, C3, R1, W1, C4>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1, C2, C3, C4?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3), R1.Match == (W1, C4) {
   .init(node: lhs.regex.root.appendingAlternationCase(rhs.regex.root))
 }
 extension AlternationBuilder {
   public static func buildBlock<R0, W0, C0, C1, C2, C3, R1, W1, C4, C5>(
     combining next: R1, into combined: R0
-  ) -> Regex<(Substring, C0, C1, C2, C3, C4?, C5?)> where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0, C1, C2, C3), R1.Match == (W1, C4, C5) {
+  ) -> Regex<(Substring, C0, C1, C2, C3, C4?, C5?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3), R1.Match == (W1, C4, C5) {
     .init(node: combined.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 
-public func | <R0, W0, C0, C1, C2, C3, R1, W1, C4, C5>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1, C2, C3, C4?, C5?)> where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0, C1, C2, C3), R1.Match == (W1, C4, C5) {
+public func | <R0, W0, C0, C1, C2, C3, R1, W1, C4, C5>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1, C2, C3, C4?, C5?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3), R1.Match == (W1, C4, C5) {
   .init(node: lhs.regex.root.appendingAlternationCase(rhs.regex.root))
 }
 extension AlternationBuilder {
   public static func buildBlock<R0, W0, C0, C1, C2, C3, R1, W1, C4, C5, C6>(
     combining next: R1, into combined: R0
-  ) -> Regex<(Substring, C0, C1, C2, C3, C4?, C5?, C6?)> where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0, C1, C2, C3), R1.Match == (W1, C4, C5, C6) {
+  ) -> Regex<(Substring, C0, C1, C2, C3, C4?, C5?, C6?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3), R1.Match == (W1, C4, C5, C6) {
     .init(node: combined.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 
-public func | <R0, W0, C0, C1, C2, C3, R1, W1, C4, C5, C6>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1, C2, C3, C4?, C5?, C6?)> where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0, C1, C2, C3), R1.Match == (W1, C4, C5, C6) {
+public func | <R0, W0, C0, C1, C2, C3, R1, W1, C4, C5, C6>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1, C2, C3, C4?, C5?, C6?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3), R1.Match == (W1, C4, C5, C6) {
   .init(node: lhs.regex.root.appendingAlternationCase(rhs.regex.root))
 }
 extension AlternationBuilder {
   public static func buildBlock<R0, W0, C0, C1, C2, C3, R1, W1, C4, C5, C6, C7>(
     combining next: R1, into combined: R0
-  ) -> Regex<(Substring, C0, C1, C2, C3, C4?, C5?, C6?, C7?)> where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0, C1, C2, C3), R1.Match == (W1, C4, C5, C6, C7) {
+  ) -> Regex<(Substring, C0, C1, C2, C3, C4?, C5?, C6?, C7?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3), R1.Match == (W1, C4, C5, C6, C7) {
     .init(node: combined.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 
-public func | <R0, W0, C0, C1, C2, C3, R1, W1, C4, C5, C6, C7>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1, C2, C3, C4?, C5?, C6?, C7?)> where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0, C1, C2, C3), R1.Match == (W1, C4, C5, C6, C7) {
+public func | <R0, W0, C0, C1, C2, C3, R1, W1, C4, C5, C6, C7>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1, C2, C3, C4?, C5?, C6?, C7?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3), R1.Match == (W1, C4, C5, C6, C7) {
   .init(node: lhs.regex.root.appendingAlternationCase(rhs.regex.root))
 }
 extension AlternationBuilder {
   public static func buildBlock<R0, W0, C0, C1, C2, C3, R1, W1, C4, C5, C6, C7, C8>(
     combining next: R1, into combined: R0
-  ) -> Regex<(Substring, C0, C1, C2, C3, C4?, C5?, C6?, C7?, C8?)> where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0, C1, C2, C3), R1.Match == (W1, C4, C5, C6, C7, C8) {
+  ) -> Regex<(Substring, C0, C1, C2, C3, C4?, C5?, C6?, C7?, C8?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3), R1.Match == (W1, C4, C5, C6, C7, C8) {
     .init(node: combined.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 
-public func | <R0, W0, C0, C1, C2, C3, R1, W1, C4, C5, C6, C7, C8>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1, C2, C3, C4?, C5?, C6?, C7?, C8?)> where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0, C1, C2, C3), R1.Match == (W1, C4, C5, C6, C7, C8) {
+public func | <R0, W0, C0, C1, C2, C3, R1, W1, C4, C5, C6, C7, C8>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1, C2, C3, C4?, C5?, C6?, C7?, C8?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3), R1.Match == (W1, C4, C5, C6, C7, C8) {
   .init(node: lhs.regex.root.appendingAlternationCase(rhs.regex.root))
 }
 extension AlternationBuilder {
   public static func buildBlock<R0, W0, C0, C1, C2, C3, R1, W1, C4, C5, C6, C7, C8, C9>(
     combining next: R1, into combined: R0
-  ) -> Regex<(Substring, C0, C1, C2, C3, C4?, C5?, C6?, C7?, C8?, C9?)> where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0, C1, C2, C3), R1.Match == (W1, C4, C5, C6, C7, C8, C9) {
+  ) -> Regex<(Substring, C0, C1, C2, C3, C4?, C5?, C6?, C7?, C8?, C9?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3), R1.Match == (W1, C4, C5, C6, C7, C8, C9) {
     .init(node: combined.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 
-public func | <R0, W0, C0, C1, C2, C3, R1, W1, C4, C5, C6, C7, C8, C9>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1, C2, C3, C4?, C5?, C6?, C7?, C8?, C9?)> where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0, C1, C2, C3), R1.Match == (W1, C4, C5, C6, C7, C8, C9) {
+public func | <R0, W0, C0, C1, C2, C3, R1, W1, C4, C5, C6, C7, C8, C9>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1, C2, C3, C4?, C5?, C6?, C7?, C8?, C9?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3), R1.Match == (W1, C4, C5, C6, C7, C8, C9) {
   .init(node: lhs.regex.root.appendingAlternationCase(rhs.regex.root))
 }
 extension AlternationBuilder {
   public static func buildBlock<R0, W0, C0, C1, C2, C3, C4, R1>(
     combining next: R1, into combined: R0
-  ) -> Regex<(Substring, C0, C1, C2, C3, C4)> where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0, C1, C2, C3, C4) {
+  ) -> Regex<(Substring, C0, C1, C2, C3, C4)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3, C4) {
     .init(node: combined.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 
-public func | <R0, W0, C0, C1, C2, C3, C4, R1>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1, C2, C3, C4)> where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0, C1, C2, C3, C4) {
+public func | <R0, W0, C0, C1, C2, C3, C4, R1>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1, C2, C3, C4)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3, C4) {
   .init(node: lhs.regex.root.appendingAlternationCase(rhs.regex.root))
 }
 extension AlternationBuilder {
   public static func buildBlock<R0, W0, C0, C1, C2, C3, C4, R1, W1, C5>(
     combining next: R1, into combined: R0
-  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5?)> where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0, C1, C2, C3, C4), R1.Match == (W1, C5) {
+  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3, C4), R1.Match == (W1, C5) {
     .init(node: combined.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 
-public func | <R0, W0, C0, C1, C2, C3, C4, R1, W1, C5>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1, C2, C3, C4, C5?)> where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0, C1, C2, C3, C4), R1.Match == (W1, C5) {
+public func | <R0, W0, C0, C1, C2, C3, C4, R1, W1, C5>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1, C2, C3, C4, C5?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3, C4), R1.Match == (W1, C5) {
   .init(node: lhs.regex.root.appendingAlternationCase(rhs.regex.root))
 }
 extension AlternationBuilder {
   public static func buildBlock<R0, W0, C0, C1, C2, C3, C4, R1, W1, C5, C6>(
     combining next: R1, into combined: R0
-  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5?, C6?)> where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0, C1, C2, C3, C4), R1.Match == (W1, C5, C6) {
+  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5?, C6?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3, C4), R1.Match == (W1, C5, C6) {
     .init(node: combined.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 
-public func | <R0, W0, C0, C1, C2, C3, C4, R1, W1, C5, C6>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1, C2, C3, C4, C5?, C6?)> where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0, C1, C2, C3, C4), R1.Match == (W1, C5, C6) {
+public func | <R0, W0, C0, C1, C2, C3, C4, R1, W1, C5, C6>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1, C2, C3, C4, C5?, C6?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3, C4), R1.Match == (W1, C5, C6) {
   .init(node: lhs.regex.root.appendingAlternationCase(rhs.regex.root))
 }
 extension AlternationBuilder {
   public static func buildBlock<R0, W0, C0, C1, C2, C3, C4, R1, W1, C5, C6, C7>(
     combining next: R1, into combined: R0
-  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5?, C6?, C7?)> where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0, C1, C2, C3, C4), R1.Match == (W1, C5, C6, C7) {
+  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5?, C6?, C7?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3, C4), R1.Match == (W1, C5, C6, C7) {
     .init(node: combined.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 
-public func | <R0, W0, C0, C1, C2, C3, C4, R1, W1, C5, C6, C7>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1, C2, C3, C4, C5?, C6?, C7?)> where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0, C1, C2, C3, C4), R1.Match == (W1, C5, C6, C7) {
+public func | <R0, W0, C0, C1, C2, C3, C4, R1, W1, C5, C6, C7>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1, C2, C3, C4, C5?, C6?, C7?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3, C4), R1.Match == (W1, C5, C6, C7) {
   .init(node: lhs.regex.root.appendingAlternationCase(rhs.regex.root))
 }
 extension AlternationBuilder {
   public static func buildBlock<R0, W0, C0, C1, C2, C3, C4, R1, W1, C5, C6, C7, C8>(
     combining next: R1, into combined: R0
-  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5?, C6?, C7?, C8?)> where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0, C1, C2, C3, C4), R1.Match == (W1, C5, C6, C7, C8) {
+  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5?, C6?, C7?, C8?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3, C4), R1.Match == (W1, C5, C6, C7, C8) {
     .init(node: combined.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 
-public func | <R0, W0, C0, C1, C2, C3, C4, R1, W1, C5, C6, C7, C8>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1, C2, C3, C4, C5?, C6?, C7?, C8?)> where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0, C1, C2, C3, C4), R1.Match == (W1, C5, C6, C7, C8) {
+public func | <R0, W0, C0, C1, C2, C3, C4, R1, W1, C5, C6, C7, C8>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1, C2, C3, C4, C5?, C6?, C7?, C8?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3, C4), R1.Match == (W1, C5, C6, C7, C8) {
   .init(node: lhs.regex.root.appendingAlternationCase(rhs.regex.root))
 }
 extension AlternationBuilder {
   public static func buildBlock<R0, W0, C0, C1, C2, C3, C4, R1, W1, C5, C6, C7, C8, C9>(
     combining next: R1, into combined: R0
-  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5?, C6?, C7?, C8?, C9?)> where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0, C1, C2, C3, C4), R1.Match == (W1, C5, C6, C7, C8, C9) {
+  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5?, C6?, C7?, C8?, C9?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3, C4), R1.Match == (W1, C5, C6, C7, C8, C9) {
     .init(node: combined.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 
-public func | <R0, W0, C0, C1, C2, C3, C4, R1, W1, C5, C6, C7, C8, C9>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1, C2, C3, C4, C5?, C6?, C7?, C8?, C9?)> where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0, C1, C2, C3, C4), R1.Match == (W1, C5, C6, C7, C8, C9) {
+public func | <R0, W0, C0, C1, C2, C3, C4, R1, W1, C5, C6, C7, C8, C9>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1, C2, C3, C4, C5?, C6?, C7?, C8?, C9?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3, C4), R1.Match == (W1, C5, C6, C7, C8, C9) {
   .init(node: lhs.regex.root.appendingAlternationCase(rhs.regex.root))
 }
 extension AlternationBuilder {
   public static func buildBlock<R0, W0, C0, C1, C2, C3, C4, C5, R1>(
     combining next: R1, into combined: R0
-  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5)> where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0, C1, C2, C3, C4, C5) {
+  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3, C4, C5) {
     .init(node: combined.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 
-public func | <R0, W0, C0, C1, C2, C3, C4, C5, R1>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1, C2, C3, C4, C5)> where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0, C1, C2, C3, C4, C5) {
+public func | <R0, W0, C0, C1, C2, C3, C4, C5, R1>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1, C2, C3, C4, C5)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3, C4, C5) {
   .init(node: lhs.regex.root.appendingAlternationCase(rhs.regex.root))
 }
 extension AlternationBuilder {
   public static func buildBlock<R0, W0, C0, C1, C2, C3, C4, C5, R1, W1, C6>(
     combining next: R1, into combined: R0
-  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6?)> where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0, C1, C2, C3, C4, C5), R1.Match == (W1, C6) {
+  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3, C4, C5), R1.Match == (W1, C6) {
     .init(node: combined.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 
-public func | <R0, W0, C0, C1, C2, C3, C4, C5, R1, W1, C6>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6?)> where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0, C1, C2, C3, C4, C5), R1.Match == (W1, C6) {
+public func | <R0, W0, C0, C1, C2, C3, C4, C5, R1, W1, C6>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3, C4, C5), R1.Match == (W1, C6) {
   .init(node: lhs.regex.root.appendingAlternationCase(rhs.regex.root))
 }
 extension AlternationBuilder {
   public static func buildBlock<R0, W0, C0, C1, C2, C3, C4, C5, R1, W1, C6, C7>(
     combining next: R1, into combined: R0
-  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6?, C7?)> where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0, C1, C2, C3, C4, C5), R1.Match == (W1, C6, C7) {
+  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6?, C7?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3, C4, C5), R1.Match == (W1, C6, C7) {
     .init(node: combined.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 
-public func | <R0, W0, C0, C1, C2, C3, C4, C5, R1, W1, C6, C7>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6?, C7?)> where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0, C1, C2, C3, C4, C5), R1.Match == (W1, C6, C7) {
+public func | <R0, W0, C0, C1, C2, C3, C4, C5, R1, W1, C6, C7>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6?, C7?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3, C4, C5), R1.Match == (W1, C6, C7) {
   .init(node: lhs.regex.root.appendingAlternationCase(rhs.regex.root))
 }
 extension AlternationBuilder {
   public static func buildBlock<R0, W0, C0, C1, C2, C3, C4, C5, R1, W1, C6, C7, C8>(
     combining next: R1, into combined: R0
-  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6?, C7?, C8?)> where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0, C1, C2, C3, C4, C5), R1.Match == (W1, C6, C7, C8) {
+  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6?, C7?, C8?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3, C4, C5), R1.Match == (W1, C6, C7, C8) {
     .init(node: combined.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 
-public func | <R0, W0, C0, C1, C2, C3, C4, C5, R1, W1, C6, C7, C8>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6?, C7?, C8?)> where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0, C1, C2, C3, C4, C5), R1.Match == (W1, C6, C7, C8) {
+public func | <R0, W0, C0, C1, C2, C3, C4, C5, R1, W1, C6, C7, C8>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6?, C7?, C8?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3, C4, C5), R1.Match == (W1, C6, C7, C8) {
   .init(node: lhs.regex.root.appendingAlternationCase(rhs.regex.root))
 }
 extension AlternationBuilder {
   public static func buildBlock<R0, W0, C0, C1, C2, C3, C4, C5, R1, W1, C6, C7, C8, C9>(
     combining next: R1, into combined: R0
-  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6?, C7?, C8?, C9?)> where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0, C1, C2, C3, C4, C5), R1.Match == (W1, C6, C7, C8, C9) {
+  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6?, C7?, C8?, C9?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3, C4, C5), R1.Match == (W1, C6, C7, C8, C9) {
     .init(node: combined.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 
-public func | <R0, W0, C0, C1, C2, C3, C4, C5, R1, W1, C6, C7, C8, C9>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6?, C7?, C8?, C9?)> where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0, C1, C2, C3, C4, C5), R1.Match == (W1, C6, C7, C8, C9) {
+public func | <R0, W0, C0, C1, C2, C3, C4, C5, R1, W1, C6, C7, C8, C9>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6?, C7?, C8?, C9?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3, C4, C5), R1.Match == (W1, C6, C7, C8, C9) {
   .init(node: lhs.regex.root.appendingAlternationCase(rhs.regex.root))
 }
 extension AlternationBuilder {
   public static func buildBlock<R0, W0, C0, C1, C2, C3, C4, C5, C6, R1>(
     combining next: R1, into combined: R0
-  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6)> where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0, C1, C2, C3, C4, C5, C6) {
+  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3, C4, C5, C6) {
     .init(node: combined.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 
-public func | <R0, W0, C0, C1, C2, C3, C4, C5, C6, R1>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6)> where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0, C1, C2, C3, C4, C5, C6) {
+public func | <R0, W0, C0, C1, C2, C3, C4, C5, C6, R1>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3, C4, C5, C6) {
   .init(node: lhs.regex.root.appendingAlternationCase(rhs.regex.root))
 }
 extension AlternationBuilder {
   public static func buildBlock<R0, W0, C0, C1, C2, C3, C4, C5, C6, R1, W1, C7>(
     combining next: R1, into combined: R0
-  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7?)> where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0, C1, C2, C3, C4, C5, C6), R1.Match == (W1, C7) {
+  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3, C4, C5, C6), R1.Match == (W1, C7) {
     .init(node: combined.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 
-public func | <R0, W0, C0, C1, C2, C3, C4, C5, C6, R1, W1, C7>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7?)> where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0, C1, C2, C3, C4, C5, C6), R1.Match == (W1, C7) {
+public func | <R0, W0, C0, C1, C2, C3, C4, C5, C6, R1, W1, C7>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3, C4, C5, C6), R1.Match == (W1, C7) {
   .init(node: lhs.regex.root.appendingAlternationCase(rhs.regex.root))
 }
 extension AlternationBuilder {
   public static func buildBlock<R0, W0, C0, C1, C2, C3, C4, C5, C6, R1, W1, C7, C8>(
     combining next: R1, into combined: R0
-  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7?, C8?)> where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0, C1, C2, C3, C4, C5, C6), R1.Match == (W1, C7, C8) {
+  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7?, C8?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3, C4, C5, C6), R1.Match == (W1, C7, C8) {
     .init(node: combined.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 
-public func | <R0, W0, C0, C1, C2, C3, C4, C5, C6, R1, W1, C7, C8>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7?, C8?)> where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0, C1, C2, C3, C4, C5, C6), R1.Match == (W1, C7, C8) {
+public func | <R0, W0, C0, C1, C2, C3, C4, C5, C6, R1, W1, C7, C8>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7?, C8?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3, C4, C5, C6), R1.Match == (W1, C7, C8) {
   .init(node: lhs.regex.root.appendingAlternationCase(rhs.regex.root))
 }
 extension AlternationBuilder {
   public static func buildBlock<R0, W0, C0, C1, C2, C3, C4, C5, C6, R1, W1, C7, C8, C9>(
     combining next: R1, into combined: R0
-  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7?, C8?, C9?)> where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0, C1, C2, C3, C4, C5, C6), R1.Match == (W1, C7, C8, C9) {
+  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7?, C8?, C9?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3, C4, C5, C6), R1.Match == (W1, C7, C8, C9) {
     .init(node: combined.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 
-public func | <R0, W0, C0, C1, C2, C3, C4, C5, C6, R1, W1, C7, C8, C9>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7?, C8?, C9?)> where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0, C1, C2, C3, C4, C5, C6), R1.Match == (W1, C7, C8, C9) {
+public func | <R0, W0, C0, C1, C2, C3, C4, C5, C6, R1, W1, C7, C8, C9>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7?, C8?, C9?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3, C4, C5, C6), R1.Match == (W1, C7, C8, C9) {
   .init(node: lhs.regex.root.appendingAlternationCase(rhs.regex.root))
 }
 extension AlternationBuilder {
   public static func buildBlock<R0, W0, C0, C1, C2, C3, C4, C5, C6, C7, R1>(
     combining next: R1, into combined: R0
-  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7)> where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0, C1, C2, C3, C4, C5, C6, C7) {
+  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3, C4, C5, C6, C7) {
     .init(node: combined.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 
-public func | <R0, W0, C0, C1, C2, C3, C4, C5, C6, C7, R1>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7)> where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0, C1, C2, C3, C4, C5, C6, C7) {
+public func | <R0, W0, C0, C1, C2, C3, C4, C5, C6, C7, R1>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3, C4, C5, C6, C7) {
   .init(node: lhs.regex.root.appendingAlternationCase(rhs.regex.root))
 }
 extension AlternationBuilder {
   public static func buildBlock<R0, W0, C0, C1, C2, C3, C4, C5, C6, C7, R1, W1, C8>(
     combining next: R1, into combined: R0
-  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8?)> where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0, C1, C2, C3, C4, C5, C6, C7), R1.Match == (W1, C8) {
+  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3, C4, C5, C6, C7), R1.Match == (W1, C8) {
     .init(node: combined.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 
-public func | <R0, W0, C0, C1, C2, C3, C4, C5, C6, C7, R1, W1, C8>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8?)> where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0, C1, C2, C3, C4, C5, C6, C7), R1.Match == (W1, C8) {
+public func | <R0, W0, C0, C1, C2, C3, C4, C5, C6, C7, R1, W1, C8>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3, C4, C5, C6, C7), R1.Match == (W1, C8) {
   .init(node: lhs.regex.root.appendingAlternationCase(rhs.regex.root))
 }
 extension AlternationBuilder {
   public static func buildBlock<R0, W0, C0, C1, C2, C3, C4, C5, C6, C7, R1, W1, C8, C9>(
     combining next: R1, into combined: R0
-  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8?, C9?)> where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0, C1, C2, C3, C4, C5, C6, C7), R1.Match == (W1, C8, C9) {
+  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8?, C9?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3, C4, C5, C6, C7), R1.Match == (W1, C8, C9) {
     .init(node: combined.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 
-public func | <R0, W0, C0, C1, C2, C3, C4, C5, C6, C7, R1, W1, C8, C9>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8?, C9?)> where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0, C1, C2, C3, C4, C5, C6, C7), R1.Match == (W1, C8, C9) {
+public func | <R0, W0, C0, C1, C2, C3, C4, C5, C6, C7, R1, W1, C8, C9>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8?, C9?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3, C4, C5, C6, C7), R1.Match == (W1, C8, C9) {
   .init(node: lhs.regex.root.appendingAlternationCase(rhs.regex.root))
 }
 extension AlternationBuilder {
   public static func buildBlock<R0, W0, C0, C1, C2, C3, C4, C5, C6, C7, C8, R1>(
     combining next: R1, into combined: R0
-  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8)> where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
+  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
     .init(node: combined.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 
-public func | <R0, W0, C0, C1, C2, C3, C4, C5, C6, C7, C8, R1>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8)> where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
+public func | <R0, W0, C0, C1, C2, C3, C4, C5, C6, C7, C8, R1>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
   .init(node: lhs.regex.root.appendingAlternationCase(rhs.regex.root))
 }
 extension AlternationBuilder {
   public static func buildBlock<R0, W0, C0, C1, C2, C3, C4, C5, C6, C7, C8, R1, W1, C9>(
     combining next: R1, into combined: R0
-  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9?)> where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0, C1, C2, C3, C4, C5, C6, C7, C8), R1.Match == (W1, C9) {
+  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3, C4, C5, C6, C7, C8), R1.Match == (W1, C9) {
     .init(node: combined.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 
-public func | <R0, W0, C0, C1, C2, C3, C4, C5, C6, C7, C8, R1, W1, C9>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9?)> where R0: RegexProtocol, R1: RegexProtocol, R0.Match == (W0, C0, C1, C2, C3, C4, C5, C6, C7, C8), R1.Match == (W1, C9) {
+public func | <R0, W0, C0, C1, C2, C3, C4, C5, C6, C7, C8, R1, W1, C9>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3, C4, C5, C6, C7, C8), R1.Match == (W1, C9) {
   .init(node: lhs.regex.root.appendingAlternationCase(rhs.regex.root))
 }
 extension AlternationBuilder {
-  public static func buildBlock<R, W, C0>(_ regex: R) -> Regex<(W, C0?)> where R: RegexProtocol, R.Match == (W, C0) {
+  public static func buildBlock<R, W, C0>(_ regex: R) -> Regex<(W, C0?)> where R: RegexComponent, R.Match == (W, C0) {
     .init(node: .alternation([regex.regex.root]))
   }
 }
 extension AlternationBuilder {
-  public static func buildBlock<R, W, C0, C1>(_ regex: R) -> Regex<(W, C0?, C1?)> where R: RegexProtocol, R.Match == (W, C0, C1) {
+  public static func buildBlock<R, W, C0, C1>(_ regex: R) -> Regex<(W, C0?, C1?)> where R: RegexComponent, R.Match == (W, C0, C1) {
     .init(node: .alternation([regex.regex.root]))
   }
 }
 extension AlternationBuilder {
-  public static func buildBlock<R, W, C0, C1, C2>(_ regex: R) -> Regex<(W, C0?, C1?, C2?)> where R: RegexProtocol, R.Match == (W, C0, C1, C2) {
+  public static func buildBlock<R, W, C0, C1, C2>(_ regex: R) -> Regex<(W, C0?, C1?, C2?)> where R: RegexComponent, R.Match == (W, C0, C1, C2) {
     .init(node: .alternation([regex.regex.root]))
   }
 }
 extension AlternationBuilder {
-  public static func buildBlock<R, W, C0, C1, C2, C3>(_ regex: R) -> Regex<(W, C0?, C1?, C2?, C3?)> where R: RegexProtocol, R.Match == (W, C0, C1, C2, C3) {
+  public static func buildBlock<R, W, C0, C1, C2, C3>(_ regex: R) -> Regex<(W, C0?, C1?, C2?, C3?)> where R: RegexComponent, R.Match == (W, C0, C1, C2, C3) {
     .init(node: .alternation([regex.regex.root]))
   }
 }
 extension AlternationBuilder {
-  public static func buildBlock<R, W, C0, C1, C2, C3, C4>(_ regex: R) -> Regex<(W, C0?, C1?, C2?, C3?, C4?)> where R: RegexProtocol, R.Match == (W, C0, C1, C2, C3, C4) {
+  public static func buildBlock<R, W, C0, C1, C2, C3, C4>(_ regex: R) -> Regex<(W, C0?, C1?, C2?, C3?, C4?)> where R: RegexComponent, R.Match == (W, C0, C1, C2, C3, C4) {
     .init(node: .alternation([regex.regex.root]))
   }
 }
 extension AlternationBuilder {
-  public static func buildBlock<R, W, C0, C1, C2, C3, C4, C5>(_ regex: R) -> Regex<(W, C0?, C1?, C2?, C3?, C4?, C5?)> where R: RegexProtocol, R.Match == (W, C0, C1, C2, C3, C4, C5) {
+  public static func buildBlock<R, W, C0, C1, C2, C3, C4, C5>(_ regex: R) -> Regex<(W, C0?, C1?, C2?, C3?, C4?, C5?)> where R: RegexComponent, R.Match == (W, C0, C1, C2, C3, C4, C5) {
     .init(node: .alternation([regex.regex.root]))
   }
 }
 extension AlternationBuilder {
-  public static func buildBlock<R, W, C0, C1, C2, C3, C4, C5, C6>(_ regex: R) -> Regex<(W, C0?, C1?, C2?, C3?, C4?, C5?, C6?)> where R: RegexProtocol, R.Match == (W, C0, C1, C2, C3, C4, C5, C6) {
+  public static func buildBlock<R, W, C0, C1, C2, C3, C4, C5, C6>(_ regex: R) -> Regex<(W, C0?, C1?, C2?, C3?, C4?, C5?, C6?)> where R: RegexComponent, R.Match == (W, C0, C1, C2, C3, C4, C5, C6) {
     .init(node: .alternation([regex.regex.root]))
   }
 }
 extension AlternationBuilder {
-  public static func buildBlock<R, W, C0, C1, C2, C3, C4, C5, C6, C7>(_ regex: R) -> Regex<(W, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?)> where R: RegexProtocol, R.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
+  public static func buildBlock<R, W, C0, C1, C2, C3, C4, C5, C6, C7>(_ regex: R) -> Regex<(W, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?)> where R: RegexComponent, R.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
     .init(node: .alternation([regex.regex.root]))
   }
 }
 extension AlternationBuilder {
-  public static func buildBlock<R, W, C0, C1, C2, C3, C4, C5, C6, C7, C8>(_ regex: R) -> Regex<(W, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?)> where R: RegexProtocol, R.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
+  public static func buildBlock<R, W, C0, C1, C2, C3, C4, C5, C6, C7, C8>(_ regex: R) -> Regex<(W, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?)> where R: RegexComponent, R.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
     .init(node: .alternation([regex.regex.root]))
   }
 }
 // MARK: - Non-builder capture arity 0
 
-public func capture<R: RegexProtocol, W>(
+public func capture<R: RegexComponent, W>(
   _ component: R
 ) -> Regex<(Substring, W)> where R.Match == W {
   .init(node: .group(.capture, component.regex.root))
 }
 
-public func capture<R: RegexProtocol, W>(
+public func capture<R: RegexComponent, W>(
   _ component: R, as reference: Reference<W>
 ) -> Regex<(Substring, W)> where R.Match == W {
   .init(node: .group(.capture, component.regex.root, reference.id))
 }
 
-public func capture<R: RegexProtocol, W, NewCapture>(
+public func capture<R: RegexComponent, W, NewCapture>(
   _ component: R,
   transform: @escaping (Substring) -> NewCapture
 ) -> Regex<(Substring, NewCapture)> where R.Match == W {
@@ -2289,7 +2289,7 @@ public func capture<R: RegexProtocol, W, NewCapture>(
     }))
 }
 
-public func capture<R: RegexProtocol, W, NewCapture>(
+public func capture<R: RegexComponent, W, NewCapture>(
   _ component: R,
   as reference: Reference<NewCapture>,
   transform: @escaping (Substring) -> NewCapture
@@ -2303,7 +2303,7 @@ public func capture<R: RegexProtocol, W, NewCapture>(
     reference.id))
 }
 
-public func tryCapture<R: RegexProtocol, W, NewCapture>(
+public func tryCapture<R: RegexComponent, W, NewCapture>(
   _ component: R,
   transform: @escaping (Substring) throws -> NewCapture
 ) -> Regex<(Substring, NewCapture)> where R.Match == W {
@@ -2315,7 +2315,7 @@ public func tryCapture<R: RegexProtocol, W, NewCapture>(
     }))
 }
 
-public func tryCapture<R: RegexProtocol, W, NewCapture>(
+public func tryCapture<R: RegexComponent, W, NewCapture>(
   _ component: R,
   as reference: Reference<NewCapture>,
   transform: @escaping (Substring) throws -> NewCapture
@@ -2329,7 +2329,7 @@ public func tryCapture<R: RegexProtocol, W, NewCapture>(
     reference.id))
 }
 
-public func tryCapture<R: RegexProtocol, W, NewCapture>(
+public func tryCapture<R: RegexComponent, W, NewCapture>(
   _ component: R,
   transform: @escaping (Substring) -> NewCapture?
 ) -> Regex<(Substring, NewCapture)> where R.Match == W {
@@ -2341,7 +2341,7 @@ public func tryCapture<R: RegexProtocol, W, NewCapture>(
     }))
 }
 
-public func tryCapture<R: RegexProtocol, W, NewCapture>(
+public func tryCapture<R: RegexComponent, W, NewCapture>(
   _ component: R,
   as reference: Reference<NewCapture>,
   transform: @escaping (Substring) -> NewCapture?
@@ -2357,21 +2357,21 @@ public func tryCapture<R: RegexProtocol, W, NewCapture>(
 
 // MARK: - Builder capture arity 0
 
-public func capture<R: RegexProtocol, W>(
-  @RegexBuilder _ component: () -> R
+public func capture<R: RegexComponent, W>(
+  @RegexComponentBuilder _ component: () -> R
 ) -> Regex<(Substring, W)> where R.Match == W {
   .init(node: .group(.capture, component().regex.root))
 }
 
-public func capture<R: RegexProtocol, W>(
+public func capture<R: RegexComponent, W>(
   as reference: Reference<W>,
-  @RegexBuilder _ component: () -> R
+  @RegexComponentBuilder _ component: () -> R
 ) -> Regex<(Substring, W)> where R.Match == W {
   .init(node: .group(.capture, component().regex.root, reference.id))
 }
 
-public func capture<R: RegexProtocol, W, NewCapture>(
-  @RegexBuilder _ component: () -> R,
+public func capture<R: RegexComponent, W, NewCapture>(
+  @RegexComponentBuilder _ component: () -> R,
   transform: @escaping (Substring) -> NewCapture
 ) -> Regex<(Substring, NewCapture)> where R.Match == W {
   .init(node: .groupTransform(
@@ -2382,9 +2382,9 @@ public func capture<R: RegexProtocol, W, NewCapture>(
     }))
 }
 
-public func tryCapture<R: RegexProtocol, W, NewCapture>(
+public func tryCapture<R: RegexComponent, W, NewCapture>(
   as reference: Reference<NewCapture>,
-  @RegexBuilder _ component: () -> R,
+  @RegexComponentBuilder _ component: () -> R,
   transform: @escaping (Substring) throws -> NewCapture
 ) -> Regex<(Substring, NewCapture)> where R.Match == W {
   .init(node: .groupTransform(
@@ -2396,8 +2396,8 @@ public func tryCapture<R: RegexProtocol, W, NewCapture>(
     reference.id))
 }
 
-public func tryCapture<R: RegexProtocol, W, NewCapture>(
-  @RegexBuilder _ component: () -> R,
+public func tryCapture<R: RegexComponent, W, NewCapture>(
+  @RegexComponentBuilder _ component: () -> R,
   transform: @escaping (Substring) -> NewCapture?
 ) -> Regex<(Substring, NewCapture)> where R.Match == W {
   .init(node: .groupTransform(
@@ -2408,9 +2408,9 @@ public func tryCapture<R: RegexProtocol, W, NewCapture>(
     }))
 }
 
-public func tryCapture<R: RegexProtocol, W, NewCapture>(
+public func tryCapture<R: RegexComponent, W, NewCapture>(
   as reference: Reference<NewCapture>,
-  @RegexBuilder _ component: () -> R,
+  @RegexComponentBuilder _ component: () -> R,
   transform: @escaping (Substring) -> NewCapture?
 ) -> Regex<(Substring, NewCapture)> where R.Match == W {
   .init(node: .groupTransform(
@@ -2424,19 +2424,19 @@ public func tryCapture<R: RegexProtocol, W, NewCapture>(
 
 // MARK: - Non-builder capture arity 1
 
-public func capture<R: RegexProtocol, W, C0>(
+public func capture<R: RegexComponent, W, C0>(
   _ component: R
 ) -> Regex<(Substring, W, C0)> where R.Match == (W, C0) {
   .init(node: .group(.capture, component.regex.root))
 }
 
-public func capture<R: RegexProtocol, W, C0>(
+public func capture<R: RegexComponent, W, C0>(
   _ component: R, as reference: Reference<W>
 ) -> Regex<(Substring, W, C0)> where R.Match == (W, C0) {
   .init(node: .group(.capture, component.regex.root, reference.id))
 }
 
-public func capture<R: RegexProtocol, W, C0, NewCapture>(
+public func capture<R: RegexComponent, W, C0, NewCapture>(
   _ component: R,
   transform: @escaping (Substring) -> NewCapture
 ) -> Regex<(Substring, NewCapture, C0)> where R.Match == (W, C0) {
@@ -2448,7 +2448,7 @@ public func capture<R: RegexProtocol, W, C0, NewCapture>(
     }))
 }
 
-public func capture<R: RegexProtocol, W, C0, NewCapture>(
+public func capture<R: RegexComponent, W, C0, NewCapture>(
   _ component: R,
   as reference: Reference<NewCapture>,
   transform: @escaping (Substring) -> NewCapture
@@ -2462,7 +2462,7 @@ public func capture<R: RegexProtocol, W, C0, NewCapture>(
     reference.id))
 }
 
-public func tryCapture<R: RegexProtocol, W, C0, NewCapture>(
+public func tryCapture<R: RegexComponent, W, C0, NewCapture>(
   _ component: R,
   transform: @escaping (Substring) throws -> NewCapture
 ) -> Regex<(Substring, NewCapture, C0)> where R.Match == (W, C0) {
@@ -2474,7 +2474,7 @@ public func tryCapture<R: RegexProtocol, W, C0, NewCapture>(
     }))
 }
 
-public func tryCapture<R: RegexProtocol, W, C0, NewCapture>(
+public func tryCapture<R: RegexComponent, W, C0, NewCapture>(
   _ component: R,
   as reference: Reference<NewCapture>,
   transform: @escaping (Substring) throws -> NewCapture
@@ -2488,7 +2488,7 @@ public func tryCapture<R: RegexProtocol, W, C0, NewCapture>(
     reference.id))
 }
 
-public func tryCapture<R: RegexProtocol, W, C0, NewCapture>(
+public func tryCapture<R: RegexComponent, W, C0, NewCapture>(
   _ component: R,
   transform: @escaping (Substring) -> NewCapture?
 ) -> Regex<(Substring, NewCapture, C0)> where R.Match == (W, C0) {
@@ -2500,7 +2500,7 @@ public func tryCapture<R: RegexProtocol, W, C0, NewCapture>(
     }))
 }
 
-public func tryCapture<R: RegexProtocol, W, C0, NewCapture>(
+public func tryCapture<R: RegexComponent, W, C0, NewCapture>(
   _ component: R,
   as reference: Reference<NewCapture>,
   transform: @escaping (Substring) -> NewCapture?
@@ -2516,21 +2516,21 @@ public func tryCapture<R: RegexProtocol, W, C0, NewCapture>(
 
 // MARK: - Builder capture arity 1
 
-public func capture<R: RegexProtocol, W, C0>(
-  @RegexBuilder _ component: () -> R
+public func capture<R: RegexComponent, W, C0>(
+  @RegexComponentBuilder _ component: () -> R
 ) -> Regex<(Substring, W, C0)> where R.Match == (W, C0) {
   .init(node: .group(.capture, component().regex.root))
 }
 
-public func capture<R: RegexProtocol, W, C0>(
+public func capture<R: RegexComponent, W, C0>(
   as reference: Reference<W>,
-  @RegexBuilder _ component: () -> R
+  @RegexComponentBuilder _ component: () -> R
 ) -> Regex<(Substring, W, C0)> where R.Match == (W, C0) {
   .init(node: .group(.capture, component().regex.root, reference.id))
 }
 
-public func capture<R: RegexProtocol, W, C0, NewCapture>(
-  @RegexBuilder _ component: () -> R,
+public func capture<R: RegexComponent, W, C0, NewCapture>(
+  @RegexComponentBuilder _ component: () -> R,
   transform: @escaping (Substring) -> NewCapture
 ) -> Regex<(Substring, NewCapture, C0)> where R.Match == (W, C0) {
   .init(node: .groupTransform(
@@ -2541,9 +2541,9 @@ public func capture<R: RegexProtocol, W, C0, NewCapture>(
     }))
 }
 
-public func tryCapture<R: RegexProtocol, W, C0, NewCapture>(
+public func tryCapture<R: RegexComponent, W, C0, NewCapture>(
   as reference: Reference<NewCapture>,
-  @RegexBuilder _ component: () -> R,
+  @RegexComponentBuilder _ component: () -> R,
   transform: @escaping (Substring) throws -> NewCapture
 ) -> Regex<(Substring, NewCapture, C0)> where R.Match == (W, C0) {
   .init(node: .groupTransform(
@@ -2555,8 +2555,8 @@ public func tryCapture<R: RegexProtocol, W, C0, NewCapture>(
     reference.id))
 }
 
-public func tryCapture<R: RegexProtocol, W, C0, NewCapture>(
-  @RegexBuilder _ component: () -> R,
+public func tryCapture<R: RegexComponent, W, C0, NewCapture>(
+  @RegexComponentBuilder _ component: () -> R,
   transform: @escaping (Substring) -> NewCapture?
 ) -> Regex<(Substring, NewCapture, C0)> where R.Match == (W, C0) {
   .init(node: .groupTransform(
@@ -2567,9 +2567,9 @@ public func tryCapture<R: RegexProtocol, W, C0, NewCapture>(
     }))
 }
 
-public func tryCapture<R: RegexProtocol, W, C0, NewCapture>(
+public func tryCapture<R: RegexComponent, W, C0, NewCapture>(
   as reference: Reference<NewCapture>,
-  @RegexBuilder _ component: () -> R,
+  @RegexComponentBuilder _ component: () -> R,
   transform: @escaping (Substring) -> NewCapture?
 ) -> Regex<(Substring, NewCapture, C0)> where R.Match == (W, C0) {
   .init(node: .groupTransform(
@@ -2583,19 +2583,19 @@ public func tryCapture<R: RegexProtocol, W, C0, NewCapture>(
 
 // MARK: - Non-builder capture arity 2
 
-public func capture<R: RegexProtocol, W, C0, C1>(
+public func capture<R: RegexComponent, W, C0, C1>(
   _ component: R
 ) -> Regex<(Substring, W, C0, C1)> where R.Match == (W, C0, C1) {
   .init(node: .group(.capture, component.regex.root))
 }
 
-public func capture<R: RegexProtocol, W, C0, C1>(
+public func capture<R: RegexComponent, W, C0, C1>(
   _ component: R, as reference: Reference<W>
 ) -> Regex<(Substring, W, C0, C1)> where R.Match == (W, C0, C1) {
   .init(node: .group(.capture, component.regex.root, reference.id))
 }
 
-public func capture<R: RegexProtocol, W, C0, C1, NewCapture>(
+public func capture<R: RegexComponent, W, C0, C1, NewCapture>(
   _ component: R,
   transform: @escaping (Substring) -> NewCapture
 ) -> Regex<(Substring, NewCapture, C0, C1)> where R.Match == (W, C0, C1) {
@@ -2607,7 +2607,7 @@ public func capture<R: RegexProtocol, W, C0, C1, NewCapture>(
     }))
 }
 
-public func capture<R: RegexProtocol, W, C0, C1, NewCapture>(
+public func capture<R: RegexComponent, W, C0, C1, NewCapture>(
   _ component: R,
   as reference: Reference<NewCapture>,
   transform: @escaping (Substring) -> NewCapture
@@ -2621,7 +2621,7 @@ public func capture<R: RegexProtocol, W, C0, C1, NewCapture>(
     reference.id))
 }
 
-public func tryCapture<R: RegexProtocol, W, C0, C1, NewCapture>(
+public func tryCapture<R: RegexComponent, W, C0, C1, NewCapture>(
   _ component: R,
   transform: @escaping (Substring) throws -> NewCapture
 ) -> Regex<(Substring, NewCapture, C0, C1)> where R.Match == (W, C0, C1) {
@@ -2633,7 +2633,7 @@ public func tryCapture<R: RegexProtocol, W, C0, C1, NewCapture>(
     }))
 }
 
-public func tryCapture<R: RegexProtocol, W, C0, C1, NewCapture>(
+public func tryCapture<R: RegexComponent, W, C0, C1, NewCapture>(
   _ component: R,
   as reference: Reference<NewCapture>,
   transform: @escaping (Substring) throws -> NewCapture
@@ -2647,7 +2647,7 @@ public func tryCapture<R: RegexProtocol, W, C0, C1, NewCapture>(
     reference.id))
 }
 
-public func tryCapture<R: RegexProtocol, W, C0, C1, NewCapture>(
+public func tryCapture<R: RegexComponent, W, C0, C1, NewCapture>(
   _ component: R,
   transform: @escaping (Substring) -> NewCapture?
 ) -> Regex<(Substring, NewCapture, C0, C1)> where R.Match == (W, C0, C1) {
@@ -2659,7 +2659,7 @@ public func tryCapture<R: RegexProtocol, W, C0, C1, NewCapture>(
     }))
 }
 
-public func tryCapture<R: RegexProtocol, W, C0, C1, NewCapture>(
+public func tryCapture<R: RegexComponent, W, C0, C1, NewCapture>(
   _ component: R,
   as reference: Reference<NewCapture>,
   transform: @escaping (Substring) -> NewCapture?
@@ -2675,21 +2675,21 @@ public func tryCapture<R: RegexProtocol, W, C0, C1, NewCapture>(
 
 // MARK: - Builder capture arity 2
 
-public func capture<R: RegexProtocol, W, C0, C1>(
-  @RegexBuilder _ component: () -> R
+public func capture<R: RegexComponent, W, C0, C1>(
+  @RegexComponentBuilder _ component: () -> R
 ) -> Regex<(Substring, W, C0, C1)> where R.Match == (W, C0, C1) {
   .init(node: .group(.capture, component().regex.root))
 }
 
-public func capture<R: RegexProtocol, W, C0, C1>(
+public func capture<R: RegexComponent, W, C0, C1>(
   as reference: Reference<W>,
-  @RegexBuilder _ component: () -> R
+  @RegexComponentBuilder _ component: () -> R
 ) -> Regex<(Substring, W, C0, C1)> where R.Match == (W, C0, C1) {
   .init(node: .group(.capture, component().regex.root, reference.id))
 }
 
-public func capture<R: RegexProtocol, W, C0, C1, NewCapture>(
-  @RegexBuilder _ component: () -> R,
+public func capture<R: RegexComponent, W, C0, C1, NewCapture>(
+  @RegexComponentBuilder _ component: () -> R,
   transform: @escaping (Substring) -> NewCapture
 ) -> Regex<(Substring, NewCapture, C0, C1)> where R.Match == (W, C0, C1) {
   .init(node: .groupTransform(
@@ -2700,9 +2700,9 @@ public func capture<R: RegexProtocol, W, C0, C1, NewCapture>(
     }))
 }
 
-public func tryCapture<R: RegexProtocol, W, C0, C1, NewCapture>(
+public func tryCapture<R: RegexComponent, W, C0, C1, NewCapture>(
   as reference: Reference<NewCapture>,
-  @RegexBuilder _ component: () -> R,
+  @RegexComponentBuilder _ component: () -> R,
   transform: @escaping (Substring) throws -> NewCapture
 ) -> Regex<(Substring, NewCapture, C0, C1)> where R.Match == (W, C0, C1) {
   .init(node: .groupTransform(
@@ -2714,8 +2714,8 @@ public func tryCapture<R: RegexProtocol, W, C0, C1, NewCapture>(
     reference.id))
 }
 
-public func tryCapture<R: RegexProtocol, W, C0, C1, NewCapture>(
-  @RegexBuilder _ component: () -> R,
+public func tryCapture<R: RegexComponent, W, C0, C1, NewCapture>(
+  @RegexComponentBuilder _ component: () -> R,
   transform: @escaping (Substring) -> NewCapture?
 ) -> Regex<(Substring, NewCapture, C0, C1)> where R.Match == (W, C0, C1) {
   .init(node: .groupTransform(
@@ -2726,9 +2726,9 @@ public func tryCapture<R: RegexProtocol, W, C0, C1, NewCapture>(
     }))
 }
 
-public func tryCapture<R: RegexProtocol, W, C0, C1, NewCapture>(
+public func tryCapture<R: RegexComponent, W, C0, C1, NewCapture>(
   as reference: Reference<NewCapture>,
-  @RegexBuilder _ component: () -> R,
+  @RegexComponentBuilder _ component: () -> R,
   transform: @escaping (Substring) -> NewCapture?
 ) -> Regex<(Substring, NewCapture, C0, C1)> where R.Match == (W, C0, C1) {
   .init(node: .groupTransform(
@@ -2742,19 +2742,19 @@ public func tryCapture<R: RegexProtocol, W, C0, C1, NewCapture>(
 
 // MARK: - Non-builder capture arity 3
 
-public func capture<R: RegexProtocol, W, C0, C1, C2>(
+public func capture<R: RegexComponent, W, C0, C1, C2>(
   _ component: R
 ) -> Regex<(Substring, W, C0, C1, C2)> where R.Match == (W, C0, C1, C2) {
   .init(node: .group(.capture, component.regex.root))
 }
 
-public func capture<R: RegexProtocol, W, C0, C1, C2>(
+public func capture<R: RegexComponent, W, C0, C1, C2>(
   _ component: R, as reference: Reference<W>
 ) -> Regex<(Substring, W, C0, C1, C2)> where R.Match == (W, C0, C1, C2) {
   .init(node: .group(.capture, component.regex.root, reference.id))
 }
 
-public func capture<R: RegexProtocol, W, C0, C1, C2, NewCapture>(
+public func capture<R: RegexComponent, W, C0, C1, C2, NewCapture>(
   _ component: R,
   transform: @escaping (Substring) -> NewCapture
 ) -> Regex<(Substring, NewCapture, C0, C1, C2)> where R.Match == (W, C0, C1, C2) {
@@ -2766,7 +2766,7 @@ public func capture<R: RegexProtocol, W, C0, C1, C2, NewCapture>(
     }))
 }
 
-public func capture<R: RegexProtocol, W, C0, C1, C2, NewCapture>(
+public func capture<R: RegexComponent, W, C0, C1, C2, NewCapture>(
   _ component: R,
   as reference: Reference<NewCapture>,
   transform: @escaping (Substring) -> NewCapture
@@ -2780,7 +2780,7 @@ public func capture<R: RegexProtocol, W, C0, C1, C2, NewCapture>(
     reference.id))
 }
 
-public func tryCapture<R: RegexProtocol, W, C0, C1, C2, NewCapture>(
+public func tryCapture<R: RegexComponent, W, C0, C1, C2, NewCapture>(
   _ component: R,
   transform: @escaping (Substring) throws -> NewCapture
 ) -> Regex<(Substring, NewCapture, C0, C1, C2)> where R.Match == (W, C0, C1, C2) {
@@ -2792,7 +2792,7 @@ public func tryCapture<R: RegexProtocol, W, C0, C1, C2, NewCapture>(
     }))
 }
 
-public func tryCapture<R: RegexProtocol, W, C0, C1, C2, NewCapture>(
+public func tryCapture<R: RegexComponent, W, C0, C1, C2, NewCapture>(
   _ component: R,
   as reference: Reference<NewCapture>,
   transform: @escaping (Substring) throws -> NewCapture
@@ -2806,7 +2806,7 @@ public func tryCapture<R: RegexProtocol, W, C0, C1, C2, NewCapture>(
     reference.id))
 }
 
-public func tryCapture<R: RegexProtocol, W, C0, C1, C2, NewCapture>(
+public func tryCapture<R: RegexComponent, W, C0, C1, C2, NewCapture>(
   _ component: R,
   transform: @escaping (Substring) -> NewCapture?
 ) -> Regex<(Substring, NewCapture, C0, C1, C2)> where R.Match == (W, C0, C1, C2) {
@@ -2818,7 +2818,7 @@ public func tryCapture<R: RegexProtocol, W, C0, C1, C2, NewCapture>(
     }))
 }
 
-public func tryCapture<R: RegexProtocol, W, C0, C1, C2, NewCapture>(
+public func tryCapture<R: RegexComponent, W, C0, C1, C2, NewCapture>(
   _ component: R,
   as reference: Reference<NewCapture>,
   transform: @escaping (Substring) -> NewCapture?
@@ -2834,21 +2834,21 @@ public func tryCapture<R: RegexProtocol, W, C0, C1, C2, NewCapture>(
 
 // MARK: - Builder capture arity 3
 
-public func capture<R: RegexProtocol, W, C0, C1, C2>(
-  @RegexBuilder _ component: () -> R
+public func capture<R: RegexComponent, W, C0, C1, C2>(
+  @RegexComponentBuilder _ component: () -> R
 ) -> Regex<(Substring, W, C0, C1, C2)> where R.Match == (W, C0, C1, C2) {
   .init(node: .group(.capture, component().regex.root))
 }
 
-public func capture<R: RegexProtocol, W, C0, C1, C2>(
+public func capture<R: RegexComponent, W, C0, C1, C2>(
   as reference: Reference<W>,
-  @RegexBuilder _ component: () -> R
+  @RegexComponentBuilder _ component: () -> R
 ) -> Regex<(Substring, W, C0, C1, C2)> where R.Match == (W, C0, C1, C2) {
   .init(node: .group(.capture, component().regex.root, reference.id))
 }
 
-public func capture<R: RegexProtocol, W, C0, C1, C2, NewCapture>(
-  @RegexBuilder _ component: () -> R,
+public func capture<R: RegexComponent, W, C0, C1, C2, NewCapture>(
+  @RegexComponentBuilder _ component: () -> R,
   transform: @escaping (Substring) -> NewCapture
 ) -> Regex<(Substring, NewCapture, C0, C1, C2)> where R.Match == (W, C0, C1, C2) {
   .init(node: .groupTransform(
@@ -2859,9 +2859,9 @@ public func capture<R: RegexProtocol, W, C0, C1, C2, NewCapture>(
     }))
 }
 
-public func tryCapture<R: RegexProtocol, W, C0, C1, C2, NewCapture>(
+public func tryCapture<R: RegexComponent, W, C0, C1, C2, NewCapture>(
   as reference: Reference<NewCapture>,
-  @RegexBuilder _ component: () -> R,
+  @RegexComponentBuilder _ component: () -> R,
   transform: @escaping (Substring) throws -> NewCapture
 ) -> Regex<(Substring, NewCapture, C0, C1, C2)> where R.Match == (W, C0, C1, C2) {
   .init(node: .groupTransform(
@@ -2873,8 +2873,8 @@ public func tryCapture<R: RegexProtocol, W, C0, C1, C2, NewCapture>(
     reference.id))
 }
 
-public func tryCapture<R: RegexProtocol, W, C0, C1, C2, NewCapture>(
-  @RegexBuilder _ component: () -> R,
+public func tryCapture<R: RegexComponent, W, C0, C1, C2, NewCapture>(
+  @RegexComponentBuilder _ component: () -> R,
   transform: @escaping (Substring) -> NewCapture?
 ) -> Regex<(Substring, NewCapture, C0, C1, C2)> where R.Match == (W, C0, C1, C2) {
   .init(node: .groupTransform(
@@ -2885,9 +2885,9 @@ public func tryCapture<R: RegexProtocol, W, C0, C1, C2, NewCapture>(
     }))
 }
 
-public func tryCapture<R: RegexProtocol, W, C0, C1, C2, NewCapture>(
+public func tryCapture<R: RegexComponent, W, C0, C1, C2, NewCapture>(
   as reference: Reference<NewCapture>,
-  @RegexBuilder _ component: () -> R,
+  @RegexComponentBuilder _ component: () -> R,
   transform: @escaping (Substring) -> NewCapture?
 ) -> Regex<(Substring, NewCapture, C0, C1, C2)> where R.Match == (W, C0, C1, C2) {
   .init(node: .groupTransform(
@@ -2901,19 +2901,19 @@ public func tryCapture<R: RegexProtocol, W, C0, C1, C2, NewCapture>(
 
 // MARK: - Non-builder capture arity 4
 
-public func capture<R: RegexProtocol, W, C0, C1, C2, C3>(
+public func capture<R: RegexComponent, W, C0, C1, C2, C3>(
   _ component: R
 ) -> Regex<(Substring, W, C0, C1, C2, C3)> where R.Match == (W, C0, C1, C2, C3) {
   .init(node: .group(.capture, component.regex.root))
 }
 
-public func capture<R: RegexProtocol, W, C0, C1, C2, C3>(
+public func capture<R: RegexComponent, W, C0, C1, C2, C3>(
   _ component: R, as reference: Reference<W>
 ) -> Regex<(Substring, W, C0, C1, C2, C3)> where R.Match == (W, C0, C1, C2, C3) {
   .init(node: .group(.capture, component.regex.root, reference.id))
 }
 
-public func capture<R: RegexProtocol, W, C0, C1, C2, C3, NewCapture>(
+public func capture<R: RegexComponent, W, C0, C1, C2, C3, NewCapture>(
   _ component: R,
   transform: @escaping (Substring) -> NewCapture
 ) -> Regex<(Substring, NewCapture, C0, C1, C2, C3)> where R.Match == (W, C0, C1, C2, C3) {
@@ -2925,7 +2925,7 @@ public func capture<R: RegexProtocol, W, C0, C1, C2, C3, NewCapture>(
     }))
 }
 
-public func capture<R: RegexProtocol, W, C0, C1, C2, C3, NewCapture>(
+public func capture<R: RegexComponent, W, C0, C1, C2, C3, NewCapture>(
   _ component: R,
   as reference: Reference<NewCapture>,
   transform: @escaping (Substring) -> NewCapture
@@ -2939,7 +2939,7 @@ public func capture<R: RegexProtocol, W, C0, C1, C2, C3, NewCapture>(
     reference.id))
 }
 
-public func tryCapture<R: RegexProtocol, W, C0, C1, C2, C3, NewCapture>(
+public func tryCapture<R: RegexComponent, W, C0, C1, C2, C3, NewCapture>(
   _ component: R,
   transform: @escaping (Substring) throws -> NewCapture
 ) -> Regex<(Substring, NewCapture, C0, C1, C2, C3)> where R.Match == (W, C0, C1, C2, C3) {
@@ -2951,7 +2951,7 @@ public func tryCapture<R: RegexProtocol, W, C0, C1, C2, C3, NewCapture>(
     }))
 }
 
-public func tryCapture<R: RegexProtocol, W, C0, C1, C2, C3, NewCapture>(
+public func tryCapture<R: RegexComponent, W, C0, C1, C2, C3, NewCapture>(
   _ component: R,
   as reference: Reference<NewCapture>,
   transform: @escaping (Substring) throws -> NewCapture
@@ -2965,7 +2965,7 @@ public func tryCapture<R: RegexProtocol, W, C0, C1, C2, C3, NewCapture>(
     reference.id))
 }
 
-public func tryCapture<R: RegexProtocol, W, C0, C1, C2, C3, NewCapture>(
+public func tryCapture<R: RegexComponent, W, C0, C1, C2, C3, NewCapture>(
   _ component: R,
   transform: @escaping (Substring) -> NewCapture?
 ) -> Regex<(Substring, NewCapture, C0, C1, C2, C3)> where R.Match == (W, C0, C1, C2, C3) {
@@ -2977,7 +2977,7 @@ public func tryCapture<R: RegexProtocol, W, C0, C1, C2, C3, NewCapture>(
     }))
 }
 
-public func tryCapture<R: RegexProtocol, W, C0, C1, C2, C3, NewCapture>(
+public func tryCapture<R: RegexComponent, W, C0, C1, C2, C3, NewCapture>(
   _ component: R,
   as reference: Reference<NewCapture>,
   transform: @escaping (Substring) -> NewCapture?
@@ -2993,21 +2993,21 @@ public func tryCapture<R: RegexProtocol, W, C0, C1, C2, C3, NewCapture>(
 
 // MARK: - Builder capture arity 4
 
-public func capture<R: RegexProtocol, W, C0, C1, C2, C3>(
-  @RegexBuilder _ component: () -> R
+public func capture<R: RegexComponent, W, C0, C1, C2, C3>(
+  @RegexComponentBuilder _ component: () -> R
 ) -> Regex<(Substring, W, C0, C1, C2, C3)> where R.Match == (W, C0, C1, C2, C3) {
   .init(node: .group(.capture, component().regex.root))
 }
 
-public func capture<R: RegexProtocol, W, C0, C1, C2, C3>(
+public func capture<R: RegexComponent, W, C0, C1, C2, C3>(
   as reference: Reference<W>,
-  @RegexBuilder _ component: () -> R
+  @RegexComponentBuilder _ component: () -> R
 ) -> Regex<(Substring, W, C0, C1, C2, C3)> where R.Match == (W, C0, C1, C2, C3) {
   .init(node: .group(.capture, component().regex.root, reference.id))
 }
 
-public func capture<R: RegexProtocol, W, C0, C1, C2, C3, NewCapture>(
-  @RegexBuilder _ component: () -> R,
+public func capture<R: RegexComponent, W, C0, C1, C2, C3, NewCapture>(
+  @RegexComponentBuilder _ component: () -> R,
   transform: @escaping (Substring) -> NewCapture
 ) -> Regex<(Substring, NewCapture, C0, C1, C2, C3)> where R.Match == (W, C0, C1, C2, C3) {
   .init(node: .groupTransform(
@@ -3018,9 +3018,9 @@ public func capture<R: RegexProtocol, W, C0, C1, C2, C3, NewCapture>(
     }))
 }
 
-public func tryCapture<R: RegexProtocol, W, C0, C1, C2, C3, NewCapture>(
+public func tryCapture<R: RegexComponent, W, C0, C1, C2, C3, NewCapture>(
   as reference: Reference<NewCapture>,
-  @RegexBuilder _ component: () -> R,
+  @RegexComponentBuilder _ component: () -> R,
   transform: @escaping (Substring) throws -> NewCapture
 ) -> Regex<(Substring, NewCapture, C0, C1, C2, C3)> where R.Match == (W, C0, C1, C2, C3) {
   .init(node: .groupTransform(
@@ -3032,8 +3032,8 @@ public func tryCapture<R: RegexProtocol, W, C0, C1, C2, C3, NewCapture>(
     reference.id))
 }
 
-public func tryCapture<R: RegexProtocol, W, C0, C1, C2, C3, NewCapture>(
-  @RegexBuilder _ component: () -> R,
+public func tryCapture<R: RegexComponent, W, C0, C1, C2, C3, NewCapture>(
+  @RegexComponentBuilder _ component: () -> R,
   transform: @escaping (Substring) -> NewCapture?
 ) -> Regex<(Substring, NewCapture, C0, C1, C2, C3)> where R.Match == (W, C0, C1, C2, C3) {
   .init(node: .groupTransform(
@@ -3044,9 +3044,9 @@ public func tryCapture<R: RegexProtocol, W, C0, C1, C2, C3, NewCapture>(
     }))
 }
 
-public func tryCapture<R: RegexProtocol, W, C0, C1, C2, C3, NewCapture>(
+public func tryCapture<R: RegexComponent, W, C0, C1, C2, C3, NewCapture>(
   as reference: Reference<NewCapture>,
-  @RegexBuilder _ component: () -> R,
+  @RegexComponentBuilder _ component: () -> R,
   transform: @escaping (Substring) -> NewCapture?
 ) -> Regex<(Substring, NewCapture, C0, C1, C2, C3)> where R.Match == (W, C0, C1, C2, C3) {
   .init(node: .groupTransform(
@@ -3060,19 +3060,19 @@ public func tryCapture<R: RegexProtocol, W, C0, C1, C2, C3, NewCapture>(
 
 // MARK: - Non-builder capture arity 5
 
-public func capture<R: RegexProtocol, W, C0, C1, C2, C3, C4>(
+public func capture<R: RegexComponent, W, C0, C1, C2, C3, C4>(
   _ component: R
 ) -> Regex<(Substring, W, C0, C1, C2, C3, C4)> where R.Match == (W, C0, C1, C2, C3, C4) {
   .init(node: .group(.capture, component.regex.root))
 }
 
-public func capture<R: RegexProtocol, W, C0, C1, C2, C3, C4>(
+public func capture<R: RegexComponent, W, C0, C1, C2, C3, C4>(
   _ component: R, as reference: Reference<W>
 ) -> Regex<(Substring, W, C0, C1, C2, C3, C4)> where R.Match == (W, C0, C1, C2, C3, C4) {
   .init(node: .group(.capture, component.regex.root, reference.id))
 }
 
-public func capture<R: RegexProtocol, W, C0, C1, C2, C3, C4, NewCapture>(
+public func capture<R: RegexComponent, W, C0, C1, C2, C3, C4, NewCapture>(
   _ component: R,
   transform: @escaping (Substring) -> NewCapture
 ) -> Regex<(Substring, NewCapture, C0, C1, C2, C3, C4)> where R.Match == (W, C0, C1, C2, C3, C4) {
@@ -3084,7 +3084,7 @@ public func capture<R: RegexProtocol, W, C0, C1, C2, C3, C4, NewCapture>(
     }))
 }
 
-public func capture<R: RegexProtocol, W, C0, C1, C2, C3, C4, NewCapture>(
+public func capture<R: RegexComponent, W, C0, C1, C2, C3, C4, NewCapture>(
   _ component: R,
   as reference: Reference<NewCapture>,
   transform: @escaping (Substring) -> NewCapture
@@ -3098,7 +3098,7 @@ public func capture<R: RegexProtocol, W, C0, C1, C2, C3, C4, NewCapture>(
     reference.id))
 }
 
-public func tryCapture<R: RegexProtocol, W, C0, C1, C2, C3, C4, NewCapture>(
+public func tryCapture<R: RegexComponent, W, C0, C1, C2, C3, C4, NewCapture>(
   _ component: R,
   transform: @escaping (Substring) throws -> NewCapture
 ) -> Regex<(Substring, NewCapture, C0, C1, C2, C3, C4)> where R.Match == (W, C0, C1, C2, C3, C4) {
@@ -3110,7 +3110,7 @@ public func tryCapture<R: RegexProtocol, W, C0, C1, C2, C3, C4, NewCapture>(
     }))
 }
 
-public func tryCapture<R: RegexProtocol, W, C0, C1, C2, C3, C4, NewCapture>(
+public func tryCapture<R: RegexComponent, W, C0, C1, C2, C3, C4, NewCapture>(
   _ component: R,
   as reference: Reference<NewCapture>,
   transform: @escaping (Substring) throws -> NewCapture
@@ -3124,7 +3124,7 @@ public func tryCapture<R: RegexProtocol, W, C0, C1, C2, C3, C4, NewCapture>(
     reference.id))
 }
 
-public func tryCapture<R: RegexProtocol, W, C0, C1, C2, C3, C4, NewCapture>(
+public func tryCapture<R: RegexComponent, W, C0, C1, C2, C3, C4, NewCapture>(
   _ component: R,
   transform: @escaping (Substring) -> NewCapture?
 ) -> Regex<(Substring, NewCapture, C0, C1, C2, C3, C4)> where R.Match == (W, C0, C1, C2, C3, C4) {
@@ -3136,7 +3136,7 @@ public func tryCapture<R: RegexProtocol, W, C0, C1, C2, C3, C4, NewCapture>(
     }))
 }
 
-public func tryCapture<R: RegexProtocol, W, C0, C1, C2, C3, C4, NewCapture>(
+public func tryCapture<R: RegexComponent, W, C0, C1, C2, C3, C4, NewCapture>(
   _ component: R,
   as reference: Reference<NewCapture>,
   transform: @escaping (Substring) -> NewCapture?
@@ -3152,21 +3152,21 @@ public func tryCapture<R: RegexProtocol, W, C0, C1, C2, C3, C4, NewCapture>(
 
 // MARK: - Builder capture arity 5
 
-public func capture<R: RegexProtocol, W, C0, C1, C2, C3, C4>(
-  @RegexBuilder _ component: () -> R
+public func capture<R: RegexComponent, W, C0, C1, C2, C3, C4>(
+  @RegexComponentBuilder _ component: () -> R
 ) -> Regex<(Substring, W, C0, C1, C2, C3, C4)> where R.Match == (W, C0, C1, C2, C3, C4) {
   .init(node: .group(.capture, component().regex.root))
 }
 
-public func capture<R: RegexProtocol, W, C0, C1, C2, C3, C4>(
+public func capture<R: RegexComponent, W, C0, C1, C2, C3, C4>(
   as reference: Reference<W>,
-  @RegexBuilder _ component: () -> R
+  @RegexComponentBuilder _ component: () -> R
 ) -> Regex<(Substring, W, C0, C1, C2, C3, C4)> where R.Match == (W, C0, C1, C2, C3, C4) {
   .init(node: .group(.capture, component().regex.root, reference.id))
 }
 
-public func capture<R: RegexProtocol, W, C0, C1, C2, C3, C4, NewCapture>(
-  @RegexBuilder _ component: () -> R,
+public func capture<R: RegexComponent, W, C0, C1, C2, C3, C4, NewCapture>(
+  @RegexComponentBuilder _ component: () -> R,
   transform: @escaping (Substring) -> NewCapture
 ) -> Regex<(Substring, NewCapture, C0, C1, C2, C3, C4)> where R.Match == (W, C0, C1, C2, C3, C4) {
   .init(node: .groupTransform(
@@ -3177,9 +3177,9 @@ public func capture<R: RegexProtocol, W, C0, C1, C2, C3, C4, NewCapture>(
     }))
 }
 
-public func tryCapture<R: RegexProtocol, W, C0, C1, C2, C3, C4, NewCapture>(
+public func tryCapture<R: RegexComponent, W, C0, C1, C2, C3, C4, NewCapture>(
   as reference: Reference<NewCapture>,
-  @RegexBuilder _ component: () -> R,
+  @RegexComponentBuilder _ component: () -> R,
   transform: @escaping (Substring) throws -> NewCapture
 ) -> Regex<(Substring, NewCapture, C0, C1, C2, C3, C4)> where R.Match == (W, C0, C1, C2, C3, C4) {
   .init(node: .groupTransform(
@@ -3191,8 +3191,8 @@ public func tryCapture<R: RegexProtocol, W, C0, C1, C2, C3, C4, NewCapture>(
     reference.id))
 }
 
-public func tryCapture<R: RegexProtocol, W, C0, C1, C2, C3, C4, NewCapture>(
-  @RegexBuilder _ component: () -> R,
+public func tryCapture<R: RegexComponent, W, C0, C1, C2, C3, C4, NewCapture>(
+  @RegexComponentBuilder _ component: () -> R,
   transform: @escaping (Substring) -> NewCapture?
 ) -> Regex<(Substring, NewCapture, C0, C1, C2, C3, C4)> where R.Match == (W, C0, C1, C2, C3, C4) {
   .init(node: .groupTransform(
@@ -3203,9 +3203,9 @@ public func tryCapture<R: RegexProtocol, W, C0, C1, C2, C3, C4, NewCapture>(
     }))
 }
 
-public func tryCapture<R: RegexProtocol, W, C0, C1, C2, C3, C4, NewCapture>(
+public func tryCapture<R: RegexComponent, W, C0, C1, C2, C3, C4, NewCapture>(
   as reference: Reference<NewCapture>,
-  @RegexBuilder _ component: () -> R,
+  @RegexComponentBuilder _ component: () -> R,
   transform: @escaping (Substring) -> NewCapture?
 ) -> Regex<(Substring, NewCapture, C0, C1, C2, C3, C4)> where R.Match == (W, C0, C1, C2, C3, C4) {
   .init(node: .groupTransform(
@@ -3219,19 +3219,19 @@ public func tryCapture<R: RegexProtocol, W, C0, C1, C2, C3, C4, NewCapture>(
 
 // MARK: - Non-builder capture arity 6
 
-public func capture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5>(
+public func capture<R: RegexComponent, W, C0, C1, C2, C3, C4, C5>(
   _ component: R
 ) -> Regex<(Substring, W, C0, C1, C2, C3, C4, C5)> where R.Match == (W, C0, C1, C2, C3, C4, C5) {
   .init(node: .group(.capture, component.regex.root))
 }
 
-public func capture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5>(
+public func capture<R: RegexComponent, W, C0, C1, C2, C3, C4, C5>(
   _ component: R, as reference: Reference<W>
 ) -> Regex<(Substring, W, C0, C1, C2, C3, C4, C5)> where R.Match == (W, C0, C1, C2, C3, C4, C5) {
   .init(node: .group(.capture, component.regex.root, reference.id))
 }
 
-public func capture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5, NewCapture>(
+public func capture<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, NewCapture>(
   _ component: R,
   transform: @escaping (Substring) -> NewCapture
 ) -> Regex<(Substring, NewCapture, C0, C1, C2, C3, C4, C5)> where R.Match == (W, C0, C1, C2, C3, C4, C5) {
@@ -3243,7 +3243,7 @@ public func capture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5, NewCapture>(
     }))
 }
 
-public func capture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5, NewCapture>(
+public func capture<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, NewCapture>(
   _ component: R,
   as reference: Reference<NewCapture>,
   transform: @escaping (Substring) -> NewCapture
@@ -3257,7 +3257,7 @@ public func capture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5, NewCapture>(
     reference.id))
 }
 
-public func tryCapture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5, NewCapture>(
+public func tryCapture<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, NewCapture>(
   _ component: R,
   transform: @escaping (Substring) throws -> NewCapture
 ) -> Regex<(Substring, NewCapture, C0, C1, C2, C3, C4, C5)> where R.Match == (W, C0, C1, C2, C3, C4, C5) {
@@ -3269,7 +3269,7 @@ public func tryCapture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5, NewCapture>(
     }))
 }
 
-public func tryCapture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5, NewCapture>(
+public func tryCapture<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, NewCapture>(
   _ component: R,
   as reference: Reference<NewCapture>,
   transform: @escaping (Substring) throws -> NewCapture
@@ -3283,7 +3283,7 @@ public func tryCapture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5, NewCapture>(
     reference.id))
 }
 
-public func tryCapture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5, NewCapture>(
+public func tryCapture<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, NewCapture>(
   _ component: R,
   transform: @escaping (Substring) -> NewCapture?
 ) -> Regex<(Substring, NewCapture, C0, C1, C2, C3, C4, C5)> where R.Match == (W, C0, C1, C2, C3, C4, C5) {
@@ -3295,7 +3295,7 @@ public func tryCapture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5, NewCapture>(
     }))
 }
 
-public func tryCapture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5, NewCapture>(
+public func tryCapture<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, NewCapture>(
   _ component: R,
   as reference: Reference<NewCapture>,
   transform: @escaping (Substring) -> NewCapture?
@@ -3311,21 +3311,21 @@ public func tryCapture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5, NewCapture>(
 
 // MARK: - Builder capture arity 6
 
-public func capture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5>(
-  @RegexBuilder _ component: () -> R
+public func capture<R: RegexComponent, W, C0, C1, C2, C3, C4, C5>(
+  @RegexComponentBuilder _ component: () -> R
 ) -> Regex<(Substring, W, C0, C1, C2, C3, C4, C5)> where R.Match == (W, C0, C1, C2, C3, C4, C5) {
   .init(node: .group(.capture, component().regex.root))
 }
 
-public func capture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5>(
+public func capture<R: RegexComponent, W, C0, C1, C2, C3, C4, C5>(
   as reference: Reference<W>,
-  @RegexBuilder _ component: () -> R
+  @RegexComponentBuilder _ component: () -> R
 ) -> Regex<(Substring, W, C0, C1, C2, C3, C4, C5)> where R.Match == (W, C0, C1, C2, C3, C4, C5) {
   .init(node: .group(.capture, component().regex.root, reference.id))
 }
 
-public func capture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5, NewCapture>(
-  @RegexBuilder _ component: () -> R,
+public func capture<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, NewCapture>(
+  @RegexComponentBuilder _ component: () -> R,
   transform: @escaping (Substring) -> NewCapture
 ) -> Regex<(Substring, NewCapture, C0, C1, C2, C3, C4, C5)> where R.Match == (W, C0, C1, C2, C3, C4, C5) {
   .init(node: .groupTransform(
@@ -3336,9 +3336,9 @@ public func capture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5, NewCapture>(
     }))
 }
 
-public func tryCapture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5, NewCapture>(
+public func tryCapture<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, NewCapture>(
   as reference: Reference<NewCapture>,
-  @RegexBuilder _ component: () -> R,
+  @RegexComponentBuilder _ component: () -> R,
   transform: @escaping (Substring) throws -> NewCapture
 ) -> Regex<(Substring, NewCapture, C0, C1, C2, C3, C4, C5)> where R.Match == (W, C0, C1, C2, C3, C4, C5) {
   .init(node: .groupTransform(
@@ -3350,8 +3350,8 @@ public func tryCapture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5, NewCapture>(
     reference.id))
 }
 
-public func tryCapture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5, NewCapture>(
-  @RegexBuilder _ component: () -> R,
+public func tryCapture<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, NewCapture>(
+  @RegexComponentBuilder _ component: () -> R,
   transform: @escaping (Substring) -> NewCapture?
 ) -> Regex<(Substring, NewCapture, C0, C1, C2, C3, C4, C5)> where R.Match == (W, C0, C1, C2, C3, C4, C5) {
   .init(node: .groupTransform(
@@ -3362,9 +3362,9 @@ public func tryCapture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5, NewCapture>(
     }))
 }
 
-public func tryCapture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5, NewCapture>(
+public func tryCapture<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, NewCapture>(
   as reference: Reference<NewCapture>,
-  @RegexBuilder _ component: () -> R,
+  @RegexComponentBuilder _ component: () -> R,
   transform: @escaping (Substring) -> NewCapture?
 ) -> Regex<(Substring, NewCapture, C0, C1, C2, C3, C4, C5)> where R.Match == (W, C0, C1, C2, C3, C4, C5) {
   .init(node: .groupTransform(
@@ -3378,19 +3378,19 @@ public func tryCapture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5, NewCapture>(
 
 // MARK: - Non-builder capture arity 7
 
-public func capture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5, C6>(
+public func capture<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6>(
   _ component: R
 ) -> Regex<(Substring, W, C0, C1, C2, C3, C4, C5, C6)> where R.Match == (W, C0, C1, C2, C3, C4, C5, C6) {
   .init(node: .group(.capture, component.regex.root))
 }
 
-public func capture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5, C6>(
+public func capture<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6>(
   _ component: R, as reference: Reference<W>
 ) -> Regex<(Substring, W, C0, C1, C2, C3, C4, C5, C6)> where R.Match == (W, C0, C1, C2, C3, C4, C5, C6) {
   .init(node: .group(.capture, component.regex.root, reference.id))
 }
 
-public func capture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5, C6, NewCapture>(
+public func capture<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, NewCapture>(
   _ component: R,
   transform: @escaping (Substring) -> NewCapture
 ) -> Regex<(Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6)> where R.Match == (W, C0, C1, C2, C3, C4, C5, C6) {
@@ -3402,7 +3402,7 @@ public func capture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5, C6, NewCapture>
     }))
 }
 
-public func capture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5, C6, NewCapture>(
+public func capture<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, NewCapture>(
   _ component: R,
   as reference: Reference<NewCapture>,
   transform: @escaping (Substring) -> NewCapture
@@ -3416,7 +3416,7 @@ public func capture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5, C6, NewCapture>
     reference.id))
 }
 
-public func tryCapture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5, C6, NewCapture>(
+public func tryCapture<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, NewCapture>(
   _ component: R,
   transform: @escaping (Substring) throws -> NewCapture
 ) -> Regex<(Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6)> where R.Match == (W, C0, C1, C2, C3, C4, C5, C6) {
@@ -3428,7 +3428,7 @@ public func tryCapture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5, C6, NewCaptu
     }))
 }
 
-public func tryCapture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5, C6, NewCapture>(
+public func tryCapture<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, NewCapture>(
   _ component: R,
   as reference: Reference<NewCapture>,
   transform: @escaping (Substring) throws -> NewCapture
@@ -3442,7 +3442,7 @@ public func tryCapture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5, C6, NewCaptu
     reference.id))
 }
 
-public func tryCapture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5, C6, NewCapture>(
+public func tryCapture<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, NewCapture>(
   _ component: R,
   transform: @escaping (Substring) -> NewCapture?
 ) -> Regex<(Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6)> where R.Match == (W, C0, C1, C2, C3, C4, C5, C6) {
@@ -3454,7 +3454,7 @@ public func tryCapture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5, C6, NewCaptu
     }))
 }
 
-public func tryCapture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5, C6, NewCapture>(
+public func tryCapture<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, NewCapture>(
   _ component: R,
   as reference: Reference<NewCapture>,
   transform: @escaping (Substring) -> NewCapture?
@@ -3470,21 +3470,21 @@ public func tryCapture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5, C6, NewCaptu
 
 // MARK: - Builder capture arity 7
 
-public func capture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5, C6>(
-  @RegexBuilder _ component: () -> R
+public func capture<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6>(
+  @RegexComponentBuilder _ component: () -> R
 ) -> Regex<(Substring, W, C0, C1, C2, C3, C4, C5, C6)> where R.Match == (W, C0, C1, C2, C3, C4, C5, C6) {
   .init(node: .group(.capture, component().regex.root))
 }
 
-public func capture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5, C6>(
+public func capture<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6>(
   as reference: Reference<W>,
-  @RegexBuilder _ component: () -> R
+  @RegexComponentBuilder _ component: () -> R
 ) -> Regex<(Substring, W, C0, C1, C2, C3, C4, C5, C6)> where R.Match == (W, C0, C1, C2, C3, C4, C5, C6) {
   .init(node: .group(.capture, component().regex.root, reference.id))
 }
 
-public func capture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5, C6, NewCapture>(
-  @RegexBuilder _ component: () -> R,
+public func capture<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, NewCapture>(
+  @RegexComponentBuilder _ component: () -> R,
   transform: @escaping (Substring) -> NewCapture
 ) -> Regex<(Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6)> where R.Match == (W, C0, C1, C2, C3, C4, C5, C6) {
   .init(node: .groupTransform(
@@ -3495,9 +3495,9 @@ public func capture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5, C6, NewCapture>
     }))
 }
 
-public func tryCapture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5, C6, NewCapture>(
+public func tryCapture<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, NewCapture>(
   as reference: Reference<NewCapture>,
-  @RegexBuilder _ component: () -> R,
+  @RegexComponentBuilder _ component: () -> R,
   transform: @escaping (Substring) throws -> NewCapture
 ) -> Regex<(Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6)> where R.Match == (W, C0, C1, C2, C3, C4, C5, C6) {
   .init(node: .groupTransform(
@@ -3509,8 +3509,8 @@ public func tryCapture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5, C6, NewCaptu
     reference.id))
 }
 
-public func tryCapture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5, C6, NewCapture>(
-  @RegexBuilder _ component: () -> R,
+public func tryCapture<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, NewCapture>(
+  @RegexComponentBuilder _ component: () -> R,
   transform: @escaping (Substring) -> NewCapture?
 ) -> Regex<(Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6)> where R.Match == (W, C0, C1, C2, C3, C4, C5, C6) {
   .init(node: .groupTransform(
@@ -3521,9 +3521,9 @@ public func tryCapture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5, C6, NewCaptu
     }))
 }
 
-public func tryCapture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5, C6, NewCapture>(
+public func tryCapture<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, NewCapture>(
   as reference: Reference<NewCapture>,
-  @RegexBuilder _ component: () -> R,
+  @RegexComponentBuilder _ component: () -> R,
   transform: @escaping (Substring) -> NewCapture?
 ) -> Regex<(Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6)> where R.Match == (W, C0, C1, C2, C3, C4, C5, C6) {
   .init(node: .groupTransform(
@@ -3537,19 +3537,19 @@ public func tryCapture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5, C6, NewCaptu
 
 // MARK: - Non-builder capture arity 8
 
-public func capture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5, C6, C7>(
+public func capture<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7>(
   _ component: R
 ) -> Regex<(Substring, W, C0, C1, C2, C3, C4, C5, C6, C7)> where R.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
   .init(node: .group(.capture, component.regex.root))
 }
 
-public func capture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5, C6, C7>(
+public func capture<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7>(
   _ component: R, as reference: Reference<W>
 ) -> Regex<(Substring, W, C0, C1, C2, C3, C4, C5, C6, C7)> where R.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
   .init(node: .group(.capture, component.regex.root, reference.id))
 }
 
-public func capture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5, C6, C7, NewCapture>(
+public func capture<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, NewCapture>(
   _ component: R,
   transform: @escaping (Substring) -> NewCapture
 ) -> Regex<(Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6, C7)> where R.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
@@ -3561,7 +3561,7 @@ public func capture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5, C6, C7, NewCapt
     }))
 }
 
-public func capture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5, C6, C7, NewCapture>(
+public func capture<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, NewCapture>(
   _ component: R,
   as reference: Reference<NewCapture>,
   transform: @escaping (Substring) -> NewCapture
@@ -3575,7 +3575,7 @@ public func capture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5, C6, C7, NewCapt
     reference.id))
 }
 
-public func tryCapture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5, C6, C7, NewCapture>(
+public func tryCapture<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, NewCapture>(
   _ component: R,
   transform: @escaping (Substring) throws -> NewCapture
 ) -> Regex<(Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6, C7)> where R.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
@@ -3587,7 +3587,7 @@ public func tryCapture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5, C6, C7, NewC
     }))
 }
 
-public func tryCapture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5, C6, C7, NewCapture>(
+public func tryCapture<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, NewCapture>(
   _ component: R,
   as reference: Reference<NewCapture>,
   transform: @escaping (Substring) throws -> NewCapture
@@ -3601,7 +3601,7 @@ public func tryCapture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5, C6, C7, NewC
     reference.id))
 }
 
-public func tryCapture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5, C6, C7, NewCapture>(
+public func tryCapture<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, NewCapture>(
   _ component: R,
   transform: @escaping (Substring) -> NewCapture?
 ) -> Regex<(Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6, C7)> where R.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
@@ -3613,7 +3613,7 @@ public func tryCapture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5, C6, C7, NewC
     }))
 }
 
-public func tryCapture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5, C6, C7, NewCapture>(
+public func tryCapture<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, NewCapture>(
   _ component: R,
   as reference: Reference<NewCapture>,
   transform: @escaping (Substring) -> NewCapture?
@@ -3629,21 +3629,21 @@ public func tryCapture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5, C6, C7, NewC
 
 // MARK: - Builder capture arity 8
 
-public func capture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5, C6, C7>(
-  @RegexBuilder _ component: () -> R
+public func capture<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7>(
+  @RegexComponentBuilder _ component: () -> R
 ) -> Regex<(Substring, W, C0, C1, C2, C3, C4, C5, C6, C7)> where R.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
   .init(node: .group(.capture, component().regex.root))
 }
 
-public func capture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5, C6, C7>(
+public func capture<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7>(
   as reference: Reference<W>,
-  @RegexBuilder _ component: () -> R
+  @RegexComponentBuilder _ component: () -> R
 ) -> Regex<(Substring, W, C0, C1, C2, C3, C4, C5, C6, C7)> where R.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
   .init(node: .group(.capture, component().regex.root, reference.id))
 }
 
-public func capture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5, C6, C7, NewCapture>(
-  @RegexBuilder _ component: () -> R,
+public func capture<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, NewCapture>(
+  @RegexComponentBuilder _ component: () -> R,
   transform: @escaping (Substring) -> NewCapture
 ) -> Regex<(Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6, C7)> where R.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
   .init(node: .groupTransform(
@@ -3654,9 +3654,9 @@ public func capture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5, C6, C7, NewCapt
     }))
 }
 
-public func tryCapture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5, C6, C7, NewCapture>(
+public func tryCapture<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, NewCapture>(
   as reference: Reference<NewCapture>,
-  @RegexBuilder _ component: () -> R,
+  @RegexComponentBuilder _ component: () -> R,
   transform: @escaping (Substring) throws -> NewCapture
 ) -> Regex<(Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6, C7)> where R.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
   .init(node: .groupTransform(
@@ -3668,8 +3668,8 @@ public func tryCapture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5, C6, C7, NewC
     reference.id))
 }
 
-public func tryCapture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5, C6, C7, NewCapture>(
-  @RegexBuilder _ component: () -> R,
+public func tryCapture<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, NewCapture>(
+  @RegexComponentBuilder _ component: () -> R,
   transform: @escaping (Substring) -> NewCapture?
 ) -> Regex<(Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6, C7)> where R.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
   .init(node: .groupTransform(
@@ -3680,9 +3680,9 @@ public func tryCapture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5, C6, C7, NewC
     }))
 }
 
-public func tryCapture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5, C6, C7, NewCapture>(
+public func tryCapture<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, NewCapture>(
   as reference: Reference<NewCapture>,
-  @RegexBuilder _ component: () -> R,
+  @RegexComponentBuilder _ component: () -> R,
   transform: @escaping (Substring) -> NewCapture?
 ) -> Regex<(Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6, C7)> where R.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
   .init(node: .groupTransform(
@@ -3696,19 +3696,19 @@ public func tryCapture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5, C6, C7, NewC
 
 // MARK: - Non-builder capture arity 9
 
-public func capture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5, C6, C7, C8>(
+public func capture<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, C8>(
   _ component: R
 ) -> Regex<(Substring, W, C0, C1, C2, C3, C4, C5, C6, C7, C8)> where R.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
   .init(node: .group(.capture, component.regex.root))
 }
 
-public func capture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5, C6, C7, C8>(
+public func capture<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, C8>(
   _ component: R, as reference: Reference<W>
 ) -> Regex<(Substring, W, C0, C1, C2, C3, C4, C5, C6, C7, C8)> where R.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
   .init(node: .group(.capture, component.regex.root, reference.id))
 }
 
-public func capture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5, C6, C7, C8, NewCapture>(
+public func capture<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, C8, NewCapture>(
   _ component: R,
   transform: @escaping (Substring) -> NewCapture
 ) -> Regex<(Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6, C7, C8)> where R.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
@@ -3720,7 +3720,7 @@ public func capture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5, C6, C7, C8, New
     }))
 }
 
-public func capture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5, C6, C7, C8, NewCapture>(
+public func capture<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, C8, NewCapture>(
   _ component: R,
   as reference: Reference<NewCapture>,
   transform: @escaping (Substring) -> NewCapture
@@ -3734,7 +3734,7 @@ public func capture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5, C6, C7, C8, New
     reference.id))
 }
 
-public func tryCapture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5, C6, C7, C8, NewCapture>(
+public func tryCapture<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, C8, NewCapture>(
   _ component: R,
   transform: @escaping (Substring) throws -> NewCapture
 ) -> Regex<(Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6, C7, C8)> where R.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
@@ -3746,7 +3746,7 @@ public func tryCapture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5, C6, C7, C8, 
     }))
 }
 
-public func tryCapture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5, C6, C7, C8, NewCapture>(
+public func tryCapture<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, C8, NewCapture>(
   _ component: R,
   as reference: Reference<NewCapture>,
   transform: @escaping (Substring) throws -> NewCapture
@@ -3760,7 +3760,7 @@ public func tryCapture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5, C6, C7, C8, 
     reference.id))
 }
 
-public func tryCapture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5, C6, C7, C8, NewCapture>(
+public func tryCapture<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, C8, NewCapture>(
   _ component: R,
   transform: @escaping (Substring) -> NewCapture?
 ) -> Regex<(Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6, C7, C8)> where R.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
@@ -3772,7 +3772,7 @@ public func tryCapture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5, C6, C7, C8, 
     }))
 }
 
-public func tryCapture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5, C6, C7, C8, NewCapture>(
+public func tryCapture<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, C8, NewCapture>(
   _ component: R,
   as reference: Reference<NewCapture>,
   transform: @escaping (Substring) -> NewCapture?
@@ -3788,21 +3788,21 @@ public func tryCapture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5, C6, C7, C8, 
 
 // MARK: - Builder capture arity 9
 
-public func capture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5, C6, C7, C8>(
-  @RegexBuilder _ component: () -> R
+public func capture<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, C8>(
+  @RegexComponentBuilder _ component: () -> R
 ) -> Regex<(Substring, W, C0, C1, C2, C3, C4, C5, C6, C7, C8)> where R.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
   .init(node: .group(.capture, component().regex.root))
 }
 
-public func capture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5, C6, C7, C8>(
+public func capture<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, C8>(
   as reference: Reference<W>,
-  @RegexBuilder _ component: () -> R
+  @RegexComponentBuilder _ component: () -> R
 ) -> Regex<(Substring, W, C0, C1, C2, C3, C4, C5, C6, C7, C8)> where R.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
   .init(node: .group(.capture, component().regex.root, reference.id))
 }
 
-public func capture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5, C6, C7, C8, NewCapture>(
-  @RegexBuilder _ component: () -> R,
+public func capture<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, C8, NewCapture>(
+  @RegexComponentBuilder _ component: () -> R,
   transform: @escaping (Substring) -> NewCapture
 ) -> Regex<(Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6, C7, C8)> where R.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
   .init(node: .groupTransform(
@@ -3813,9 +3813,9 @@ public func capture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5, C6, C7, C8, New
     }))
 }
 
-public func tryCapture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5, C6, C7, C8, NewCapture>(
+public func tryCapture<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, C8, NewCapture>(
   as reference: Reference<NewCapture>,
-  @RegexBuilder _ component: () -> R,
+  @RegexComponentBuilder _ component: () -> R,
   transform: @escaping (Substring) throws -> NewCapture
 ) -> Regex<(Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6, C7, C8)> where R.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
   .init(node: .groupTransform(
@@ -3827,8 +3827,8 @@ public func tryCapture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5, C6, C7, C8, 
     reference.id))
 }
 
-public func tryCapture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5, C6, C7, C8, NewCapture>(
-  @RegexBuilder _ component: () -> R,
+public func tryCapture<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, C8, NewCapture>(
+  @RegexComponentBuilder _ component: () -> R,
   transform: @escaping (Substring) -> NewCapture?
 ) -> Regex<(Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6, C7, C8)> where R.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
   .init(node: .groupTransform(
@@ -3839,9 +3839,9 @@ public func tryCapture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5, C6, C7, C8, 
     }))
 }
 
-public func tryCapture<R: RegexProtocol, W, C0, C1, C2, C3, C4, C5, C6, C7, C8, NewCapture>(
+public func tryCapture<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, C8, NewCapture>(
   as reference: Reference<NewCapture>,
-  @RegexBuilder _ component: () -> R,
+  @RegexComponentBuilder _ component: () -> R,
   transform: @escaping (Substring) -> NewCapture?
 ) -> Regex<(Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6, C7, C8)> where R.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
   .init(node: .groupTransform(

--- a/Tests/RegexTests/AlgorithmsTests.swift
+++ b/Tests/RegexTests/AlgorithmsTests.swift
@@ -122,7 +122,7 @@ class RegexConsumerTests: XCTestCase {
   }
   
   func testMatchReplace() {
-    func replaceTest<R: RegexProtocol>(
+    func replaceTest<R: RegexComponent>(
       _ regex: R,
       input: String,
       result: String,

--- a/Tests/RegexTests/RegexDSLTests.swift
+++ b/Tests/RegexTests/RegexDSLTests.swift
@@ -19,13 +19,13 @@ func dynCap(
 }
 
 class RegexDSLTests: XCTestCase {
-  func _testDSLCaptures<Content: RegexProtocol, CaptureType>(
+  func _testDSLCaptures<Content: RegexComponent, CaptureType>(
     _ tests: (input: String, expectedCaptures: CaptureType?)...,
     matchType: CaptureType.Type,
     _ equivalence: (CaptureType, CaptureType) -> Bool,
     file: StaticString = #file,
     line: UInt = #line,
-    @RegexBuilder _ content: () -> Content
+    @RegexComponentBuilder _ content: () -> Content
   ) throws {
     let regex = Regex(content())
     for (input, maybeExpectedCaptures) in tests {


### PR DESCRIPTION
We've decided to use `RegexComponent` for the protocol, and use `RegexComponentBuilder` for the builder type since we want the user to import a module named `RegexBuilder` to get the DSL.