### PR TITLE
DSL free functions -> types

### DIFF
--- a/Sources/Exercises/Participants/RegexParticipant.swift
+++ b/Sources/Exercises/Participants/RegexParticipant.swift
@@ -80,16 +80,16 @@ private func graphemeBreakPropertyData(
   forLine line: String
 ) -> GraphemeBreakEntry? {
   line.match {
-    tryCapture(oneOrMore(.hexDigit)) { Unicode.Scalar(hex: $0) }
-    optionally {
+    TryCapture(OneOrMore(.hexDigit)) { Unicode.Scalar(hex: $0) }
+    Optionally {
       ".."
-      tryCapture(oneOrMore(.hexDigit)) { Unicode.Scalar(hex: $0) }
+      TryCapture(OneOrMore(.hexDigit)) { Unicode.Scalar(hex: $0) }
     }
-    oneOrMore(.whitespace)
+    OneOrMore(.whitespace)
     ";"
-    oneOrMore(.whitespace)
-    tryCapture(oneOrMore(.word)) { Unicode.GraphemeBreakProperty($0) }
-    zeroOrMore(.any)
+    OneOrMore(.whitespace)
+    TryCapture(OneOrMore(.word)) { Unicode.GraphemeBreakProperty($0) }
+    ZeroOrMore(.any)
   }.map {
     let (_, lower, upper, property) = $0.match
     return GraphemeBreakEntry(lower...(upper ?? lower), property)

--- a/Sources/_StringProcessing/RegexDSL/Builder.swift
+++ b/Sources/_StringProcessing/RegexDSL/Builder.swift
@@ -11,7 +11,11 @@
 
 @resultBuilder
 public enum RegexComponentBuilder {
-  @_disfavoredOverload
+  public static func buildBlock() -> Regex<Substring> {
+    .init(node: .empty)
+  }
+
+  // TODO: Rename to `buildPartialBlock(first:)` when the feature lands.
   public static func buildBlock<R0: RegexComponent>(_ r0: R0) -> R0 {
     r0
   }

--- a/Sources/_StringProcessing/RegexDSL/DSL.swift
+++ b/Sources/_StringProcessing/RegexDSL/DSL.swift
@@ -11,6 +11,18 @@
 
 import _MatchingEngine
 
+// A convenience protocol for builtin regex components that are initialized with
+// a `DSLTree` node.
+internal protocol _BuiltinRegexComponent: RegexComponent {
+  init(_ regex: Regex<Match>)
+}
+
+extension _BuiltinRegexComponent {
+  init(node: DSLTree.Node) {
+    self.init(Regex(node: node))
+  }
+}
+
 // MARK: - Primitives
 
 extension String: RegexComponent {
@@ -115,37 +127,49 @@ extension QuantificationBehavior {
   }
 }
 
-// TODO: Variadic generics
-// struct _OneOrMore<W, C..., Component: RegexComponent>
-// where R.Match == (W, C...)
-// {
-//   typealias Match = (Substring, [(C...)])
-//   let regex: Regex<Match>
-//   init(_ component: Component) {
-//     regex = .init(oneOrMore(r0))
-//   }
-// }
-//
-// struct _OneOrMoreNonCapturing<Component: RegexComponent> {
-//   typealias Match = Substring
-//   let regex: Regex<Match>
-//   init(_ component: Component) {
-//     regex = .init(oneOrMore(r0))
-//   }
-// }
-//
-// func oneOrMore<W, C..., Component: RegexComponent>(
-//   _ component: Component
-// ) -> <R: RegexComponent where R.Match == (Substring, [(C...)])> R {
-//   _OneOrMore(component)
-// }
-//
-// @_disfavoredOverload
-// func oneOrMore<Component: RegexComponent>(
-//   _ component: Component
-// ) -> <R: RegexComponent where R.Match == Substring> R {
-//   _OneOrMoreNonCapturing(component)
-// }
+public struct OneOrMore<Match>: _BuiltinRegexComponent {
+  public var regex: Regex<Match>
+
+  internal init(_ regex: Regex<Match>) {
+    self.regex = regex
+  }
+
+  // Note: Public initializers and operators are currently gyb'd. See
+  // Variadics.swift.
+}
+
+public struct ZeroOrMore<Match>: _BuiltinRegexComponent {
+  public var regex: Regex<Match>
+
+  internal init(_ regex: Regex<Match>) {
+    self.regex = regex
+  }
+
+  // Note: Public initializers and operators are currently gyb'd. See
+  // Variadics.swift.
+}
+
+public struct Optionally<Match>: _BuiltinRegexComponent {
+  public var regex: Regex<Match>
+
+  internal init(_ regex: Regex<Match>) {
+    self.regex = regex
+  }
+
+  // Note: Public initializers and operators are currently gyb'd. See
+  // Variadics.swift.
+}
+
+public struct Repeat<Match>: _BuiltinRegexComponent {
+  public var regex: Regex<Match>
+
+  internal init(_ regex: Regex<Match>) {
+    self.regex = regex
+  }
+
+  // Note: Public initializers and operators are currently gyb'd. See
+  // Variadics.swift.
+}
 
 postfix operator .?
 postfix operator .*
@@ -168,8 +192,8 @@ postfix operator .+
 @resultBuilder
 public struct AlternationBuilder {
   @_disfavoredOverload
-  public static func buildBlock<R: RegexComponent>(_ regex: R) -> R {
-    regex
+  public static func buildBlock<R: RegexComponent>(_ component: R) -> ChoiceOf<R.Match> {
+    .init(component.regex)
   }
 
   public static func buildExpression<R: RegexComponent>(_ regex: R) -> R {
@@ -185,10 +209,38 @@ public struct AlternationBuilder {
   }
 }
 
-public func choiceOf<R: RegexComponent>(
-  @AlternationBuilder builder: () -> R
-) -> R {
-  builder()
+public struct ChoiceOf<Match>: _BuiltinRegexComponent {
+  public var regex: Regex<Match>
+
+  internal init(_ regex: Regex<Match>) {
+    self.regex = regex
+  }
+
+  public init(@AlternationBuilder _ builder: () -> Self) {
+    self = builder()
+  }
+}
+
+// MARK: - Capture
+
+public struct Capture<Match>: _BuiltinRegexComponent {
+  public var regex: Regex<Match>
+
+  internal init(_ regex: Regex<Match>) {
+    self.regex = regex
+  }
+
+  // Note: Public initializers are currently gyb'd. See Variadics.swift.
+}
+
+public struct TryCapture<Match>: _BuiltinRegexComponent {
+  public var regex: Regex<Match>
+
+  internal init(_ regex: Regex<Match>) {
+    self.regex = regex
+  }
+
+  // Note: Public initializers are currently gyb'd. See Variadics.swift.
 }
 
 // MARK: - Backreference

--- a/Sources/_StringProcessing/RegexDSL/Variadics.swift
+++ b/Sources/_StringProcessing/RegexDSL/Variadics.swift
@@ -468,28 +468,39 @@ extension RegexComponentBuilder {
     .init(node: combined.regex.root.appending(next.regex.root))
   }
 }
-
-
-@_disfavoredOverload
-public func optionally<Component: RegexComponent>(
-  _ component: Component,
-  _ behavior: QuantificationBehavior = .eagerly
-) -> Regex<Substring>  {
-  .init(node: .quantification(.zeroOrOne, behavior.astKind, component.regex.root))
+extension RegexComponentBuilder {
+  public static func buildBlock<W0, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9, R0: RegexComponent, R1: RegexComponent>(
+    combining next: R1, into combined: R0
+  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9)> where R0.Match == (W0, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9)  {
+    .init(node: combined.regex.root.appending(next.regex.root))
+  }
 }
 
-@_disfavoredOverload
-public func optionally<Component: RegexComponent>(
-  _ behavior: QuantificationBehavior = .eagerly,
-  @RegexComponentBuilder _ component: () -> Component
-) -> Regex<Substring>  {
-  .init(node: .quantification(.zeroOrOne, behavior.astKind, component().regex.root))
+
+extension Optionally {
+  @_disfavoredOverload
+  public init<Component: RegexComponent>(
+    _ component: Component,
+    _ behavior: QuantificationBehavior = .eagerly
+  ) where Match == Substring {
+    self.init(node: .quantification(.zeroOrOne, behavior.astKind, component.regex.root))
+  }
+}
+
+extension Optionally {
+  @_disfavoredOverload
+  public init<Component: RegexComponent>(
+    _ behavior: QuantificationBehavior = .eagerly,
+    @RegexComponentBuilder _ component: () -> Component
+  ) where Match == Substring {
+    self.init(node: .quantification(.zeroOrOne, behavior.astKind, component().regex.root))
+  }
 }
 
 @_disfavoredOverload
 public postfix func .?<Component: RegexComponent>(
   _ component: Component
-) -> Regex<Substring>  {
+) -> Optionally<Substring>  {
   .init(node: .quantification(.zeroOrOne, .eager, component.regex.root))
 }
 
@@ -500,108 +511,122 @@ extension RegexComponentBuilder {
     .init(node: .quantification(.zeroOrOne, .eager, component.regex.root))
   }
 }
-@_disfavoredOverload
-public func zeroOrMore<Component: RegexComponent>(
-  _ component: Component,
-  _ behavior: QuantificationBehavior = .eagerly
-) -> Regex<Substring>  {
-  .init(node: .quantification(.zeroOrMore, behavior.astKind, component.regex.root))
+extension ZeroOrMore {
+  @_disfavoredOverload
+  public init<Component: RegexComponent>(
+    _ component: Component,
+    _ behavior: QuantificationBehavior = .eagerly
+  ) where Match == Substring {
+    self.init(node: .quantification(.zeroOrMore, behavior.astKind, component.regex.root))
+  }
 }
 
-@_disfavoredOverload
-public func zeroOrMore<Component: RegexComponent>(
-  _ behavior: QuantificationBehavior = .eagerly,
-  @RegexComponentBuilder _ component: () -> Component
-) -> Regex<Substring>  {
-  .init(node: .quantification(.zeroOrMore, behavior.astKind, component().regex.root))
+extension ZeroOrMore {
+  @_disfavoredOverload
+  public init<Component: RegexComponent>(
+    _ behavior: QuantificationBehavior = .eagerly,
+    @RegexComponentBuilder _ component: () -> Component
+  ) where Match == Substring {
+    self.init(node: .quantification(.zeroOrMore, behavior.astKind, component().regex.root))
+  }
 }
 
 @_disfavoredOverload
 public postfix func .*<Component: RegexComponent>(
   _ component: Component
-) -> Regex<Substring>  {
+) -> ZeroOrMore<Substring>  {
   .init(node: .quantification(.zeroOrMore, .eager, component.regex.root))
 }
 
 
-@_disfavoredOverload
-public func oneOrMore<Component: RegexComponent>(
-  _ component: Component,
-  _ behavior: QuantificationBehavior = .eagerly
-) -> Regex<Substring>  {
-  .init(node: .quantification(.oneOrMore, behavior.astKind, component.regex.root))
+extension OneOrMore {
+  @_disfavoredOverload
+  public init<Component: RegexComponent>(
+    _ component: Component,
+    _ behavior: QuantificationBehavior = .eagerly
+  ) where Match == Substring {
+    self.init(node: .quantification(.oneOrMore, behavior.astKind, component.regex.root))
+  }
 }
 
-@_disfavoredOverload
-public func oneOrMore<Component: RegexComponent>(
-  _ behavior: QuantificationBehavior = .eagerly,
-  @RegexComponentBuilder _ component: () -> Component
-) -> Regex<Substring>  {
-  .init(node: .quantification(.oneOrMore, behavior.astKind, component().regex.root))
+extension OneOrMore {
+  @_disfavoredOverload
+  public init<Component: RegexComponent>(
+    _ behavior: QuantificationBehavior = .eagerly,
+    @RegexComponentBuilder _ component: () -> Component
+  ) where Match == Substring {
+    self.init(node: .quantification(.oneOrMore, behavior.astKind, component().regex.root))
+  }
 }
 
 @_disfavoredOverload
 public postfix func .+<Component: RegexComponent>(
   _ component: Component
-) -> Regex<Substring>  {
+) -> OneOrMore<Substring>  {
   .init(node: .quantification(.oneOrMore, .eager, component.regex.root))
 }
 
 
-@_disfavoredOverload
-public func repeating<Component: RegexComponent>(
-  _ component: Component,
-  count: Int
-) -> Regex<Substring>  {
-  assert(count > 0, "Must specify a positive count")
-  // TODO: Emit a warning about `repeatMatch(count: 0)` or `repeatMatch(count: 1)`
-  return Regex(node: .quantification(.exactly(.init(faking: count)), .eager, component.regex.root))
+extension Repeat {
+  @_disfavoredOverload
+  public init<Component: RegexComponent>(
+    _ component: Component,
+    count: Int
+  ) where Match == Substring {
+    assert(count > 0, "Must specify a positive count")
+    // TODO: Emit a warning about `repeatMatch(count: 0)` or `repeatMatch(count: 1)`
+    self.init(node: .quantification(.exactly(.init(faking: count)), .eager, component.regex.root))
+  }
+
+  @_disfavoredOverload
+  public init<Component: RegexComponent>(
+    count: Int,
+    @RegexComponentBuilder _ component: () -> Component
+  ) where Match == Substring {
+    assert(count > 0, "Must specify a positive count")
+    // TODO: Emit a warning about `repeatMatch(count: 0)` or `repeatMatch(count: 1)`
+    self.init(node: .quantification(.exactly(.init(faking: count)), .eager, component().regex.root))
+  }
+
+  @_disfavoredOverload
+  public init<Component: RegexComponent, R: RangeExpression>(
+    _ component: Component,
+    _ expression: R,
+    _ behavior: QuantificationBehavior = .eagerly
+  ) where Match == Substring, R.Bound == Int {
+    self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component.regex.root))
+  }
+
+  @_disfavoredOverload
+  public init<Component: RegexComponent, R: RangeExpression>(
+    _ expression: R,
+    _ behavior: QuantificationBehavior = .eagerly,
+    @RegexComponentBuilder _ component: () -> Component
+  ) where Match == Substring, R.Bound == Int {
+    self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component().regex.root))
+  }
+}
+extension Optionally {
+    public init<W, C0, Component: RegexComponent>(
+    _ component: Component,
+    _ behavior: QuantificationBehavior = .eagerly
+  ) where Match == (Substring, C0?), Component.Match == (W, C0) {
+    self.init(node: .quantification(.zeroOrOne, behavior.astKind, component.regex.root))
+  }
 }
 
-@_disfavoredOverload
-public func repeating<Component: RegexComponent>(
-  count: Int,
-  @RegexComponentBuilder _ component: () -> Component
-) -> Regex<Substring>  {
-  assert(count > 0, "Must specify a positive count")
-  // TODO: Emit a warning about `repeatMatch(count: 0)` or `repeatMatch(count: 1)`
-  return Regex(node: .quantification(.exactly(.init(faking: count)), .eager, component().regex.root))
-}
-
-@_disfavoredOverload
-public func repeating<Component: RegexComponent, R: RangeExpression>(
-  _ component: Component,
-  _ expression: R,
-  _ behavior: QuantificationBehavior = .eagerly
-) -> Regex<Substring> where R.Bound == Int {
-  .init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component.regex.root))
-}
-
-@_disfavoredOverload
-public func repeating<Component: RegexComponent, R: RangeExpression>(
-  _ expression: R,
-  _ behavior: QuantificationBehavior = .eagerly,
-  @RegexComponentBuilder _ component: () -> Component
-) -> Regex<Substring> where R.Bound == Int {
-  .init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component().regex.root))
-}
-public func optionally<W, C0, Component: RegexComponent>(
-  _ component: Component,
-  _ behavior: QuantificationBehavior = .eagerly
-) -> Regex<(Substring, C0?)> where Component.Match == (W, C0) {
-  .init(node: .quantification(.zeroOrOne, behavior.astKind, component.regex.root))
-}
-
-public func optionally<W, C0, Component: RegexComponent>(
-  _ behavior: QuantificationBehavior = .eagerly,
-  @RegexComponentBuilder _ component: () -> Component
-) -> Regex<(Substring, C0?)> where Component.Match == (W, C0) {
-  .init(node: .quantification(.zeroOrOne, behavior.astKind, component().regex.root))
+extension Optionally {
+    public init<W, C0, Component: RegexComponent>(
+    _ behavior: QuantificationBehavior = .eagerly,
+    @RegexComponentBuilder _ component: () -> Component
+  ) where Match == (Substring, C0?), Component.Match == (W, C0) {
+    self.init(node: .quantification(.zeroOrOne, behavior.astKind, component().regex.root))
+  }
 }
 
 public postfix func .?<W, C0, Component: RegexComponent>(
   _ component: Component
-) -> Regex<(Substring, C0?)> where Component.Match == (W, C0) {
+) -> Optionally<(Substring, C0?)> where Component.Match == (W, C0) {
   .init(node: .quantification(.zeroOrOne, .eager, component.regex.root))
 }
 
@@ -612,98 +637,112 @@ extension RegexComponentBuilder {
     .init(node: .quantification(.zeroOrOne, .eager, component.regex.root))
   }
 }
-public func zeroOrMore<W, C0, Component: RegexComponent>(
-  _ component: Component,
-  _ behavior: QuantificationBehavior = .eagerly
-) -> Regex<(Substring, C0?)> where Component.Match == (W, C0) {
-  .init(node: .quantification(.zeroOrMore, behavior.astKind, component.regex.root))
+extension ZeroOrMore {
+    public init<W, C0, Component: RegexComponent>(
+    _ component: Component,
+    _ behavior: QuantificationBehavior = .eagerly
+  ) where Match == (Substring, C0?), Component.Match == (W, C0) {
+    self.init(node: .quantification(.zeroOrMore, behavior.astKind, component.regex.root))
+  }
 }
 
-public func zeroOrMore<W, C0, Component: RegexComponent>(
-  _ behavior: QuantificationBehavior = .eagerly,
-  @RegexComponentBuilder _ component: () -> Component
-) -> Regex<(Substring, C0?)> where Component.Match == (W, C0) {
-  .init(node: .quantification(.zeroOrMore, behavior.astKind, component().regex.root))
+extension ZeroOrMore {
+    public init<W, C0, Component: RegexComponent>(
+    _ behavior: QuantificationBehavior = .eagerly,
+    @RegexComponentBuilder _ component: () -> Component
+  ) where Match == (Substring, C0?), Component.Match == (W, C0) {
+    self.init(node: .quantification(.zeroOrMore, behavior.astKind, component().regex.root))
+  }
 }
 
 public postfix func .*<W, C0, Component: RegexComponent>(
   _ component: Component
-) -> Regex<(Substring, C0?)> where Component.Match == (W, C0) {
+) -> ZeroOrMore<(Substring, C0?)> where Component.Match == (W, C0) {
   .init(node: .quantification(.zeroOrMore, .eager, component.regex.root))
 }
 
 
-public func oneOrMore<W, C0, Component: RegexComponent>(
-  _ component: Component,
-  _ behavior: QuantificationBehavior = .eagerly
-) -> Regex<(Substring, C0)> where Component.Match == (W, C0) {
-  .init(node: .quantification(.oneOrMore, behavior.astKind, component.regex.root))
+extension OneOrMore {
+    public init<W, C0, Component: RegexComponent>(
+    _ component: Component,
+    _ behavior: QuantificationBehavior = .eagerly
+  ) where Match == (Substring, C0), Component.Match == (W, C0) {
+    self.init(node: .quantification(.oneOrMore, behavior.astKind, component.regex.root))
+  }
 }
 
-public func oneOrMore<W, C0, Component: RegexComponent>(
-  _ behavior: QuantificationBehavior = .eagerly,
-  @RegexComponentBuilder _ component: () -> Component
-) -> Regex<(Substring, C0)> where Component.Match == (W, C0) {
-  .init(node: .quantification(.oneOrMore, behavior.astKind, component().regex.root))
+extension OneOrMore {
+    public init<W, C0, Component: RegexComponent>(
+    _ behavior: QuantificationBehavior = .eagerly,
+    @RegexComponentBuilder _ component: () -> Component
+  ) where Match == (Substring, C0), Component.Match == (W, C0) {
+    self.init(node: .quantification(.oneOrMore, behavior.astKind, component().regex.root))
+  }
 }
 
 public postfix func .+<W, C0, Component: RegexComponent>(
   _ component: Component
-) -> Regex<(Substring, C0)> where Component.Match == (W, C0) {
+) -> OneOrMore<(Substring, C0)> where Component.Match == (W, C0) {
   .init(node: .quantification(.oneOrMore, .eager, component.regex.root))
 }
 
 
-public func repeating<W, C0, Component: RegexComponent>(
-  _ component: Component,
-  count: Int
-) -> Regex<(Substring, C0?)> where Component.Match == (W, C0) {
-  assert(count > 0, "Must specify a positive count")
-  // TODO: Emit a warning about `repeatMatch(count: 0)` or `repeatMatch(count: 1)`
-  return Regex(node: .quantification(.exactly(.init(faking: count)), .eager, component.regex.root))
+extension Repeat {
+    public init<W, C0, Component: RegexComponent>(
+    _ component: Component,
+    count: Int
+  ) where Match == (Substring, C0?), Component.Match == (W, C0) {
+    assert(count > 0, "Must specify a positive count")
+    // TODO: Emit a warning about `repeatMatch(count: 0)` or `repeatMatch(count: 1)`
+    self.init(node: .quantification(.exactly(.init(faking: count)), .eager, component.regex.root))
+  }
+
+    public init<W, C0, Component: RegexComponent>(
+    count: Int,
+    @RegexComponentBuilder _ component: () -> Component
+  ) where Match == (Substring, C0?), Component.Match == (W, C0) {
+    assert(count > 0, "Must specify a positive count")
+    // TODO: Emit a warning about `repeatMatch(count: 0)` or `repeatMatch(count: 1)`
+    self.init(node: .quantification(.exactly(.init(faking: count)), .eager, component().regex.root))
+  }
+
+    public init<W, C0, Component: RegexComponent, R: RangeExpression>(
+    _ component: Component,
+    _ expression: R,
+    _ behavior: QuantificationBehavior = .eagerly
+  ) where Match == (Substring, C0?), Component.Match == (W, C0), R.Bound == Int {
+    self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component.regex.root))
+  }
+
+    public init<W, C0, Component: RegexComponent, R: RangeExpression>(
+    _ expression: R,
+    _ behavior: QuantificationBehavior = .eagerly,
+    @RegexComponentBuilder _ component: () -> Component
+  ) where Match == (Substring, C0?), Component.Match == (W, C0), R.Bound == Int {
+    self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component().regex.root))
+  }
+}
+extension Optionally {
+    public init<W, C0, C1, Component: RegexComponent>(
+    _ component: Component,
+    _ behavior: QuantificationBehavior = .eagerly
+  ) where Match == (Substring, C0?, C1?), Component.Match == (W, C0, C1) {
+    self.init(node: .quantification(.zeroOrOne, behavior.astKind, component.regex.root))
+  }
 }
 
-public func repeating<W, C0, Component: RegexComponent>(
-  count: Int,
-  @RegexComponentBuilder _ component: () -> Component
-) -> Regex<(Substring, C0?)> where Component.Match == (W, C0) {
-  assert(count > 0, "Must specify a positive count")
-  // TODO: Emit a warning about `repeatMatch(count: 0)` or `repeatMatch(count: 1)`
-  return Regex(node: .quantification(.exactly(.init(faking: count)), .eager, component().regex.root))
-}
-
-public func repeating<W, C0, Component: RegexComponent, R: RangeExpression>(
-  _ component: Component,
-  _ expression: R,
-  _ behavior: QuantificationBehavior = .eagerly
-) -> Regex<(Substring, C0?)> where Component.Match == (W, C0), R.Bound == Int {
-  .init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component.regex.root))
-}
-
-public func repeating<W, C0, Component: RegexComponent, R: RangeExpression>(
-  _ expression: R,
-  _ behavior: QuantificationBehavior = .eagerly,
-  @RegexComponentBuilder _ component: () -> Component
-) -> Regex<(Substring, C0?)> where Component.Match == (W, C0), R.Bound == Int {
-  .init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component().regex.root))
-}
-public func optionally<W, C0, C1, Component: RegexComponent>(
-  _ component: Component,
-  _ behavior: QuantificationBehavior = .eagerly
-) -> Regex<(Substring, C0?, C1?)> where Component.Match == (W, C0, C1) {
-  .init(node: .quantification(.zeroOrOne, behavior.astKind, component.regex.root))
-}
-
-public func optionally<W, C0, C1, Component: RegexComponent>(
-  _ behavior: QuantificationBehavior = .eagerly,
-  @RegexComponentBuilder _ component: () -> Component
-) -> Regex<(Substring, C0?, C1?)> where Component.Match == (W, C0, C1) {
-  .init(node: .quantification(.zeroOrOne, behavior.astKind, component().regex.root))
+extension Optionally {
+    public init<W, C0, C1, Component: RegexComponent>(
+    _ behavior: QuantificationBehavior = .eagerly,
+    @RegexComponentBuilder _ component: () -> Component
+  ) where Match == (Substring, C0?, C1?), Component.Match == (W, C0, C1) {
+    self.init(node: .quantification(.zeroOrOne, behavior.astKind, component().regex.root))
+  }
 }
 
 public postfix func .?<W, C0, C1, Component: RegexComponent>(
   _ component: Component
-) -> Regex<(Substring, C0?, C1?)> where Component.Match == (W, C0, C1) {
+) -> Optionally<(Substring, C0?, C1?)> where Component.Match == (W, C0, C1) {
   .init(node: .quantification(.zeroOrOne, .eager, component.regex.root))
 }
 
@@ -714,98 +753,112 @@ extension RegexComponentBuilder {
     .init(node: .quantification(.zeroOrOne, .eager, component.regex.root))
   }
 }
-public func zeroOrMore<W, C0, C1, Component: RegexComponent>(
-  _ component: Component,
-  _ behavior: QuantificationBehavior = .eagerly
-) -> Regex<(Substring, C0?, C1?)> where Component.Match == (W, C0, C1) {
-  .init(node: .quantification(.zeroOrMore, behavior.astKind, component.regex.root))
+extension ZeroOrMore {
+    public init<W, C0, C1, Component: RegexComponent>(
+    _ component: Component,
+    _ behavior: QuantificationBehavior = .eagerly
+  ) where Match == (Substring, C0?, C1?), Component.Match == (W, C0, C1) {
+    self.init(node: .quantification(.zeroOrMore, behavior.astKind, component.regex.root))
+  }
 }
 
-public func zeroOrMore<W, C0, C1, Component: RegexComponent>(
-  _ behavior: QuantificationBehavior = .eagerly,
-  @RegexComponentBuilder _ component: () -> Component
-) -> Regex<(Substring, C0?, C1?)> where Component.Match == (W, C0, C1) {
-  .init(node: .quantification(.zeroOrMore, behavior.astKind, component().regex.root))
+extension ZeroOrMore {
+    public init<W, C0, C1, Component: RegexComponent>(
+    _ behavior: QuantificationBehavior = .eagerly,
+    @RegexComponentBuilder _ component: () -> Component
+  ) where Match == (Substring, C0?, C1?), Component.Match == (W, C0, C1) {
+    self.init(node: .quantification(.zeroOrMore, behavior.astKind, component().regex.root))
+  }
 }
 
 public postfix func .*<W, C0, C1, Component: RegexComponent>(
   _ component: Component
-) -> Regex<(Substring, C0?, C1?)> where Component.Match == (W, C0, C1) {
+) -> ZeroOrMore<(Substring, C0?, C1?)> where Component.Match == (W, C0, C1) {
   .init(node: .quantification(.zeroOrMore, .eager, component.regex.root))
 }
 
 
-public func oneOrMore<W, C0, C1, Component: RegexComponent>(
-  _ component: Component,
-  _ behavior: QuantificationBehavior = .eagerly
-) -> Regex<(Substring, C0, C1)> where Component.Match == (W, C0, C1) {
-  .init(node: .quantification(.oneOrMore, behavior.astKind, component.regex.root))
+extension OneOrMore {
+    public init<W, C0, C1, Component: RegexComponent>(
+    _ component: Component,
+    _ behavior: QuantificationBehavior = .eagerly
+  ) where Match == (Substring, C0, C1), Component.Match == (W, C0, C1) {
+    self.init(node: .quantification(.oneOrMore, behavior.astKind, component.regex.root))
+  }
 }
 
-public func oneOrMore<W, C0, C1, Component: RegexComponent>(
-  _ behavior: QuantificationBehavior = .eagerly,
-  @RegexComponentBuilder _ component: () -> Component
-) -> Regex<(Substring, C0, C1)> where Component.Match == (W, C0, C1) {
-  .init(node: .quantification(.oneOrMore, behavior.astKind, component().regex.root))
+extension OneOrMore {
+    public init<W, C0, C1, Component: RegexComponent>(
+    _ behavior: QuantificationBehavior = .eagerly,
+    @RegexComponentBuilder _ component: () -> Component
+  ) where Match == (Substring, C0, C1), Component.Match == (W, C0, C1) {
+    self.init(node: .quantification(.oneOrMore, behavior.astKind, component().regex.root))
+  }
 }
 
 public postfix func .+<W, C0, C1, Component: RegexComponent>(
   _ component: Component
-) -> Regex<(Substring, C0, C1)> where Component.Match == (W, C0, C1) {
+) -> OneOrMore<(Substring, C0, C1)> where Component.Match == (W, C0, C1) {
   .init(node: .quantification(.oneOrMore, .eager, component.regex.root))
 }
 
 
-public func repeating<W, C0, C1, Component: RegexComponent>(
-  _ component: Component,
-  count: Int
-) -> Regex<(Substring, C0?, C1?)> where Component.Match == (W, C0, C1) {
-  assert(count > 0, "Must specify a positive count")
-  // TODO: Emit a warning about `repeatMatch(count: 0)` or `repeatMatch(count: 1)`
-  return Regex(node: .quantification(.exactly(.init(faking: count)), .eager, component.regex.root))
+extension Repeat {
+    public init<W, C0, C1, Component: RegexComponent>(
+    _ component: Component,
+    count: Int
+  ) where Match == (Substring, C0?, C1?), Component.Match == (W, C0, C1) {
+    assert(count > 0, "Must specify a positive count")
+    // TODO: Emit a warning about `repeatMatch(count: 0)` or `repeatMatch(count: 1)`
+    self.init(node: .quantification(.exactly(.init(faking: count)), .eager, component.regex.root))
+  }
+
+    public init<W, C0, C1, Component: RegexComponent>(
+    count: Int,
+    @RegexComponentBuilder _ component: () -> Component
+  ) where Match == (Substring, C0?, C1?), Component.Match == (W, C0, C1) {
+    assert(count > 0, "Must specify a positive count")
+    // TODO: Emit a warning about `repeatMatch(count: 0)` or `repeatMatch(count: 1)`
+    self.init(node: .quantification(.exactly(.init(faking: count)), .eager, component().regex.root))
+  }
+
+    public init<W, C0, C1, Component: RegexComponent, R: RangeExpression>(
+    _ component: Component,
+    _ expression: R,
+    _ behavior: QuantificationBehavior = .eagerly
+  ) where Match == (Substring, C0?, C1?), Component.Match == (W, C0, C1), R.Bound == Int {
+    self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component.regex.root))
+  }
+
+    public init<W, C0, C1, Component: RegexComponent, R: RangeExpression>(
+    _ expression: R,
+    _ behavior: QuantificationBehavior = .eagerly,
+    @RegexComponentBuilder _ component: () -> Component
+  ) where Match == (Substring, C0?, C1?), Component.Match == (W, C0, C1), R.Bound == Int {
+    self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component().regex.root))
+  }
+}
+extension Optionally {
+    public init<W, C0, C1, C2, Component: RegexComponent>(
+    _ component: Component,
+    _ behavior: QuantificationBehavior = .eagerly
+  ) where Match == (Substring, C0?, C1?, C2?), Component.Match == (W, C0, C1, C2) {
+    self.init(node: .quantification(.zeroOrOne, behavior.astKind, component.regex.root))
+  }
 }
 
-public func repeating<W, C0, C1, Component: RegexComponent>(
-  count: Int,
-  @RegexComponentBuilder _ component: () -> Component
-) -> Regex<(Substring, C0?, C1?)> where Component.Match == (W, C0, C1) {
-  assert(count > 0, "Must specify a positive count")
-  // TODO: Emit a warning about `repeatMatch(count: 0)` or `repeatMatch(count: 1)`
-  return Regex(node: .quantification(.exactly(.init(faking: count)), .eager, component().regex.root))
-}
-
-public func repeating<W, C0, C1, Component: RegexComponent, R: RangeExpression>(
-  _ component: Component,
-  _ expression: R,
-  _ behavior: QuantificationBehavior = .eagerly
-) -> Regex<(Substring, C0?, C1?)> where Component.Match == (W, C0, C1), R.Bound == Int {
-  .init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component.regex.root))
-}
-
-public func repeating<W, C0, C1, Component: RegexComponent, R: RangeExpression>(
-  _ expression: R,
-  _ behavior: QuantificationBehavior = .eagerly,
-  @RegexComponentBuilder _ component: () -> Component
-) -> Regex<(Substring, C0?, C1?)> where Component.Match == (W, C0, C1), R.Bound == Int {
-  .init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component().regex.root))
-}
-public func optionally<W, C0, C1, C2, Component: RegexComponent>(
-  _ component: Component,
-  _ behavior: QuantificationBehavior = .eagerly
-) -> Regex<(Substring, C0?, C1?, C2?)> where Component.Match == (W, C0, C1, C2) {
-  .init(node: .quantification(.zeroOrOne, behavior.astKind, component.regex.root))
-}
-
-public func optionally<W, C0, C1, C2, Component: RegexComponent>(
-  _ behavior: QuantificationBehavior = .eagerly,
-  @RegexComponentBuilder _ component: () -> Component
-) -> Regex<(Substring, C0?, C1?, C2?)> where Component.Match == (W, C0, C1, C2) {
-  .init(node: .quantification(.zeroOrOne, behavior.astKind, component().regex.root))
+extension Optionally {
+    public init<W, C0, C1, C2, Component: RegexComponent>(
+    _ behavior: QuantificationBehavior = .eagerly,
+    @RegexComponentBuilder _ component: () -> Component
+  ) where Match == (Substring, C0?, C1?, C2?), Component.Match == (W, C0, C1, C2) {
+    self.init(node: .quantification(.zeroOrOne, behavior.astKind, component().regex.root))
+  }
 }
 
 public postfix func .?<W, C0, C1, C2, Component: RegexComponent>(
   _ component: Component
-) -> Regex<(Substring, C0?, C1?, C2?)> where Component.Match == (W, C0, C1, C2) {
+) -> Optionally<(Substring, C0?, C1?, C2?)> where Component.Match == (W, C0, C1, C2) {
   .init(node: .quantification(.zeroOrOne, .eager, component.regex.root))
 }
 
@@ -816,98 +869,112 @@ extension RegexComponentBuilder {
     .init(node: .quantification(.zeroOrOne, .eager, component.regex.root))
   }
 }
-public func zeroOrMore<W, C0, C1, C2, Component: RegexComponent>(
-  _ component: Component,
-  _ behavior: QuantificationBehavior = .eagerly
-) -> Regex<(Substring, C0?, C1?, C2?)> where Component.Match == (W, C0, C1, C2) {
-  .init(node: .quantification(.zeroOrMore, behavior.astKind, component.regex.root))
+extension ZeroOrMore {
+    public init<W, C0, C1, C2, Component: RegexComponent>(
+    _ component: Component,
+    _ behavior: QuantificationBehavior = .eagerly
+  ) where Match == (Substring, C0?, C1?, C2?), Component.Match == (W, C0, C1, C2) {
+    self.init(node: .quantification(.zeroOrMore, behavior.astKind, component.regex.root))
+  }
 }
 
-public func zeroOrMore<W, C0, C1, C2, Component: RegexComponent>(
-  _ behavior: QuantificationBehavior = .eagerly,
-  @RegexComponentBuilder _ component: () -> Component
-) -> Regex<(Substring, C0?, C1?, C2?)> where Component.Match == (W, C0, C1, C2) {
-  .init(node: .quantification(.zeroOrMore, behavior.astKind, component().regex.root))
+extension ZeroOrMore {
+    public init<W, C0, C1, C2, Component: RegexComponent>(
+    _ behavior: QuantificationBehavior = .eagerly,
+    @RegexComponentBuilder _ component: () -> Component
+  ) where Match == (Substring, C0?, C1?, C2?), Component.Match == (W, C0, C1, C2) {
+    self.init(node: .quantification(.zeroOrMore, behavior.astKind, component().regex.root))
+  }
 }
 
 public postfix func .*<W, C0, C1, C2, Component: RegexComponent>(
   _ component: Component
-) -> Regex<(Substring, C0?, C1?, C2?)> where Component.Match == (W, C0, C1, C2) {
+) -> ZeroOrMore<(Substring, C0?, C1?, C2?)> where Component.Match == (W, C0, C1, C2) {
   .init(node: .quantification(.zeroOrMore, .eager, component.regex.root))
 }
 
 
-public func oneOrMore<W, C0, C1, C2, Component: RegexComponent>(
-  _ component: Component,
-  _ behavior: QuantificationBehavior = .eagerly
-) -> Regex<(Substring, C0, C1, C2)> where Component.Match == (W, C0, C1, C2) {
-  .init(node: .quantification(.oneOrMore, behavior.astKind, component.regex.root))
+extension OneOrMore {
+    public init<W, C0, C1, C2, Component: RegexComponent>(
+    _ component: Component,
+    _ behavior: QuantificationBehavior = .eagerly
+  ) where Match == (Substring, C0, C1, C2), Component.Match == (W, C0, C1, C2) {
+    self.init(node: .quantification(.oneOrMore, behavior.astKind, component.regex.root))
+  }
 }
 
-public func oneOrMore<W, C0, C1, C2, Component: RegexComponent>(
-  _ behavior: QuantificationBehavior = .eagerly,
-  @RegexComponentBuilder _ component: () -> Component
-) -> Regex<(Substring, C0, C1, C2)> where Component.Match == (W, C0, C1, C2) {
-  .init(node: .quantification(.oneOrMore, behavior.astKind, component().regex.root))
+extension OneOrMore {
+    public init<W, C0, C1, C2, Component: RegexComponent>(
+    _ behavior: QuantificationBehavior = .eagerly,
+    @RegexComponentBuilder _ component: () -> Component
+  ) where Match == (Substring, C0, C1, C2), Component.Match == (W, C0, C1, C2) {
+    self.init(node: .quantification(.oneOrMore, behavior.astKind, component().regex.root))
+  }
 }
 
 public postfix func .+<W, C0, C1, C2, Component: RegexComponent>(
   _ component: Component
-) -> Regex<(Substring, C0, C1, C2)> where Component.Match == (W, C0, C1, C2) {
+) -> OneOrMore<(Substring, C0, C1, C2)> where Component.Match == (W, C0, C1, C2) {
   .init(node: .quantification(.oneOrMore, .eager, component.regex.root))
 }
 
 
-public func repeating<W, C0, C1, C2, Component: RegexComponent>(
-  _ component: Component,
-  count: Int
-) -> Regex<(Substring, C0?, C1?, C2?)> where Component.Match == (W, C0, C1, C2) {
-  assert(count > 0, "Must specify a positive count")
-  // TODO: Emit a warning about `repeatMatch(count: 0)` or `repeatMatch(count: 1)`
-  return Regex(node: .quantification(.exactly(.init(faking: count)), .eager, component.regex.root))
+extension Repeat {
+    public init<W, C0, C1, C2, Component: RegexComponent>(
+    _ component: Component,
+    count: Int
+  ) where Match == (Substring, C0?, C1?, C2?), Component.Match == (W, C0, C1, C2) {
+    assert(count > 0, "Must specify a positive count")
+    // TODO: Emit a warning about `repeatMatch(count: 0)` or `repeatMatch(count: 1)`
+    self.init(node: .quantification(.exactly(.init(faking: count)), .eager, component.regex.root))
+  }
+
+    public init<W, C0, C1, C2, Component: RegexComponent>(
+    count: Int,
+    @RegexComponentBuilder _ component: () -> Component
+  ) where Match == (Substring, C0?, C1?, C2?), Component.Match == (W, C0, C1, C2) {
+    assert(count > 0, "Must specify a positive count")
+    // TODO: Emit a warning about `repeatMatch(count: 0)` or `repeatMatch(count: 1)`
+    self.init(node: .quantification(.exactly(.init(faking: count)), .eager, component().regex.root))
+  }
+
+    public init<W, C0, C1, C2, Component: RegexComponent, R: RangeExpression>(
+    _ component: Component,
+    _ expression: R,
+    _ behavior: QuantificationBehavior = .eagerly
+  ) where Match == (Substring, C0?, C1?, C2?), Component.Match == (W, C0, C1, C2), R.Bound == Int {
+    self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component.regex.root))
+  }
+
+    public init<W, C0, C1, C2, Component: RegexComponent, R: RangeExpression>(
+    _ expression: R,
+    _ behavior: QuantificationBehavior = .eagerly,
+    @RegexComponentBuilder _ component: () -> Component
+  ) where Match == (Substring, C0?, C1?, C2?), Component.Match == (W, C0, C1, C2), R.Bound == Int {
+    self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component().regex.root))
+  }
+}
+extension Optionally {
+    public init<W, C0, C1, C2, C3, Component: RegexComponent>(
+    _ component: Component,
+    _ behavior: QuantificationBehavior = .eagerly
+  ) where Match == (Substring, C0?, C1?, C2?, C3?), Component.Match == (W, C0, C1, C2, C3) {
+    self.init(node: .quantification(.zeroOrOne, behavior.astKind, component.regex.root))
+  }
 }
 
-public func repeating<W, C0, C1, C2, Component: RegexComponent>(
-  count: Int,
-  @RegexComponentBuilder _ component: () -> Component
-) -> Regex<(Substring, C0?, C1?, C2?)> where Component.Match == (W, C0, C1, C2) {
-  assert(count > 0, "Must specify a positive count")
-  // TODO: Emit a warning about `repeatMatch(count: 0)` or `repeatMatch(count: 1)`
-  return Regex(node: .quantification(.exactly(.init(faking: count)), .eager, component().regex.root))
-}
-
-public func repeating<W, C0, C1, C2, Component: RegexComponent, R: RangeExpression>(
-  _ component: Component,
-  _ expression: R,
-  _ behavior: QuantificationBehavior = .eagerly
-) -> Regex<(Substring, C0?, C1?, C2?)> where Component.Match == (W, C0, C1, C2), R.Bound == Int {
-  .init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component.regex.root))
-}
-
-public func repeating<W, C0, C1, C2, Component: RegexComponent, R: RangeExpression>(
-  _ expression: R,
-  _ behavior: QuantificationBehavior = .eagerly,
-  @RegexComponentBuilder _ component: () -> Component
-) -> Regex<(Substring, C0?, C1?, C2?)> where Component.Match == (W, C0, C1, C2), R.Bound == Int {
-  .init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component().regex.root))
-}
-public func optionally<W, C0, C1, C2, C3, Component: RegexComponent>(
-  _ component: Component,
-  _ behavior: QuantificationBehavior = .eagerly
-) -> Regex<(Substring, C0?, C1?, C2?, C3?)> where Component.Match == (W, C0, C1, C2, C3) {
-  .init(node: .quantification(.zeroOrOne, behavior.astKind, component.regex.root))
-}
-
-public func optionally<W, C0, C1, C2, C3, Component: RegexComponent>(
-  _ behavior: QuantificationBehavior = .eagerly,
-  @RegexComponentBuilder _ component: () -> Component
-) -> Regex<(Substring, C0?, C1?, C2?, C3?)> where Component.Match == (W, C0, C1, C2, C3) {
-  .init(node: .quantification(.zeroOrOne, behavior.astKind, component().regex.root))
+extension Optionally {
+    public init<W, C0, C1, C2, C3, Component: RegexComponent>(
+    _ behavior: QuantificationBehavior = .eagerly,
+    @RegexComponentBuilder _ component: () -> Component
+  ) where Match == (Substring, C0?, C1?, C2?, C3?), Component.Match == (W, C0, C1, C2, C3) {
+    self.init(node: .quantification(.zeroOrOne, behavior.astKind, component().regex.root))
+  }
 }
 
 public postfix func .?<W, C0, C1, C2, C3, Component: RegexComponent>(
   _ component: Component
-) -> Regex<(Substring, C0?, C1?, C2?, C3?)> where Component.Match == (W, C0, C1, C2, C3) {
+) -> Optionally<(Substring, C0?, C1?, C2?, C3?)> where Component.Match == (W, C0, C1, C2, C3) {
   .init(node: .quantification(.zeroOrOne, .eager, component.regex.root))
 }
 
@@ -918,98 +985,112 @@ extension RegexComponentBuilder {
     .init(node: .quantification(.zeroOrOne, .eager, component.regex.root))
   }
 }
-public func zeroOrMore<W, C0, C1, C2, C3, Component: RegexComponent>(
-  _ component: Component,
-  _ behavior: QuantificationBehavior = .eagerly
-) -> Regex<(Substring, C0?, C1?, C2?, C3?)> where Component.Match == (W, C0, C1, C2, C3) {
-  .init(node: .quantification(.zeroOrMore, behavior.astKind, component.regex.root))
+extension ZeroOrMore {
+    public init<W, C0, C1, C2, C3, Component: RegexComponent>(
+    _ component: Component,
+    _ behavior: QuantificationBehavior = .eagerly
+  ) where Match == (Substring, C0?, C1?, C2?, C3?), Component.Match == (W, C0, C1, C2, C3) {
+    self.init(node: .quantification(.zeroOrMore, behavior.astKind, component.regex.root))
+  }
 }
 
-public func zeroOrMore<W, C0, C1, C2, C3, Component: RegexComponent>(
-  _ behavior: QuantificationBehavior = .eagerly,
-  @RegexComponentBuilder _ component: () -> Component
-) -> Regex<(Substring, C0?, C1?, C2?, C3?)> where Component.Match == (W, C0, C1, C2, C3) {
-  .init(node: .quantification(.zeroOrMore, behavior.astKind, component().regex.root))
+extension ZeroOrMore {
+    public init<W, C0, C1, C2, C3, Component: RegexComponent>(
+    _ behavior: QuantificationBehavior = .eagerly,
+    @RegexComponentBuilder _ component: () -> Component
+  ) where Match == (Substring, C0?, C1?, C2?, C3?), Component.Match == (W, C0, C1, C2, C3) {
+    self.init(node: .quantification(.zeroOrMore, behavior.astKind, component().regex.root))
+  }
 }
 
 public postfix func .*<W, C0, C1, C2, C3, Component: RegexComponent>(
   _ component: Component
-) -> Regex<(Substring, C0?, C1?, C2?, C3?)> where Component.Match == (W, C0, C1, C2, C3) {
+) -> ZeroOrMore<(Substring, C0?, C1?, C2?, C3?)> where Component.Match == (W, C0, C1, C2, C3) {
   .init(node: .quantification(.zeroOrMore, .eager, component.regex.root))
 }
 
 
-public func oneOrMore<W, C0, C1, C2, C3, Component: RegexComponent>(
-  _ component: Component,
-  _ behavior: QuantificationBehavior = .eagerly
-) -> Regex<(Substring, C0, C1, C2, C3)> where Component.Match == (W, C0, C1, C2, C3) {
-  .init(node: .quantification(.oneOrMore, behavior.astKind, component.regex.root))
+extension OneOrMore {
+    public init<W, C0, C1, C2, C3, Component: RegexComponent>(
+    _ component: Component,
+    _ behavior: QuantificationBehavior = .eagerly
+  ) where Match == (Substring, C0, C1, C2, C3), Component.Match == (W, C0, C1, C2, C3) {
+    self.init(node: .quantification(.oneOrMore, behavior.astKind, component.regex.root))
+  }
 }
 
-public func oneOrMore<W, C0, C1, C2, C3, Component: RegexComponent>(
-  _ behavior: QuantificationBehavior = .eagerly,
-  @RegexComponentBuilder _ component: () -> Component
-) -> Regex<(Substring, C0, C1, C2, C3)> where Component.Match == (W, C0, C1, C2, C3) {
-  .init(node: .quantification(.oneOrMore, behavior.astKind, component().regex.root))
+extension OneOrMore {
+    public init<W, C0, C1, C2, C3, Component: RegexComponent>(
+    _ behavior: QuantificationBehavior = .eagerly,
+    @RegexComponentBuilder _ component: () -> Component
+  ) where Match == (Substring, C0, C1, C2, C3), Component.Match == (W, C0, C1, C2, C3) {
+    self.init(node: .quantification(.oneOrMore, behavior.astKind, component().regex.root))
+  }
 }
 
 public postfix func .+<W, C0, C1, C2, C3, Component: RegexComponent>(
   _ component: Component
-) -> Regex<(Substring, C0, C1, C2, C3)> where Component.Match == (W, C0, C1, C2, C3) {
+) -> OneOrMore<(Substring, C0, C1, C2, C3)> where Component.Match == (W, C0, C1, C2, C3) {
   .init(node: .quantification(.oneOrMore, .eager, component.regex.root))
 }
 
 
-public func repeating<W, C0, C1, C2, C3, Component: RegexComponent>(
-  _ component: Component,
-  count: Int
-) -> Regex<(Substring, C0?, C1?, C2?, C3?)> where Component.Match == (W, C0, C1, C2, C3) {
-  assert(count > 0, "Must specify a positive count")
-  // TODO: Emit a warning about `repeatMatch(count: 0)` or `repeatMatch(count: 1)`
-  return Regex(node: .quantification(.exactly(.init(faking: count)), .eager, component.regex.root))
+extension Repeat {
+    public init<W, C0, C1, C2, C3, Component: RegexComponent>(
+    _ component: Component,
+    count: Int
+  ) where Match == (Substring, C0?, C1?, C2?, C3?), Component.Match == (W, C0, C1, C2, C3) {
+    assert(count > 0, "Must specify a positive count")
+    // TODO: Emit a warning about `repeatMatch(count: 0)` or `repeatMatch(count: 1)`
+    self.init(node: .quantification(.exactly(.init(faking: count)), .eager, component.regex.root))
+  }
+
+    public init<W, C0, C1, C2, C3, Component: RegexComponent>(
+    count: Int,
+    @RegexComponentBuilder _ component: () -> Component
+  ) where Match == (Substring, C0?, C1?, C2?, C3?), Component.Match == (W, C0, C1, C2, C3) {
+    assert(count > 0, "Must specify a positive count")
+    // TODO: Emit a warning about `repeatMatch(count: 0)` or `repeatMatch(count: 1)`
+    self.init(node: .quantification(.exactly(.init(faking: count)), .eager, component().regex.root))
+  }
+
+    public init<W, C0, C1, C2, C3, Component: RegexComponent, R: RangeExpression>(
+    _ component: Component,
+    _ expression: R,
+    _ behavior: QuantificationBehavior = .eagerly
+  ) where Match == (Substring, C0?, C1?, C2?, C3?), Component.Match == (W, C0, C1, C2, C3), R.Bound == Int {
+    self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component.regex.root))
+  }
+
+    public init<W, C0, C1, C2, C3, Component: RegexComponent, R: RangeExpression>(
+    _ expression: R,
+    _ behavior: QuantificationBehavior = .eagerly,
+    @RegexComponentBuilder _ component: () -> Component
+  ) where Match == (Substring, C0?, C1?, C2?, C3?), Component.Match == (W, C0, C1, C2, C3), R.Bound == Int {
+    self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component().regex.root))
+  }
+}
+extension Optionally {
+    public init<W, C0, C1, C2, C3, C4, Component: RegexComponent>(
+    _ component: Component,
+    _ behavior: QuantificationBehavior = .eagerly
+  ) where Match == (Substring, C0?, C1?, C2?, C3?, C4?), Component.Match == (W, C0, C1, C2, C3, C4) {
+    self.init(node: .quantification(.zeroOrOne, behavior.astKind, component.regex.root))
+  }
 }
 
-public func repeating<W, C0, C1, C2, C3, Component: RegexComponent>(
-  count: Int,
-  @RegexComponentBuilder _ component: () -> Component
-) -> Regex<(Substring, C0?, C1?, C2?, C3?)> where Component.Match == (W, C0, C1, C2, C3) {
-  assert(count > 0, "Must specify a positive count")
-  // TODO: Emit a warning about `repeatMatch(count: 0)` or `repeatMatch(count: 1)`
-  return Regex(node: .quantification(.exactly(.init(faking: count)), .eager, component().regex.root))
-}
-
-public func repeating<W, C0, C1, C2, C3, Component: RegexComponent, R: RangeExpression>(
-  _ component: Component,
-  _ expression: R,
-  _ behavior: QuantificationBehavior = .eagerly
-) -> Regex<(Substring, C0?, C1?, C2?, C3?)> where Component.Match == (W, C0, C1, C2, C3), R.Bound == Int {
-  .init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component.regex.root))
-}
-
-public func repeating<W, C0, C1, C2, C3, Component: RegexComponent, R: RangeExpression>(
-  _ expression: R,
-  _ behavior: QuantificationBehavior = .eagerly,
-  @RegexComponentBuilder _ component: () -> Component
-) -> Regex<(Substring, C0?, C1?, C2?, C3?)> where Component.Match == (W, C0, C1, C2, C3), R.Bound == Int {
-  .init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component().regex.root))
-}
-public func optionally<W, C0, C1, C2, C3, C4, Component: RegexComponent>(
-  _ component: Component,
-  _ behavior: QuantificationBehavior = .eagerly
-) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?)> where Component.Match == (W, C0, C1, C2, C3, C4) {
-  .init(node: .quantification(.zeroOrOne, behavior.astKind, component.regex.root))
-}
-
-public func optionally<W, C0, C1, C2, C3, C4, Component: RegexComponent>(
-  _ behavior: QuantificationBehavior = .eagerly,
-  @RegexComponentBuilder _ component: () -> Component
-) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?)> where Component.Match == (W, C0, C1, C2, C3, C4) {
-  .init(node: .quantification(.zeroOrOne, behavior.astKind, component().regex.root))
+extension Optionally {
+    public init<W, C0, C1, C2, C3, C4, Component: RegexComponent>(
+    _ behavior: QuantificationBehavior = .eagerly,
+    @RegexComponentBuilder _ component: () -> Component
+  ) where Match == (Substring, C0?, C1?, C2?, C3?, C4?), Component.Match == (W, C0, C1, C2, C3, C4) {
+    self.init(node: .quantification(.zeroOrOne, behavior.astKind, component().regex.root))
+  }
 }
 
 public postfix func .?<W, C0, C1, C2, C3, C4, Component: RegexComponent>(
   _ component: Component
-) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?)> where Component.Match == (W, C0, C1, C2, C3, C4) {
+) -> Optionally<(Substring, C0?, C1?, C2?, C3?, C4?)> where Component.Match == (W, C0, C1, C2, C3, C4) {
   .init(node: .quantification(.zeroOrOne, .eager, component.regex.root))
 }
 
@@ -1020,98 +1101,112 @@ extension RegexComponentBuilder {
     .init(node: .quantification(.zeroOrOne, .eager, component.regex.root))
   }
 }
-public func zeroOrMore<W, C0, C1, C2, C3, C4, Component: RegexComponent>(
-  _ component: Component,
-  _ behavior: QuantificationBehavior = .eagerly
-) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?)> where Component.Match == (W, C0, C1, C2, C3, C4) {
-  .init(node: .quantification(.zeroOrMore, behavior.astKind, component.regex.root))
+extension ZeroOrMore {
+    public init<W, C0, C1, C2, C3, C4, Component: RegexComponent>(
+    _ component: Component,
+    _ behavior: QuantificationBehavior = .eagerly
+  ) where Match == (Substring, C0?, C1?, C2?, C3?, C4?), Component.Match == (W, C0, C1, C2, C3, C4) {
+    self.init(node: .quantification(.zeroOrMore, behavior.astKind, component.regex.root))
+  }
 }
 
-public func zeroOrMore<W, C0, C1, C2, C3, C4, Component: RegexComponent>(
-  _ behavior: QuantificationBehavior = .eagerly,
-  @RegexComponentBuilder _ component: () -> Component
-) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?)> where Component.Match == (W, C0, C1, C2, C3, C4) {
-  .init(node: .quantification(.zeroOrMore, behavior.astKind, component().regex.root))
+extension ZeroOrMore {
+    public init<W, C0, C1, C2, C3, C4, Component: RegexComponent>(
+    _ behavior: QuantificationBehavior = .eagerly,
+    @RegexComponentBuilder _ component: () -> Component
+  ) where Match == (Substring, C0?, C1?, C2?, C3?, C4?), Component.Match == (W, C0, C1, C2, C3, C4) {
+    self.init(node: .quantification(.zeroOrMore, behavior.astKind, component().regex.root))
+  }
 }
 
 public postfix func .*<W, C0, C1, C2, C3, C4, Component: RegexComponent>(
   _ component: Component
-) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?)> where Component.Match == (W, C0, C1, C2, C3, C4) {
+) -> ZeroOrMore<(Substring, C0?, C1?, C2?, C3?, C4?)> where Component.Match == (W, C0, C1, C2, C3, C4) {
   .init(node: .quantification(.zeroOrMore, .eager, component.regex.root))
 }
 
 
-public func oneOrMore<W, C0, C1, C2, C3, C4, Component: RegexComponent>(
-  _ component: Component,
-  _ behavior: QuantificationBehavior = .eagerly
-) -> Regex<(Substring, C0, C1, C2, C3, C4)> where Component.Match == (W, C0, C1, C2, C3, C4) {
-  .init(node: .quantification(.oneOrMore, behavior.astKind, component.regex.root))
+extension OneOrMore {
+    public init<W, C0, C1, C2, C3, C4, Component: RegexComponent>(
+    _ component: Component,
+    _ behavior: QuantificationBehavior = .eagerly
+  ) where Match == (Substring, C0, C1, C2, C3, C4), Component.Match == (W, C0, C1, C2, C3, C4) {
+    self.init(node: .quantification(.oneOrMore, behavior.astKind, component.regex.root))
+  }
 }
 
-public func oneOrMore<W, C0, C1, C2, C3, C4, Component: RegexComponent>(
-  _ behavior: QuantificationBehavior = .eagerly,
-  @RegexComponentBuilder _ component: () -> Component
-) -> Regex<(Substring, C0, C1, C2, C3, C4)> where Component.Match == (W, C0, C1, C2, C3, C4) {
-  .init(node: .quantification(.oneOrMore, behavior.astKind, component().regex.root))
+extension OneOrMore {
+    public init<W, C0, C1, C2, C3, C4, Component: RegexComponent>(
+    _ behavior: QuantificationBehavior = .eagerly,
+    @RegexComponentBuilder _ component: () -> Component
+  ) where Match == (Substring, C0, C1, C2, C3, C4), Component.Match == (W, C0, C1, C2, C3, C4) {
+    self.init(node: .quantification(.oneOrMore, behavior.astKind, component().regex.root))
+  }
 }
 
 public postfix func .+<W, C0, C1, C2, C3, C4, Component: RegexComponent>(
   _ component: Component
-) -> Regex<(Substring, C0, C1, C2, C3, C4)> where Component.Match == (W, C0, C1, C2, C3, C4) {
+) -> OneOrMore<(Substring, C0, C1, C2, C3, C4)> where Component.Match == (W, C0, C1, C2, C3, C4) {
   .init(node: .quantification(.oneOrMore, .eager, component.regex.root))
 }
 
 
-public func repeating<W, C0, C1, C2, C3, C4, Component: RegexComponent>(
-  _ component: Component,
-  count: Int
-) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?)> where Component.Match == (W, C0, C1, C2, C3, C4) {
-  assert(count > 0, "Must specify a positive count")
-  // TODO: Emit a warning about `repeatMatch(count: 0)` or `repeatMatch(count: 1)`
-  return Regex(node: .quantification(.exactly(.init(faking: count)), .eager, component.regex.root))
+extension Repeat {
+    public init<W, C0, C1, C2, C3, C4, Component: RegexComponent>(
+    _ component: Component,
+    count: Int
+  ) where Match == (Substring, C0?, C1?, C2?, C3?, C4?), Component.Match == (W, C0, C1, C2, C3, C4) {
+    assert(count > 0, "Must specify a positive count")
+    // TODO: Emit a warning about `repeatMatch(count: 0)` or `repeatMatch(count: 1)`
+    self.init(node: .quantification(.exactly(.init(faking: count)), .eager, component.regex.root))
+  }
+
+    public init<W, C0, C1, C2, C3, C4, Component: RegexComponent>(
+    count: Int,
+    @RegexComponentBuilder _ component: () -> Component
+  ) where Match == (Substring, C0?, C1?, C2?, C3?, C4?), Component.Match == (W, C0, C1, C2, C3, C4) {
+    assert(count > 0, "Must specify a positive count")
+    // TODO: Emit a warning about `repeatMatch(count: 0)` or `repeatMatch(count: 1)`
+    self.init(node: .quantification(.exactly(.init(faking: count)), .eager, component().regex.root))
+  }
+
+    public init<W, C0, C1, C2, C3, C4, Component: RegexComponent, R: RangeExpression>(
+    _ component: Component,
+    _ expression: R,
+    _ behavior: QuantificationBehavior = .eagerly
+  ) where Match == (Substring, C0?, C1?, C2?, C3?, C4?), Component.Match == (W, C0, C1, C2, C3, C4), R.Bound == Int {
+    self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component.regex.root))
+  }
+
+    public init<W, C0, C1, C2, C3, C4, Component: RegexComponent, R: RangeExpression>(
+    _ expression: R,
+    _ behavior: QuantificationBehavior = .eagerly,
+    @RegexComponentBuilder _ component: () -> Component
+  ) where Match == (Substring, C0?, C1?, C2?, C3?, C4?), Component.Match == (W, C0, C1, C2, C3, C4), R.Bound == Int {
+    self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component().regex.root))
+  }
+}
+extension Optionally {
+    public init<W, C0, C1, C2, C3, C4, C5, Component: RegexComponent>(
+    _ component: Component,
+    _ behavior: QuantificationBehavior = .eagerly
+  ) where Match == (Substring, C0?, C1?, C2?, C3?, C4?, C5?), Component.Match == (W, C0, C1, C2, C3, C4, C5) {
+    self.init(node: .quantification(.zeroOrOne, behavior.astKind, component.regex.root))
+  }
 }
 
-public func repeating<W, C0, C1, C2, C3, C4, Component: RegexComponent>(
-  count: Int,
-  @RegexComponentBuilder _ component: () -> Component
-) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?)> where Component.Match == (W, C0, C1, C2, C3, C4) {
-  assert(count > 0, "Must specify a positive count")
-  // TODO: Emit a warning about `repeatMatch(count: 0)` or `repeatMatch(count: 1)`
-  return Regex(node: .quantification(.exactly(.init(faking: count)), .eager, component().regex.root))
-}
-
-public func repeating<W, C0, C1, C2, C3, C4, Component: RegexComponent, R: RangeExpression>(
-  _ component: Component,
-  _ expression: R,
-  _ behavior: QuantificationBehavior = .eagerly
-) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?)> where Component.Match == (W, C0, C1, C2, C3, C4), R.Bound == Int {
-  .init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component.regex.root))
-}
-
-public func repeating<W, C0, C1, C2, C3, C4, Component: RegexComponent, R: RangeExpression>(
-  _ expression: R,
-  _ behavior: QuantificationBehavior = .eagerly,
-  @RegexComponentBuilder _ component: () -> Component
-) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?)> where Component.Match == (W, C0, C1, C2, C3, C4), R.Bound == Int {
-  .init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component().regex.root))
-}
-public func optionally<W, C0, C1, C2, C3, C4, C5, Component: RegexComponent>(
-  _ component: Component,
-  _ behavior: QuantificationBehavior = .eagerly
-) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?)> where Component.Match == (W, C0, C1, C2, C3, C4, C5) {
-  .init(node: .quantification(.zeroOrOne, behavior.astKind, component.regex.root))
-}
-
-public func optionally<W, C0, C1, C2, C3, C4, C5, Component: RegexComponent>(
-  _ behavior: QuantificationBehavior = .eagerly,
-  @RegexComponentBuilder _ component: () -> Component
-) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?)> where Component.Match == (W, C0, C1, C2, C3, C4, C5) {
-  .init(node: .quantification(.zeroOrOne, behavior.astKind, component().regex.root))
+extension Optionally {
+    public init<W, C0, C1, C2, C3, C4, C5, Component: RegexComponent>(
+    _ behavior: QuantificationBehavior = .eagerly,
+    @RegexComponentBuilder _ component: () -> Component
+  ) where Match == (Substring, C0?, C1?, C2?, C3?, C4?, C5?), Component.Match == (W, C0, C1, C2, C3, C4, C5) {
+    self.init(node: .quantification(.zeroOrOne, behavior.astKind, component().regex.root))
+  }
 }
 
 public postfix func .?<W, C0, C1, C2, C3, C4, C5, Component: RegexComponent>(
   _ component: Component
-) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?)> where Component.Match == (W, C0, C1, C2, C3, C4, C5) {
+) -> Optionally<(Substring, C0?, C1?, C2?, C3?, C4?, C5?)> where Component.Match == (W, C0, C1, C2, C3, C4, C5) {
   .init(node: .quantification(.zeroOrOne, .eager, component.regex.root))
 }
 
@@ -1122,98 +1217,112 @@ extension RegexComponentBuilder {
     .init(node: .quantification(.zeroOrOne, .eager, component.regex.root))
   }
 }
-public func zeroOrMore<W, C0, C1, C2, C3, C4, C5, Component: RegexComponent>(
-  _ component: Component,
-  _ behavior: QuantificationBehavior = .eagerly
-) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?)> where Component.Match == (W, C0, C1, C2, C3, C4, C5) {
-  .init(node: .quantification(.zeroOrMore, behavior.astKind, component.regex.root))
+extension ZeroOrMore {
+    public init<W, C0, C1, C2, C3, C4, C5, Component: RegexComponent>(
+    _ component: Component,
+    _ behavior: QuantificationBehavior = .eagerly
+  ) where Match == (Substring, C0?, C1?, C2?, C3?, C4?, C5?), Component.Match == (W, C0, C1, C2, C3, C4, C5) {
+    self.init(node: .quantification(.zeroOrMore, behavior.astKind, component.regex.root))
+  }
 }
 
-public func zeroOrMore<W, C0, C1, C2, C3, C4, C5, Component: RegexComponent>(
-  _ behavior: QuantificationBehavior = .eagerly,
-  @RegexComponentBuilder _ component: () -> Component
-) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?)> where Component.Match == (W, C0, C1, C2, C3, C4, C5) {
-  .init(node: .quantification(.zeroOrMore, behavior.astKind, component().regex.root))
+extension ZeroOrMore {
+    public init<W, C0, C1, C2, C3, C4, C5, Component: RegexComponent>(
+    _ behavior: QuantificationBehavior = .eagerly,
+    @RegexComponentBuilder _ component: () -> Component
+  ) where Match == (Substring, C0?, C1?, C2?, C3?, C4?, C5?), Component.Match == (W, C0, C1, C2, C3, C4, C5) {
+    self.init(node: .quantification(.zeroOrMore, behavior.astKind, component().regex.root))
+  }
 }
 
 public postfix func .*<W, C0, C1, C2, C3, C4, C5, Component: RegexComponent>(
   _ component: Component
-) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?)> where Component.Match == (W, C0, C1, C2, C3, C4, C5) {
+) -> ZeroOrMore<(Substring, C0?, C1?, C2?, C3?, C4?, C5?)> where Component.Match == (W, C0, C1, C2, C3, C4, C5) {
   .init(node: .quantification(.zeroOrMore, .eager, component.regex.root))
 }
 
 
-public func oneOrMore<W, C0, C1, C2, C3, C4, C5, Component: RegexComponent>(
-  _ component: Component,
-  _ behavior: QuantificationBehavior = .eagerly
-) -> Regex<(Substring, C0, C1, C2, C3, C4, C5)> where Component.Match == (W, C0, C1, C2, C3, C4, C5) {
-  .init(node: .quantification(.oneOrMore, behavior.astKind, component.regex.root))
+extension OneOrMore {
+    public init<W, C0, C1, C2, C3, C4, C5, Component: RegexComponent>(
+    _ component: Component,
+    _ behavior: QuantificationBehavior = .eagerly
+  ) where Match == (Substring, C0, C1, C2, C3, C4, C5), Component.Match == (W, C0, C1, C2, C3, C4, C5) {
+    self.init(node: .quantification(.oneOrMore, behavior.astKind, component.regex.root))
+  }
 }
 
-public func oneOrMore<W, C0, C1, C2, C3, C4, C5, Component: RegexComponent>(
-  _ behavior: QuantificationBehavior = .eagerly,
-  @RegexComponentBuilder _ component: () -> Component
-) -> Regex<(Substring, C0, C1, C2, C3, C4, C5)> where Component.Match == (W, C0, C1, C2, C3, C4, C5) {
-  .init(node: .quantification(.oneOrMore, behavior.astKind, component().regex.root))
+extension OneOrMore {
+    public init<W, C0, C1, C2, C3, C4, C5, Component: RegexComponent>(
+    _ behavior: QuantificationBehavior = .eagerly,
+    @RegexComponentBuilder _ component: () -> Component
+  ) where Match == (Substring, C0, C1, C2, C3, C4, C5), Component.Match == (W, C0, C1, C2, C3, C4, C5) {
+    self.init(node: .quantification(.oneOrMore, behavior.astKind, component().regex.root))
+  }
 }
 
 public postfix func .+<W, C0, C1, C2, C3, C4, C5, Component: RegexComponent>(
   _ component: Component
-) -> Regex<(Substring, C0, C1, C2, C3, C4, C5)> where Component.Match == (W, C0, C1, C2, C3, C4, C5) {
+) -> OneOrMore<(Substring, C0, C1, C2, C3, C4, C5)> where Component.Match == (W, C0, C1, C2, C3, C4, C5) {
   .init(node: .quantification(.oneOrMore, .eager, component.regex.root))
 }
 
 
-public func repeating<W, C0, C1, C2, C3, C4, C5, Component: RegexComponent>(
-  _ component: Component,
-  count: Int
-) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?)> where Component.Match == (W, C0, C1, C2, C3, C4, C5) {
-  assert(count > 0, "Must specify a positive count")
-  // TODO: Emit a warning about `repeatMatch(count: 0)` or `repeatMatch(count: 1)`
-  return Regex(node: .quantification(.exactly(.init(faking: count)), .eager, component.regex.root))
+extension Repeat {
+    public init<W, C0, C1, C2, C3, C4, C5, Component: RegexComponent>(
+    _ component: Component,
+    count: Int
+  ) where Match == (Substring, C0?, C1?, C2?, C3?, C4?, C5?), Component.Match == (W, C0, C1, C2, C3, C4, C5) {
+    assert(count > 0, "Must specify a positive count")
+    // TODO: Emit a warning about `repeatMatch(count: 0)` or `repeatMatch(count: 1)`
+    self.init(node: .quantification(.exactly(.init(faking: count)), .eager, component.regex.root))
+  }
+
+    public init<W, C0, C1, C2, C3, C4, C5, Component: RegexComponent>(
+    count: Int,
+    @RegexComponentBuilder _ component: () -> Component
+  ) where Match == (Substring, C0?, C1?, C2?, C3?, C4?, C5?), Component.Match == (W, C0, C1, C2, C3, C4, C5) {
+    assert(count > 0, "Must specify a positive count")
+    // TODO: Emit a warning about `repeatMatch(count: 0)` or `repeatMatch(count: 1)`
+    self.init(node: .quantification(.exactly(.init(faking: count)), .eager, component().regex.root))
+  }
+
+    public init<W, C0, C1, C2, C3, C4, C5, Component: RegexComponent, R: RangeExpression>(
+    _ component: Component,
+    _ expression: R,
+    _ behavior: QuantificationBehavior = .eagerly
+  ) where Match == (Substring, C0?, C1?, C2?, C3?, C4?, C5?), Component.Match == (W, C0, C1, C2, C3, C4, C5), R.Bound == Int {
+    self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component.regex.root))
+  }
+
+    public init<W, C0, C1, C2, C3, C4, C5, Component: RegexComponent, R: RangeExpression>(
+    _ expression: R,
+    _ behavior: QuantificationBehavior = .eagerly,
+    @RegexComponentBuilder _ component: () -> Component
+  ) where Match == (Substring, C0?, C1?, C2?, C3?, C4?, C5?), Component.Match == (W, C0, C1, C2, C3, C4, C5), R.Bound == Int {
+    self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component().regex.root))
+  }
+}
+extension Optionally {
+    public init<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexComponent>(
+    _ component: Component,
+    _ behavior: QuantificationBehavior = .eagerly
+  ) where Match == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?), Component.Match == (W, C0, C1, C2, C3, C4, C5, C6) {
+    self.init(node: .quantification(.zeroOrOne, behavior.astKind, component.regex.root))
+  }
 }
 
-public func repeating<W, C0, C1, C2, C3, C4, C5, Component: RegexComponent>(
-  count: Int,
-  @RegexComponentBuilder _ component: () -> Component
-) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?)> where Component.Match == (W, C0, C1, C2, C3, C4, C5) {
-  assert(count > 0, "Must specify a positive count")
-  // TODO: Emit a warning about `repeatMatch(count: 0)` or `repeatMatch(count: 1)`
-  return Regex(node: .quantification(.exactly(.init(faking: count)), .eager, component().regex.root))
-}
-
-public func repeating<W, C0, C1, C2, C3, C4, C5, Component: RegexComponent, R: RangeExpression>(
-  _ component: Component,
-  _ expression: R,
-  _ behavior: QuantificationBehavior = .eagerly
-) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?)> where Component.Match == (W, C0, C1, C2, C3, C4, C5), R.Bound == Int {
-  .init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component.regex.root))
-}
-
-public func repeating<W, C0, C1, C2, C3, C4, C5, Component: RegexComponent, R: RangeExpression>(
-  _ expression: R,
-  _ behavior: QuantificationBehavior = .eagerly,
-  @RegexComponentBuilder _ component: () -> Component
-) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?)> where Component.Match == (W, C0, C1, C2, C3, C4, C5), R.Bound == Int {
-  .init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component().regex.root))
-}
-public func optionally<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexComponent>(
-  _ component: Component,
-  _ behavior: QuantificationBehavior = .eagerly
-) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?)> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6) {
-  .init(node: .quantification(.zeroOrOne, behavior.astKind, component.regex.root))
-}
-
-public func optionally<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexComponent>(
-  _ behavior: QuantificationBehavior = .eagerly,
-  @RegexComponentBuilder _ component: () -> Component
-) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?)> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6) {
-  .init(node: .quantification(.zeroOrOne, behavior.astKind, component().regex.root))
+extension Optionally {
+    public init<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexComponent>(
+    _ behavior: QuantificationBehavior = .eagerly,
+    @RegexComponentBuilder _ component: () -> Component
+  ) where Match == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?), Component.Match == (W, C0, C1, C2, C3, C4, C5, C6) {
+    self.init(node: .quantification(.zeroOrOne, behavior.astKind, component().regex.root))
+  }
 }
 
 public postfix func .?<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexComponent>(
   _ component: Component
-) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?)> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6) {
+) -> Optionally<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?)> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6) {
   .init(node: .quantification(.zeroOrOne, .eager, component.regex.root))
 }
 
@@ -1224,98 +1333,112 @@ extension RegexComponentBuilder {
     .init(node: .quantification(.zeroOrOne, .eager, component.regex.root))
   }
 }
-public func zeroOrMore<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexComponent>(
-  _ component: Component,
-  _ behavior: QuantificationBehavior = .eagerly
-) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?)> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6) {
-  .init(node: .quantification(.zeroOrMore, behavior.astKind, component.regex.root))
+extension ZeroOrMore {
+    public init<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexComponent>(
+    _ component: Component,
+    _ behavior: QuantificationBehavior = .eagerly
+  ) where Match == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?), Component.Match == (W, C0, C1, C2, C3, C4, C5, C6) {
+    self.init(node: .quantification(.zeroOrMore, behavior.astKind, component.regex.root))
+  }
 }
 
-public func zeroOrMore<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexComponent>(
-  _ behavior: QuantificationBehavior = .eagerly,
-  @RegexComponentBuilder _ component: () -> Component
-) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?)> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6) {
-  .init(node: .quantification(.zeroOrMore, behavior.astKind, component().regex.root))
+extension ZeroOrMore {
+    public init<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexComponent>(
+    _ behavior: QuantificationBehavior = .eagerly,
+    @RegexComponentBuilder _ component: () -> Component
+  ) where Match == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?), Component.Match == (W, C0, C1, C2, C3, C4, C5, C6) {
+    self.init(node: .quantification(.zeroOrMore, behavior.astKind, component().regex.root))
+  }
 }
 
 public postfix func .*<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexComponent>(
   _ component: Component
-) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?)> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6) {
+) -> ZeroOrMore<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?)> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6) {
   .init(node: .quantification(.zeroOrMore, .eager, component.regex.root))
 }
 
 
-public func oneOrMore<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexComponent>(
-  _ component: Component,
-  _ behavior: QuantificationBehavior = .eagerly
-) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6)> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6) {
-  .init(node: .quantification(.oneOrMore, behavior.astKind, component.regex.root))
+extension OneOrMore {
+    public init<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexComponent>(
+    _ component: Component,
+    _ behavior: QuantificationBehavior = .eagerly
+  ) where Match == (Substring, C0, C1, C2, C3, C4, C5, C6), Component.Match == (W, C0, C1, C2, C3, C4, C5, C6) {
+    self.init(node: .quantification(.oneOrMore, behavior.astKind, component.regex.root))
+  }
 }
 
-public func oneOrMore<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexComponent>(
-  _ behavior: QuantificationBehavior = .eagerly,
-  @RegexComponentBuilder _ component: () -> Component
-) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6)> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6) {
-  .init(node: .quantification(.oneOrMore, behavior.astKind, component().regex.root))
+extension OneOrMore {
+    public init<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexComponent>(
+    _ behavior: QuantificationBehavior = .eagerly,
+    @RegexComponentBuilder _ component: () -> Component
+  ) where Match == (Substring, C0, C1, C2, C3, C4, C5, C6), Component.Match == (W, C0, C1, C2, C3, C4, C5, C6) {
+    self.init(node: .quantification(.oneOrMore, behavior.astKind, component().regex.root))
+  }
 }
 
 public postfix func .+<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexComponent>(
   _ component: Component
-) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6)> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6) {
+) -> OneOrMore<(Substring, C0, C1, C2, C3, C4, C5, C6)> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6) {
   .init(node: .quantification(.oneOrMore, .eager, component.regex.root))
 }
 
 
-public func repeating<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexComponent>(
-  _ component: Component,
-  count: Int
-) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?)> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6) {
-  assert(count > 0, "Must specify a positive count")
-  // TODO: Emit a warning about `repeatMatch(count: 0)` or `repeatMatch(count: 1)`
-  return Regex(node: .quantification(.exactly(.init(faking: count)), .eager, component.regex.root))
+extension Repeat {
+    public init<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexComponent>(
+    _ component: Component,
+    count: Int
+  ) where Match == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?), Component.Match == (W, C0, C1, C2, C3, C4, C5, C6) {
+    assert(count > 0, "Must specify a positive count")
+    // TODO: Emit a warning about `repeatMatch(count: 0)` or `repeatMatch(count: 1)`
+    self.init(node: .quantification(.exactly(.init(faking: count)), .eager, component.regex.root))
+  }
+
+    public init<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexComponent>(
+    count: Int,
+    @RegexComponentBuilder _ component: () -> Component
+  ) where Match == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?), Component.Match == (W, C0, C1, C2, C3, C4, C5, C6) {
+    assert(count > 0, "Must specify a positive count")
+    // TODO: Emit a warning about `repeatMatch(count: 0)` or `repeatMatch(count: 1)`
+    self.init(node: .quantification(.exactly(.init(faking: count)), .eager, component().regex.root))
+  }
+
+    public init<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexComponent, R: RangeExpression>(
+    _ component: Component,
+    _ expression: R,
+    _ behavior: QuantificationBehavior = .eagerly
+  ) where Match == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?), Component.Match == (W, C0, C1, C2, C3, C4, C5, C6), R.Bound == Int {
+    self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component.regex.root))
+  }
+
+    public init<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexComponent, R: RangeExpression>(
+    _ expression: R,
+    _ behavior: QuantificationBehavior = .eagerly,
+    @RegexComponentBuilder _ component: () -> Component
+  ) where Match == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?), Component.Match == (W, C0, C1, C2, C3, C4, C5, C6), R.Bound == Int {
+    self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component().regex.root))
+  }
+}
+extension Optionally {
+    public init<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexComponent>(
+    _ component: Component,
+    _ behavior: QuantificationBehavior = .eagerly
+  ) where Match == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?), Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
+    self.init(node: .quantification(.zeroOrOne, behavior.astKind, component.regex.root))
+  }
 }
 
-public func repeating<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexComponent>(
-  count: Int,
-  @RegexComponentBuilder _ component: () -> Component
-) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?)> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6) {
-  assert(count > 0, "Must specify a positive count")
-  // TODO: Emit a warning about `repeatMatch(count: 0)` or `repeatMatch(count: 1)`
-  return Regex(node: .quantification(.exactly(.init(faking: count)), .eager, component().regex.root))
-}
-
-public func repeating<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexComponent, R: RangeExpression>(
-  _ component: Component,
-  _ expression: R,
-  _ behavior: QuantificationBehavior = .eagerly
-) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?)> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6), R.Bound == Int {
-  .init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component.regex.root))
-}
-
-public func repeating<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexComponent, R: RangeExpression>(
-  _ expression: R,
-  _ behavior: QuantificationBehavior = .eagerly,
-  @RegexComponentBuilder _ component: () -> Component
-) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?)> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6), R.Bound == Int {
-  .init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component().regex.root))
-}
-public func optionally<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexComponent>(
-  _ component: Component,
-  _ behavior: QuantificationBehavior = .eagerly
-) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?)> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
-  .init(node: .quantification(.zeroOrOne, behavior.astKind, component.regex.root))
-}
-
-public func optionally<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexComponent>(
-  _ behavior: QuantificationBehavior = .eagerly,
-  @RegexComponentBuilder _ component: () -> Component
-) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?)> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
-  .init(node: .quantification(.zeroOrOne, behavior.astKind, component().regex.root))
+extension Optionally {
+    public init<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexComponent>(
+    _ behavior: QuantificationBehavior = .eagerly,
+    @RegexComponentBuilder _ component: () -> Component
+  ) where Match == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?), Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
+    self.init(node: .quantification(.zeroOrOne, behavior.astKind, component().regex.root))
+  }
 }
 
 public postfix func .?<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexComponent>(
   _ component: Component
-) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?)> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
+) -> Optionally<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?)> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
   .init(node: .quantification(.zeroOrOne, .eager, component.regex.root))
 }
 
@@ -1326,98 +1449,112 @@ extension RegexComponentBuilder {
     .init(node: .quantification(.zeroOrOne, .eager, component.regex.root))
   }
 }
-public func zeroOrMore<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexComponent>(
-  _ component: Component,
-  _ behavior: QuantificationBehavior = .eagerly
-) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?)> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
-  .init(node: .quantification(.zeroOrMore, behavior.astKind, component.regex.root))
+extension ZeroOrMore {
+    public init<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexComponent>(
+    _ component: Component,
+    _ behavior: QuantificationBehavior = .eagerly
+  ) where Match == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?), Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
+    self.init(node: .quantification(.zeroOrMore, behavior.astKind, component.regex.root))
+  }
 }
 
-public func zeroOrMore<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexComponent>(
-  _ behavior: QuantificationBehavior = .eagerly,
-  @RegexComponentBuilder _ component: () -> Component
-) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?)> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
-  .init(node: .quantification(.zeroOrMore, behavior.astKind, component().regex.root))
+extension ZeroOrMore {
+    public init<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexComponent>(
+    _ behavior: QuantificationBehavior = .eagerly,
+    @RegexComponentBuilder _ component: () -> Component
+  ) where Match == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?), Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
+    self.init(node: .quantification(.zeroOrMore, behavior.astKind, component().regex.root))
+  }
 }
 
 public postfix func .*<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexComponent>(
   _ component: Component
-) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?)> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
+) -> ZeroOrMore<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?)> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
   .init(node: .quantification(.zeroOrMore, .eager, component.regex.root))
 }
 
 
-public func oneOrMore<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexComponent>(
-  _ component: Component,
-  _ behavior: QuantificationBehavior = .eagerly
-) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7)> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
-  .init(node: .quantification(.oneOrMore, behavior.astKind, component.regex.root))
+extension OneOrMore {
+    public init<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexComponent>(
+    _ component: Component,
+    _ behavior: QuantificationBehavior = .eagerly
+  ) where Match == (Substring, C0, C1, C2, C3, C4, C5, C6, C7), Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
+    self.init(node: .quantification(.oneOrMore, behavior.astKind, component.regex.root))
+  }
 }
 
-public func oneOrMore<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexComponent>(
-  _ behavior: QuantificationBehavior = .eagerly,
-  @RegexComponentBuilder _ component: () -> Component
-) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7)> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
-  .init(node: .quantification(.oneOrMore, behavior.astKind, component().regex.root))
+extension OneOrMore {
+    public init<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexComponent>(
+    _ behavior: QuantificationBehavior = .eagerly,
+    @RegexComponentBuilder _ component: () -> Component
+  ) where Match == (Substring, C0, C1, C2, C3, C4, C5, C6, C7), Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
+    self.init(node: .quantification(.oneOrMore, behavior.astKind, component().regex.root))
+  }
 }
 
 public postfix func .+<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexComponent>(
   _ component: Component
-) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7)> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
+) -> OneOrMore<(Substring, C0, C1, C2, C3, C4, C5, C6, C7)> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
   .init(node: .quantification(.oneOrMore, .eager, component.regex.root))
 }
 
 
-public func repeating<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexComponent>(
-  _ component: Component,
-  count: Int
-) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?)> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
-  assert(count > 0, "Must specify a positive count")
-  // TODO: Emit a warning about `repeatMatch(count: 0)` or `repeatMatch(count: 1)`
-  return Regex(node: .quantification(.exactly(.init(faking: count)), .eager, component.regex.root))
+extension Repeat {
+    public init<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexComponent>(
+    _ component: Component,
+    count: Int
+  ) where Match == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?), Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
+    assert(count > 0, "Must specify a positive count")
+    // TODO: Emit a warning about `repeatMatch(count: 0)` or `repeatMatch(count: 1)`
+    self.init(node: .quantification(.exactly(.init(faking: count)), .eager, component.regex.root))
+  }
+
+    public init<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexComponent>(
+    count: Int,
+    @RegexComponentBuilder _ component: () -> Component
+  ) where Match == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?), Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
+    assert(count > 0, "Must specify a positive count")
+    // TODO: Emit a warning about `repeatMatch(count: 0)` or `repeatMatch(count: 1)`
+    self.init(node: .quantification(.exactly(.init(faking: count)), .eager, component().regex.root))
+  }
+
+    public init<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexComponent, R: RangeExpression>(
+    _ component: Component,
+    _ expression: R,
+    _ behavior: QuantificationBehavior = .eagerly
+  ) where Match == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?), Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7), R.Bound == Int {
+    self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component.regex.root))
+  }
+
+    public init<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexComponent, R: RangeExpression>(
+    _ expression: R,
+    _ behavior: QuantificationBehavior = .eagerly,
+    @RegexComponentBuilder _ component: () -> Component
+  ) where Match == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?), Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7), R.Bound == Int {
+    self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component().regex.root))
+  }
+}
+extension Optionally {
+    public init<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexComponent>(
+    _ component: Component,
+    _ behavior: QuantificationBehavior = .eagerly
+  ) where Match == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?), Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
+    self.init(node: .quantification(.zeroOrOne, behavior.astKind, component.regex.root))
+  }
 }
 
-public func repeating<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexComponent>(
-  count: Int,
-  @RegexComponentBuilder _ component: () -> Component
-) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?)> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
-  assert(count > 0, "Must specify a positive count")
-  // TODO: Emit a warning about `repeatMatch(count: 0)` or `repeatMatch(count: 1)`
-  return Regex(node: .quantification(.exactly(.init(faking: count)), .eager, component().regex.root))
-}
-
-public func repeating<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexComponent, R: RangeExpression>(
-  _ component: Component,
-  _ expression: R,
-  _ behavior: QuantificationBehavior = .eagerly
-) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?)> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7), R.Bound == Int {
-  .init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component.regex.root))
-}
-
-public func repeating<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexComponent, R: RangeExpression>(
-  _ expression: R,
-  _ behavior: QuantificationBehavior = .eagerly,
-  @RegexComponentBuilder _ component: () -> Component
-) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?)> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7), R.Bound == Int {
-  .init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component().regex.root))
-}
-public func optionally<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexComponent>(
-  _ component: Component,
-  _ behavior: QuantificationBehavior = .eagerly
-) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?)> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
-  .init(node: .quantification(.zeroOrOne, behavior.astKind, component.regex.root))
-}
-
-public func optionally<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexComponent>(
-  _ behavior: QuantificationBehavior = .eagerly,
-  @RegexComponentBuilder _ component: () -> Component
-) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?)> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
-  .init(node: .quantification(.zeroOrOne, behavior.astKind, component().regex.root))
+extension Optionally {
+    public init<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexComponent>(
+    _ behavior: QuantificationBehavior = .eagerly,
+    @RegexComponentBuilder _ component: () -> Component
+  ) where Match == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?), Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
+    self.init(node: .quantification(.zeroOrOne, behavior.astKind, component().regex.root))
+  }
 }
 
 public postfix func .?<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexComponent>(
   _ component: Component
-) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?)> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
+) -> Optionally<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?)> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
   .init(node: .quantification(.zeroOrOne, .eager, component.regex.root))
 }
 
@@ -1428,2429 +1565,3109 @@ extension RegexComponentBuilder {
     .init(node: .quantification(.zeroOrOne, .eager, component.regex.root))
   }
 }
-public func zeroOrMore<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexComponent>(
-  _ component: Component,
-  _ behavior: QuantificationBehavior = .eagerly
-) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?)> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
-  .init(node: .quantification(.zeroOrMore, behavior.astKind, component.regex.root))
+extension ZeroOrMore {
+    public init<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexComponent>(
+    _ component: Component,
+    _ behavior: QuantificationBehavior = .eagerly
+  ) where Match == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?), Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
+    self.init(node: .quantification(.zeroOrMore, behavior.astKind, component.regex.root))
+  }
 }
 
-public func zeroOrMore<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexComponent>(
-  _ behavior: QuantificationBehavior = .eagerly,
-  @RegexComponentBuilder _ component: () -> Component
-) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?)> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
-  .init(node: .quantification(.zeroOrMore, behavior.astKind, component().regex.root))
+extension ZeroOrMore {
+    public init<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexComponent>(
+    _ behavior: QuantificationBehavior = .eagerly,
+    @RegexComponentBuilder _ component: () -> Component
+  ) where Match == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?), Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
+    self.init(node: .quantification(.zeroOrMore, behavior.astKind, component().regex.root))
+  }
 }
 
 public postfix func .*<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexComponent>(
   _ component: Component
-) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?)> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
+) -> ZeroOrMore<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?)> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
   .init(node: .quantification(.zeroOrMore, .eager, component.regex.root))
 }
 
 
-public func oneOrMore<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexComponent>(
-  _ component: Component,
-  _ behavior: QuantificationBehavior = .eagerly
-) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8)> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
-  .init(node: .quantification(.oneOrMore, behavior.astKind, component.regex.root))
+extension OneOrMore {
+    public init<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexComponent>(
+    _ component: Component,
+    _ behavior: QuantificationBehavior = .eagerly
+  ) where Match == (Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8), Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
+    self.init(node: .quantification(.oneOrMore, behavior.astKind, component.regex.root))
+  }
 }
 
-public func oneOrMore<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexComponent>(
-  _ behavior: QuantificationBehavior = .eagerly,
-  @RegexComponentBuilder _ component: () -> Component
-) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8)> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
-  .init(node: .quantification(.oneOrMore, behavior.astKind, component().regex.root))
+extension OneOrMore {
+    public init<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexComponent>(
+    _ behavior: QuantificationBehavior = .eagerly,
+    @RegexComponentBuilder _ component: () -> Component
+  ) where Match == (Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8), Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
+    self.init(node: .quantification(.oneOrMore, behavior.astKind, component().regex.root))
+  }
 }
 
 public postfix func .+<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexComponent>(
   _ component: Component
-) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8)> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
+) -> OneOrMore<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8)> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
   .init(node: .quantification(.oneOrMore, .eager, component.regex.root))
 }
 
 
-public func repeating<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexComponent>(
-  _ component: Component,
-  count: Int
-) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?)> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
-  assert(count > 0, "Must specify a positive count")
-  // TODO: Emit a warning about `repeatMatch(count: 0)` or `repeatMatch(count: 1)`
-  return Regex(node: .quantification(.exactly(.init(faking: count)), .eager, component.regex.root))
+extension Repeat {
+    public init<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexComponent>(
+    _ component: Component,
+    count: Int
+  ) where Match == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?), Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
+    assert(count > 0, "Must specify a positive count")
+    // TODO: Emit a warning about `repeatMatch(count: 0)` or `repeatMatch(count: 1)`
+    self.init(node: .quantification(.exactly(.init(faking: count)), .eager, component.regex.root))
+  }
+
+    public init<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexComponent>(
+    count: Int,
+    @RegexComponentBuilder _ component: () -> Component
+  ) where Match == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?), Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
+    assert(count > 0, "Must specify a positive count")
+    // TODO: Emit a warning about `repeatMatch(count: 0)` or `repeatMatch(count: 1)`
+    self.init(node: .quantification(.exactly(.init(faking: count)), .eager, component().regex.root))
+  }
+
+    public init<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexComponent, R: RangeExpression>(
+    _ component: Component,
+    _ expression: R,
+    _ behavior: QuantificationBehavior = .eagerly
+  ) where Match == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?), Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8), R.Bound == Int {
+    self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component.regex.root))
+  }
+
+    public init<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexComponent, R: RangeExpression>(
+    _ expression: R,
+    _ behavior: QuantificationBehavior = .eagerly,
+    @RegexComponentBuilder _ component: () -> Component
+  ) where Match == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?), Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8), R.Bound == Int {
+    self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component().regex.root))
+  }
+}
+extension Optionally {
+    public init<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9, Component: RegexComponent>(
+    _ component: Component,
+    _ behavior: QuantificationBehavior = .eagerly
+  ) where Match == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?), Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
+    self.init(node: .quantification(.zeroOrOne, behavior.astKind, component.regex.root))
+  }
 }
 
-public func repeating<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexComponent>(
-  count: Int,
-  @RegexComponentBuilder _ component: () -> Component
-) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?)> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
-  assert(count > 0, "Must specify a positive count")
-  // TODO: Emit a warning about `repeatMatch(count: 0)` or `repeatMatch(count: 1)`
-  return Regex(node: .quantification(.exactly(.init(faking: count)), .eager, component().regex.root))
+extension Optionally {
+    public init<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9, Component: RegexComponent>(
+    _ behavior: QuantificationBehavior = .eagerly,
+    @RegexComponentBuilder _ component: () -> Component
+  ) where Match == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?), Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
+    self.init(node: .quantification(.zeroOrOne, behavior.astKind, component().regex.root))
+  }
 }
 
-public func repeating<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexComponent, R: RangeExpression>(
-  _ component: Component,
-  _ expression: R,
-  _ behavior: QuantificationBehavior = .eagerly
-) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?)> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8), R.Bound == Int {
-  .init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component.regex.root))
+public postfix func .?<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9, Component: RegexComponent>(
+  _ component: Component
+) -> Optionally<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?)> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
+  .init(node: .quantification(.zeroOrOne, .eager, component.regex.root))
 }
 
-public func repeating<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexComponent, R: RangeExpression>(
-  _ expression: R,
-  _ behavior: QuantificationBehavior = .eagerly,
-  @RegexComponentBuilder _ component: () -> Component
-) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?)> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8), R.Bound == Int {
-  .init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component().regex.root))
+extension RegexComponentBuilder {
+  public static func buildLimitedAvailability<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9, Component: RegexComponent>(
+    _ component: Component
+  ) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?)> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
+    .init(node: .quantification(.zeroOrOne, .eager, component.regex.root))
+  }
+}
+extension ZeroOrMore {
+    public init<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9, Component: RegexComponent>(
+    _ component: Component,
+    _ behavior: QuantificationBehavior = .eagerly
+  ) where Match == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?), Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
+    self.init(node: .quantification(.zeroOrMore, behavior.astKind, component.regex.root))
+  }
+}
+
+extension ZeroOrMore {
+    public init<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9, Component: RegexComponent>(
+    _ behavior: QuantificationBehavior = .eagerly,
+    @RegexComponentBuilder _ component: () -> Component
+  ) where Match == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?), Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
+    self.init(node: .quantification(.zeroOrMore, behavior.astKind, component().regex.root))
+  }
+}
+
+public postfix func .*<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9, Component: RegexComponent>(
+  _ component: Component
+) -> ZeroOrMore<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?)> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
+  .init(node: .quantification(.zeroOrMore, .eager, component.regex.root))
+}
+
+
+extension OneOrMore {
+    public init<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9, Component: RegexComponent>(
+    _ component: Component,
+    _ behavior: QuantificationBehavior = .eagerly
+  ) where Match == (Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9), Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
+    self.init(node: .quantification(.oneOrMore, behavior.astKind, component.regex.root))
+  }
+}
+
+extension OneOrMore {
+    public init<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9, Component: RegexComponent>(
+    _ behavior: QuantificationBehavior = .eagerly,
+    @RegexComponentBuilder _ component: () -> Component
+  ) where Match == (Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9), Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
+    self.init(node: .quantification(.oneOrMore, behavior.astKind, component().regex.root))
+  }
+}
+
+public postfix func .+<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9, Component: RegexComponent>(
+  _ component: Component
+) -> OneOrMore<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9)> where Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
+  .init(node: .quantification(.oneOrMore, .eager, component.regex.root))
+}
+
+
+extension Repeat {
+    public init<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9, Component: RegexComponent>(
+    _ component: Component,
+    count: Int
+  ) where Match == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?), Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
+    assert(count > 0, "Must specify a positive count")
+    // TODO: Emit a warning about `repeatMatch(count: 0)` or `repeatMatch(count: 1)`
+    self.init(node: .quantification(.exactly(.init(faking: count)), .eager, component.regex.root))
+  }
+
+    public init<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9, Component: RegexComponent>(
+    count: Int,
+    @RegexComponentBuilder _ component: () -> Component
+  ) where Match == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?), Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
+    assert(count > 0, "Must specify a positive count")
+    // TODO: Emit a warning about `repeatMatch(count: 0)` or `repeatMatch(count: 1)`
+    self.init(node: .quantification(.exactly(.init(faking: count)), .eager, component().regex.root))
+  }
+
+    public init<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9, Component: RegexComponent, R: RangeExpression>(
+    _ component: Component,
+    _ expression: R,
+    _ behavior: QuantificationBehavior = .eagerly
+  ) where Match == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?), Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9), R.Bound == Int {
+    self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component.regex.root))
+  }
+
+    public init<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9, Component: RegexComponent, R: RangeExpression>(
+    _ expression: R,
+    _ behavior: QuantificationBehavior = .eagerly,
+    @RegexComponentBuilder _ component: () -> Component
+  ) where Match == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?), Component.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9), R.Bound == Int {
+    self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component().regex.root))
+  }
 }
 extension AlternationBuilder {
   public static func buildBlock<R0, R1>(
     combining next: R1, into combined: R0
-  ) -> Regex<Substring> where R0: RegexComponent, R1: RegexComponent {
+  ) -> ChoiceOf<Substring> where R0: RegexComponent, R1: RegexComponent {
     .init(node: combined.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 
-public func | <R0, R1>(lhs: R0, rhs: R1) -> Regex<Substring> where R0: RegexComponent, R1: RegexComponent {
+public func | <R0, R1>(lhs: R0, rhs: R1) -> ChoiceOf<Substring> where R0: RegexComponent, R1: RegexComponent {
   .init(node: lhs.regex.root.appendingAlternationCase(rhs.regex.root))
 }
 extension AlternationBuilder {
   public static func buildBlock<R0, R1, W1, C0>(
     combining next: R1, into combined: R0
-  ) -> Regex<(Substring, C0?)> where R0: RegexComponent, R1: RegexComponent, R1.Match == (W1, C0) {
+  ) -> ChoiceOf<(Substring, C0?)> where R0: RegexComponent, R1: RegexComponent, R1.Match == (W1, C0) {
     .init(node: combined.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 
-public func | <R0, R1, W1, C0>(lhs: R0, rhs: R1) -> Regex<(Substring, C0?)> where R0: RegexComponent, R1: RegexComponent, R1.Match == (W1, C0) {
+public func | <R0, R1, W1, C0>(lhs: R0, rhs: R1) -> ChoiceOf<(Substring, C0?)> where R0: RegexComponent, R1: RegexComponent, R1.Match == (W1, C0) {
   .init(node: lhs.regex.root.appendingAlternationCase(rhs.regex.root))
 }
 extension AlternationBuilder {
   public static func buildBlock<R0, R1, W1, C0, C1>(
     combining next: R1, into combined: R0
-  ) -> Regex<(Substring, C0?, C1?)> where R0: RegexComponent, R1: RegexComponent, R1.Match == (W1, C0, C1) {
+  ) -> ChoiceOf<(Substring, C0?, C1?)> where R0: RegexComponent, R1: RegexComponent, R1.Match == (W1, C0, C1) {
     .init(node: combined.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 
-public func | <R0, R1, W1, C0, C1>(lhs: R0, rhs: R1) -> Regex<(Substring, C0?, C1?)> where R0: RegexComponent, R1: RegexComponent, R1.Match == (W1, C0, C1) {
+public func | <R0, R1, W1, C0, C1>(lhs: R0, rhs: R1) -> ChoiceOf<(Substring, C0?, C1?)> where R0: RegexComponent, R1: RegexComponent, R1.Match == (W1, C0, C1) {
   .init(node: lhs.regex.root.appendingAlternationCase(rhs.regex.root))
 }
 extension AlternationBuilder {
   public static func buildBlock<R0, R1, W1, C0, C1, C2>(
     combining next: R1, into combined: R0
-  ) -> Regex<(Substring, C0?, C1?, C2?)> where R0: RegexComponent, R1: RegexComponent, R1.Match == (W1, C0, C1, C2) {
+  ) -> ChoiceOf<(Substring, C0?, C1?, C2?)> where R0: RegexComponent, R1: RegexComponent, R1.Match == (W1, C0, C1, C2) {
     .init(node: combined.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 
-public func | <R0, R1, W1, C0, C1, C2>(lhs: R0, rhs: R1) -> Regex<(Substring, C0?, C1?, C2?)> where R0: RegexComponent, R1: RegexComponent, R1.Match == (W1, C0, C1, C2) {
+public func | <R0, R1, W1, C0, C1, C2>(lhs: R0, rhs: R1) -> ChoiceOf<(Substring, C0?, C1?, C2?)> where R0: RegexComponent, R1: RegexComponent, R1.Match == (W1, C0, C1, C2) {
   .init(node: lhs.regex.root.appendingAlternationCase(rhs.regex.root))
 }
 extension AlternationBuilder {
   public static func buildBlock<R0, R1, W1, C0, C1, C2, C3>(
     combining next: R1, into combined: R0
-  ) -> Regex<(Substring, C0?, C1?, C2?, C3?)> where R0: RegexComponent, R1: RegexComponent, R1.Match == (W1, C0, C1, C2, C3) {
+  ) -> ChoiceOf<(Substring, C0?, C1?, C2?, C3?)> where R0: RegexComponent, R1: RegexComponent, R1.Match == (W1, C0, C1, C2, C3) {
     .init(node: combined.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 
-public func | <R0, R1, W1, C0, C1, C2, C3>(lhs: R0, rhs: R1) -> Regex<(Substring, C0?, C1?, C2?, C3?)> where R0: RegexComponent, R1: RegexComponent, R1.Match == (W1, C0, C1, C2, C3) {
+public func | <R0, R1, W1, C0, C1, C2, C3>(lhs: R0, rhs: R1) -> ChoiceOf<(Substring, C0?, C1?, C2?, C3?)> where R0: RegexComponent, R1: RegexComponent, R1.Match == (W1, C0, C1, C2, C3) {
   .init(node: lhs.regex.root.appendingAlternationCase(rhs.regex.root))
 }
 extension AlternationBuilder {
   public static func buildBlock<R0, R1, W1, C0, C1, C2, C3, C4>(
     combining next: R1, into combined: R0
-  ) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?)> where R0: RegexComponent, R1: RegexComponent, R1.Match == (W1, C0, C1, C2, C3, C4) {
+  ) -> ChoiceOf<(Substring, C0?, C1?, C2?, C3?, C4?)> where R0: RegexComponent, R1: RegexComponent, R1.Match == (W1, C0, C1, C2, C3, C4) {
     .init(node: combined.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 
-public func | <R0, R1, W1, C0, C1, C2, C3, C4>(lhs: R0, rhs: R1) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?)> where R0: RegexComponent, R1: RegexComponent, R1.Match == (W1, C0, C1, C2, C3, C4) {
+public func | <R0, R1, W1, C0, C1, C2, C3, C4>(lhs: R0, rhs: R1) -> ChoiceOf<(Substring, C0?, C1?, C2?, C3?, C4?)> where R0: RegexComponent, R1: RegexComponent, R1.Match == (W1, C0, C1, C2, C3, C4) {
   .init(node: lhs.regex.root.appendingAlternationCase(rhs.regex.root))
 }
 extension AlternationBuilder {
   public static func buildBlock<R0, R1, W1, C0, C1, C2, C3, C4, C5>(
     combining next: R1, into combined: R0
-  ) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?)> where R0: RegexComponent, R1: RegexComponent, R1.Match == (W1, C0, C1, C2, C3, C4, C5) {
+  ) -> ChoiceOf<(Substring, C0?, C1?, C2?, C3?, C4?, C5?)> where R0: RegexComponent, R1: RegexComponent, R1.Match == (W1, C0, C1, C2, C3, C4, C5) {
     .init(node: combined.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 
-public func | <R0, R1, W1, C0, C1, C2, C3, C4, C5>(lhs: R0, rhs: R1) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?)> where R0: RegexComponent, R1: RegexComponent, R1.Match == (W1, C0, C1, C2, C3, C4, C5) {
+public func | <R0, R1, W1, C0, C1, C2, C3, C4, C5>(lhs: R0, rhs: R1) -> ChoiceOf<(Substring, C0?, C1?, C2?, C3?, C4?, C5?)> where R0: RegexComponent, R1: RegexComponent, R1.Match == (W1, C0, C1, C2, C3, C4, C5) {
   .init(node: lhs.regex.root.appendingAlternationCase(rhs.regex.root))
 }
 extension AlternationBuilder {
   public static func buildBlock<R0, R1, W1, C0, C1, C2, C3, C4, C5, C6>(
     combining next: R1, into combined: R0
-  ) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?)> where R0: RegexComponent, R1: RegexComponent, R1.Match == (W1, C0, C1, C2, C3, C4, C5, C6) {
+  ) -> ChoiceOf<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?)> where R0: RegexComponent, R1: RegexComponent, R1.Match == (W1, C0, C1, C2, C3, C4, C5, C6) {
     .init(node: combined.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 
-public func | <R0, R1, W1, C0, C1, C2, C3, C4, C5, C6>(lhs: R0, rhs: R1) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?)> where R0: RegexComponent, R1: RegexComponent, R1.Match == (W1, C0, C1, C2, C3, C4, C5, C6) {
+public func | <R0, R1, W1, C0, C1, C2, C3, C4, C5, C6>(lhs: R0, rhs: R1) -> ChoiceOf<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?)> where R0: RegexComponent, R1: RegexComponent, R1.Match == (W1, C0, C1, C2, C3, C4, C5, C6) {
   .init(node: lhs.regex.root.appendingAlternationCase(rhs.regex.root))
 }
 extension AlternationBuilder {
   public static func buildBlock<R0, R1, W1, C0, C1, C2, C3, C4, C5, C6, C7>(
     combining next: R1, into combined: R0
-  ) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?)> where R0: RegexComponent, R1: RegexComponent, R1.Match == (W1, C0, C1, C2, C3, C4, C5, C6, C7) {
+  ) -> ChoiceOf<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?)> where R0: RegexComponent, R1: RegexComponent, R1.Match == (W1, C0, C1, C2, C3, C4, C5, C6, C7) {
     .init(node: combined.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 
-public func | <R0, R1, W1, C0, C1, C2, C3, C4, C5, C6, C7>(lhs: R0, rhs: R1) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?)> where R0: RegexComponent, R1: RegexComponent, R1.Match == (W1, C0, C1, C2, C3, C4, C5, C6, C7) {
+public func | <R0, R1, W1, C0, C1, C2, C3, C4, C5, C6, C7>(lhs: R0, rhs: R1) -> ChoiceOf<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?)> where R0: RegexComponent, R1: RegexComponent, R1.Match == (W1, C0, C1, C2, C3, C4, C5, C6, C7) {
   .init(node: lhs.regex.root.appendingAlternationCase(rhs.regex.root))
 }
 extension AlternationBuilder {
   public static func buildBlock<R0, R1, W1, C0, C1, C2, C3, C4, C5, C6, C7, C8>(
     combining next: R1, into combined: R0
-  ) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?)> where R0: RegexComponent, R1: RegexComponent, R1.Match == (W1, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
+  ) -> ChoiceOf<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?)> where R0: RegexComponent, R1: RegexComponent, R1.Match == (W1, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
     .init(node: combined.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 
-public func | <R0, R1, W1, C0, C1, C2, C3, C4, C5, C6, C7, C8>(lhs: R0, rhs: R1) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?)> where R0: RegexComponent, R1: RegexComponent, R1.Match == (W1, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
+public func | <R0, R1, W1, C0, C1, C2, C3, C4, C5, C6, C7, C8>(lhs: R0, rhs: R1) -> ChoiceOf<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?)> where R0: RegexComponent, R1: RegexComponent, R1.Match == (W1, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
   .init(node: lhs.regex.root.appendingAlternationCase(rhs.regex.root))
 }
 extension AlternationBuilder {
   public static func buildBlock<R0, R1, W1, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9>(
     combining next: R1, into combined: R0
-  ) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?)> where R0: RegexComponent, R1: RegexComponent, R1.Match == (W1, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
+  ) -> ChoiceOf<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?)> where R0: RegexComponent, R1: RegexComponent, R1.Match == (W1, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
     .init(node: combined.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 
-public func | <R0, R1, W1, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9>(lhs: R0, rhs: R1) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?)> where R0: RegexComponent, R1: RegexComponent, R1.Match == (W1, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
+public func | <R0, R1, W1, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9>(lhs: R0, rhs: R1) -> ChoiceOf<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?)> where R0: RegexComponent, R1: RegexComponent, R1.Match == (W1, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
   .init(node: lhs.regex.root.appendingAlternationCase(rhs.regex.root))
 }
 extension AlternationBuilder {
   public static func buildBlock<R0, W0, C0, R1>(
     combining next: R1, into combined: R0
-  ) -> Regex<(Substring, C0)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0) {
+  ) -> ChoiceOf<(Substring, C0)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0) {
     .init(node: combined.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 
-public func | <R0, W0, C0, R1>(lhs: R0, rhs: R1) -> Regex<(Substring, C0)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0) {
+public func | <R0, W0, C0, R1>(lhs: R0, rhs: R1) -> ChoiceOf<(Substring, C0)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0) {
   .init(node: lhs.regex.root.appendingAlternationCase(rhs.regex.root))
 }
 extension AlternationBuilder {
   public static func buildBlock<R0, W0, C0, R1, W1, C1>(
     combining next: R1, into combined: R0
-  ) -> Regex<(Substring, C0, C1?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0), R1.Match == (W1, C1) {
+  ) -> ChoiceOf<(Substring, C0, C1?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0), R1.Match == (W1, C1) {
     .init(node: combined.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 
-public func | <R0, W0, C0, R1, W1, C1>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0), R1.Match == (W1, C1) {
+public func | <R0, W0, C0, R1, W1, C1>(lhs: R0, rhs: R1) -> ChoiceOf<(Substring, C0, C1?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0), R1.Match == (W1, C1) {
   .init(node: lhs.regex.root.appendingAlternationCase(rhs.regex.root))
 }
 extension AlternationBuilder {
   public static func buildBlock<R0, W0, C0, R1, W1, C1, C2>(
     combining next: R1, into combined: R0
-  ) -> Regex<(Substring, C0, C1?, C2?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0), R1.Match == (W1, C1, C2) {
+  ) -> ChoiceOf<(Substring, C0, C1?, C2?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0), R1.Match == (W1, C1, C2) {
     .init(node: combined.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 
-public func | <R0, W0, C0, R1, W1, C1, C2>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1?, C2?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0), R1.Match == (W1, C1, C2) {
+public func | <R0, W0, C0, R1, W1, C1, C2>(lhs: R0, rhs: R1) -> ChoiceOf<(Substring, C0, C1?, C2?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0), R1.Match == (W1, C1, C2) {
   .init(node: lhs.regex.root.appendingAlternationCase(rhs.regex.root))
 }
 extension AlternationBuilder {
   public static func buildBlock<R0, W0, C0, R1, W1, C1, C2, C3>(
     combining next: R1, into combined: R0
-  ) -> Regex<(Substring, C0, C1?, C2?, C3?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0), R1.Match == (W1, C1, C2, C3) {
+  ) -> ChoiceOf<(Substring, C0, C1?, C2?, C3?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0), R1.Match == (W1, C1, C2, C3) {
     .init(node: combined.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 
-public func | <R0, W0, C0, R1, W1, C1, C2, C3>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1?, C2?, C3?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0), R1.Match == (W1, C1, C2, C3) {
+public func | <R0, W0, C0, R1, W1, C1, C2, C3>(lhs: R0, rhs: R1) -> ChoiceOf<(Substring, C0, C1?, C2?, C3?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0), R1.Match == (W1, C1, C2, C3) {
   .init(node: lhs.regex.root.appendingAlternationCase(rhs.regex.root))
 }
 extension AlternationBuilder {
   public static func buildBlock<R0, W0, C0, R1, W1, C1, C2, C3, C4>(
     combining next: R1, into combined: R0
-  ) -> Regex<(Substring, C0, C1?, C2?, C3?, C4?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0), R1.Match == (W1, C1, C2, C3, C4) {
+  ) -> ChoiceOf<(Substring, C0, C1?, C2?, C3?, C4?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0), R1.Match == (W1, C1, C2, C3, C4) {
     .init(node: combined.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 
-public func | <R0, W0, C0, R1, W1, C1, C2, C3, C4>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1?, C2?, C3?, C4?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0), R1.Match == (W1, C1, C2, C3, C4) {
+public func | <R0, W0, C0, R1, W1, C1, C2, C3, C4>(lhs: R0, rhs: R1) -> ChoiceOf<(Substring, C0, C1?, C2?, C3?, C4?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0), R1.Match == (W1, C1, C2, C3, C4) {
   .init(node: lhs.regex.root.appendingAlternationCase(rhs.regex.root))
 }
 extension AlternationBuilder {
   public static func buildBlock<R0, W0, C0, R1, W1, C1, C2, C3, C4, C5>(
     combining next: R1, into combined: R0
-  ) -> Regex<(Substring, C0, C1?, C2?, C3?, C4?, C5?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0), R1.Match == (W1, C1, C2, C3, C4, C5) {
+  ) -> ChoiceOf<(Substring, C0, C1?, C2?, C3?, C4?, C5?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0), R1.Match == (W1, C1, C2, C3, C4, C5) {
     .init(node: combined.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 
-public func | <R0, W0, C0, R1, W1, C1, C2, C3, C4, C5>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1?, C2?, C3?, C4?, C5?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0), R1.Match == (W1, C1, C2, C3, C4, C5) {
+public func | <R0, W0, C0, R1, W1, C1, C2, C3, C4, C5>(lhs: R0, rhs: R1) -> ChoiceOf<(Substring, C0, C1?, C2?, C3?, C4?, C5?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0), R1.Match == (W1, C1, C2, C3, C4, C5) {
   .init(node: lhs.regex.root.appendingAlternationCase(rhs.regex.root))
 }
 extension AlternationBuilder {
   public static func buildBlock<R0, W0, C0, R1, W1, C1, C2, C3, C4, C5, C6>(
     combining next: R1, into combined: R0
-  ) -> Regex<(Substring, C0, C1?, C2?, C3?, C4?, C5?, C6?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0), R1.Match == (W1, C1, C2, C3, C4, C5, C6) {
+  ) -> ChoiceOf<(Substring, C0, C1?, C2?, C3?, C4?, C5?, C6?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0), R1.Match == (W1, C1, C2, C3, C4, C5, C6) {
     .init(node: combined.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 
-public func | <R0, W0, C0, R1, W1, C1, C2, C3, C4, C5, C6>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1?, C2?, C3?, C4?, C5?, C6?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0), R1.Match == (W1, C1, C2, C3, C4, C5, C6) {
+public func | <R0, W0, C0, R1, W1, C1, C2, C3, C4, C5, C6>(lhs: R0, rhs: R1) -> ChoiceOf<(Substring, C0, C1?, C2?, C3?, C4?, C5?, C6?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0), R1.Match == (W1, C1, C2, C3, C4, C5, C6) {
   .init(node: lhs.regex.root.appendingAlternationCase(rhs.regex.root))
 }
 extension AlternationBuilder {
   public static func buildBlock<R0, W0, C0, R1, W1, C1, C2, C3, C4, C5, C6, C7>(
     combining next: R1, into combined: R0
-  ) -> Regex<(Substring, C0, C1?, C2?, C3?, C4?, C5?, C6?, C7?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0), R1.Match == (W1, C1, C2, C3, C4, C5, C6, C7) {
+  ) -> ChoiceOf<(Substring, C0, C1?, C2?, C3?, C4?, C5?, C6?, C7?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0), R1.Match == (W1, C1, C2, C3, C4, C5, C6, C7) {
     .init(node: combined.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 
-public func | <R0, W0, C0, R1, W1, C1, C2, C3, C4, C5, C6, C7>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1?, C2?, C3?, C4?, C5?, C6?, C7?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0), R1.Match == (W1, C1, C2, C3, C4, C5, C6, C7) {
+public func | <R0, W0, C0, R1, W1, C1, C2, C3, C4, C5, C6, C7>(lhs: R0, rhs: R1) -> ChoiceOf<(Substring, C0, C1?, C2?, C3?, C4?, C5?, C6?, C7?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0), R1.Match == (W1, C1, C2, C3, C4, C5, C6, C7) {
   .init(node: lhs.regex.root.appendingAlternationCase(rhs.regex.root))
 }
 extension AlternationBuilder {
   public static func buildBlock<R0, W0, C0, R1, W1, C1, C2, C3, C4, C5, C6, C7, C8>(
     combining next: R1, into combined: R0
-  ) -> Regex<(Substring, C0, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0), R1.Match == (W1, C1, C2, C3, C4, C5, C6, C7, C8) {
+  ) -> ChoiceOf<(Substring, C0, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0), R1.Match == (W1, C1, C2, C3, C4, C5, C6, C7, C8) {
     .init(node: combined.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 
-public func | <R0, W0, C0, R1, W1, C1, C2, C3, C4, C5, C6, C7, C8>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0), R1.Match == (W1, C1, C2, C3, C4, C5, C6, C7, C8) {
+public func | <R0, W0, C0, R1, W1, C1, C2, C3, C4, C5, C6, C7, C8>(lhs: R0, rhs: R1) -> ChoiceOf<(Substring, C0, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0), R1.Match == (W1, C1, C2, C3, C4, C5, C6, C7, C8) {
   .init(node: lhs.regex.root.appendingAlternationCase(rhs.regex.root))
 }
 extension AlternationBuilder {
   public static func buildBlock<R0, W0, C0, R1, W1, C1, C2, C3, C4, C5, C6, C7, C8, C9>(
     combining next: R1, into combined: R0
-  ) -> Regex<(Substring, C0, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0), R1.Match == (W1, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
+  ) -> ChoiceOf<(Substring, C0, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0), R1.Match == (W1, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
     .init(node: combined.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 
-public func | <R0, W0, C0, R1, W1, C1, C2, C3, C4, C5, C6, C7, C8, C9>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0), R1.Match == (W1, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
+public func | <R0, W0, C0, R1, W1, C1, C2, C3, C4, C5, C6, C7, C8, C9>(lhs: R0, rhs: R1) -> ChoiceOf<(Substring, C0, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0), R1.Match == (W1, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
   .init(node: lhs.regex.root.appendingAlternationCase(rhs.regex.root))
 }
 extension AlternationBuilder {
   public static func buildBlock<R0, W0, C0, C1, R1>(
     combining next: R1, into combined: R0
-  ) -> Regex<(Substring, C0, C1)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1) {
+  ) -> ChoiceOf<(Substring, C0, C1)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1) {
     .init(node: combined.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 
-public func | <R0, W0, C0, C1, R1>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1) {
+public func | <R0, W0, C0, C1, R1>(lhs: R0, rhs: R1) -> ChoiceOf<(Substring, C0, C1)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1) {
   .init(node: lhs.regex.root.appendingAlternationCase(rhs.regex.root))
 }
 extension AlternationBuilder {
   public static func buildBlock<R0, W0, C0, C1, R1, W1, C2>(
     combining next: R1, into combined: R0
-  ) -> Regex<(Substring, C0, C1, C2?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1), R1.Match == (W1, C2) {
+  ) -> ChoiceOf<(Substring, C0, C1, C2?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1), R1.Match == (W1, C2) {
     .init(node: combined.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 
-public func | <R0, W0, C0, C1, R1, W1, C2>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1, C2?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1), R1.Match == (W1, C2) {
+public func | <R0, W0, C0, C1, R1, W1, C2>(lhs: R0, rhs: R1) -> ChoiceOf<(Substring, C0, C1, C2?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1), R1.Match == (W1, C2) {
   .init(node: lhs.regex.root.appendingAlternationCase(rhs.regex.root))
 }
 extension AlternationBuilder {
   public static func buildBlock<R0, W0, C0, C1, R1, W1, C2, C3>(
     combining next: R1, into combined: R0
-  ) -> Regex<(Substring, C0, C1, C2?, C3?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1), R1.Match == (W1, C2, C3) {
+  ) -> ChoiceOf<(Substring, C0, C1, C2?, C3?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1), R1.Match == (W1, C2, C3) {
     .init(node: combined.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 
-public func | <R0, W0, C0, C1, R1, W1, C2, C3>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1, C2?, C3?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1), R1.Match == (W1, C2, C3) {
+public func | <R0, W0, C0, C1, R1, W1, C2, C3>(lhs: R0, rhs: R1) -> ChoiceOf<(Substring, C0, C1, C2?, C3?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1), R1.Match == (W1, C2, C3) {
   .init(node: lhs.regex.root.appendingAlternationCase(rhs.regex.root))
 }
 extension AlternationBuilder {
   public static func buildBlock<R0, W0, C0, C1, R1, W1, C2, C3, C4>(
     combining next: R1, into combined: R0
-  ) -> Regex<(Substring, C0, C1, C2?, C3?, C4?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1), R1.Match == (W1, C2, C3, C4) {
+  ) -> ChoiceOf<(Substring, C0, C1, C2?, C3?, C4?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1), R1.Match == (W1, C2, C3, C4) {
     .init(node: combined.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 
-public func | <R0, W0, C0, C1, R1, W1, C2, C3, C4>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1, C2?, C3?, C4?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1), R1.Match == (W1, C2, C3, C4) {
+public func | <R0, W0, C0, C1, R1, W1, C2, C3, C4>(lhs: R0, rhs: R1) -> ChoiceOf<(Substring, C0, C1, C2?, C3?, C4?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1), R1.Match == (W1, C2, C3, C4) {
   .init(node: lhs.regex.root.appendingAlternationCase(rhs.regex.root))
 }
 extension AlternationBuilder {
   public static func buildBlock<R0, W0, C0, C1, R1, W1, C2, C3, C4, C5>(
     combining next: R1, into combined: R0
-  ) -> Regex<(Substring, C0, C1, C2?, C3?, C4?, C5?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1), R1.Match == (W1, C2, C3, C4, C5) {
+  ) -> ChoiceOf<(Substring, C0, C1, C2?, C3?, C4?, C5?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1), R1.Match == (W1, C2, C3, C4, C5) {
     .init(node: combined.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 
-public func | <R0, W0, C0, C1, R1, W1, C2, C3, C4, C5>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1, C2?, C3?, C4?, C5?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1), R1.Match == (W1, C2, C3, C4, C5) {
+public func | <R0, W0, C0, C1, R1, W1, C2, C3, C4, C5>(lhs: R0, rhs: R1) -> ChoiceOf<(Substring, C0, C1, C2?, C3?, C4?, C5?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1), R1.Match == (W1, C2, C3, C4, C5) {
   .init(node: lhs.regex.root.appendingAlternationCase(rhs.regex.root))
 }
 extension AlternationBuilder {
   public static func buildBlock<R0, W0, C0, C1, R1, W1, C2, C3, C4, C5, C6>(
     combining next: R1, into combined: R0
-  ) -> Regex<(Substring, C0, C1, C2?, C3?, C4?, C5?, C6?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1), R1.Match == (W1, C2, C3, C4, C5, C6) {
+  ) -> ChoiceOf<(Substring, C0, C1, C2?, C3?, C4?, C5?, C6?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1), R1.Match == (W1, C2, C3, C4, C5, C6) {
     .init(node: combined.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 
-public func | <R0, W0, C0, C1, R1, W1, C2, C3, C4, C5, C6>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1, C2?, C3?, C4?, C5?, C6?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1), R1.Match == (W1, C2, C3, C4, C5, C6) {
+public func | <R0, W0, C0, C1, R1, W1, C2, C3, C4, C5, C6>(lhs: R0, rhs: R1) -> ChoiceOf<(Substring, C0, C1, C2?, C3?, C4?, C5?, C6?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1), R1.Match == (W1, C2, C3, C4, C5, C6) {
   .init(node: lhs.regex.root.appendingAlternationCase(rhs.regex.root))
 }
 extension AlternationBuilder {
   public static func buildBlock<R0, W0, C0, C1, R1, W1, C2, C3, C4, C5, C6, C7>(
     combining next: R1, into combined: R0
-  ) -> Regex<(Substring, C0, C1, C2?, C3?, C4?, C5?, C6?, C7?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1), R1.Match == (W1, C2, C3, C4, C5, C6, C7) {
+  ) -> ChoiceOf<(Substring, C0, C1, C2?, C3?, C4?, C5?, C6?, C7?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1), R1.Match == (W1, C2, C3, C4, C5, C6, C7) {
     .init(node: combined.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 
-public func | <R0, W0, C0, C1, R1, W1, C2, C3, C4, C5, C6, C7>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1, C2?, C3?, C4?, C5?, C6?, C7?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1), R1.Match == (W1, C2, C3, C4, C5, C6, C7) {
+public func | <R0, W0, C0, C1, R1, W1, C2, C3, C4, C5, C6, C7>(lhs: R0, rhs: R1) -> ChoiceOf<(Substring, C0, C1, C2?, C3?, C4?, C5?, C6?, C7?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1), R1.Match == (W1, C2, C3, C4, C5, C6, C7) {
   .init(node: lhs.regex.root.appendingAlternationCase(rhs.regex.root))
 }
 extension AlternationBuilder {
   public static func buildBlock<R0, W0, C0, C1, R1, W1, C2, C3, C4, C5, C6, C7, C8>(
     combining next: R1, into combined: R0
-  ) -> Regex<(Substring, C0, C1, C2?, C3?, C4?, C5?, C6?, C7?, C8?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1), R1.Match == (W1, C2, C3, C4, C5, C6, C7, C8) {
+  ) -> ChoiceOf<(Substring, C0, C1, C2?, C3?, C4?, C5?, C6?, C7?, C8?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1), R1.Match == (W1, C2, C3, C4, C5, C6, C7, C8) {
     .init(node: combined.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 
-public func | <R0, W0, C0, C1, R1, W1, C2, C3, C4, C5, C6, C7, C8>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1, C2?, C3?, C4?, C5?, C6?, C7?, C8?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1), R1.Match == (W1, C2, C3, C4, C5, C6, C7, C8) {
+public func | <R0, W0, C0, C1, R1, W1, C2, C3, C4, C5, C6, C7, C8>(lhs: R0, rhs: R1) -> ChoiceOf<(Substring, C0, C1, C2?, C3?, C4?, C5?, C6?, C7?, C8?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1), R1.Match == (W1, C2, C3, C4, C5, C6, C7, C8) {
   .init(node: lhs.regex.root.appendingAlternationCase(rhs.regex.root))
 }
 extension AlternationBuilder {
   public static func buildBlock<R0, W0, C0, C1, R1, W1, C2, C3, C4, C5, C6, C7, C8, C9>(
     combining next: R1, into combined: R0
-  ) -> Regex<(Substring, C0, C1, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1), R1.Match == (W1, C2, C3, C4, C5, C6, C7, C8, C9) {
+  ) -> ChoiceOf<(Substring, C0, C1, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1), R1.Match == (W1, C2, C3, C4, C5, C6, C7, C8, C9) {
     .init(node: combined.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 
-public func | <R0, W0, C0, C1, R1, W1, C2, C3, C4, C5, C6, C7, C8, C9>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1), R1.Match == (W1, C2, C3, C4, C5, C6, C7, C8, C9) {
+public func | <R0, W0, C0, C1, R1, W1, C2, C3, C4, C5, C6, C7, C8, C9>(lhs: R0, rhs: R1) -> ChoiceOf<(Substring, C0, C1, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1), R1.Match == (W1, C2, C3, C4, C5, C6, C7, C8, C9) {
   .init(node: lhs.regex.root.appendingAlternationCase(rhs.regex.root))
 }
 extension AlternationBuilder {
   public static func buildBlock<R0, W0, C0, C1, C2, R1>(
     combining next: R1, into combined: R0
-  ) -> Regex<(Substring, C0, C1, C2)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2) {
+  ) -> ChoiceOf<(Substring, C0, C1, C2)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2) {
     .init(node: combined.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 
-public func | <R0, W0, C0, C1, C2, R1>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1, C2)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2) {
+public func | <R0, W0, C0, C1, C2, R1>(lhs: R0, rhs: R1) -> ChoiceOf<(Substring, C0, C1, C2)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2) {
   .init(node: lhs.regex.root.appendingAlternationCase(rhs.regex.root))
 }
 extension AlternationBuilder {
   public static func buildBlock<R0, W0, C0, C1, C2, R1, W1, C3>(
     combining next: R1, into combined: R0
-  ) -> Regex<(Substring, C0, C1, C2, C3?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2), R1.Match == (W1, C3) {
+  ) -> ChoiceOf<(Substring, C0, C1, C2, C3?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2), R1.Match == (W1, C3) {
     .init(node: combined.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 
-public func | <R0, W0, C0, C1, C2, R1, W1, C3>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1, C2, C3?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2), R1.Match == (W1, C3) {
+public func | <R0, W0, C0, C1, C2, R1, W1, C3>(lhs: R0, rhs: R1) -> ChoiceOf<(Substring, C0, C1, C2, C3?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2), R1.Match == (W1, C3) {
   .init(node: lhs.regex.root.appendingAlternationCase(rhs.regex.root))
 }
 extension AlternationBuilder {
   public static func buildBlock<R0, W0, C0, C1, C2, R1, W1, C3, C4>(
     combining next: R1, into combined: R0
-  ) -> Regex<(Substring, C0, C1, C2, C3?, C4?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2), R1.Match == (W1, C3, C4) {
+  ) -> ChoiceOf<(Substring, C0, C1, C2, C3?, C4?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2), R1.Match == (W1, C3, C4) {
     .init(node: combined.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 
-public func | <R0, W0, C0, C1, C2, R1, W1, C3, C4>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1, C2, C3?, C4?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2), R1.Match == (W1, C3, C4) {
+public func | <R0, W0, C0, C1, C2, R1, W1, C3, C4>(lhs: R0, rhs: R1) -> ChoiceOf<(Substring, C0, C1, C2, C3?, C4?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2), R1.Match == (W1, C3, C4) {
   .init(node: lhs.regex.root.appendingAlternationCase(rhs.regex.root))
 }
 extension AlternationBuilder {
   public static func buildBlock<R0, W0, C0, C1, C2, R1, W1, C3, C4, C5>(
     combining next: R1, into combined: R0
-  ) -> Regex<(Substring, C0, C1, C2, C3?, C4?, C5?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2), R1.Match == (W1, C3, C4, C5) {
+  ) -> ChoiceOf<(Substring, C0, C1, C2, C3?, C4?, C5?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2), R1.Match == (W1, C3, C4, C5) {
     .init(node: combined.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 
-public func | <R0, W0, C0, C1, C2, R1, W1, C3, C4, C5>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1, C2, C3?, C4?, C5?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2), R1.Match == (W1, C3, C4, C5) {
+public func | <R0, W0, C0, C1, C2, R1, W1, C3, C4, C5>(lhs: R0, rhs: R1) -> ChoiceOf<(Substring, C0, C1, C2, C3?, C4?, C5?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2), R1.Match == (W1, C3, C4, C5) {
   .init(node: lhs.regex.root.appendingAlternationCase(rhs.regex.root))
 }
 extension AlternationBuilder {
   public static func buildBlock<R0, W0, C0, C1, C2, R1, W1, C3, C4, C5, C6>(
     combining next: R1, into combined: R0
-  ) -> Regex<(Substring, C0, C1, C2, C3?, C4?, C5?, C6?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2), R1.Match == (W1, C3, C4, C5, C6) {
+  ) -> ChoiceOf<(Substring, C0, C1, C2, C3?, C4?, C5?, C6?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2), R1.Match == (W1, C3, C4, C5, C6) {
     .init(node: combined.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 
-public func | <R0, W0, C0, C1, C2, R1, W1, C3, C4, C5, C6>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1, C2, C3?, C4?, C5?, C6?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2), R1.Match == (W1, C3, C4, C5, C6) {
+public func | <R0, W0, C0, C1, C2, R1, W1, C3, C4, C5, C6>(lhs: R0, rhs: R1) -> ChoiceOf<(Substring, C0, C1, C2, C3?, C4?, C5?, C6?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2), R1.Match == (W1, C3, C4, C5, C6) {
   .init(node: lhs.regex.root.appendingAlternationCase(rhs.regex.root))
 }
 extension AlternationBuilder {
   public static func buildBlock<R0, W0, C0, C1, C2, R1, W1, C3, C4, C5, C6, C7>(
     combining next: R1, into combined: R0
-  ) -> Regex<(Substring, C0, C1, C2, C3?, C4?, C5?, C6?, C7?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2), R1.Match == (W1, C3, C4, C5, C6, C7) {
+  ) -> ChoiceOf<(Substring, C0, C1, C2, C3?, C4?, C5?, C6?, C7?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2), R1.Match == (W1, C3, C4, C5, C6, C7) {
     .init(node: combined.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 
-public func | <R0, W0, C0, C1, C2, R1, W1, C3, C4, C5, C6, C7>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1, C2, C3?, C4?, C5?, C6?, C7?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2), R1.Match == (W1, C3, C4, C5, C6, C7) {
+public func | <R0, W0, C0, C1, C2, R1, W1, C3, C4, C5, C6, C7>(lhs: R0, rhs: R1) -> ChoiceOf<(Substring, C0, C1, C2, C3?, C4?, C5?, C6?, C7?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2), R1.Match == (W1, C3, C4, C5, C6, C7) {
   .init(node: lhs.regex.root.appendingAlternationCase(rhs.regex.root))
 }
 extension AlternationBuilder {
   public static func buildBlock<R0, W0, C0, C1, C2, R1, W1, C3, C4, C5, C6, C7, C8>(
     combining next: R1, into combined: R0
-  ) -> Regex<(Substring, C0, C1, C2, C3?, C4?, C5?, C6?, C7?, C8?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2), R1.Match == (W1, C3, C4, C5, C6, C7, C8) {
+  ) -> ChoiceOf<(Substring, C0, C1, C2, C3?, C4?, C5?, C6?, C7?, C8?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2), R1.Match == (W1, C3, C4, C5, C6, C7, C8) {
     .init(node: combined.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 
-public func | <R0, W0, C0, C1, C2, R1, W1, C3, C4, C5, C6, C7, C8>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1, C2, C3?, C4?, C5?, C6?, C7?, C8?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2), R1.Match == (W1, C3, C4, C5, C6, C7, C8) {
+public func | <R0, W0, C0, C1, C2, R1, W1, C3, C4, C5, C6, C7, C8>(lhs: R0, rhs: R1) -> ChoiceOf<(Substring, C0, C1, C2, C3?, C4?, C5?, C6?, C7?, C8?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2), R1.Match == (W1, C3, C4, C5, C6, C7, C8) {
   .init(node: lhs.regex.root.appendingAlternationCase(rhs.regex.root))
 }
 extension AlternationBuilder {
   public static func buildBlock<R0, W0, C0, C1, C2, R1, W1, C3, C4, C5, C6, C7, C8, C9>(
     combining next: R1, into combined: R0
-  ) -> Regex<(Substring, C0, C1, C2, C3?, C4?, C5?, C6?, C7?, C8?, C9?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2), R1.Match == (W1, C3, C4, C5, C6, C7, C8, C9) {
+  ) -> ChoiceOf<(Substring, C0, C1, C2, C3?, C4?, C5?, C6?, C7?, C8?, C9?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2), R1.Match == (W1, C3, C4, C5, C6, C7, C8, C9) {
     .init(node: combined.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 
-public func | <R0, W0, C0, C1, C2, R1, W1, C3, C4, C5, C6, C7, C8, C9>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1, C2, C3?, C4?, C5?, C6?, C7?, C8?, C9?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2), R1.Match == (W1, C3, C4, C5, C6, C7, C8, C9) {
+public func | <R0, W0, C0, C1, C2, R1, W1, C3, C4, C5, C6, C7, C8, C9>(lhs: R0, rhs: R1) -> ChoiceOf<(Substring, C0, C1, C2, C3?, C4?, C5?, C6?, C7?, C8?, C9?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2), R1.Match == (W1, C3, C4, C5, C6, C7, C8, C9) {
   .init(node: lhs.regex.root.appendingAlternationCase(rhs.regex.root))
 }
 extension AlternationBuilder {
   public static func buildBlock<R0, W0, C0, C1, C2, C3, R1>(
     combining next: R1, into combined: R0
-  ) -> Regex<(Substring, C0, C1, C2, C3)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3) {
+  ) -> ChoiceOf<(Substring, C0, C1, C2, C3)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3) {
     .init(node: combined.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 
-public func | <R0, W0, C0, C1, C2, C3, R1>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1, C2, C3)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3) {
+public func | <R0, W0, C0, C1, C2, C3, R1>(lhs: R0, rhs: R1) -> ChoiceOf<(Substring, C0, C1, C2, C3)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3) {
   .init(node: lhs.regex.root.appendingAlternationCase(rhs.regex.root))
 }
 extension AlternationBuilder {
   public static func buildBlock<R0, W0, C0, C1, C2, C3, R1, W1, C4>(
     combining next: R1, into combined: R0
-  ) -> Regex<(Substring, C0, C1, C2, C3, C4?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3), R1.Match == (W1, C4) {
+  ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3), R1.Match == (W1, C4) {
     .init(node: combined.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 
-public func | <R0, W0, C0, C1, C2, C3, R1, W1, C4>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1, C2, C3, C4?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3), R1.Match == (W1, C4) {
+public func | <R0, W0, C0, C1, C2, C3, R1, W1, C4>(lhs: R0, rhs: R1) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3), R1.Match == (W1, C4) {
   .init(node: lhs.regex.root.appendingAlternationCase(rhs.regex.root))
 }
 extension AlternationBuilder {
   public static func buildBlock<R0, W0, C0, C1, C2, C3, R1, W1, C4, C5>(
     combining next: R1, into combined: R0
-  ) -> Regex<(Substring, C0, C1, C2, C3, C4?, C5?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3), R1.Match == (W1, C4, C5) {
+  ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4?, C5?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3), R1.Match == (W1, C4, C5) {
     .init(node: combined.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 
-public func | <R0, W0, C0, C1, C2, C3, R1, W1, C4, C5>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1, C2, C3, C4?, C5?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3), R1.Match == (W1, C4, C5) {
+public func | <R0, W0, C0, C1, C2, C3, R1, W1, C4, C5>(lhs: R0, rhs: R1) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4?, C5?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3), R1.Match == (W1, C4, C5) {
   .init(node: lhs.regex.root.appendingAlternationCase(rhs.regex.root))
 }
 extension AlternationBuilder {
   public static func buildBlock<R0, W0, C0, C1, C2, C3, R1, W1, C4, C5, C6>(
     combining next: R1, into combined: R0
-  ) -> Regex<(Substring, C0, C1, C2, C3, C4?, C5?, C6?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3), R1.Match == (W1, C4, C5, C6) {
+  ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4?, C5?, C6?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3), R1.Match == (W1, C4, C5, C6) {
     .init(node: combined.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 
-public func | <R0, W0, C0, C1, C2, C3, R1, W1, C4, C5, C6>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1, C2, C3, C4?, C5?, C6?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3), R1.Match == (W1, C4, C5, C6) {
+public func | <R0, W0, C0, C1, C2, C3, R1, W1, C4, C5, C6>(lhs: R0, rhs: R1) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4?, C5?, C6?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3), R1.Match == (W1, C4, C5, C6) {
   .init(node: lhs.regex.root.appendingAlternationCase(rhs.regex.root))
 }
 extension AlternationBuilder {
   public static func buildBlock<R0, W0, C0, C1, C2, C3, R1, W1, C4, C5, C6, C7>(
     combining next: R1, into combined: R0
-  ) -> Regex<(Substring, C0, C1, C2, C3, C4?, C5?, C6?, C7?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3), R1.Match == (W1, C4, C5, C6, C7) {
+  ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4?, C5?, C6?, C7?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3), R1.Match == (W1, C4, C5, C6, C7) {
     .init(node: combined.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 
-public func | <R0, W0, C0, C1, C2, C3, R1, W1, C4, C5, C6, C7>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1, C2, C3, C4?, C5?, C6?, C7?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3), R1.Match == (W1, C4, C5, C6, C7) {
+public func | <R0, W0, C0, C1, C2, C3, R1, W1, C4, C5, C6, C7>(lhs: R0, rhs: R1) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4?, C5?, C6?, C7?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3), R1.Match == (W1, C4, C5, C6, C7) {
   .init(node: lhs.regex.root.appendingAlternationCase(rhs.regex.root))
 }
 extension AlternationBuilder {
   public static func buildBlock<R0, W0, C0, C1, C2, C3, R1, W1, C4, C5, C6, C7, C8>(
     combining next: R1, into combined: R0
-  ) -> Regex<(Substring, C0, C1, C2, C3, C4?, C5?, C6?, C7?, C8?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3), R1.Match == (W1, C4, C5, C6, C7, C8) {
+  ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4?, C5?, C6?, C7?, C8?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3), R1.Match == (W1, C4, C5, C6, C7, C8) {
     .init(node: combined.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 
-public func | <R0, W0, C0, C1, C2, C3, R1, W1, C4, C5, C6, C7, C8>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1, C2, C3, C4?, C5?, C6?, C7?, C8?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3), R1.Match == (W1, C4, C5, C6, C7, C8) {
+public func | <R0, W0, C0, C1, C2, C3, R1, W1, C4, C5, C6, C7, C8>(lhs: R0, rhs: R1) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4?, C5?, C6?, C7?, C8?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3), R1.Match == (W1, C4, C5, C6, C7, C8) {
   .init(node: lhs.regex.root.appendingAlternationCase(rhs.regex.root))
 }
 extension AlternationBuilder {
   public static func buildBlock<R0, W0, C0, C1, C2, C3, R1, W1, C4, C5, C6, C7, C8, C9>(
     combining next: R1, into combined: R0
-  ) -> Regex<(Substring, C0, C1, C2, C3, C4?, C5?, C6?, C7?, C8?, C9?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3), R1.Match == (W1, C4, C5, C6, C7, C8, C9) {
+  ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4?, C5?, C6?, C7?, C8?, C9?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3), R1.Match == (W1, C4, C5, C6, C7, C8, C9) {
     .init(node: combined.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 
-public func | <R0, W0, C0, C1, C2, C3, R1, W1, C4, C5, C6, C7, C8, C9>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1, C2, C3, C4?, C5?, C6?, C7?, C8?, C9?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3), R1.Match == (W1, C4, C5, C6, C7, C8, C9) {
+public func | <R0, W0, C0, C1, C2, C3, R1, W1, C4, C5, C6, C7, C8, C9>(lhs: R0, rhs: R1) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4?, C5?, C6?, C7?, C8?, C9?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3), R1.Match == (W1, C4, C5, C6, C7, C8, C9) {
   .init(node: lhs.regex.root.appendingAlternationCase(rhs.regex.root))
 }
 extension AlternationBuilder {
   public static func buildBlock<R0, W0, C0, C1, C2, C3, C4, R1>(
     combining next: R1, into combined: R0
-  ) -> Regex<(Substring, C0, C1, C2, C3, C4)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3, C4) {
+  ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3, C4) {
     .init(node: combined.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 
-public func | <R0, W0, C0, C1, C2, C3, C4, R1>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1, C2, C3, C4)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3, C4) {
+public func | <R0, W0, C0, C1, C2, C3, C4, R1>(lhs: R0, rhs: R1) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3, C4) {
   .init(node: lhs.regex.root.appendingAlternationCase(rhs.regex.root))
 }
 extension AlternationBuilder {
   public static func buildBlock<R0, W0, C0, C1, C2, C3, C4, R1, W1, C5>(
     combining next: R1, into combined: R0
-  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3, C4), R1.Match == (W1, C5) {
+  ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4, C5?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3, C4), R1.Match == (W1, C5) {
     .init(node: combined.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 
-public func | <R0, W0, C0, C1, C2, C3, C4, R1, W1, C5>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1, C2, C3, C4, C5?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3, C4), R1.Match == (W1, C5) {
+public func | <R0, W0, C0, C1, C2, C3, C4, R1, W1, C5>(lhs: R0, rhs: R1) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4, C5?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3, C4), R1.Match == (W1, C5) {
   .init(node: lhs.regex.root.appendingAlternationCase(rhs.regex.root))
 }
 extension AlternationBuilder {
   public static func buildBlock<R0, W0, C0, C1, C2, C3, C4, R1, W1, C5, C6>(
     combining next: R1, into combined: R0
-  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5?, C6?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3, C4), R1.Match == (W1, C5, C6) {
+  ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4, C5?, C6?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3, C4), R1.Match == (W1, C5, C6) {
     .init(node: combined.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 
-public func | <R0, W0, C0, C1, C2, C3, C4, R1, W1, C5, C6>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1, C2, C3, C4, C5?, C6?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3, C4), R1.Match == (W1, C5, C6) {
+public func | <R0, W0, C0, C1, C2, C3, C4, R1, W1, C5, C6>(lhs: R0, rhs: R1) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4, C5?, C6?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3, C4), R1.Match == (W1, C5, C6) {
   .init(node: lhs.regex.root.appendingAlternationCase(rhs.regex.root))
 }
 extension AlternationBuilder {
   public static func buildBlock<R0, W0, C0, C1, C2, C3, C4, R1, W1, C5, C6, C7>(
     combining next: R1, into combined: R0
-  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5?, C6?, C7?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3, C4), R1.Match == (W1, C5, C6, C7) {
+  ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4, C5?, C6?, C7?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3, C4), R1.Match == (W1, C5, C6, C7) {
     .init(node: combined.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 
-public func | <R0, W0, C0, C1, C2, C3, C4, R1, W1, C5, C6, C7>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1, C2, C3, C4, C5?, C6?, C7?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3, C4), R1.Match == (W1, C5, C6, C7) {
+public func | <R0, W0, C0, C1, C2, C3, C4, R1, W1, C5, C6, C7>(lhs: R0, rhs: R1) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4, C5?, C6?, C7?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3, C4), R1.Match == (W1, C5, C6, C7) {
   .init(node: lhs.regex.root.appendingAlternationCase(rhs.regex.root))
 }
 extension AlternationBuilder {
   public static func buildBlock<R0, W0, C0, C1, C2, C3, C4, R1, W1, C5, C6, C7, C8>(
     combining next: R1, into combined: R0
-  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5?, C6?, C7?, C8?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3, C4), R1.Match == (W1, C5, C6, C7, C8) {
+  ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4, C5?, C6?, C7?, C8?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3, C4), R1.Match == (W1, C5, C6, C7, C8) {
     .init(node: combined.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 
-public func | <R0, W0, C0, C1, C2, C3, C4, R1, W1, C5, C6, C7, C8>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1, C2, C3, C4, C5?, C6?, C7?, C8?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3, C4), R1.Match == (W1, C5, C6, C7, C8) {
+public func | <R0, W0, C0, C1, C2, C3, C4, R1, W1, C5, C6, C7, C8>(lhs: R0, rhs: R1) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4, C5?, C6?, C7?, C8?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3, C4), R1.Match == (W1, C5, C6, C7, C8) {
   .init(node: lhs.regex.root.appendingAlternationCase(rhs.regex.root))
 }
 extension AlternationBuilder {
   public static func buildBlock<R0, W0, C0, C1, C2, C3, C4, R1, W1, C5, C6, C7, C8, C9>(
     combining next: R1, into combined: R0
-  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5?, C6?, C7?, C8?, C9?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3, C4), R1.Match == (W1, C5, C6, C7, C8, C9) {
+  ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4, C5?, C6?, C7?, C8?, C9?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3, C4), R1.Match == (W1, C5, C6, C7, C8, C9) {
     .init(node: combined.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 
-public func | <R0, W0, C0, C1, C2, C3, C4, R1, W1, C5, C6, C7, C8, C9>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1, C2, C3, C4, C5?, C6?, C7?, C8?, C9?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3, C4), R1.Match == (W1, C5, C6, C7, C8, C9) {
+public func | <R0, W0, C0, C1, C2, C3, C4, R1, W1, C5, C6, C7, C8, C9>(lhs: R0, rhs: R1) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4, C5?, C6?, C7?, C8?, C9?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3, C4), R1.Match == (W1, C5, C6, C7, C8, C9) {
   .init(node: lhs.regex.root.appendingAlternationCase(rhs.regex.root))
 }
 extension AlternationBuilder {
   public static func buildBlock<R0, W0, C0, C1, C2, C3, C4, C5, R1>(
     combining next: R1, into combined: R0
-  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3, C4, C5) {
+  ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4, C5)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3, C4, C5) {
     .init(node: combined.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 
-public func | <R0, W0, C0, C1, C2, C3, C4, C5, R1>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1, C2, C3, C4, C5)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3, C4, C5) {
+public func | <R0, W0, C0, C1, C2, C3, C4, C5, R1>(lhs: R0, rhs: R1) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4, C5)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3, C4, C5) {
   .init(node: lhs.regex.root.appendingAlternationCase(rhs.regex.root))
 }
 extension AlternationBuilder {
   public static func buildBlock<R0, W0, C0, C1, C2, C3, C4, C5, R1, W1, C6>(
     combining next: R1, into combined: R0
-  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3, C4, C5), R1.Match == (W1, C6) {
+  ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4, C5, C6?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3, C4, C5), R1.Match == (W1, C6) {
     .init(node: combined.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 
-public func | <R0, W0, C0, C1, C2, C3, C4, C5, R1, W1, C6>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3, C4, C5), R1.Match == (W1, C6) {
+public func | <R0, W0, C0, C1, C2, C3, C4, C5, R1, W1, C6>(lhs: R0, rhs: R1) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4, C5, C6?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3, C4, C5), R1.Match == (W1, C6) {
   .init(node: lhs.regex.root.appendingAlternationCase(rhs.regex.root))
 }
 extension AlternationBuilder {
   public static func buildBlock<R0, W0, C0, C1, C2, C3, C4, C5, R1, W1, C6, C7>(
     combining next: R1, into combined: R0
-  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6?, C7?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3, C4, C5), R1.Match == (W1, C6, C7) {
+  ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4, C5, C6?, C7?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3, C4, C5), R1.Match == (W1, C6, C7) {
     .init(node: combined.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 
-public func | <R0, W0, C0, C1, C2, C3, C4, C5, R1, W1, C6, C7>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6?, C7?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3, C4, C5), R1.Match == (W1, C6, C7) {
+public func | <R0, W0, C0, C1, C2, C3, C4, C5, R1, W1, C6, C7>(lhs: R0, rhs: R1) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4, C5, C6?, C7?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3, C4, C5), R1.Match == (W1, C6, C7) {
   .init(node: lhs.regex.root.appendingAlternationCase(rhs.regex.root))
 }
 extension AlternationBuilder {
   public static func buildBlock<R0, W0, C0, C1, C2, C3, C4, C5, R1, W1, C6, C7, C8>(
     combining next: R1, into combined: R0
-  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6?, C7?, C8?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3, C4, C5), R1.Match == (W1, C6, C7, C8) {
+  ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4, C5, C6?, C7?, C8?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3, C4, C5), R1.Match == (W1, C6, C7, C8) {
     .init(node: combined.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 
-public func | <R0, W0, C0, C1, C2, C3, C4, C5, R1, W1, C6, C7, C8>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6?, C7?, C8?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3, C4, C5), R1.Match == (W1, C6, C7, C8) {
+public func | <R0, W0, C0, C1, C2, C3, C4, C5, R1, W1, C6, C7, C8>(lhs: R0, rhs: R1) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4, C5, C6?, C7?, C8?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3, C4, C5), R1.Match == (W1, C6, C7, C8) {
   .init(node: lhs.regex.root.appendingAlternationCase(rhs.regex.root))
 }
 extension AlternationBuilder {
   public static func buildBlock<R0, W0, C0, C1, C2, C3, C4, C5, R1, W1, C6, C7, C8, C9>(
     combining next: R1, into combined: R0
-  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6?, C7?, C8?, C9?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3, C4, C5), R1.Match == (W1, C6, C7, C8, C9) {
+  ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4, C5, C6?, C7?, C8?, C9?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3, C4, C5), R1.Match == (W1, C6, C7, C8, C9) {
     .init(node: combined.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 
-public func | <R0, W0, C0, C1, C2, C3, C4, C5, R1, W1, C6, C7, C8, C9>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6?, C7?, C8?, C9?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3, C4, C5), R1.Match == (W1, C6, C7, C8, C9) {
+public func | <R0, W0, C0, C1, C2, C3, C4, C5, R1, W1, C6, C7, C8, C9>(lhs: R0, rhs: R1) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4, C5, C6?, C7?, C8?, C9?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3, C4, C5), R1.Match == (W1, C6, C7, C8, C9) {
   .init(node: lhs.regex.root.appendingAlternationCase(rhs.regex.root))
 }
 extension AlternationBuilder {
   public static func buildBlock<R0, W0, C0, C1, C2, C3, C4, C5, C6, R1>(
     combining next: R1, into combined: R0
-  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3, C4, C5, C6) {
+  ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4, C5, C6)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3, C4, C5, C6) {
     .init(node: combined.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 
-public func | <R0, W0, C0, C1, C2, C3, C4, C5, C6, R1>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3, C4, C5, C6) {
+public func | <R0, W0, C0, C1, C2, C3, C4, C5, C6, R1>(lhs: R0, rhs: R1) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4, C5, C6)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3, C4, C5, C6) {
   .init(node: lhs.regex.root.appendingAlternationCase(rhs.regex.root))
 }
 extension AlternationBuilder {
   public static func buildBlock<R0, W0, C0, C1, C2, C3, C4, C5, C6, R1, W1, C7>(
     combining next: R1, into combined: R0
-  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3, C4, C5, C6), R1.Match == (W1, C7) {
+  ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4, C5, C6, C7?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3, C4, C5, C6), R1.Match == (W1, C7) {
     .init(node: combined.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 
-public func | <R0, W0, C0, C1, C2, C3, C4, C5, C6, R1, W1, C7>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3, C4, C5, C6), R1.Match == (W1, C7) {
+public func | <R0, W0, C0, C1, C2, C3, C4, C5, C6, R1, W1, C7>(lhs: R0, rhs: R1) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4, C5, C6, C7?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3, C4, C5, C6), R1.Match == (W1, C7) {
   .init(node: lhs.regex.root.appendingAlternationCase(rhs.regex.root))
 }
 extension AlternationBuilder {
   public static func buildBlock<R0, W0, C0, C1, C2, C3, C4, C5, C6, R1, W1, C7, C8>(
     combining next: R1, into combined: R0
-  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7?, C8?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3, C4, C5, C6), R1.Match == (W1, C7, C8) {
+  ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4, C5, C6, C7?, C8?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3, C4, C5, C6), R1.Match == (W1, C7, C8) {
     .init(node: combined.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 
-public func | <R0, W0, C0, C1, C2, C3, C4, C5, C6, R1, W1, C7, C8>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7?, C8?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3, C4, C5, C6), R1.Match == (W1, C7, C8) {
+public func | <R0, W0, C0, C1, C2, C3, C4, C5, C6, R1, W1, C7, C8>(lhs: R0, rhs: R1) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4, C5, C6, C7?, C8?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3, C4, C5, C6), R1.Match == (W1, C7, C8) {
   .init(node: lhs.regex.root.appendingAlternationCase(rhs.regex.root))
 }
 extension AlternationBuilder {
   public static func buildBlock<R0, W0, C0, C1, C2, C3, C4, C5, C6, R1, W1, C7, C8, C9>(
     combining next: R1, into combined: R0
-  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7?, C8?, C9?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3, C4, C5, C6), R1.Match == (W1, C7, C8, C9) {
+  ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4, C5, C6, C7?, C8?, C9?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3, C4, C5, C6), R1.Match == (W1, C7, C8, C9) {
     .init(node: combined.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 
-public func | <R0, W0, C0, C1, C2, C3, C4, C5, C6, R1, W1, C7, C8, C9>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7?, C8?, C9?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3, C4, C5, C6), R1.Match == (W1, C7, C8, C9) {
+public func | <R0, W0, C0, C1, C2, C3, C4, C5, C6, R1, W1, C7, C8, C9>(lhs: R0, rhs: R1) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4, C5, C6, C7?, C8?, C9?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3, C4, C5, C6), R1.Match == (W1, C7, C8, C9) {
   .init(node: lhs.regex.root.appendingAlternationCase(rhs.regex.root))
 }
 extension AlternationBuilder {
   public static func buildBlock<R0, W0, C0, C1, C2, C3, C4, C5, C6, C7, R1>(
     combining next: R1, into combined: R0
-  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3, C4, C5, C6, C7) {
+  ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4, C5, C6, C7)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3, C4, C5, C6, C7) {
     .init(node: combined.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 
-public func | <R0, W0, C0, C1, C2, C3, C4, C5, C6, C7, R1>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3, C4, C5, C6, C7) {
+public func | <R0, W0, C0, C1, C2, C3, C4, C5, C6, C7, R1>(lhs: R0, rhs: R1) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4, C5, C6, C7)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3, C4, C5, C6, C7) {
   .init(node: lhs.regex.root.appendingAlternationCase(rhs.regex.root))
 }
 extension AlternationBuilder {
   public static func buildBlock<R0, W0, C0, C1, C2, C3, C4, C5, C6, C7, R1, W1, C8>(
     combining next: R1, into combined: R0
-  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3, C4, C5, C6, C7), R1.Match == (W1, C8) {
+  ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3, C4, C5, C6, C7), R1.Match == (W1, C8) {
     .init(node: combined.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 
-public func | <R0, W0, C0, C1, C2, C3, C4, C5, C6, C7, R1, W1, C8>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3, C4, C5, C6, C7), R1.Match == (W1, C8) {
+public func | <R0, W0, C0, C1, C2, C3, C4, C5, C6, C7, R1, W1, C8>(lhs: R0, rhs: R1) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3, C4, C5, C6, C7), R1.Match == (W1, C8) {
   .init(node: lhs.regex.root.appendingAlternationCase(rhs.regex.root))
 }
 extension AlternationBuilder {
   public static func buildBlock<R0, W0, C0, C1, C2, C3, C4, C5, C6, C7, R1, W1, C8, C9>(
     combining next: R1, into combined: R0
-  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8?, C9?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3, C4, C5, C6, C7), R1.Match == (W1, C8, C9) {
+  ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8?, C9?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3, C4, C5, C6, C7), R1.Match == (W1, C8, C9) {
     .init(node: combined.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 
-public func | <R0, W0, C0, C1, C2, C3, C4, C5, C6, C7, R1, W1, C8, C9>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8?, C9?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3, C4, C5, C6, C7), R1.Match == (W1, C8, C9) {
+public func | <R0, W0, C0, C1, C2, C3, C4, C5, C6, C7, R1, W1, C8, C9>(lhs: R0, rhs: R1) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8?, C9?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3, C4, C5, C6, C7), R1.Match == (W1, C8, C9) {
   .init(node: lhs.regex.root.appendingAlternationCase(rhs.regex.root))
 }
 extension AlternationBuilder {
   public static func buildBlock<R0, W0, C0, C1, C2, C3, C4, C5, C6, C7, C8, R1>(
     combining next: R1, into combined: R0
-  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
+  ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
     .init(node: combined.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 
-public func | <R0, W0, C0, C1, C2, C3, C4, C5, C6, C7, C8, R1>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
+public func | <R0, W0, C0, C1, C2, C3, C4, C5, C6, C7, C8, R1>(lhs: R0, rhs: R1) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
   .init(node: lhs.regex.root.appendingAlternationCase(rhs.regex.root))
 }
 extension AlternationBuilder {
   public static func buildBlock<R0, W0, C0, C1, C2, C3, C4, C5, C6, C7, C8, R1, W1, C9>(
     combining next: R1, into combined: R0
-  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3, C4, C5, C6, C7, C8), R1.Match == (W1, C9) {
+  ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3, C4, C5, C6, C7, C8), R1.Match == (W1, C9) {
     .init(node: combined.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 
-public func | <R0, W0, C0, C1, C2, C3, C4, C5, C6, C7, C8, R1, W1, C9>(lhs: R0, rhs: R1) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3, C4, C5, C6, C7, C8), R1.Match == (W1, C9) {
+public func | <R0, W0, C0, C1, C2, C3, C4, C5, C6, C7, C8, R1, W1, C9>(lhs: R0, rhs: R1) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9?)> where R0: RegexComponent, R1: RegexComponent, R0.Match == (W0, C0, C1, C2, C3, C4, C5, C6, C7, C8), R1.Match == (W1, C9) {
   .init(node: lhs.regex.root.appendingAlternationCase(rhs.regex.root))
 }
 extension AlternationBuilder {
-  public static func buildBlock<R, W, C0>(_ regex: R) -> Regex<(W, C0?)> where R: RegexComponent, R.Match == (W, C0) {
+  public static func buildBlock<R, W, C0>(_ regex: R) -> ChoiceOf<(W, C0?)> where R: RegexComponent, R.Match == (W, C0) {
     .init(node: .alternation([regex.regex.root]))
   }
 }
 extension AlternationBuilder {
-  public static func buildBlock<R, W, C0, C1>(_ regex: R) -> Regex<(W, C0?, C1?)> where R: RegexComponent, R.Match == (W, C0, C1) {
+  public static func buildBlock<R, W, C0, C1>(_ regex: R) -> ChoiceOf<(W, C0?, C1?)> where R: RegexComponent, R.Match == (W, C0, C1) {
     .init(node: .alternation([regex.regex.root]))
   }
 }
 extension AlternationBuilder {
-  public static func buildBlock<R, W, C0, C1, C2>(_ regex: R) -> Regex<(W, C0?, C1?, C2?)> where R: RegexComponent, R.Match == (W, C0, C1, C2) {
+  public static func buildBlock<R, W, C0, C1, C2>(_ regex: R) -> ChoiceOf<(W, C0?, C1?, C2?)> where R: RegexComponent, R.Match == (W, C0, C1, C2) {
     .init(node: .alternation([regex.regex.root]))
   }
 }
 extension AlternationBuilder {
-  public static func buildBlock<R, W, C0, C1, C2, C3>(_ regex: R) -> Regex<(W, C0?, C1?, C2?, C3?)> where R: RegexComponent, R.Match == (W, C0, C1, C2, C3) {
+  public static func buildBlock<R, W, C0, C1, C2, C3>(_ regex: R) -> ChoiceOf<(W, C0?, C1?, C2?, C3?)> where R: RegexComponent, R.Match == (W, C0, C1, C2, C3) {
     .init(node: .alternation([regex.regex.root]))
   }
 }
 extension AlternationBuilder {
-  public static func buildBlock<R, W, C0, C1, C2, C3, C4>(_ regex: R) -> Regex<(W, C0?, C1?, C2?, C3?, C4?)> where R: RegexComponent, R.Match == (W, C0, C1, C2, C3, C4) {
+  public static func buildBlock<R, W, C0, C1, C2, C3, C4>(_ regex: R) -> ChoiceOf<(W, C0?, C1?, C2?, C3?, C4?)> where R: RegexComponent, R.Match == (W, C0, C1, C2, C3, C4) {
     .init(node: .alternation([regex.regex.root]))
   }
 }
 extension AlternationBuilder {
-  public static func buildBlock<R, W, C0, C1, C2, C3, C4, C5>(_ regex: R) -> Regex<(W, C0?, C1?, C2?, C3?, C4?, C5?)> where R: RegexComponent, R.Match == (W, C0, C1, C2, C3, C4, C5) {
+  public static func buildBlock<R, W, C0, C1, C2, C3, C4, C5>(_ regex: R) -> ChoiceOf<(W, C0?, C1?, C2?, C3?, C4?, C5?)> where R: RegexComponent, R.Match == (W, C0, C1, C2, C3, C4, C5) {
     .init(node: .alternation([regex.regex.root]))
   }
 }
 extension AlternationBuilder {
-  public static func buildBlock<R, W, C0, C1, C2, C3, C4, C5, C6>(_ regex: R) -> Regex<(W, C0?, C1?, C2?, C3?, C4?, C5?, C6?)> where R: RegexComponent, R.Match == (W, C0, C1, C2, C3, C4, C5, C6) {
+  public static func buildBlock<R, W, C0, C1, C2, C3, C4, C5, C6>(_ regex: R) -> ChoiceOf<(W, C0?, C1?, C2?, C3?, C4?, C5?, C6?)> where R: RegexComponent, R.Match == (W, C0, C1, C2, C3, C4, C5, C6) {
     .init(node: .alternation([regex.regex.root]))
   }
 }
 extension AlternationBuilder {
-  public static func buildBlock<R, W, C0, C1, C2, C3, C4, C5, C6, C7>(_ regex: R) -> Regex<(W, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?)> where R: RegexComponent, R.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
+  public static func buildBlock<R, W, C0, C1, C2, C3, C4, C5, C6, C7>(_ regex: R) -> ChoiceOf<(W, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?)> where R: RegexComponent, R.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
     .init(node: .alternation([regex.regex.root]))
   }
 }
 extension AlternationBuilder {
-  public static func buildBlock<R, W, C0, C1, C2, C3, C4, C5, C6, C7, C8>(_ regex: R) -> Regex<(W, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?)> where R: RegexComponent, R.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
+  public static func buildBlock<R, W, C0, C1, C2, C3, C4, C5, C6, C7, C8>(_ regex: R) -> ChoiceOf<(W, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?)> where R: RegexComponent, R.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
+    .init(node: .alternation([regex.regex.root]))
+  }
+}
+extension AlternationBuilder {
+  public static func buildBlock<R, W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9>(_ regex: R) -> ChoiceOf<(W, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?)> where R: RegexComponent, R.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
     .init(node: .alternation([regex.regex.root]))
   }
 }
 // MARK: - Non-builder capture arity 0
 
-public func capture<R: RegexComponent, W>(
-  _ component: R
-) -> Regex<(Substring, W)> where R.Match == W {
-  .init(node: .group(.capture, component.regex.root))
+extension Capture {
+  @_disfavoredOverload
+  public init<R: RegexComponent, W>(
+    _ component: R
+  ) where Match == (Substring, W), R.Match == W {
+    self.init(node: .group(.capture, component.regex.root))
+  }
+
+  @_disfavoredOverload
+  public init<R: RegexComponent, W>(
+    _ component: R, as reference: Reference<W>
+  ) where Match == (Substring, W), R.Match == W {
+    self.init(node: .group(.capture, component.regex.root, reference.id))
+  }
+
+  @_disfavoredOverload
+  public init<R: RegexComponent, W, NewCapture>(
+    _ component: R,
+    transform: @escaping (Substring) -> NewCapture
+  ) where Match == (Substring, NewCapture), R.Match == W {
+    self.init(node: .groupTransform(
+      .capture,
+      component.regex.root,
+      CaptureTransform(resultType: NewCapture.self) {
+        transform($0) as Any
+      }))
+  }
+
+  @_disfavoredOverload
+  public init<R: RegexComponent, W, NewCapture>(
+    _ component: R,
+    as reference: Reference<NewCapture>,
+    transform: @escaping (Substring) -> NewCapture
+  ) where Match == (Substring, NewCapture), R.Match == W {
+    self.init(node: .groupTransform(
+      .capture,
+      component.regex.root,
+      CaptureTransform(resultType: NewCapture.self) {
+        transform($0) as Any
+      },
+      reference.id))
+  }
 }
 
-public func capture<R: RegexComponent, W>(
-  _ component: R, as reference: Reference<W>
-) -> Regex<(Substring, W)> where R.Match == W {
-  .init(node: .group(.capture, component.regex.root, reference.id))
-}
+extension TryCapture {
+  @_disfavoredOverload
+  public init<R: RegexComponent, W, NewCapture>(
+    _ component: R,
+    transform: @escaping (Substring) throws -> NewCapture
+  ) where Match == (Substring, NewCapture), R.Match == W {
+    self.init(node: .groupTransform(
+      .capture,
+      component.regex.root,
+      CaptureTransform(resultType: NewCapture.self) {
+        try transform($0) as Any
+      }))
+  }
 
-public func capture<R: RegexComponent, W, NewCapture>(
-  _ component: R,
-  transform: @escaping (Substring) -> NewCapture
-) -> Regex<(Substring, NewCapture)> where R.Match == W {
-  .init(node: .groupTransform(
-    .capture,
-    component.regex.root,
-    CaptureTransform(resultType: NewCapture.self) {
-      transform($0) as Any
-    }))
-}
+  @_disfavoredOverload
+  public init<R: RegexComponent, W, NewCapture>(
+    _ component: R,
+    as reference: Reference<NewCapture>,
+    transform: @escaping (Substring) throws -> NewCapture
+  ) where Match == (Substring, NewCapture), R.Match == W {
+    self.init(node: .groupTransform(
+      .capture,
+      component.regex.root,
+      CaptureTransform(resultType: NewCapture.self) {
+        try transform($0) as Any
+      },
+      reference.id))
+  }
 
-public func capture<R: RegexComponent, W, NewCapture>(
-  _ component: R,
-  as reference: Reference<NewCapture>,
-  transform: @escaping (Substring) -> NewCapture
-) -> Regex<(Substring, NewCapture)> where R.Match == W {
-  .init(node: .groupTransform(
-    .capture,
-    component.regex.root,
-    CaptureTransform(resultType: NewCapture.self) {
-      transform($0) as Any
-    },
-    reference.id))
-}
+  @_disfavoredOverload
+  public init<R: RegexComponent, W, NewCapture>(
+    _ component: R,
+    transform: @escaping (Substring) -> NewCapture?
+  ) where Match == (Substring, NewCapture), R.Match == W {
+    self.init(node: .groupTransform(
+      .capture,
+      component.regex.root,
+      CaptureTransform(resultType: NewCapture.self) {
+        transform($0) as Any?
+      }))
+  }
 
-public func tryCapture<R: RegexComponent, W, NewCapture>(
-  _ component: R,
-  transform: @escaping (Substring) throws -> NewCapture
-) -> Regex<(Substring, NewCapture)> where R.Match == W {
-  .init(node: .groupTransform(
-    .capture,
-    component.regex.root,
-    CaptureTransform(resultType: NewCapture.self) {
-      try transform($0) as Any
-    }))
-}
-
-public func tryCapture<R: RegexComponent, W, NewCapture>(
-  _ component: R,
-  as reference: Reference<NewCapture>,
-  transform: @escaping (Substring) throws -> NewCapture
-) -> Regex<(Substring, NewCapture)> where R.Match == W {
-  .init(node: .groupTransform(
-    .capture,
-    component.regex.root,
-    CaptureTransform(resultType: NewCapture.self) {
-      try transform($0) as Any
-    },
-    reference.id))
-}
-
-public func tryCapture<R: RegexComponent, W, NewCapture>(
-  _ component: R,
-  transform: @escaping (Substring) -> NewCapture?
-) -> Regex<(Substring, NewCapture)> where R.Match == W {
-  .init(node: .groupTransform(
-    .capture,
-    component.regex.root,
-    CaptureTransform(resultType: NewCapture.self) {
-      transform($0) as Any?
-    }))
-}
-
-public func tryCapture<R: RegexComponent, W, NewCapture>(
-  _ component: R,
-  as reference: Reference<NewCapture>,
-  transform: @escaping (Substring) -> NewCapture?
-) -> Regex<(Substring, NewCapture)> where R.Match == W {
-  .init(node: .groupTransform(
-    .capture,
-    component.regex.root,
-    CaptureTransform(resultType: NewCapture.self) {
-      transform($0) as Any?
-    },
-    reference.id))
+  @_disfavoredOverload
+  public init<R: RegexComponent, W, NewCapture>(
+    _ component: R,
+    as reference: Reference<NewCapture>,
+    transform: @escaping (Substring) -> NewCapture?
+  ) where Match == (Substring, NewCapture), R.Match == W {
+    self.init(node: .groupTransform(
+      .capture,
+      component.regex.root,
+      CaptureTransform(resultType: NewCapture.self) {
+        transform($0) as Any?
+      },
+      reference.id))
+  }
 }
 
 // MARK: - Builder capture arity 0
 
-public func capture<R: RegexComponent, W>(
-  @RegexComponentBuilder _ component: () -> R
-) -> Regex<(Substring, W)> where R.Match == W {
-  .init(node: .group(.capture, component().regex.root))
+extension Capture {
+  @_disfavoredOverload
+  public init<R: RegexComponent, W>(
+    @RegexComponentBuilder _ component: () -> R
+  ) where Match == (Substring, W), R.Match == W {
+    self.init(node: .group(.capture, component().regex.root))
+  }
+
+  @_disfavoredOverload
+  public init<R: RegexComponent, W>(
+    as reference: Reference<W>,
+    @RegexComponentBuilder _ component: () -> R
+  ) where Match == (Substring, W), R.Match == W {
+    self.init(node: .group(.capture, component().regex.root, reference.id))
+  }
+
+  @_disfavoredOverload
+  public init<R: RegexComponent, W, NewCapture>(
+    @RegexComponentBuilder _ component: () -> R,
+    transform: @escaping (Substring) -> NewCapture
+  ) where Match == (Substring, NewCapture), R.Match == W {
+    self.init(node: .groupTransform(
+      .capture,
+      component().regex.root,
+      CaptureTransform(resultType: NewCapture.self) {
+        transform($0) as Any
+      }))
+  }
+
+  @_disfavoredOverload
+  public init<R: RegexComponent, W, NewCapture>(
+    as reference: Reference<NewCapture>,
+    @RegexComponentBuilder _ component: () -> R,
+    transform: @escaping (Substring) -> NewCapture
+  ) where Match == (Substring, NewCapture), R.Match == W {
+    self.init(node: .groupTransform(
+      .capture,
+      component().regex.root,
+      CaptureTransform(resultType: NewCapture.self) {
+        transform($0) as Any
+      },
+      reference.id))
+  }
 }
 
-public func capture<R: RegexComponent, W>(
-  as reference: Reference<W>,
-  @RegexComponentBuilder _ component: () -> R
-) -> Regex<(Substring, W)> where R.Match == W {
-  .init(node: .group(.capture, component().regex.root, reference.id))
-}
+extension TryCapture {
+  @_disfavoredOverload
+  public init<R: RegexComponent, W, NewCapture>(
+    @RegexComponentBuilder _ component: () -> R,
+    transform: @escaping (Substring) throws -> NewCapture
+  ) where Match == (Substring, NewCapture), R.Match == W {
+    self.init(node: .groupTransform(
+      .capture,
+      component().regex.root,
+      CaptureTransform(resultType: NewCapture.self) {
+        try transform($0) as Any
+      }))
+  }
 
-public func capture<R: RegexComponent, W, NewCapture>(
-  @RegexComponentBuilder _ component: () -> R,
-  transform: @escaping (Substring) -> NewCapture
-) -> Regex<(Substring, NewCapture)> where R.Match == W {
-  .init(node: .groupTransform(
-    .capture,
-    component().regex.root,
-    CaptureTransform(resultType: NewCapture.self) {
-      transform($0) as Any
-    }))
-}
+  @_disfavoredOverload
+  public init<R: RegexComponent, W, NewCapture>(
+    as reference: Reference<NewCapture>,
+    @RegexComponentBuilder _ component: () -> R,
+    transform: @escaping (Substring) throws -> NewCapture
+  ) where Match == (Substring, NewCapture), R.Match == W {
+    self.init(node: .groupTransform(
+      .capture,
+      component().regex.root,
+      CaptureTransform(resultType: NewCapture.self) {
+        try transform($0) as Any
+      },
+      reference.id))
+  }
 
-public func tryCapture<R: RegexComponent, W, NewCapture>(
-  as reference: Reference<NewCapture>,
-  @RegexComponentBuilder _ component: () -> R,
-  transform: @escaping (Substring) throws -> NewCapture
-) -> Regex<(Substring, NewCapture)> where R.Match == W {
-  .init(node: .groupTransform(
-    .capture,
-    component().regex.root,
-    CaptureTransform(resultType: NewCapture.self) {
-      try transform($0) as Any
-    },
-    reference.id))
-}
+  @_disfavoredOverload
+  public init<R: RegexComponent, W, NewCapture>(
+    @RegexComponentBuilder _ component: () -> R,
+    transform: @escaping (Substring) -> NewCapture?
+  ) where Match == (Substring, NewCapture), R.Match == W {
+    self.init(node: .groupTransform(
+      .capture,
+      component().regex.root,
+      CaptureTransform(resultType: NewCapture.self) {
+        transform($0) as Any?
+      }))
+  }
 
-public func tryCapture<R: RegexComponent, W, NewCapture>(
-  @RegexComponentBuilder _ component: () -> R,
-  transform: @escaping (Substring) -> NewCapture?
-) -> Regex<(Substring, NewCapture)> where R.Match == W {
-  .init(node: .groupTransform(
-    .capture,
-    component().regex.root,
-    CaptureTransform(resultType: NewCapture.self) {
-      transform($0) as Any?
-    }))
-}
-
-public func tryCapture<R: RegexComponent, W, NewCapture>(
-  as reference: Reference<NewCapture>,
-  @RegexComponentBuilder _ component: () -> R,
-  transform: @escaping (Substring) -> NewCapture?
-) -> Regex<(Substring, NewCapture)> where R.Match == W {
-  .init(node: .groupTransform(
-    .capture,
-    component().regex.root,
-    CaptureTransform(resultType: NewCapture.self) {
-      transform($0) as Any?
-    },
-    reference.id))
+  @_disfavoredOverload
+  public init<R: RegexComponent, W, NewCapture>(
+    as reference: Reference<NewCapture>,
+    @RegexComponentBuilder _ component: () -> R,
+    transform: @escaping (Substring) -> NewCapture?
+  ) where Match == (Substring, NewCapture), R.Match == W {
+    self.init(node: .groupTransform(
+      .capture,
+      component().regex.root,
+      CaptureTransform(resultType: NewCapture.self) {
+        transform($0) as Any?
+      },
+      reference.id))
+  }
 }
 
 // MARK: - Non-builder capture arity 1
 
-public func capture<R: RegexComponent, W, C0>(
-  _ component: R
-) -> Regex<(Substring, W, C0)> where R.Match == (W, C0) {
-  .init(node: .group(.capture, component.regex.root))
+extension Capture {
+    public init<R: RegexComponent, W, C0>(
+    _ component: R
+  ) where Match == (Substring, W, C0), R.Match == (W, C0) {
+    self.init(node: .group(.capture, component.regex.root))
+  }
+
+    public init<R: RegexComponent, W, C0>(
+    _ component: R, as reference: Reference<W>
+  ) where Match == (Substring, W, C0), R.Match == (W, C0) {
+    self.init(node: .group(.capture, component.regex.root, reference.id))
+  }
+
+    public init<R: RegexComponent, W, C0, NewCapture>(
+    _ component: R,
+    transform: @escaping (Substring) -> NewCapture
+  ) where Match == (Substring, NewCapture, C0), R.Match == (W, C0) {
+    self.init(node: .groupTransform(
+      .capture,
+      component.regex.root,
+      CaptureTransform(resultType: NewCapture.self) {
+        transform($0) as Any
+      }))
+  }
+
+    public init<R: RegexComponent, W, C0, NewCapture>(
+    _ component: R,
+    as reference: Reference<NewCapture>,
+    transform: @escaping (Substring) -> NewCapture
+  ) where Match == (Substring, NewCapture, C0), R.Match == (W, C0) {
+    self.init(node: .groupTransform(
+      .capture,
+      component.regex.root,
+      CaptureTransform(resultType: NewCapture.self) {
+        transform($0) as Any
+      },
+      reference.id))
+  }
 }
 
-public func capture<R: RegexComponent, W, C0>(
-  _ component: R, as reference: Reference<W>
-) -> Regex<(Substring, W, C0)> where R.Match == (W, C0) {
-  .init(node: .group(.capture, component.regex.root, reference.id))
-}
+extension TryCapture {
+    public init<R: RegexComponent, W, C0, NewCapture>(
+    _ component: R,
+    transform: @escaping (Substring) throws -> NewCapture
+  ) where Match == (Substring, NewCapture, C0), R.Match == (W, C0) {
+    self.init(node: .groupTransform(
+      .capture,
+      component.regex.root,
+      CaptureTransform(resultType: NewCapture.self) {
+        try transform($0) as Any
+      }))
+  }
 
-public func capture<R: RegexComponent, W, C0, NewCapture>(
-  _ component: R,
-  transform: @escaping (Substring) -> NewCapture
-) -> Regex<(Substring, NewCapture, C0)> where R.Match == (W, C0) {
-  .init(node: .groupTransform(
-    .capture,
-    component.regex.root,
-    CaptureTransform(resultType: NewCapture.self) {
-      transform($0) as Any
-    }))
-}
+    public init<R: RegexComponent, W, C0, NewCapture>(
+    _ component: R,
+    as reference: Reference<NewCapture>,
+    transform: @escaping (Substring) throws -> NewCapture
+  ) where Match == (Substring, NewCapture, C0), R.Match == (W, C0) {
+    self.init(node: .groupTransform(
+      .capture,
+      component.regex.root,
+      CaptureTransform(resultType: NewCapture.self) {
+        try transform($0) as Any
+      },
+      reference.id))
+  }
 
-public func capture<R: RegexComponent, W, C0, NewCapture>(
-  _ component: R,
-  as reference: Reference<NewCapture>,
-  transform: @escaping (Substring) -> NewCapture
-) -> Regex<(Substring, NewCapture, C0)> where R.Match == (W, C0) {
-  .init(node: .groupTransform(
-    .capture,
-    component.regex.root,
-    CaptureTransform(resultType: NewCapture.self) {
-      transform($0) as Any
-    },
-    reference.id))
-}
+    public init<R: RegexComponent, W, C0, NewCapture>(
+    _ component: R,
+    transform: @escaping (Substring) -> NewCapture?
+  ) where Match == (Substring, NewCapture, C0), R.Match == (W, C0) {
+    self.init(node: .groupTransform(
+      .capture,
+      component.regex.root,
+      CaptureTransform(resultType: NewCapture.self) {
+        transform($0) as Any?
+      }))
+  }
 
-public func tryCapture<R: RegexComponent, W, C0, NewCapture>(
-  _ component: R,
-  transform: @escaping (Substring) throws -> NewCapture
-) -> Regex<(Substring, NewCapture, C0)> where R.Match == (W, C0) {
-  .init(node: .groupTransform(
-    .capture,
-    component.regex.root,
-    CaptureTransform(resultType: NewCapture.self) {
-      try transform($0) as Any
-    }))
-}
-
-public func tryCapture<R: RegexComponent, W, C0, NewCapture>(
-  _ component: R,
-  as reference: Reference<NewCapture>,
-  transform: @escaping (Substring) throws -> NewCapture
-) -> Regex<(Substring, NewCapture, C0)> where R.Match == (W, C0) {
-  .init(node: .groupTransform(
-    .capture,
-    component.regex.root,
-    CaptureTransform(resultType: NewCapture.self) {
-      try transform($0) as Any
-    },
-    reference.id))
-}
-
-public func tryCapture<R: RegexComponent, W, C0, NewCapture>(
-  _ component: R,
-  transform: @escaping (Substring) -> NewCapture?
-) -> Regex<(Substring, NewCapture, C0)> where R.Match == (W, C0) {
-  .init(node: .groupTransform(
-    .capture,
-    component.regex.root,
-    CaptureTransform(resultType: NewCapture.self) {
-      transform($0) as Any?
-    }))
-}
-
-public func tryCapture<R: RegexComponent, W, C0, NewCapture>(
-  _ component: R,
-  as reference: Reference<NewCapture>,
-  transform: @escaping (Substring) -> NewCapture?
-) -> Regex<(Substring, NewCapture, C0)> where R.Match == (W, C0) {
-  .init(node: .groupTransform(
-    .capture,
-    component.regex.root,
-    CaptureTransform(resultType: NewCapture.self) {
-      transform($0) as Any?
-    },
-    reference.id))
+    public init<R: RegexComponent, W, C0, NewCapture>(
+    _ component: R,
+    as reference: Reference<NewCapture>,
+    transform: @escaping (Substring) -> NewCapture?
+  ) where Match == (Substring, NewCapture, C0), R.Match == (W, C0) {
+    self.init(node: .groupTransform(
+      .capture,
+      component.regex.root,
+      CaptureTransform(resultType: NewCapture.self) {
+        transform($0) as Any?
+      },
+      reference.id))
+  }
 }
 
 // MARK: - Builder capture arity 1
 
-public func capture<R: RegexComponent, W, C0>(
-  @RegexComponentBuilder _ component: () -> R
-) -> Regex<(Substring, W, C0)> where R.Match == (W, C0) {
-  .init(node: .group(.capture, component().regex.root))
+extension Capture {
+    public init<R: RegexComponent, W, C0>(
+    @RegexComponentBuilder _ component: () -> R
+  ) where Match == (Substring, W, C0), R.Match == (W, C0) {
+    self.init(node: .group(.capture, component().regex.root))
+  }
+
+    public init<R: RegexComponent, W, C0>(
+    as reference: Reference<W>,
+    @RegexComponentBuilder _ component: () -> R
+  ) where Match == (Substring, W, C0), R.Match == (W, C0) {
+    self.init(node: .group(.capture, component().regex.root, reference.id))
+  }
+
+    public init<R: RegexComponent, W, C0, NewCapture>(
+    @RegexComponentBuilder _ component: () -> R,
+    transform: @escaping (Substring) -> NewCapture
+  ) where Match == (Substring, NewCapture, C0), R.Match == (W, C0) {
+    self.init(node: .groupTransform(
+      .capture,
+      component().regex.root,
+      CaptureTransform(resultType: NewCapture.self) {
+        transform($0) as Any
+      }))
+  }
+
+    public init<R: RegexComponent, W, C0, NewCapture>(
+    as reference: Reference<NewCapture>,
+    @RegexComponentBuilder _ component: () -> R,
+    transform: @escaping (Substring) -> NewCapture
+  ) where Match == (Substring, NewCapture, C0), R.Match == (W, C0) {
+    self.init(node: .groupTransform(
+      .capture,
+      component().regex.root,
+      CaptureTransform(resultType: NewCapture.self) {
+        transform($0) as Any
+      },
+      reference.id))
+  }
 }
 
-public func capture<R: RegexComponent, W, C0>(
-  as reference: Reference<W>,
-  @RegexComponentBuilder _ component: () -> R
-) -> Regex<(Substring, W, C0)> where R.Match == (W, C0) {
-  .init(node: .group(.capture, component().regex.root, reference.id))
-}
+extension TryCapture {
+    public init<R: RegexComponent, W, C0, NewCapture>(
+    @RegexComponentBuilder _ component: () -> R,
+    transform: @escaping (Substring) throws -> NewCapture
+  ) where Match == (Substring, NewCapture, C0), R.Match == (W, C0) {
+    self.init(node: .groupTransform(
+      .capture,
+      component().regex.root,
+      CaptureTransform(resultType: NewCapture.self) {
+        try transform($0) as Any
+      }))
+  }
 
-public func capture<R: RegexComponent, W, C0, NewCapture>(
-  @RegexComponentBuilder _ component: () -> R,
-  transform: @escaping (Substring) -> NewCapture
-) -> Regex<(Substring, NewCapture, C0)> where R.Match == (W, C0) {
-  .init(node: .groupTransform(
-    .capture,
-    component().regex.root,
-    CaptureTransform(resultType: NewCapture.self) {
-      transform($0) as Any
-    }))
-}
+    public init<R: RegexComponent, W, C0, NewCapture>(
+    as reference: Reference<NewCapture>,
+    @RegexComponentBuilder _ component: () -> R,
+    transform: @escaping (Substring) throws -> NewCapture
+  ) where Match == (Substring, NewCapture, C0), R.Match == (W, C0) {
+    self.init(node: .groupTransform(
+      .capture,
+      component().regex.root,
+      CaptureTransform(resultType: NewCapture.self) {
+        try transform($0) as Any
+      },
+      reference.id))
+  }
 
-public func tryCapture<R: RegexComponent, W, C0, NewCapture>(
-  as reference: Reference<NewCapture>,
-  @RegexComponentBuilder _ component: () -> R,
-  transform: @escaping (Substring) throws -> NewCapture
-) -> Regex<(Substring, NewCapture, C0)> where R.Match == (W, C0) {
-  .init(node: .groupTransform(
-    .capture,
-    component().regex.root,
-    CaptureTransform(resultType: NewCapture.self) {
-      try transform($0) as Any
-    },
-    reference.id))
-}
+    public init<R: RegexComponent, W, C0, NewCapture>(
+    @RegexComponentBuilder _ component: () -> R,
+    transform: @escaping (Substring) -> NewCapture?
+  ) where Match == (Substring, NewCapture, C0), R.Match == (W, C0) {
+    self.init(node: .groupTransform(
+      .capture,
+      component().regex.root,
+      CaptureTransform(resultType: NewCapture.self) {
+        transform($0) as Any?
+      }))
+  }
 
-public func tryCapture<R: RegexComponent, W, C0, NewCapture>(
-  @RegexComponentBuilder _ component: () -> R,
-  transform: @escaping (Substring) -> NewCapture?
-) -> Regex<(Substring, NewCapture, C0)> where R.Match == (W, C0) {
-  .init(node: .groupTransform(
-    .capture,
-    component().regex.root,
-    CaptureTransform(resultType: NewCapture.self) {
-      transform($0) as Any?
-    }))
-}
-
-public func tryCapture<R: RegexComponent, W, C0, NewCapture>(
-  as reference: Reference<NewCapture>,
-  @RegexComponentBuilder _ component: () -> R,
-  transform: @escaping (Substring) -> NewCapture?
-) -> Regex<(Substring, NewCapture, C0)> where R.Match == (W, C0) {
-  .init(node: .groupTransform(
-    .capture,
-    component().regex.root,
-    CaptureTransform(resultType: NewCapture.self) {
-      transform($0) as Any?
-    },
-    reference.id))
+    public init<R: RegexComponent, W, C0, NewCapture>(
+    as reference: Reference<NewCapture>,
+    @RegexComponentBuilder _ component: () -> R,
+    transform: @escaping (Substring) -> NewCapture?
+  ) where Match == (Substring, NewCapture, C0), R.Match == (W, C0) {
+    self.init(node: .groupTransform(
+      .capture,
+      component().regex.root,
+      CaptureTransform(resultType: NewCapture.self) {
+        transform($0) as Any?
+      },
+      reference.id))
+  }
 }
 
 // MARK: - Non-builder capture arity 2
 
-public func capture<R: RegexComponent, W, C0, C1>(
-  _ component: R
-) -> Regex<(Substring, W, C0, C1)> where R.Match == (W, C0, C1) {
-  .init(node: .group(.capture, component.regex.root))
+extension Capture {
+    public init<R: RegexComponent, W, C0, C1>(
+    _ component: R
+  ) where Match == (Substring, W, C0, C1), R.Match == (W, C0, C1) {
+    self.init(node: .group(.capture, component.regex.root))
+  }
+
+    public init<R: RegexComponent, W, C0, C1>(
+    _ component: R, as reference: Reference<W>
+  ) where Match == (Substring, W, C0, C1), R.Match == (W, C0, C1) {
+    self.init(node: .group(.capture, component.regex.root, reference.id))
+  }
+
+    public init<R: RegexComponent, W, C0, C1, NewCapture>(
+    _ component: R,
+    transform: @escaping (Substring) -> NewCapture
+  ) where Match == (Substring, NewCapture, C0, C1), R.Match == (W, C0, C1) {
+    self.init(node: .groupTransform(
+      .capture,
+      component.regex.root,
+      CaptureTransform(resultType: NewCapture.self) {
+        transform($0) as Any
+      }))
+  }
+
+    public init<R: RegexComponent, W, C0, C1, NewCapture>(
+    _ component: R,
+    as reference: Reference<NewCapture>,
+    transform: @escaping (Substring) -> NewCapture
+  ) where Match == (Substring, NewCapture, C0, C1), R.Match == (W, C0, C1) {
+    self.init(node: .groupTransform(
+      .capture,
+      component.regex.root,
+      CaptureTransform(resultType: NewCapture.self) {
+        transform($0) as Any
+      },
+      reference.id))
+  }
 }
 
-public func capture<R: RegexComponent, W, C0, C1>(
-  _ component: R, as reference: Reference<W>
-) -> Regex<(Substring, W, C0, C1)> where R.Match == (W, C0, C1) {
-  .init(node: .group(.capture, component.regex.root, reference.id))
-}
+extension TryCapture {
+    public init<R: RegexComponent, W, C0, C1, NewCapture>(
+    _ component: R,
+    transform: @escaping (Substring) throws -> NewCapture
+  ) where Match == (Substring, NewCapture, C0, C1), R.Match == (W, C0, C1) {
+    self.init(node: .groupTransform(
+      .capture,
+      component.regex.root,
+      CaptureTransform(resultType: NewCapture.self) {
+        try transform($0) as Any
+      }))
+  }
 
-public func capture<R: RegexComponent, W, C0, C1, NewCapture>(
-  _ component: R,
-  transform: @escaping (Substring) -> NewCapture
-) -> Regex<(Substring, NewCapture, C0, C1)> where R.Match == (W, C0, C1) {
-  .init(node: .groupTransform(
-    .capture,
-    component.regex.root,
-    CaptureTransform(resultType: NewCapture.self) {
-      transform($0) as Any
-    }))
-}
+    public init<R: RegexComponent, W, C0, C1, NewCapture>(
+    _ component: R,
+    as reference: Reference<NewCapture>,
+    transform: @escaping (Substring) throws -> NewCapture
+  ) where Match == (Substring, NewCapture, C0, C1), R.Match == (W, C0, C1) {
+    self.init(node: .groupTransform(
+      .capture,
+      component.regex.root,
+      CaptureTransform(resultType: NewCapture.self) {
+        try transform($0) as Any
+      },
+      reference.id))
+  }
 
-public func capture<R: RegexComponent, W, C0, C1, NewCapture>(
-  _ component: R,
-  as reference: Reference<NewCapture>,
-  transform: @escaping (Substring) -> NewCapture
-) -> Regex<(Substring, NewCapture, C0, C1)> where R.Match == (W, C0, C1) {
-  .init(node: .groupTransform(
-    .capture,
-    component.regex.root,
-    CaptureTransform(resultType: NewCapture.self) {
-      transform($0) as Any
-    },
-    reference.id))
-}
+    public init<R: RegexComponent, W, C0, C1, NewCapture>(
+    _ component: R,
+    transform: @escaping (Substring) -> NewCapture?
+  ) where Match == (Substring, NewCapture, C0, C1), R.Match == (W, C0, C1) {
+    self.init(node: .groupTransform(
+      .capture,
+      component.regex.root,
+      CaptureTransform(resultType: NewCapture.self) {
+        transform($0) as Any?
+      }))
+  }
 
-public func tryCapture<R: RegexComponent, W, C0, C1, NewCapture>(
-  _ component: R,
-  transform: @escaping (Substring) throws -> NewCapture
-) -> Regex<(Substring, NewCapture, C0, C1)> where R.Match == (W, C0, C1) {
-  .init(node: .groupTransform(
-    .capture,
-    component.regex.root,
-    CaptureTransform(resultType: NewCapture.self) {
-      try transform($0) as Any
-    }))
-}
-
-public func tryCapture<R: RegexComponent, W, C0, C1, NewCapture>(
-  _ component: R,
-  as reference: Reference<NewCapture>,
-  transform: @escaping (Substring) throws -> NewCapture
-) -> Regex<(Substring, NewCapture, C0, C1)> where R.Match == (W, C0, C1) {
-  .init(node: .groupTransform(
-    .capture,
-    component.regex.root,
-    CaptureTransform(resultType: NewCapture.self) {
-      try transform($0) as Any
-    },
-    reference.id))
-}
-
-public func tryCapture<R: RegexComponent, W, C0, C1, NewCapture>(
-  _ component: R,
-  transform: @escaping (Substring) -> NewCapture?
-) -> Regex<(Substring, NewCapture, C0, C1)> where R.Match == (W, C0, C1) {
-  .init(node: .groupTransform(
-    .capture,
-    component.regex.root,
-    CaptureTransform(resultType: NewCapture.self) {
-      transform($0) as Any?
-    }))
-}
-
-public func tryCapture<R: RegexComponent, W, C0, C1, NewCapture>(
-  _ component: R,
-  as reference: Reference<NewCapture>,
-  transform: @escaping (Substring) -> NewCapture?
-) -> Regex<(Substring, NewCapture, C0, C1)> where R.Match == (W, C0, C1) {
-  .init(node: .groupTransform(
-    .capture,
-    component.regex.root,
-    CaptureTransform(resultType: NewCapture.self) {
-      transform($0) as Any?
-    },
-    reference.id))
+    public init<R: RegexComponent, W, C0, C1, NewCapture>(
+    _ component: R,
+    as reference: Reference<NewCapture>,
+    transform: @escaping (Substring) -> NewCapture?
+  ) where Match == (Substring, NewCapture, C0, C1), R.Match == (W, C0, C1) {
+    self.init(node: .groupTransform(
+      .capture,
+      component.regex.root,
+      CaptureTransform(resultType: NewCapture.self) {
+        transform($0) as Any?
+      },
+      reference.id))
+  }
 }
 
 // MARK: - Builder capture arity 2
 
-public func capture<R: RegexComponent, W, C0, C1>(
-  @RegexComponentBuilder _ component: () -> R
-) -> Regex<(Substring, W, C0, C1)> where R.Match == (W, C0, C1) {
-  .init(node: .group(.capture, component().regex.root))
+extension Capture {
+    public init<R: RegexComponent, W, C0, C1>(
+    @RegexComponentBuilder _ component: () -> R
+  ) where Match == (Substring, W, C0, C1), R.Match == (W, C0, C1) {
+    self.init(node: .group(.capture, component().regex.root))
+  }
+
+    public init<R: RegexComponent, W, C0, C1>(
+    as reference: Reference<W>,
+    @RegexComponentBuilder _ component: () -> R
+  ) where Match == (Substring, W, C0, C1), R.Match == (W, C0, C1) {
+    self.init(node: .group(.capture, component().regex.root, reference.id))
+  }
+
+    public init<R: RegexComponent, W, C0, C1, NewCapture>(
+    @RegexComponentBuilder _ component: () -> R,
+    transform: @escaping (Substring) -> NewCapture
+  ) where Match == (Substring, NewCapture, C0, C1), R.Match == (W, C0, C1) {
+    self.init(node: .groupTransform(
+      .capture,
+      component().regex.root,
+      CaptureTransform(resultType: NewCapture.self) {
+        transform($0) as Any
+      }))
+  }
+
+    public init<R: RegexComponent, W, C0, C1, NewCapture>(
+    as reference: Reference<NewCapture>,
+    @RegexComponentBuilder _ component: () -> R,
+    transform: @escaping (Substring) -> NewCapture
+  ) where Match == (Substring, NewCapture, C0, C1), R.Match == (W, C0, C1) {
+    self.init(node: .groupTransform(
+      .capture,
+      component().regex.root,
+      CaptureTransform(resultType: NewCapture.self) {
+        transform($0) as Any
+      },
+      reference.id))
+  }
 }
 
-public func capture<R: RegexComponent, W, C0, C1>(
-  as reference: Reference<W>,
-  @RegexComponentBuilder _ component: () -> R
-) -> Regex<(Substring, W, C0, C1)> where R.Match == (W, C0, C1) {
-  .init(node: .group(.capture, component().regex.root, reference.id))
-}
+extension TryCapture {
+    public init<R: RegexComponent, W, C0, C1, NewCapture>(
+    @RegexComponentBuilder _ component: () -> R,
+    transform: @escaping (Substring) throws -> NewCapture
+  ) where Match == (Substring, NewCapture, C0, C1), R.Match == (W, C0, C1) {
+    self.init(node: .groupTransform(
+      .capture,
+      component().regex.root,
+      CaptureTransform(resultType: NewCapture.self) {
+        try transform($0) as Any
+      }))
+  }
 
-public func capture<R: RegexComponent, W, C0, C1, NewCapture>(
-  @RegexComponentBuilder _ component: () -> R,
-  transform: @escaping (Substring) -> NewCapture
-) -> Regex<(Substring, NewCapture, C0, C1)> where R.Match == (W, C0, C1) {
-  .init(node: .groupTransform(
-    .capture,
-    component().regex.root,
-    CaptureTransform(resultType: NewCapture.self) {
-      transform($0) as Any
-    }))
-}
+    public init<R: RegexComponent, W, C0, C1, NewCapture>(
+    as reference: Reference<NewCapture>,
+    @RegexComponentBuilder _ component: () -> R,
+    transform: @escaping (Substring) throws -> NewCapture
+  ) where Match == (Substring, NewCapture, C0, C1), R.Match == (W, C0, C1) {
+    self.init(node: .groupTransform(
+      .capture,
+      component().regex.root,
+      CaptureTransform(resultType: NewCapture.self) {
+        try transform($0) as Any
+      },
+      reference.id))
+  }
 
-public func tryCapture<R: RegexComponent, W, C0, C1, NewCapture>(
-  as reference: Reference<NewCapture>,
-  @RegexComponentBuilder _ component: () -> R,
-  transform: @escaping (Substring) throws -> NewCapture
-) -> Regex<(Substring, NewCapture, C0, C1)> where R.Match == (W, C0, C1) {
-  .init(node: .groupTransform(
-    .capture,
-    component().regex.root,
-    CaptureTransform(resultType: NewCapture.self) {
-      try transform($0) as Any
-    },
-    reference.id))
-}
+    public init<R: RegexComponent, W, C0, C1, NewCapture>(
+    @RegexComponentBuilder _ component: () -> R,
+    transform: @escaping (Substring) -> NewCapture?
+  ) where Match == (Substring, NewCapture, C0, C1), R.Match == (W, C0, C1) {
+    self.init(node: .groupTransform(
+      .capture,
+      component().regex.root,
+      CaptureTransform(resultType: NewCapture.self) {
+        transform($0) as Any?
+      }))
+  }
 
-public func tryCapture<R: RegexComponent, W, C0, C1, NewCapture>(
-  @RegexComponentBuilder _ component: () -> R,
-  transform: @escaping (Substring) -> NewCapture?
-) -> Regex<(Substring, NewCapture, C0, C1)> where R.Match == (W, C0, C1) {
-  .init(node: .groupTransform(
-    .capture,
-    component().regex.root,
-    CaptureTransform(resultType: NewCapture.self) {
-      transform($0) as Any?
-    }))
-}
-
-public func tryCapture<R: RegexComponent, W, C0, C1, NewCapture>(
-  as reference: Reference<NewCapture>,
-  @RegexComponentBuilder _ component: () -> R,
-  transform: @escaping (Substring) -> NewCapture?
-) -> Regex<(Substring, NewCapture, C0, C1)> where R.Match == (W, C0, C1) {
-  .init(node: .groupTransform(
-    .capture,
-    component().regex.root,
-    CaptureTransform(resultType: NewCapture.self) {
-      transform($0) as Any?
-    },
-    reference.id))
+    public init<R: RegexComponent, W, C0, C1, NewCapture>(
+    as reference: Reference<NewCapture>,
+    @RegexComponentBuilder _ component: () -> R,
+    transform: @escaping (Substring) -> NewCapture?
+  ) where Match == (Substring, NewCapture, C0, C1), R.Match == (W, C0, C1) {
+    self.init(node: .groupTransform(
+      .capture,
+      component().regex.root,
+      CaptureTransform(resultType: NewCapture.self) {
+        transform($0) as Any?
+      },
+      reference.id))
+  }
 }
 
 // MARK: - Non-builder capture arity 3
 
-public func capture<R: RegexComponent, W, C0, C1, C2>(
-  _ component: R
-) -> Regex<(Substring, W, C0, C1, C2)> where R.Match == (W, C0, C1, C2) {
-  .init(node: .group(.capture, component.regex.root))
+extension Capture {
+    public init<R: RegexComponent, W, C0, C1, C2>(
+    _ component: R
+  ) where Match == (Substring, W, C0, C1, C2), R.Match == (W, C0, C1, C2) {
+    self.init(node: .group(.capture, component.regex.root))
+  }
+
+    public init<R: RegexComponent, W, C0, C1, C2>(
+    _ component: R, as reference: Reference<W>
+  ) where Match == (Substring, W, C0, C1, C2), R.Match == (W, C0, C1, C2) {
+    self.init(node: .group(.capture, component.regex.root, reference.id))
+  }
+
+    public init<R: RegexComponent, W, C0, C1, C2, NewCapture>(
+    _ component: R,
+    transform: @escaping (Substring) -> NewCapture
+  ) where Match == (Substring, NewCapture, C0, C1, C2), R.Match == (W, C0, C1, C2) {
+    self.init(node: .groupTransform(
+      .capture,
+      component.regex.root,
+      CaptureTransform(resultType: NewCapture.self) {
+        transform($0) as Any
+      }))
+  }
+
+    public init<R: RegexComponent, W, C0, C1, C2, NewCapture>(
+    _ component: R,
+    as reference: Reference<NewCapture>,
+    transform: @escaping (Substring) -> NewCapture
+  ) where Match == (Substring, NewCapture, C0, C1, C2), R.Match == (W, C0, C1, C2) {
+    self.init(node: .groupTransform(
+      .capture,
+      component.regex.root,
+      CaptureTransform(resultType: NewCapture.self) {
+        transform($0) as Any
+      },
+      reference.id))
+  }
 }
 
-public func capture<R: RegexComponent, W, C0, C1, C2>(
-  _ component: R, as reference: Reference<W>
-) -> Regex<(Substring, W, C0, C1, C2)> where R.Match == (W, C0, C1, C2) {
-  .init(node: .group(.capture, component.regex.root, reference.id))
-}
+extension TryCapture {
+    public init<R: RegexComponent, W, C0, C1, C2, NewCapture>(
+    _ component: R,
+    transform: @escaping (Substring) throws -> NewCapture
+  ) where Match == (Substring, NewCapture, C0, C1, C2), R.Match == (W, C0, C1, C2) {
+    self.init(node: .groupTransform(
+      .capture,
+      component.regex.root,
+      CaptureTransform(resultType: NewCapture.self) {
+        try transform($0) as Any
+      }))
+  }
 
-public func capture<R: RegexComponent, W, C0, C1, C2, NewCapture>(
-  _ component: R,
-  transform: @escaping (Substring) -> NewCapture
-) -> Regex<(Substring, NewCapture, C0, C1, C2)> where R.Match == (W, C0, C1, C2) {
-  .init(node: .groupTransform(
-    .capture,
-    component.regex.root,
-    CaptureTransform(resultType: NewCapture.self) {
-      transform($0) as Any
-    }))
-}
+    public init<R: RegexComponent, W, C0, C1, C2, NewCapture>(
+    _ component: R,
+    as reference: Reference<NewCapture>,
+    transform: @escaping (Substring) throws -> NewCapture
+  ) where Match == (Substring, NewCapture, C0, C1, C2), R.Match == (W, C0, C1, C2) {
+    self.init(node: .groupTransform(
+      .capture,
+      component.regex.root,
+      CaptureTransform(resultType: NewCapture.self) {
+        try transform($0) as Any
+      },
+      reference.id))
+  }
 
-public func capture<R: RegexComponent, W, C0, C1, C2, NewCapture>(
-  _ component: R,
-  as reference: Reference<NewCapture>,
-  transform: @escaping (Substring) -> NewCapture
-) -> Regex<(Substring, NewCapture, C0, C1, C2)> where R.Match == (W, C0, C1, C2) {
-  .init(node: .groupTransform(
-    .capture,
-    component.regex.root,
-    CaptureTransform(resultType: NewCapture.self) {
-      transform($0) as Any
-    },
-    reference.id))
-}
+    public init<R: RegexComponent, W, C0, C1, C2, NewCapture>(
+    _ component: R,
+    transform: @escaping (Substring) -> NewCapture?
+  ) where Match == (Substring, NewCapture, C0, C1, C2), R.Match == (W, C0, C1, C2) {
+    self.init(node: .groupTransform(
+      .capture,
+      component.regex.root,
+      CaptureTransform(resultType: NewCapture.self) {
+        transform($0) as Any?
+      }))
+  }
 
-public func tryCapture<R: RegexComponent, W, C0, C1, C2, NewCapture>(
-  _ component: R,
-  transform: @escaping (Substring) throws -> NewCapture
-) -> Regex<(Substring, NewCapture, C0, C1, C2)> where R.Match == (W, C0, C1, C2) {
-  .init(node: .groupTransform(
-    .capture,
-    component.regex.root,
-    CaptureTransform(resultType: NewCapture.self) {
-      try transform($0) as Any
-    }))
-}
-
-public func tryCapture<R: RegexComponent, W, C0, C1, C2, NewCapture>(
-  _ component: R,
-  as reference: Reference<NewCapture>,
-  transform: @escaping (Substring) throws -> NewCapture
-) -> Regex<(Substring, NewCapture, C0, C1, C2)> where R.Match == (W, C0, C1, C2) {
-  .init(node: .groupTransform(
-    .capture,
-    component.regex.root,
-    CaptureTransform(resultType: NewCapture.self) {
-      try transform($0) as Any
-    },
-    reference.id))
-}
-
-public func tryCapture<R: RegexComponent, W, C0, C1, C2, NewCapture>(
-  _ component: R,
-  transform: @escaping (Substring) -> NewCapture?
-) -> Regex<(Substring, NewCapture, C0, C1, C2)> where R.Match == (W, C0, C1, C2) {
-  .init(node: .groupTransform(
-    .capture,
-    component.regex.root,
-    CaptureTransform(resultType: NewCapture.self) {
-      transform($0) as Any?
-    }))
-}
-
-public func tryCapture<R: RegexComponent, W, C0, C1, C2, NewCapture>(
-  _ component: R,
-  as reference: Reference<NewCapture>,
-  transform: @escaping (Substring) -> NewCapture?
-) -> Regex<(Substring, NewCapture, C0, C1, C2)> where R.Match == (W, C0, C1, C2) {
-  .init(node: .groupTransform(
-    .capture,
-    component.regex.root,
-    CaptureTransform(resultType: NewCapture.self) {
-      transform($0) as Any?
-    },
-    reference.id))
+    public init<R: RegexComponent, W, C0, C1, C2, NewCapture>(
+    _ component: R,
+    as reference: Reference<NewCapture>,
+    transform: @escaping (Substring) -> NewCapture?
+  ) where Match == (Substring, NewCapture, C0, C1, C2), R.Match == (W, C0, C1, C2) {
+    self.init(node: .groupTransform(
+      .capture,
+      component.regex.root,
+      CaptureTransform(resultType: NewCapture.self) {
+        transform($0) as Any?
+      },
+      reference.id))
+  }
 }
 
 // MARK: - Builder capture arity 3
 
-public func capture<R: RegexComponent, W, C0, C1, C2>(
-  @RegexComponentBuilder _ component: () -> R
-) -> Regex<(Substring, W, C0, C1, C2)> where R.Match == (W, C0, C1, C2) {
-  .init(node: .group(.capture, component().regex.root))
+extension Capture {
+    public init<R: RegexComponent, W, C0, C1, C2>(
+    @RegexComponentBuilder _ component: () -> R
+  ) where Match == (Substring, W, C0, C1, C2), R.Match == (W, C0, C1, C2) {
+    self.init(node: .group(.capture, component().regex.root))
+  }
+
+    public init<R: RegexComponent, W, C0, C1, C2>(
+    as reference: Reference<W>,
+    @RegexComponentBuilder _ component: () -> R
+  ) where Match == (Substring, W, C0, C1, C2), R.Match == (W, C0, C1, C2) {
+    self.init(node: .group(.capture, component().regex.root, reference.id))
+  }
+
+    public init<R: RegexComponent, W, C0, C1, C2, NewCapture>(
+    @RegexComponentBuilder _ component: () -> R,
+    transform: @escaping (Substring) -> NewCapture
+  ) where Match == (Substring, NewCapture, C0, C1, C2), R.Match == (W, C0, C1, C2) {
+    self.init(node: .groupTransform(
+      .capture,
+      component().regex.root,
+      CaptureTransform(resultType: NewCapture.self) {
+        transform($0) as Any
+      }))
+  }
+
+    public init<R: RegexComponent, W, C0, C1, C2, NewCapture>(
+    as reference: Reference<NewCapture>,
+    @RegexComponentBuilder _ component: () -> R,
+    transform: @escaping (Substring) -> NewCapture
+  ) where Match == (Substring, NewCapture, C0, C1, C2), R.Match == (W, C0, C1, C2) {
+    self.init(node: .groupTransform(
+      .capture,
+      component().regex.root,
+      CaptureTransform(resultType: NewCapture.self) {
+        transform($0) as Any
+      },
+      reference.id))
+  }
 }
 
-public func capture<R: RegexComponent, W, C0, C1, C2>(
-  as reference: Reference<W>,
-  @RegexComponentBuilder _ component: () -> R
-) -> Regex<(Substring, W, C0, C1, C2)> where R.Match == (W, C0, C1, C2) {
-  .init(node: .group(.capture, component().regex.root, reference.id))
-}
+extension TryCapture {
+    public init<R: RegexComponent, W, C0, C1, C2, NewCapture>(
+    @RegexComponentBuilder _ component: () -> R,
+    transform: @escaping (Substring) throws -> NewCapture
+  ) where Match == (Substring, NewCapture, C0, C1, C2), R.Match == (W, C0, C1, C2) {
+    self.init(node: .groupTransform(
+      .capture,
+      component().regex.root,
+      CaptureTransform(resultType: NewCapture.self) {
+        try transform($0) as Any
+      }))
+  }
 
-public func capture<R: RegexComponent, W, C0, C1, C2, NewCapture>(
-  @RegexComponentBuilder _ component: () -> R,
-  transform: @escaping (Substring) -> NewCapture
-) -> Regex<(Substring, NewCapture, C0, C1, C2)> where R.Match == (W, C0, C1, C2) {
-  .init(node: .groupTransform(
-    .capture,
-    component().regex.root,
-    CaptureTransform(resultType: NewCapture.self) {
-      transform($0) as Any
-    }))
-}
+    public init<R: RegexComponent, W, C0, C1, C2, NewCapture>(
+    as reference: Reference<NewCapture>,
+    @RegexComponentBuilder _ component: () -> R,
+    transform: @escaping (Substring) throws -> NewCapture
+  ) where Match == (Substring, NewCapture, C0, C1, C2), R.Match == (W, C0, C1, C2) {
+    self.init(node: .groupTransform(
+      .capture,
+      component().regex.root,
+      CaptureTransform(resultType: NewCapture.self) {
+        try transform($0) as Any
+      },
+      reference.id))
+  }
 
-public func tryCapture<R: RegexComponent, W, C0, C1, C2, NewCapture>(
-  as reference: Reference<NewCapture>,
-  @RegexComponentBuilder _ component: () -> R,
-  transform: @escaping (Substring) throws -> NewCapture
-) -> Regex<(Substring, NewCapture, C0, C1, C2)> where R.Match == (W, C0, C1, C2) {
-  .init(node: .groupTransform(
-    .capture,
-    component().regex.root,
-    CaptureTransform(resultType: NewCapture.self) {
-      try transform($0) as Any
-    },
-    reference.id))
-}
+    public init<R: RegexComponent, W, C0, C1, C2, NewCapture>(
+    @RegexComponentBuilder _ component: () -> R,
+    transform: @escaping (Substring) -> NewCapture?
+  ) where Match == (Substring, NewCapture, C0, C1, C2), R.Match == (W, C0, C1, C2) {
+    self.init(node: .groupTransform(
+      .capture,
+      component().regex.root,
+      CaptureTransform(resultType: NewCapture.self) {
+        transform($0) as Any?
+      }))
+  }
 
-public func tryCapture<R: RegexComponent, W, C0, C1, C2, NewCapture>(
-  @RegexComponentBuilder _ component: () -> R,
-  transform: @escaping (Substring) -> NewCapture?
-) -> Regex<(Substring, NewCapture, C0, C1, C2)> where R.Match == (W, C0, C1, C2) {
-  .init(node: .groupTransform(
-    .capture,
-    component().regex.root,
-    CaptureTransform(resultType: NewCapture.self) {
-      transform($0) as Any?
-    }))
-}
-
-public func tryCapture<R: RegexComponent, W, C0, C1, C2, NewCapture>(
-  as reference: Reference<NewCapture>,
-  @RegexComponentBuilder _ component: () -> R,
-  transform: @escaping (Substring) -> NewCapture?
-) -> Regex<(Substring, NewCapture, C0, C1, C2)> where R.Match == (W, C0, C1, C2) {
-  .init(node: .groupTransform(
-    .capture,
-    component().regex.root,
-    CaptureTransform(resultType: NewCapture.self) {
-      transform($0) as Any?
-    },
-    reference.id))
+    public init<R: RegexComponent, W, C0, C1, C2, NewCapture>(
+    as reference: Reference<NewCapture>,
+    @RegexComponentBuilder _ component: () -> R,
+    transform: @escaping (Substring) -> NewCapture?
+  ) where Match == (Substring, NewCapture, C0, C1, C2), R.Match == (W, C0, C1, C2) {
+    self.init(node: .groupTransform(
+      .capture,
+      component().regex.root,
+      CaptureTransform(resultType: NewCapture.self) {
+        transform($0) as Any?
+      },
+      reference.id))
+  }
 }
 
 // MARK: - Non-builder capture arity 4
 
-public func capture<R: RegexComponent, W, C0, C1, C2, C3>(
-  _ component: R
-) -> Regex<(Substring, W, C0, C1, C2, C3)> where R.Match == (W, C0, C1, C2, C3) {
-  .init(node: .group(.capture, component.regex.root))
+extension Capture {
+    public init<R: RegexComponent, W, C0, C1, C2, C3>(
+    _ component: R
+  ) where Match == (Substring, W, C0, C1, C2, C3), R.Match == (W, C0, C1, C2, C3) {
+    self.init(node: .group(.capture, component.regex.root))
+  }
+
+    public init<R: RegexComponent, W, C0, C1, C2, C3>(
+    _ component: R, as reference: Reference<W>
+  ) where Match == (Substring, W, C0, C1, C2, C3), R.Match == (W, C0, C1, C2, C3) {
+    self.init(node: .group(.capture, component.regex.root, reference.id))
+  }
+
+    public init<R: RegexComponent, W, C0, C1, C2, C3, NewCapture>(
+    _ component: R,
+    transform: @escaping (Substring) -> NewCapture
+  ) where Match == (Substring, NewCapture, C0, C1, C2, C3), R.Match == (W, C0, C1, C2, C3) {
+    self.init(node: .groupTransform(
+      .capture,
+      component.regex.root,
+      CaptureTransform(resultType: NewCapture.self) {
+        transform($0) as Any
+      }))
+  }
+
+    public init<R: RegexComponent, W, C0, C1, C2, C3, NewCapture>(
+    _ component: R,
+    as reference: Reference<NewCapture>,
+    transform: @escaping (Substring) -> NewCapture
+  ) where Match == (Substring, NewCapture, C0, C1, C2, C3), R.Match == (W, C0, C1, C2, C3) {
+    self.init(node: .groupTransform(
+      .capture,
+      component.regex.root,
+      CaptureTransform(resultType: NewCapture.self) {
+        transform($0) as Any
+      },
+      reference.id))
+  }
 }
 
-public func capture<R: RegexComponent, W, C0, C1, C2, C3>(
-  _ component: R, as reference: Reference<W>
-) -> Regex<(Substring, W, C0, C1, C2, C3)> where R.Match == (W, C0, C1, C2, C3) {
-  .init(node: .group(.capture, component.regex.root, reference.id))
-}
+extension TryCapture {
+    public init<R: RegexComponent, W, C0, C1, C2, C3, NewCapture>(
+    _ component: R,
+    transform: @escaping (Substring) throws -> NewCapture
+  ) where Match == (Substring, NewCapture, C0, C1, C2, C3), R.Match == (W, C0, C1, C2, C3) {
+    self.init(node: .groupTransform(
+      .capture,
+      component.regex.root,
+      CaptureTransform(resultType: NewCapture.self) {
+        try transform($0) as Any
+      }))
+  }
 
-public func capture<R: RegexComponent, W, C0, C1, C2, C3, NewCapture>(
-  _ component: R,
-  transform: @escaping (Substring) -> NewCapture
-) -> Regex<(Substring, NewCapture, C0, C1, C2, C3)> where R.Match == (W, C0, C1, C2, C3) {
-  .init(node: .groupTransform(
-    .capture,
-    component.regex.root,
-    CaptureTransform(resultType: NewCapture.self) {
-      transform($0) as Any
-    }))
-}
+    public init<R: RegexComponent, W, C0, C1, C2, C3, NewCapture>(
+    _ component: R,
+    as reference: Reference<NewCapture>,
+    transform: @escaping (Substring) throws -> NewCapture
+  ) where Match == (Substring, NewCapture, C0, C1, C2, C3), R.Match == (W, C0, C1, C2, C3) {
+    self.init(node: .groupTransform(
+      .capture,
+      component.regex.root,
+      CaptureTransform(resultType: NewCapture.self) {
+        try transform($0) as Any
+      },
+      reference.id))
+  }
 
-public func capture<R: RegexComponent, W, C0, C1, C2, C3, NewCapture>(
-  _ component: R,
-  as reference: Reference<NewCapture>,
-  transform: @escaping (Substring) -> NewCapture
-) -> Regex<(Substring, NewCapture, C0, C1, C2, C3)> where R.Match == (W, C0, C1, C2, C3) {
-  .init(node: .groupTransform(
-    .capture,
-    component.regex.root,
-    CaptureTransform(resultType: NewCapture.self) {
-      transform($0) as Any
-    },
-    reference.id))
-}
+    public init<R: RegexComponent, W, C0, C1, C2, C3, NewCapture>(
+    _ component: R,
+    transform: @escaping (Substring) -> NewCapture?
+  ) where Match == (Substring, NewCapture, C0, C1, C2, C3), R.Match == (W, C0, C1, C2, C3) {
+    self.init(node: .groupTransform(
+      .capture,
+      component.regex.root,
+      CaptureTransform(resultType: NewCapture.self) {
+        transform($0) as Any?
+      }))
+  }
 
-public func tryCapture<R: RegexComponent, W, C0, C1, C2, C3, NewCapture>(
-  _ component: R,
-  transform: @escaping (Substring) throws -> NewCapture
-) -> Regex<(Substring, NewCapture, C0, C1, C2, C3)> where R.Match == (W, C0, C1, C2, C3) {
-  .init(node: .groupTransform(
-    .capture,
-    component.regex.root,
-    CaptureTransform(resultType: NewCapture.self) {
-      try transform($0) as Any
-    }))
-}
-
-public func tryCapture<R: RegexComponent, W, C0, C1, C2, C3, NewCapture>(
-  _ component: R,
-  as reference: Reference<NewCapture>,
-  transform: @escaping (Substring) throws -> NewCapture
-) -> Regex<(Substring, NewCapture, C0, C1, C2, C3)> where R.Match == (W, C0, C1, C2, C3) {
-  .init(node: .groupTransform(
-    .capture,
-    component.regex.root,
-    CaptureTransform(resultType: NewCapture.self) {
-      try transform($0) as Any
-    },
-    reference.id))
-}
-
-public func tryCapture<R: RegexComponent, W, C0, C1, C2, C3, NewCapture>(
-  _ component: R,
-  transform: @escaping (Substring) -> NewCapture?
-) -> Regex<(Substring, NewCapture, C0, C1, C2, C3)> where R.Match == (W, C0, C1, C2, C3) {
-  .init(node: .groupTransform(
-    .capture,
-    component.regex.root,
-    CaptureTransform(resultType: NewCapture.self) {
-      transform($0) as Any?
-    }))
-}
-
-public func tryCapture<R: RegexComponent, W, C0, C1, C2, C3, NewCapture>(
-  _ component: R,
-  as reference: Reference<NewCapture>,
-  transform: @escaping (Substring) -> NewCapture?
-) -> Regex<(Substring, NewCapture, C0, C1, C2, C3)> where R.Match == (W, C0, C1, C2, C3) {
-  .init(node: .groupTransform(
-    .capture,
-    component.regex.root,
-    CaptureTransform(resultType: NewCapture.self) {
-      transform($0) as Any?
-    },
-    reference.id))
+    public init<R: RegexComponent, W, C0, C1, C2, C3, NewCapture>(
+    _ component: R,
+    as reference: Reference<NewCapture>,
+    transform: @escaping (Substring) -> NewCapture?
+  ) where Match == (Substring, NewCapture, C0, C1, C2, C3), R.Match == (W, C0, C1, C2, C3) {
+    self.init(node: .groupTransform(
+      .capture,
+      component.regex.root,
+      CaptureTransform(resultType: NewCapture.self) {
+        transform($0) as Any?
+      },
+      reference.id))
+  }
 }
 
 // MARK: - Builder capture arity 4
 
-public func capture<R: RegexComponent, W, C0, C1, C2, C3>(
-  @RegexComponentBuilder _ component: () -> R
-) -> Regex<(Substring, W, C0, C1, C2, C3)> where R.Match == (W, C0, C1, C2, C3) {
-  .init(node: .group(.capture, component().regex.root))
+extension Capture {
+    public init<R: RegexComponent, W, C0, C1, C2, C3>(
+    @RegexComponentBuilder _ component: () -> R
+  ) where Match == (Substring, W, C0, C1, C2, C3), R.Match == (W, C0, C1, C2, C3) {
+    self.init(node: .group(.capture, component().regex.root))
+  }
+
+    public init<R: RegexComponent, W, C0, C1, C2, C3>(
+    as reference: Reference<W>,
+    @RegexComponentBuilder _ component: () -> R
+  ) where Match == (Substring, W, C0, C1, C2, C3), R.Match == (W, C0, C1, C2, C3) {
+    self.init(node: .group(.capture, component().regex.root, reference.id))
+  }
+
+    public init<R: RegexComponent, W, C0, C1, C2, C3, NewCapture>(
+    @RegexComponentBuilder _ component: () -> R,
+    transform: @escaping (Substring) -> NewCapture
+  ) where Match == (Substring, NewCapture, C0, C1, C2, C3), R.Match == (W, C0, C1, C2, C3) {
+    self.init(node: .groupTransform(
+      .capture,
+      component().regex.root,
+      CaptureTransform(resultType: NewCapture.self) {
+        transform($0) as Any
+      }))
+  }
+
+    public init<R: RegexComponent, W, C0, C1, C2, C3, NewCapture>(
+    as reference: Reference<NewCapture>,
+    @RegexComponentBuilder _ component: () -> R,
+    transform: @escaping (Substring) -> NewCapture
+  ) where Match == (Substring, NewCapture, C0, C1, C2, C3), R.Match == (W, C0, C1, C2, C3) {
+    self.init(node: .groupTransform(
+      .capture,
+      component().regex.root,
+      CaptureTransform(resultType: NewCapture.self) {
+        transform($0) as Any
+      },
+      reference.id))
+  }
 }
 
-public func capture<R: RegexComponent, W, C0, C1, C2, C3>(
-  as reference: Reference<W>,
-  @RegexComponentBuilder _ component: () -> R
-) -> Regex<(Substring, W, C0, C1, C2, C3)> where R.Match == (W, C0, C1, C2, C3) {
-  .init(node: .group(.capture, component().regex.root, reference.id))
-}
+extension TryCapture {
+    public init<R: RegexComponent, W, C0, C1, C2, C3, NewCapture>(
+    @RegexComponentBuilder _ component: () -> R,
+    transform: @escaping (Substring) throws -> NewCapture
+  ) where Match == (Substring, NewCapture, C0, C1, C2, C3), R.Match == (W, C0, C1, C2, C3) {
+    self.init(node: .groupTransform(
+      .capture,
+      component().regex.root,
+      CaptureTransform(resultType: NewCapture.self) {
+        try transform($0) as Any
+      }))
+  }
 
-public func capture<R: RegexComponent, W, C0, C1, C2, C3, NewCapture>(
-  @RegexComponentBuilder _ component: () -> R,
-  transform: @escaping (Substring) -> NewCapture
-) -> Regex<(Substring, NewCapture, C0, C1, C2, C3)> where R.Match == (W, C0, C1, C2, C3) {
-  .init(node: .groupTransform(
-    .capture,
-    component().regex.root,
-    CaptureTransform(resultType: NewCapture.self) {
-      transform($0) as Any
-    }))
-}
+    public init<R: RegexComponent, W, C0, C1, C2, C3, NewCapture>(
+    as reference: Reference<NewCapture>,
+    @RegexComponentBuilder _ component: () -> R,
+    transform: @escaping (Substring) throws -> NewCapture
+  ) where Match == (Substring, NewCapture, C0, C1, C2, C3), R.Match == (W, C0, C1, C2, C3) {
+    self.init(node: .groupTransform(
+      .capture,
+      component().regex.root,
+      CaptureTransform(resultType: NewCapture.self) {
+        try transform($0) as Any
+      },
+      reference.id))
+  }
 
-public func tryCapture<R: RegexComponent, W, C0, C1, C2, C3, NewCapture>(
-  as reference: Reference<NewCapture>,
-  @RegexComponentBuilder _ component: () -> R,
-  transform: @escaping (Substring) throws -> NewCapture
-) -> Regex<(Substring, NewCapture, C0, C1, C2, C3)> where R.Match == (W, C0, C1, C2, C3) {
-  .init(node: .groupTransform(
-    .capture,
-    component().regex.root,
-    CaptureTransform(resultType: NewCapture.self) {
-      try transform($0) as Any
-    },
-    reference.id))
-}
+    public init<R: RegexComponent, W, C0, C1, C2, C3, NewCapture>(
+    @RegexComponentBuilder _ component: () -> R,
+    transform: @escaping (Substring) -> NewCapture?
+  ) where Match == (Substring, NewCapture, C0, C1, C2, C3), R.Match == (W, C0, C1, C2, C3) {
+    self.init(node: .groupTransform(
+      .capture,
+      component().regex.root,
+      CaptureTransform(resultType: NewCapture.self) {
+        transform($0) as Any?
+      }))
+  }
 
-public func tryCapture<R: RegexComponent, W, C0, C1, C2, C3, NewCapture>(
-  @RegexComponentBuilder _ component: () -> R,
-  transform: @escaping (Substring) -> NewCapture?
-) -> Regex<(Substring, NewCapture, C0, C1, C2, C3)> where R.Match == (W, C0, C1, C2, C3) {
-  .init(node: .groupTransform(
-    .capture,
-    component().regex.root,
-    CaptureTransform(resultType: NewCapture.self) {
-      transform($0) as Any?
-    }))
-}
-
-public func tryCapture<R: RegexComponent, W, C0, C1, C2, C3, NewCapture>(
-  as reference: Reference<NewCapture>,
-  @RegexComponentBuilder _ component: () -> R,
-  transform: @escaping (Substring) -> NewCapture?
-) -> Regex<(Substring, NewCapture, C0, C1, C2, C3)> where R.Match == (W, C0, C1, C2, C3) {
-  .init(node: .groupTransform(
-    .capture,
-    component().regex.root,
-    CaptureTransform(resultType: NewCapture.self) {
-      transform($0) as Any?
-    },
-    reference.id))
+    public init<R: RegexComponent, W, C0, C1, C2, C3, NewCapture>(
+    as reference: Reference<NewCapture>,
+    @RegexComponentBuilder _ component: () -> R,
+    transform: @escaping (Substring) -> NewCapture?
+  ) where Match == (Substring, NewCapture, C0, C1, C2, C3), R.Match == (W, C0, C1, C2, C3) {
+    self.init(node: .groupTransform(
+      .capture,
+      component().regex.root,
+      CaptureTransform(resultType: NewCapture.self) {
+        transform($0) as Any?
+      },
+      reference.id))
+  }
 }
 
 // MARK: - Non-builder capture arity 5
 
-public func capture<R: RegexComponent, W, C0, C1, C2, C3, C4>(
-  _ component: R
-) -> Regex<(Substring, W, C0, C1, C2, C3, C4)> where R.Match == (W, C0, C1, C2, C3, C4) {
-  .init(node: .group(.capture, component.regex.root))
+extension Capture {
+    public init<R: RegexComponent, W, C0, C1, C2, C3, C4>(
+    _ component: R
+  ) where Match == (Substring, W, C0, C1, C2, C3, C4), R.Match == (W, C0, C1, C2, C3, C4) {
+    self.init(node: .group(.capture, component.regex.root))
+  }
+
+    public init<R: RegexComponent, W, C0, C1, C2, C3, C4>(
+    _ component: R, as reference: Reference<W>
+  ) where Match == (Substring, W, C0, C1, C2, C3, C4), R.Match == (W, C0, C1, C2, C3, C4) {
+    self.init(node: .group(.capture, component.regex.root, reference.id))
+  }
+
+    public init<R: RegexComponent, W, C0, C1, C2, C3, C4, NewCapture>(
+    _ component: R,
+    transform: @escaping (Substring) -> NewCapture
+  ) where Match == (Substring, NewCapture, C0, C1, C2, C3, C4), R.Match == (W, C0, C1, C2, C3, C4) {
+    self.init(node: .groupTransform(
+      .capture,
+      component.regex.root,
+      CaptureTransform(resultType: NewCapture.self) {
+        transform($0) as Any
+      }))
+  }
+
+    public init<R: RegexComponent, W, C0, C1, C2, C3, C4, NewCapture>(
+    _ component: R,
+    as reference: Reference<NewCapture>,
+    transform: @escaping (Substring) -> NewCapture
+  ) where Match == (Substring, NewCapture, C0, C1, C2, C3, C4), R.Match == (W, C0, C1, C2, C3, C4) {
+    self.init(node: .groupTransform(
+      .capture,
+      component.regex.root,
+      CaptureTransform(resultType: NewCapture.self) {
+        transform($0) as Any
+      },
+      reference.id))
+  }
 }
 
-public func capture<R: RegexComponent, W, C0, C1, C2, C3, C4>(
-  _ component: R, as reference: Reference<W>
-) -> Regex<(Substring, W, C0, C1, C2, C3, C4)> where R.Match == (W, C0, C1, C2, C3, C4) {
-  .init(node: .group(.capture, component.regex.root, reference.id))
-}
+extension TryCapture {
+    public init<R: RegexComponent, W, C0, C1, C2, C3, C4, NewCapture>(
+    _ component: R,
+    transform: @escaping (Substring) throws -> NewCapture
+  ) where Match == (Substring, NewCapture, C0, C1, C2, C3, C4), R.Match == (W, C0, C1, C2, C3, C4) {
+    self.init(node: .groupTransform(
+      .capture,
+      component.regex.root,
+      CaptureTransform(resultType: NewCapture.self) {
+        try transform($0) as Any
+      }))
+  }
 
-public func capture<R: RegexComponent, W, C0, C1, C2, C3, C4, NewCapture>(
-  _ component: R,
-  transform: @escaping (Substring) -> NewCapture
-) -> Regex<(Substring, NewCapture, C0, C1, C2, C3, C4)> where R.Match == (W, C0, C1, C2, C3, C4) {
-  .init(node: .groupTransform(
-    .capture,
-    component.regex.root,
-    CaptureTransform(resultType: NewCapture.self) {
-      transform($0) as Any
-    }))
-}
+    public init<R: RegexComponent, W, C0, C1, C2, C3, C4, NewCapture>(
+    _ component: R,
+    as reference: Reference<NewCapture>,
+    transform: @escaping (Substring) throws -> NewCapture
+  ) where Match == (Substring, NewCapture, C0, C1, C2, C3, C4), R.Match == (W, C0, C1, C2, C3, C4) {
+    self.init(node: .groupTransform(
+      .capture,
+      component.regex.root,
+      CaptureTransform(resultType: NewCapture.self) {
+        try transform($0) as Any
+      },
+      reference.id))
+  }
 
-public func capture<R: RegexComponent, W, C0, C1, C2, C3, C4, NewCapture>(
-  _ component: R,
-  as reference: Reference<NewCapture>,
-  transform: @escaping (Substring) -> NewCapture
-) -> Regex<(Substring, NewCapture, C0, C1, C2, C3, C4)> where R.Match == (W, C0, C1, C2, C3, C4) {
-  .init(node: .groupTransform(
-    .capture,
-    component.regex.root,
-    CaptureTransform(resultType: NewCapture.self) {
-      transform($0) as Any
-    },
-    reference.id))
-}
+    public init<R: RegexComponent, W, C0, C1, C2, C3, C4, NewCapture>(
+    _ component: R,
+    transform: @escaping (Substring) -> NewCapture?
+  ) where Match == (Substring, NewCapture, C0, C1, C2, C3, C4), R.Match == (W, C0, C1, C2, C3, C4) {
+    self.init(node: .groupTransform(
+      .capture,
+      component.regex.root,
+      CaptureTransform(resultType: NewCapture.self) {
+        transform($0) as Any?
+      }))
+  }
 
-public func tryCapture<R: RegexComponent, W, C0, C1, C2, C3, C4, NewCapture>(
-  _ component: R,
-  transform: @escaping (Substring) throws -> NewCapture
-) -> Regex<(Substring, NewCapture, C0, C1, C2, C3, C4)> where R.Match == (W, C0, C1, C2, C3, C4) {
-  .init(node: .groupTransform(
-    .capture,
-    component.regex.root,
-    CaptureTransform(resultType: NewCapture.self) {
-      try transform($0) as Any
-    }))
-}
-
-public func tryCapture<R: RegexComponent, W, C0, C1, C2, C3, C4, NewCapture>(
-  _ component: R,
-  as reference: Reference<NewCapture>,
-  transform: @escaping (Substring) throws -> NewCapture
-) -> Regex<(Substring, NewCapture, C0, C1, C2, C3, C4)> where R.Match == (W, C0, C1, C2, C3, C4) {
-  .init(node: .groupTransform(
-    .capture,
-    component.regex.root,
-    CaptureTransform(resultType: NewCapture.self) {
-      try transform($0) as Any
-    },
-    reference.id))
-}
-
-public func tryCapture<R: RegexComponent, W, C0, C1, C2, C3, C4, NewCapture>(
-  _ component: R,
-  transform: @escaping (Substring) -> NewCapture?
-) -> Regex<(Substring, NewCapture, C0, C1, C2, C3, C4)> where R.Match == (W, C0, C1, C2, C3, C4) {
-  .init(node: .groupTransform(
-    .capture,
-    component.regex.root,
-    CaptureTransform(resultType: NewCapture.self) {
-      transform($0) as Any?
-    }))
-}
-
-public func tryCapture<R: RegexComponent, W, C0, C1, C2, C3, C4, NewCapture>(
-  _ component: R,
-  as reference: Reference<NewCapture>,
-  transform: @escaping (Substring) -> NewCapture?
-) -> Regex<(Substring, NewCapture, C0, C1, C2, C3, C4)> where R.Match == (W, C0, C1, C2, C3, C4) {
-  .init(node: .groupTransform(
-    .capture,
-    component.regex.root,
-    CaptureTransform(resultType: NewCapture.self) {
-      transform($0) as Any?
-    },
-    reference.id))
+    public init<R: RegexComponent, W, C0, C1, C2, C3, C4, NewCapture>(
+    _ component: R,
+    as reference: Reference<NewCapture>,
+    transform: @escaping (Substring) -> NewCapture?
+  ) where Match == (Substring, NewCapture, C0, C1, C2, C3, C4), R.Match == (W, C0, C1, C2, C3, C4) {
+    self.init(node: .groupTransform(
+      .capture,
+      component.regex.root,
+      CaptureTransform(resultType: NewCapture.self) {
+        transform($0) as Any?
+      },
+      reference.id))
+  }
 }
 
 // MARK: - Builder capture arity 5
 
-public func capture<R: RegexComponent, W, C0, C1, C2, C3, C4>(
-  @RegexComponentBuilder _ component: () -> R
-) -> Regex<(Substring, W, C0, C1, C2, C3, C4)> where R.Match == (W, C0, C1, C2, C3, C4) {
-  .init(node: .group(.capture, component().regex.root))
+extension Capture {
+    public init<R: RegexComponent, W, C0, C1, C2, C3, C4>(
+    @RegexComponentBuilder _ component: () -> R
+  ) where Match == (Substring, W, C0, C1, C2, C3, C4), R.Match == (W, C0, C1, C2, C3, C4) {
+    self.init(node: .group(.capture, component().regex.root))
+  }
+
+    public init<R: RegexComponent, W, C0, C1, C2, C3, C4>(
+    as reference: Reference<W>,
+    @RegexComponentBuilder _ component: () -> R
+  ) where Match == (Substring, W, C0, C1, C2, C3, C4), R.Match == (W, C0, C1, C2, C3, C4) {
+    self.init(node: .group(.capture, component().regex.root, reference.id))
+  }
+
+    public init<R: RegexComponent, W, C0, C1, C2, C3, C4, NewCapture>(
+    @RegexComponentBuilder _ component: () -> R,
+    transform: @escaping (Substring) -> NewCapture
+  ) where Match == (Substring, NewCapture, C0, C1, C2, C3, C4), R.Match == (W, C0, C1, C2, C3, C4) {
+    self.init(node: .groupTransform(
+      .capture,
+      component().regex.root,
+      CaptureTransform(resultType: NewCapture.self) {
+        transform($0) as Any
+      }))
+  }
+
+    public init<R: RegexComponent, W, C0, C1, C2, C3, C4, NewCapture>(
+    as reference: Reference<NewCapture>,
+    @RegexComponentBuilder _ component: () -> R,
+    transform: @escaping (Substring) -> NewCapture
+  ) where Match == (Substring, NewCapture, C0, C1, C2, C3, C4), R.Match == (W, C0, C1, C2, C3, C4) {
+    self.init(node: .groupTransform(
+      .capture,
+      component().regex.root,
+      CaptureTransform(resultType: NewCapture.self) {
+        transform($0) as Any
+      },
+      reference.id))
+  }
 }
 
-public func capture<R: RegexComponent, W, C0, C1, C2, C3, C4>(
-  as reference: Reference<W>,
-  @RegexComponentBuilder _ component: () -> R
-) -> Regex<(Substring, W, C0, C1, C2, C3, C4)> where R.Match == (W, C0, C1, C2, C3, C4) {
-  .init(node: .group(.capture, component().regex.root, reference.id))
-}
+extension TryCapture {
+    public init<R: RegexComponent, W, C0, C1, C2, C3, C4, NewCapture>(
+    @RegexComponentBuilder _ component: () -> R,
+    transform: @escaping (Substring) throws -> NewCapture
+  ) where Match == (Substring, NewCapture, C0, C1, C2, C3, C4), R.Match == (W, C0, C1, C2, C3, C4) {
+    self.init(node: .groupTransform(
+      .capture,
+      component().regex.root,
+      CaptureTransform(resultType: NewCapture.self) {
+        try transform($0) as Any
+      }))
+  }
 
-public func capture<R: RegexComponent, W, C0, C1, C2, C3, C4, NewCapture>(
-  @RegexComponentBuilder _ component: () -> R,
-  transform: @escaping (Substring) -> NewCapture
-) -> Regex<(Substring, NewCapture, C0, C1, C2, C3, C4)> where R.Match == (W, C0, C1, C2, C3, C4) {
-  .init(node: .groupTransform(
-    .capture,
-    component().regex.root,
-    CaptureTransform(resultType: NewCapture.self) {
-      transform($0) as Any
-    }))
-}
+    public init<R: RegexComponent, W, C0, C1, C2, C3, C4, NewCapture>(
+    as reference: Reference<NewCapture>,
+    @RegexComponentBuilder _ component: () -> R,
+    transform: @escaping (Substring) throws -> NewCapture
+  ) where Match == (Substring, NewCapture, C0, C1, C2, C3, C4), R.Match == (W, C0, C1, C2, C3, C4) {
+    self.init(node: .groupTransform(
+      .capture,
+      component().regex.root,
+      CaptureTransform(resultType: NewCapture.self) {
+        try transform($0) as Any
+      },
+      reference.id))
+  }
 
-public func tryCapture<R: RegexComponent, W, C0, C1, C2, C3, C4, NewCapture>(
-  as reference: Reference<NewCapture>,
-  @RegexComponentBuilder _ component: () -> R,
-  transform: @escaping (Substring) throws -> NewCapture
-) -> Regex<(Substring, NewCapture, C0, C1, C2, C3, C4)> where R.Match == (W, C0, C1, C2, C3, C4) {
-  .init(node: .groupTransform(
-    .capture,
-    component().regex.root,
-    CaptureTransform(resultType: NewCapture.self) {
-      try transform($0) as Any
-    },
-    reference.id))
-}
+    public init<R: RegexComponent, W, C0, C1, C2, C3, C4, NewCapture>(
+    @RegexComponentBuilder _ component: () -> R,
+    transform: @escaping (Substring) -> NewCapture?
+  ) where Match == (Substring, NewCapture, C0, C1, C2, C3, C4), R.Match == (W, C0, C1, C2, C3, C4) {
+    self.init(node: .groupTransform(
+      .capture,
+      component().regex.root,
+      CaptureTransform(resultType: NewCapture.self) {
+        transform($0) as Any?
+      }))
+  }
 
-public func tryCapture<R: RegexComponent, W, C0, C1, C2, C3, C4, NewCapture>(
-  @RegexComponentBuilder _ component: () -> R,
-  transform: @escaping (Substring) -> NewCapture?
-) -> Regex<(Substring, NewCapture, C0, C1, C2, C3, C4)> where R.Match == (W, C0, C1, C2, C3, C4) {
-  .init(node: .groupTransform(
-    .capture,
-    component().regex.root,
-    CaptureTransform(resultType: NewCapture.self) {
-      transform($0) as Any?
-    }))
-}
-
-public func tryCapture<R: RegexComponent, W, C0, C1, C2, C3, C4, NewCapture>(
-  as reference: Reference<NewCapture>,
-  @RegexComponentBuilder _ component: () -> R,
-  transform: @escaping (Substring) -> NewCapture?
-) -> Regex<(Substring, NewCapture, C0, C1, C2, C3, C4)> where R.Match == (W, C0, C1, C2, C3, C4) {
-  .init(node: .groupTransform(
-    .capture,
-    component().regex.root,
-    CaptureTransform(resultType: NewCapture.self) {
-      transform($0) as Any?
-    },
-    reference.id))
+    public init<R: RegexComponent, W, C0, C1, C2, C3, C4, NewCapture>(
+    as reference: Reference<NewCapture>,
+    @RegexComponentBuilder _ component: () -> R,
+    transform: @escaping (Substring) -> NewCapture?
+  ) where Match == (Substring, NewCapture, C0, C1, C2, C3, C4), R.Match == (W, C0, C1, C2, C3, C4) {
+    self.init(node: .groupTransform(
+      .capture,
+      component().regex.root,
+      CaptureTransform(resultType: NewCapture.self) {
+        transform($0) as Any?
+      },
+      reference.id))
+  }
 }
 
 // MARK: - Non-builder capture arity 6
 
-public func capture<R: RegexComponent, W, C0, C1, C2, C3, C4, C5>(
-  _ component: R
-) -> Regex<(Substring, W, C0, C1, C2, C3, C4, C5)> where R.Match == (W, C0, C1, C2, C3, C4, C5) {
-  .init(node: .group(.capture, component.regex.root))
+extension Capture {
+    public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5>(
+    _ component: R
+  ) where Match == (Substring, W, C0, C1, C2, C3, C4, C5), R.Match == (W, C0, C1, C2, C3, C4, C5) {
+    self.init(node: .group(.capture, component.regex.root))
+  }
+
+    public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5>(
+    _ component: R, as reference: Reference<W>
+  ) where Match == (Substring, W, C0, C1, C2, C3, C4, C5), R.Match == (W, C0, C1, C2, C3, C4, C5) {
+    self.init(node: .group(.capture, component.regex.root, reference.id))
+  }
+
+    public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, NewCapture>(
+    _ component: R,
+    transform: @escaping (Substring) -> NewCapture
+  ) where Match == (Substring, NewCapture, C0, C1, C2, C3, C4, C5), R.Match == (W, C0, C1, C2, C3, C4, C5) {
+    self.init(node: .groupTransform(
+      .capture,
+      component.regex.root,
+      CaptureTransform(resultType: NewCapture.self) {
+        transform($0) as Any
+      }))
+  }
+
+    public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, NewCapture>(
+    _ component: R,
+    as reference: Reference<NewCapture>,
+    transform: @escaping (Substring) -> NewCapture
+  ) where Match == (Substring, NewCapture, C0, C1, C2, C3, C4, C5), R.Match == (W, C0, C1, C2, C3, C4, C5) {
+    self.init(node: .groupTransform(
+      .capture,
+      component.regex.root,
+      CaptureTransform(resultType: NewCapture.self) {
+        transform($0) as Any
+      },
+      reference.id))
+  }
 }
 
-public func capture<R: RegexComponent, W, C0, C1, C2, C3, C4, C5>(
-  _ component: R, as reference: Reference<W>
-) -> Regex<(Substring, W, C0, C1, C2, C3, C4, C5)> where R.Match == (W, C0, C1, C2, C3, C4, C5) {
-  .init(node: .group(.capture, component.regex.root, reference.id))
-}
+extension TryCapture {
+    public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, NewCapture>(
+    _ component: R,
+    transform: @escaping (Substring) throws -> NewCapture
+  ) where Match == (Substring, NewCapture, C0, C1, C2, C3, C4, C5), R.Match == (W, C0, C1, C2, C3, C4, C5) {
+    self.init(node: .groupTransform(
+      .capture,
+      component.regex.root,
+      CaptureTransform(resultType: NewCapture.self) {
+        try transform($0) as Any
+      }))
+  }
 
-public func capture<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, NewCapture>(
-  _ component: R,
-  transform: @escaping (Substring) -> NewCapture
-) -> Regex<(Substring, NewCapture, C0, C1, C2, C3, C4, C5)> where R.Match == (W, C0, C1, C2, C3, C4, C5) {
-  .init(node: .groupTransform(
-    .capture,
-    component.regex.root,
-    CaptureTransform(resultType: NewCapture.self) {
-      transform($0) as Any
-    }))
-}
+    public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, NewCapture>(
+    _ component: R,
+    as reference: Reference<NewCapture>,
+    transform: @escaping (Substring) throws -> NewCapture
+  ) where Match == (Substring, NewCapture, C0, C1, C2, C3, C4, C5), R.Match == (W, C0, C1, C2, C3, C4, C5) {
+    self.init(node: .groupTransform(
+      .capture,
+      component.regex.root,
+      CaptureTransform(resultType: NewCapture.self) {
+        try transform($0) as Any
+      },
+      reference.id))
+  }
 
-public func capture<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, NewCapture>(
-  _ component: R,
-  as reference: Reference<NewCapture>,
-  transform: @escaping (Substring) -> NewCapture
-) -> Regex<(Substring, NewCapture, C0, C1, C2, C3, C4, C5)> where R.Match == (W, C0, C1, C2, C3, C4, C5) {
-  .init(node: .groupTransform(
-    .capture,
-    component.regex.root,
-    CaptureTransform(resultType: NewCapture.self) {
-      transform($0) as Any
-    },
-    reference.id))
-}
+    public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, NewCapture>(
+    _ component: R,
+    transform: @escaping (Substring) -> NewCapture?
+  ) where Match == (Substring, NewCapture, C0, C1, C2, C3, C4, C5), R.Match == (W, C0, C1, C2, C3, C4, C5) {
+    self.init(node: .groupTransform(
+      .capture,
+      component.regex.root,
+      CaptureTransform(resultType: NewCapture.self) {
+        transform($0) as Any?
+      }))
+  }
 
-public func tryCapture<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, NewCapture>(
-  _ component: R,
-  transform: @escaping (Substring) throws -> NewCapture
-) -> Regex<(Substring, NewCapture, C0, C1, C2, C3, C4, C5)> where R.Match == (W, C0, C1, C2, C3, C4, C5) {
-  .init(node: .groupTransform(
-    .capture,
-    component.regex.root,
-    CaptureTransform(resultType: NewCapture.self) {
-      try transform($0) as Any
-    }))
-}
-
-public func tryCapture<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, NewCapture>(
-  _ component: R,
-  as reference: Reference<NewCapture>,
-  transform: @escaping (Substring) throws -> NewCapture
-) -> Regex<(Substring, NewCapture, C0, C1, C2, C3, C4, C5)> where R.Match == (W, C0, C1, C2, C3, C4, C5) {
-  .init(node: .groupTransform(
-    .capture,
-    component.regex.root,
-    CaptureTransform(resultType: NewCapture.self) {
-      try transform($0) as Any
-    },
-    reference.id))
-}
-
-public func tryCapture<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, NewCapture>(
-  _ component: R,
-  transform: @escaping (Substring) -> NewCapture?
-) -> Regex<(Substring, NewCapture, C0, C1, C2, C3, C4, C5)> where R.Match == (W, C0, C1, C2, C3, C4, C5) {
-  .init(node: .groupTransform(
-    .capture,
-    component.regex.root,
-    CaptureTransform(resultType: NewCapture.self) {
-      transform($0) as Any?
-    }))
-}
-
-public func tryCapture<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, NewCapture>(
-  _ component: R,
-  as reference: Reference<NewCapture>,
-  transform: @escaping (Substring) -> NewCapture?
-) -> Regex<(Substring, NewCapture, C0, C1, C2, C3, C4, C5)> where R.Match == (W, C0, C1, C2, C3, C4, C5) {
-  .init(node: .groupTransform(
-    .capture,
-    component.regex.root,
-    CaptureTransform(resultType: NewCapture.self) {
-      transform($0) as Any?
-    },
-    reference.id))
+    public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, NewCapture>(
+    _ component: R,
+    as reference: Reference<NewCapture>,
+    transform: @escaping (Substring) -> NewCapture?
+  ) where Match == (Substring, NewCapture, C0, C1, C2, C3, C4, C5), R.Match == (W, C0, C1, C2, C3, C4, C5) {
+    self.init(node: .groupTransform(
+      .capture,
+      component.regex.root,
+      CaptureTransform(resultType: NewCapture.self) {
+        transform($0) as Any?
+      },
+      reference.id))
+  }
 }
 
 // MARK: - Builder capture arity 6
 
-public func capture<R: RegexComponent, W, C0, C1, C2, C3, C4, C5>(
-  @RegexComponentBuilder _ component: () -> R
-) -> Regex<(Substring, W, C0, C1, C2, C3, C4, C5)> where R.Match == (W, C0, C1, C2, C3, C4, C5) {
-  .init(node: .group(.capture, component().regex.root))
+extension Capture {
+    public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5>(
+    @RegexComponentBuilder _ component: () -> R
+  ) where Match == (Substring, W, C0, C1, C2, C3, C4, C5), R.Match == (W, C0, C1, C2, C3, C4, C5) {
+    self.init(node: .group(.capture, component().regex.root))
+  }
+
+    public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5>(
+    as reference: Reference<W>,
+    @RegexComponentBuilder _ component: () -> R
+  ) where Match == (Substring, W, C0, C1, C2, C3, C4, C5), R.Match == (W, C0, C1, C2, C3, C4, C5) {
+    self.init(node: .group(.capture, component().regex.root, reference.id))
+  }
+
+    public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, NewCapture>(
+    @RegexComponentBuilder _ component: () -> R,
+    transform: @escaping (Substring) -> NewCapture
+  ) where Match == (Substring, NewCapture, C0, C1, C2, C3, C4, C5), R.Match == (W, C0, C1, C2, C3, C4, C5) {
+    self.init(node: .groupTransform(
+      .capture,
+      component().regex.root,
+      CaptureTransform(resultType: NewCapture.self) {
+        transform($0) as Any
+      }))
+  }
+
+    public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, NewCapture>(
+    as reference: Reference<NewCapture>,
+    @RegexComponentBuilder _ component: () -> R,
+    transform: @escaping (Substring) -> NewCapture
+  ) where Match == (Substring, NewCapture, C0, C1, C2, C3, C4, C5), R.Match == (W, C0, C1, C2, C3, C4, C5) {
+    self.init(node: .groupTransform(
+      .capture,
+      component().regex.root,
+      CaptureTransform(resultType: NewCapture.self) {
+        transform($0) as Any
+      },
+      reference.id))
+  }
 }
 
-public func capture<R: RegexComponent, W, C0, C1, C2, C3, C4, C5>(
-  as reference: Reference<W>,
-  @RegexComponentBuilder _ component: () -> R
-) -> Regex<(Substring, W, C0, C1, C2, C3, C4, C5)> where R.Match == (W, C0, C1, C2, C3, C4, C5) {
-  .init(node: .group(.capture, component().regex.root, reference.id))
-}
+extension TryCapture {
+    public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, NewCapture>(
+    @RegexComponentBuilder _ component: () -> R,
+    transform: @escaping (Substring) throws -> NewCapture
+  ) where Match == (Substring, NewCapture, C0, C1, C2, C3, C4, C5), R.Match == (W, C0, C1, C2, C3, C4, C5) {
+    self.init(node: .groupTransform(
+      .capture,
+      component().regex.root,
+      CaptureTransform(resultType: NewCapture.self) {
+        try transform($0) as Any
+      }))
+  }
 
-public func capture<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, NewCapture>(
-  @RegexComponentBuilder _ component: () -> R,
-  transform: @escaping (Substring) -> NewCapture
-) -> Regex<(Substring, NewCapture, C0, C1, C2, C3, C4, C5)> where R.Match == (W, C0, C1, C2, C3, C4, C5) {
-  .init(node: .groupTransform(
-    .capture,
-    component().regex.root,
-    CaptureTransform(resultType: NewCapture.self) {
-      transform($0) as Any
-    }))
-}
+    public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, NewCapture>(
+    as reference: Reference<NewCapture>,
+    @RegexComponentBuilder _ component: () -> R,
+    transform: @escaping (Substring) throws -> NewCapture
+  ) where Match == (Substring, NewCapture, C0, C1, C2, C3, C4, C5), R.Match == (W, C0, C1, C2, C3, C4, C5) {
+    self.init(node: .groupTransform(
+      .capture,
+      component().regex.root,
+      CaptureTransform(resultType: NewCapture.self) {
+        try transform($0) as Any
+      },
+      reference.id))
+  }
 
-public func tryCapture<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, NewCapture>(
-  as reference: Reference<NewCapture>,
-  @RegexComponentBuilder _ component: () -> R,
-  transform: @escaping (Substring) throws -> NewCapture
-) -> Regex<(Substring, NewCapture, C0, C1, C2, C3, C4, C5)> where R.Match == (W, C0, C1, C2, C3, C4, C5) {
-  .init(node: .groupTransform(
-    .capture,
-    component().regex.root,
-    CaptureTransform(resultType: NewCapture.self) {
-      try transform($0) as Any
-    },
-    reference.id))
-}
+    public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, NewCapture>(
+    @RegexComponentBuilder _ component: () -> R,
+    transform: @escaping (Substring) -> NewCapture?
+  ) where Match == (Substring, NewCapture, C0, C1, C2, C3, C4, C5), R.Match == (W, C0, C1, C2, C3, C4, C5) {
+    self.init(node: .groupTransform(
+      .capture,
+      component().regex.root,
+      CaptureTransform(resultType: NewCapture.self) {
+        transform($0) as Any?
+      }))
+  }
 
-public func tryCapture<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, NewCapture>(
-  @RegexComponentBuilder _ component: () -> R,
-  transform: @escaping (Substring) -> NewCapture?
-) -> Regex<(Substring, NewCapture, C0, C1, C2, C3, C4, C5)> where R.Match == (W, C0, C1, C2, C3, C4, C5) {
-  .init(node: .groupTransform(
-    .capture,
-    component().regex.root,
-    CaptureTransform(resultType: NewCapture.self) {
-      transform($0) as Any?
-    }))
-}
-
-public func tryCapture<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, NewCapture>(
-  as reference: Reference<NewCapture>,
-  @RegexComponentBuilder _ component: () -> R,
-  transform: @escaping (Substring) -> NewCapture?
-) -> Regex<(Substring, NewCapture, C0, C1, C2, C3, C4, C5)> where R.Match == (W, C0, C1, C2, C3, C4, C5) {
-  .init(node: .groupTransform(
-    .capture,
-    component().regex.root,
-    CaptureTransform(resultType: NewCapture.self) {
-      transform($0) as Any?
-    },
-    reference.id))
+    public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, NewCapture>(
+    as reference: Reference<NewCapture>,
+    @RegexComponentBuilder _ component: () -> R,
+    transform: @escaping (Substring) -> NewCapture?
+  ) where Match == (Substring, NewCapture, C0, C1, C2, C3, C4, C5), R.Match == (W, C0, C1, C2, C3, C4, C5) {
+    self.init(node: .groupTransform(
+      .capture,
+      component().regex.root,
+      CaptureTransform(resultType: NewCapture.self) {
+        transform($0) as Any?
+      },
+      reference.id))
+  }
 }
 
 // MARK: - Non-builder capture arity 7
 
-public func capture<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6>(
-  _ component: R
-) -> Regex<(Substring, W, C0, C1, C2, C3, C4, C5, C6)> where R.Match == (W, C0, C1, C2, C3, C4, C5, C6) {
-  .init(node: .group(.capture, component.regex.root))
+extension Capture {
+    public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6>(
+    _ component: R
+  ) where Match == (Substring, W, C0, C1, C2, C3, C4, C5, C6), R.Match == (W, C0, C1, C2, C3, C4, C5, C6) {
+    self.init(node: .group(.capture, component.regex.root))
+  }
+
+    public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6>(
+    _ component: R, as reference: Reference<W>
+  ) where Match == (Substring, W, C0, C1, C2, C3, C4, C5, C6), R.Match == (W, C0, C1, C2, C3, C4, C5, C6) {
+    self.init(node: .group(.capture, component.regex.root, reference.id))
+  }
+
+    public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, NewCapture>(
+    _ component: R,
+    transform: @escaping (Substring) -> NewCapture
+  ) where Match == (Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6), R.Match == (W, C0, C1, C2, C3, C4, C5, C6) {
+    self.init(node: .groupTransform(
+      .capture,
+      component.regex.root,
+      CaptureTransform(resultType: NewCapture.self) {
+        transform($0) as Any
+      }))
+  }
+
+    public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, NewCapture>(
+    _ component: R,
+    as reference: Reference<NewCapture>,
+    transform: @escaping (Substring) -> NewCapture
+  ) where Match == (Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6), R.Match == (W, C0, C1, C2, C3, C4, C5, C6) {
+    self.init(node: .groupTransform(
+      .capture,
+      component.regex.root,
+      CaptureTransform(resultType: NewCapture.self) {
+        transform($0) as Any
+      },
+      reference.id))
+  }
 }
 
-public func capture<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6>(
-  _ component: R, as reference: Reference<W>
-) -> Regex<(Substring, W, C0, C1, C2, C3, C4, C5, C6)> where R.Match == (W, C0, C1, C2, C3, C4, C5, C6) {
-  .init(node: .group(.capture, component.regex.root, reference.id))
-}
+extension TryCapture {
+    public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, NewCapture>(
+    _ component: R,
+    transform: @escaping (Substring) throws -> NewCapture
+  ) where Match == (Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6), R.Match == (W, C0, C1, C2, C3, C4, C5, C6) {
+    self.init(node: .groupTransform(
+      .capture,
+      component.regex.root,
+      CaptureTransform(resultType: NewCapture.self) {
+        try transform($0) as Any
+      }))
+  }
 
-public func capture<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, NewCapture>(
-  _ component: R,
-  transform: @escaping (Substring) -> NewCapture
-) -> Regex<(Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6)> where R.Match == (W, C0, C1, C2, C3, C4, C5, C6) {
-  .init(node: .groupTransform(
-    .capture,
-    component.regex.root,
-    CaptureTransform(resultType: NewCapture.self) {
-      transform($0) as Any
-    }))
-}
+    public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, NewCapture>(
+    _ component: R,
+    as reference: Reference<NewCapture>,
+    transform: @escaping (Substring) throws -> NewCapture
+  ) where Match == (Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6), R.Match == (W, C0, C1, C2, C3, C4, C5, C6) {
+    self.init(node: .groupTransform(
+      .capture,
+      component.regex.root,
+      CaptureTransform(resultType: NewCapture.self) {
+        try transform($0) as Any
+      },
+      reference.id))
+  }
 
-public func capture<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, NewCapture>(
-  _ component: R,
-  as reference: Reference<NewCapture>,
-  transform: @escaping (Substring) -> NewCapture
-) -> Regex<(Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6)> where R.Match == (W, C0, C1, C2, C3, C4, C5, C6) {
-  .init(node: .groupTransform(
-    .capture,
-    component.regex.root,
-    CaptureTransform(resultType: NewCapture.self) {
-      transform($0) as Any
-    },
-    reference.id))
-}
+    public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, NewCapture>(
+    _ component: R,
+    transform: @escaping (Substring) -> NewCapture?
+  ) where Match == (Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6), R.Match == (W, C0, C1, C2, C3, C4, C5, C6) {
+    self.init(node: .groupTransform(
+      .capture,
+      component.regex.root,
+      CaptureTransform(resultType: NewCapture.self) {
+        transform($0) as Any?
+      }))
+  }
 
-public func tryCapture<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, NewCapture>(
-  _ component: R,
-  transform: @escaping (Substring) throws -> NewCapture
-) -> Regex<(Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6)> where R.Match == (W, C0, C1, C2, C3, C4, C5, C6) {
-  .init(node: .groupTransform(
-    .capture,
-    component.regex.root,
-    CaptureTransform(resultType: NewCapture.self) {
-      try transform($0) as Any
-    }))
-}
-
-public func tryCapture<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, NewCapture>(
-  _ component: R,
-  as reference: Reference<NewCapture>,
-  transform: @escaping (Substring) throws -> NewCapture
-) -> Regex<(Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6)> where R.Match == (W, C0, C1, C2, C3, C4, C5, C6) {
-  .init(node: .groupTransform(
-    .capture,
-    component.regex.root,
-    CaptureTransform(resultType: NewCapture.self) {
-      try transform($0) as Any
-    },
-    reference.id))
-}
-
-public func tryCapture<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, NewCapture>(
-  _ component: R,
-  transform: @escaping (Substring) -> NewCapture?
-) -> Regex<(Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6)> where R.Match == (W, C0, C1, C2, C3, C4, C5, C6) {
-  .init(node: .groupTransform(
-    .capture,
-    component.regex.root,
-    CaptureTransform(resultType: NewCapture.self) {
-      transform($0) as Any?
-    }))
-}
-
-public func tryCapture<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, NewCapture>(
-  _ component: R,
-  as reference: Reference<NewCapture>,
-  transform: @escaping (Substring) -> NewCapture?
-) -> Regex<(Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6)> where R.Match == (W, C0, C1, C2, C3, C4, C5, C6) {
-  .init(node: .groupTransform(
-    .capture,
-    component.regex.root,
-    CaptureTransform(resultType: NewCapture.self) {
-      transform($0) as Any?
-    },
-    reference.id))
+    public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, NewCapture>(
+    _ component: R,
+    as reference: Reference<NewCapture>,
+    transform: @escaping (Substring) -> NewCapture?
+  ) where Match == (Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6), R.Match == (W, C0, C1, C2, C3, C4, C5, C6) {
+    self.init(node: .groupTransform(
+      .capture,
+      component.regex.root,
+      CaptureTransform(resultType: NewCapture.self) {
+        transform($0) as Any?
+      },
+      reference.id))
+  }
 }
 
 // MARK: - Builder capture arity 7
 
-public func capture<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6>(
-  @RegexComponentBuilder _ component: () -> R
-) -> Regex<(Substring, W, C0, C1, C2, C3, C4, C5, C6)> where R.Match == (W, C0, C1, C2, C3, C4, C5, C6) {
-  .init(node: .group(.capture, component().regex.root))
+extension Capture {
+    public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6>(
+    @RegexComponentBuilder _ component: () -> R
+  ) where Match == (Substring, W, C0, C1, C2, C3, C4, C5, C6), R.Match == (W, C0, C1, C2, C3, C4, C5, C6) {
+    self.init(node: .group(.capture, component().regex.root))
+  }
+
+    public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6>(
+    as reference: Reference<W>,
+    @RegexComponentBuilder _ component: () -> R
+  ) where Match == (Substring, W, C0, C1, C2, C3, C4, C5, C6), R.Match == (W, C0, C1, C2, C3, C4, C5, C6) {
+    self.init(node: .group(.capture, component().regex.root, reference.id))
+  }
+
+    public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, NewCapture>(
+    @RegexComponentBuilder _ component: () -> R,
+    transform: @escaping (Substring) -> NewCapture
+  ) where Match == (Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6), R.Match == (W, C0, C1, C2, C3, C4, C5, C6) {
+    self.init(node: .groupTransform(
+      .capture,
+      component().regex.root,
+      CaptureTransform(resultType: NewCapture.self) {
+        transform($0) as Any
+      }))
+  }
+
+    public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, NewCapture>(
+    as reference: Reference<NewCapture>,
+    @RegexComponentBuilder _ component: () -> R,
+    transform: @escaping (Substring) -> NewCapture
+  ) where Match == (Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6), R.Match == (W, C0, C1, C2, C3, C4, C5, C6) {
+    self.init(node: .groupTransform(
+      .capture,
+      component().regex.root,
+      CaptureTransform(resultType: NewCapture.self) {
+        transform($0) as Any
+      },
+      reference.id))
+  }
 }
 
-public func capture<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6>(
-  as reference: Reference<W>,
-  @RegexComponentBuilder _ component: () -> R
-) -> Regex<(Substring, W, C0, C1, C2, C3, C4, C5, C6)> where R.Match == (W, C0, C1, C2, C3, C4, C5, C6) {
-  .init(node: .group(.capture, component().regex.root, reference.id))
-}
+extension TryCapture {
+    public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, NewCapture>(
+    @RegexComponentBuilder _ component: () -> R,
+    transform: @escaping (Substring) throws -> NewCapture
+  ) where Match == (Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6), R.Match == (W, C0, C1, C2, C3, C4, C5, C6) {
+    self.init(node: .groupTransform(
+      .capture,
+      component().regex.root,
+      CaptureTransform(resultType: NewCapture.self) {
+        try transform($0) as Any
+      }))
+  }
 
-public func capture<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, NewCapture>(
-  @RegexComponentBuilder _ component: () -> R,
-  transform: @escaping (Substring) -> NewCapture
-) -> Regex<(Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6)> where R.Match == (W, C0, C1, C2, C3, C4, C5, C6) {
-  .init(node: .groupTransform(
-    .capture,
-    component().regex.root,
-    CaptureTransform(resultType: NewCapture.self) {
-      transform($0) as Any
-    }))
-}
+    public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, NewCapture>(
+    as reference: Reference<NewCapture>,
+    @RegexComponentBuilder _ component: () -> R,
+    transform: @escaping (Substring) throws -> NewCapture
+  ) where Match == (Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6), R.Match == (W, C0, C1, C2, C3, C4, C5, C6) {
+    self.init(node: .groupTransform(
+      .capture,
+      component().regex.root,
+      CaptureTransform(resultType: NewCapture.self) {
+        try transform($0) as Any
+      },
+      reference.id))
+  }
 
-public func tryCapture<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, NewCapture>(
-  as reference: Reference<NewCapture>,
-  @RegexComponentBuilder _ component: () -> R,
-  transform: @escaping (Substring) throws -> NewCapture
-) -> Regex<(Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6)> where R.Match == (W, C0, C1, C2, C3, C4, C5, C6) {
-  .init(node: .groupTransform(
-    .capture,
-    component().regex.root,
-    CaptureTransform(resultType: NewCapture.self) {
-      try transform($0) as Any
-    },
-    reference.id))
-}
+    public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, NewCapture>(
+    @RegexComponentBuilder _ component: () -> R,
+    transform: @escaping (Substring) -> NewCapture?
+  ) where Match == (Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6), R.Match == (W, C0, C1, C2, C3, C4, C5, C6) {
+    self.init(node: .groupTransform(
+      .capture,
+      component().regex.root,
+      CaptureTransform(resultType: NewCapture.self) {
+        transform($0) as Any?
+      }))
+  }
 
-public func tryCapture<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, NewCapture>(
-  @RegexComponentBuilder _ component: () -> R,
-  transform: @escaping (Substring) -> NewCapture?
-) -> Regex<(Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6)> where R.Match == (W, C0, C1, C2, C3, C4, C5, C6) {
-  .init(node: .groupTransform(
-    .capture,
-    component().regex.root,
-    CaptureTransform(resultType: NewCapture.self) {
-      transform($0) as Any?
-    }))
-}
-
-public func tryCapture<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, NewCapture>(
-  as reference: Reference<NewCapture>,
-  @RegexComponentBuilder _ component: () -> R,
-  transform: @escaping (Substring) -> NewCapture?
-) -> Regex<(Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6)> where R.Match == (W, C0, C1, C2, C3, C4, C5, C6) {
-  .init(node: .groupTransform(
-    .capture,
-    component().regex.root,
-    CaptureTransform(resultType: NewCapture.self) {
-      transform($0) as Any?
-    },
-    reference.id))
+    public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, NewCapture>(
+    as reference: Reference<NewCapture>,
+    @RegexComponentBuilder _ component: () -> R,
+    transform: @escaping (Substring) -> NewCapture?
+  ) where Match == (Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6), R.Match == (W, C0, C1, C2, C3, C4, C5, C6) {
+    self.init(node: .groupTransform(
+      .capture,
+      component().regex.root,
+      CaptureTransform(resultType: NewCapture.self) {
+        transform($0) as Any?
+      },
+      reference.id))
+  }
 }
 
 // MARK: - Non-builder capture arity 8
 
-public func capture<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7>(
-  _ component: R
-) -> Regex<(Substring, W, C0, C1, C2, C3, C4, C5, C6, C7)> where R.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
-  .init(node: .group(.capture, component.regex.root))
+extension Capture {
+    public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7>(
+    _ component: R
+  ) where Match == (Substring, W, C0, C1, C2, C3, C4, C5, C6, C7), R.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
+    self.init(node: .group(.capture, component.regex.root))
+  }
+
+    public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7>(
+    _ component: R, as reference: Reference<W>
+  ) where Match == (Substring, W, C0, C1, C2, C3, C4, C5, C6, C7), R.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
+    self.init(node: .group(.capture, component.regex.root, reference.id))
+  }
+
+    public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, NewCapture>(
+    _ component: R,
+    transform: @escaping (Substring) -> NewCapture
+  ) where Match == (Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6, C7), R.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
+    self.init(node: .groupTransform(
+      .capture,
+      component.regex.root,
+      CaptureTransform(resultType: NewCapture.self) {
+        transform($0) as Any
+      }))
+  }
+
+    public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, NewCapture>(
+    _ component: R,
+    as reference: Reference<NewCapture>,
+    transform: @escaping (Substring) -> NewCapture
+  ) where Match == (Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6, C7), R.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
+    self.init(node: .groupTransform(
+      .capture,
+      component.regex.root,
+      CaptureTransform(resultType: NewCapture.self) {
+        transform($0) as Any
+      },
+      reference.id))
+  }
 }
 
-public func capture<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7>(
-  _ component: R, as reference: Reference<W>
-) -> Regex<(Substring, W, C0, C1, C2, C3, C4, C5, C6, C7)> where R.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
-  .init(node: .group(.capture, component.regex.root, reference.id))
-}
+extension TryCapture {
+    public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, NewCapture>(
+    _ component: R,
+    transform: @escaping (Substring) throws -> NewCapture
+  ) where Match == (Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6, C7), R.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
+    self.init(node: .groupTransform(
+      .capture,
+      component.regex.root,
+      CaptureTransform(resultType: NewCapture.self) {
+        try transform($0) as Any
+      }))
+  }
 
-public func capture<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, NewCapture>(
-  _ component: R,
-  transform: @escaping (Substring) -> NewCapture
-) -> Regex<(Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6, C7)> where R.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
-  .init(node: .groupTransform(
-    .capture,
-    component.regex.root,
-    CaptureTransform(resultType: NewCapture.self) {
-      transform($0) as Any
-    }))
-}
+    public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, NewCapture>(
+    _ component: R,
+    as reference: Reference<NewCapture>,
+    transform: @escaping (Substring) throws -> NewCapture
+  ) where Match == (Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6, C7), R.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
+    self.init(node: .groupTransform(
+      .capture,
+      component.regex.root,
+      CaptureTransform(resultType: NewCapture.self) {
+        try transform($0) as Any
+      },
+      reference.id))
+  }
 
-public func capture<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, NewCapture>(
-  _ component: R,
-  as reference: Reference<NewCapture>,
-  transform: @escaping (Substring) -> NewCapture
-) -> Regex<(Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6, C7)> where R.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
-  .init(node: .groupTransform(
-    .capture,
-    component.regex.root,
-    CaptureTransform(resultType: NewCapture.self) {
-      transform($0) as Any
-    },
-    reference.id))
-}
+    public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, NewCapture>(
+    _ component: R,
+    transform: @escaping (Substring) -> NewCapture?
+  ) where Match == (Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6, C7), R.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
+    self.init(node: .groupTransform(
+      .capture,
+      component.regex.root,
+      CaptureTransform(resultType: NewCapture.self) {
+        transform($0) as Any?
+      }))
+  }
 
-public func tryCapture<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, NewCapture>(
-  _ component: R,
-  transform: @escaping (Substring) throws -> NewCapture
-) -> Regex<(Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6, C7)> where R.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
-  .init(node: .groupTransform(
-    .capture,
-    component.regex.root,
-    CaptureTransform(resultType: NewCapture.self) {
-      try transform($0) as Any
-    }))
-}
-
-public func tryCapture<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, NewCapture>(
-  _ component: R,
-  as reference: Reference<NewCapture>,
-  transform: @escaping (Substring) throws -> NewCapture
-) -> Regex<(Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6, C7)> where R.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
-  .init(node: .groupTransform(
-    .capture,
-    component.regex.root,
-    CaptureTransform(resultType: NewCapture.self) {
-      try transform($0) as Any
-    },
-    reference.id))
-}
-
-public func tryCapture<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, NewCapture>(
-  _ component: R,
-  transform: @escaping (Substring) -> NewCapture?
-) -> Regex<(Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6, C7)> where R.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
-  .init(node: .groupTransform(
-    .capture,
-    component.regex.root,
-    CaptureTransform(resultType: NewCapture.self) {
-      transform($0) as Any?
-    }))
-}
-
-public func tryCapture<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, NewCapture>(
-  _ component: R,
-  as reference: Reference<NewCapture>,
-  transform: @escaping (Substring) -> NewCapture?
-) -> Regex<(Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6, C7)> where R.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
-  .init(node: .groupTransform(
-    .capture,
-    component.regex.root,
-    CaptureTransform(resultType: NewCapture.self) {
-      transform($0) as Any?
-    },
-    reference.id))
+    public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, NewCapture>(
+    _ component: R,
+    as reference: Reference<NewCapture>,
+    transform: @escaping (Substring) -> NewCapture?
+  ) where Match == (Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6, C7), R.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
+    self.init(node: .groupTransform(
+      .capture,
+      component.regex.root,
+      CaptureTransform(resultType: NewCapture.self) {
+        transform($0) as Any?
+      },
+      reference.id))
+  }
 }
 
 // MARK: - Builder capture arity 8
 
-public func capture<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7>(
-  @RegexComponentBuilder _ component: () -> R
-) -> Regex<(Substring, W, C0, C1, C2, C3, C4, C5, C6, C7)> where R.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
-  .init(node: .group(.capture, component().regex.root))
+extension Capture {
+    public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7>(
+    @RegexComponentBuilder _ component: () -> R
+  ) where Match == (Substring, W, C0, C1, C2, C3, C4, C5, C6, C7), R.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
+    self.init(node: .group(.capture, component().regex.root))
+  }
+
+    public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7>(
+    as reference: Reference<W>,
+    @RegexComponentBuilder _ component: () -> R
+  ) where Match == (Substring, W, C0, C1, C2, C3, C4, C5, C6, C7), R.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
+    self.init(node: .group(.capture, component().regex.root, reference.id))
+  }
+
+    public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, NewCapture>(
+    @RegexComponentBuilder _ component: () -> R,
+    transform: @escaping (Substring) -> NewCapture
+  ) where Match == (Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6, C7), R.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
+    self.init(node: .groupTransform(
+      .capture,
+      component().regex.root,
+      CaptureTransform(resultType: NewCapture.self) {
+        transform($0) as Any
+      }))
+  }
+
+    public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, NewCapture>(
+    as reference: Reference<NewCapture>,
+    @RegexComponentBuilder _ component: () -> R,
+    transform: @escaping (Substring) -> NewCapture
+  ) where Match == (Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6, C7), R.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
+    self.init(node: .groupTransform(
+      .capture,
+      component().regex.root,
+      CaptureTransform(resultType: NewCapture.self) {
+        transform($0) as Any
+      },
+      reference.id))
+  }
 }
 
-public func capture<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7>(
-  as reference: Reference<W>,
-  @RegexComponentBuilder _ component: () -> R
-) -> Regex<(Substring, W, C0, C1, C2, C3, C4, C5, C6, C7)> where R.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
-  .init(node: .group(.capture, component().regex.root, reference.id))
-}
+extension TryCapture {
+    public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, NewCapture>(
+    @RegexComponentBuilder _ component: () -> R,
+    transform: @escaping (Substring) throws -> NewCapture
+  ) where Match == (Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6, C7), R.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
+    self.init(node: .groupTransform(
+      .capture,
+      component().regex.root,
+      CaptureTransform(resultType: NewCapture.self) {
+        try transform($0) as Any
+      }))
+  }
 
-public func capture<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, NewCapture>(
-  @RegexComponentBuilder _ component: () -> R,
-  transform: @escaping (Substring) -> NewCapture
-) -> Regex<(Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6, C7)> where R.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
-  .init(node: .groupTransform(
-    .capture,
-    component().regex.root,
-    CaptureTransform(resultType: NewCapture.self) {
-      transform($0) as Any
-    }))
-}
+    public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, NewCapture>(
+    as reference: Reference<NewCapture>,
+    @RegexComponentBuilder _ component: () -> R,
+    transform: @escaping (Substring) throws -> NewCapture
+  ) where Match == (Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6, C7), R.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
+    self.init(node: .groupTransform(
+      .capture,
+      component().regex.root,
+      CaptureTransform(resultType: NewCapture.self) {
+        try transform($0) as Any
+      },
+      reference.id))
+  }
 
-public func tryCapture<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, NewCapture>(
-  as reference: Reference<NewCapture>,
-  @RegexComponentBuilder _ component: () -> R,
-  transform: @escaping (Substring) throws -> NewCapture
-) -> Regex<(Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6, C7)> where R.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
-  .init(node: .groupTransform(
-    .capture,
-    component().regex.root,
-    CaptureTransform(resultType: NewCapture.self) {
-      try transform($0) as Any
-    },
-    reference.id))
-}
+    public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, NewCapture>(
+    @RegexComponentBuilder _ component: () -> R,
+    transform: @escaping (Substring) -> NewCapture?
+  ) where Match == (Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6, C7), R.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
+    self.init(node: .groupTransform(
+      .capture,
+      component().regex.root,
+      CaptureTransform(resultType: NewCapture.self) {
+        transform($0) as Any?
+      }))
+  }
 
-public func tryCapture<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, NewCapture>(
-  @RegexComponentBuilder _ component: () -> R,
-  transform: @escaping (Substring) -> NewCapture?
-) -> Regex<(Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6, C7)> where R.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
-  .init(node: .groupTransform(
-    .capture,
-    component().regex.root,
-    CaptureTransform(resultType: NewCapture.self) {
-      transform($0) as Any?
-    }))
-}
-
-public func tryCapture<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, NewCapture>(
-  as reference: Reference<NewCapture>,
-  @RegexComponentBuilder _ component: () -> R,
-  transform: @escaping (Substring) -> NewCapture?
-) -> Regex<(Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6, C7)> where R.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
-  .init(node: .groupTransform(
-    .capture,
-    component().regex.root,
-    CaptureTransform(resultType: NewCapture.self) {
-      transform($0) as Any?
-    },
-    reference.id))
+    public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, NewCapture>(
+    as reference: Reference<NewCapture>,
+    @RegexComponentBuilder _ component: () -> R,
+    transform: @escaping (Substring) -> NewCapture?
+  ) where Match == (Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6, C7), R.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
+    self.init(node: .groupTransform(
+      .capture,
+      component().regex.root,
+      CaptureTransform(resultType: NewCapture.self) {
+        transform($0) as Any?
+      },
+      reference.id))
+  }
 }
 
 // MARK: - Non-builder capture arity 9
 
-public func capture<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, C8>(
-  _ component: R
-) -> Regex<(Substring, W, C0, C1, C2, C3, C4, C5, C6, C7, C8)> where R.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
-  .init(node: .group(.capture, component.regex.root))
+extension Capture {
+    public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, C8>(
+    _ component: R
+  ) where Match == (Substring, W, C0, C1, C2, C3, C4, C5, C6, C7, C8), R.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
+    self.init(node: .group(.capture, component.regex.root))
+  }
+
+    public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, C8>(
+    _ component: R, as reference: Reference<W>
+  ) where Match == (Substring, W, C0, C1, C2, C3, C4, C5, C6, C7, C8), R.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
+    self.init(node: .group(.capture, component.regex.root, reference.id))
+  }
+
+    public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, C8, NewCapture>(
+    _ component: R,
+    transform: @escaping (Substring) -> NewCapture
+  ) where Match == (Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6, C7, C8), R.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
+    self.init(node: .groupTransform(
+      .capture,
+      component.regex.root,
+      CaptureTransform(resultType: NewCapture.self) {
+        transform($0) as Any
+      }))
+  }
+
+    public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, C8, NewCapture>(
+    _ component: R,
+    as reference: Reference<NewCapture>,
+    transform: @escaping (Substring) -> NewCapture
+  ) where Match == (Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6, C7, C8), R.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
+    self.init(node: .groupTransform(
+      .capture,
+      component.regex.root,
+      CaptureTransform(resultType: NewCapture.self) {
+        transform($0) as Any
+      },
+      reference.id))
+  }
 }
 
-public func capture<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, C8>(
-  _ component: R, as reference: Reference<W>
-) -> Regex<(Substring, W, C0, C1, C2, C3, C4, C5, C6, C7, C8)> where R.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
-  .init(node: .group(.capture, component.regex.root, reference.id))
-}
+extension TryCapture {
+    public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, C8, NewCapture>(
+    _ component: R,
+    transform: @escaping (Substring) throws -> NewCapture
+  ) where Match == (Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6, C7, C8), R.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
+    self.init(node: .groupTransform(
+      .capture,
+      component.regex.root,
+      CaptureTransform(resultType: NewCapture.self) {
+        try transform($0) as Any
+      }))
+  }
 
-public func capture<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, C8, NewCapture>(
-  _ component: R,
-  transform: @escaping (Substring) -> NewCapture
-) -> Regex<(Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6, C7, C8)> where R.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
-  .init(node: .groupTransform(
-    .capture,
-    component.regex.root,
-    CaptureTransform(resultType: NewCapture.self) {
-      transform($0) as Any
-    }))
-}
+    public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, C8, NewCapture>(
+    _ component: R,
+    as reference: Reference<NewCapture>,
+    transform: @escaping (Substring) throws -> NewCapture
+  ) where Match == (Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6, C7, C8), R.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
+    self.init(node: .groupTransform(
+      .capture,
+      component.regex.root,
+      CaptureTransform(resultType: NewCapture.self) {
+        try transform($0) as Any
+      },
+      reference.id))
+  }
 
-public func capture<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, C8, NewCapture>(
-  _ component: R,
-  as reference: Reference<NewCapture>,
-  transform: @escaping (Substring) -> NewCapture
-) -> Regex<(Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6, C7, C8)> where R.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
-  .init(node: .groupTransform(
-    .capture,
-    component.regex.root,
-    CaptureTransform(resultType: NewCapture.self) {
-      transform($0) as Any
-    },
-    reference.id))
-}
+    public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, C8, NewCapture>(
+    _ component: R,
+    transform: @escaping (Substring) -> NewCapture?
+  ) where Match == (Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6, C7, C8), R.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
+    self.init(node: .groupTransform(
+      .capture,
+      component.regex.root,
+      CaptureTransform(resultType: NewCapture.self) {
+        transform($0) as Any?
+      }))
+  }
 
-public func tryCapture<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, C8, NewCapture>(
-  _ component: R,
-  transform: @escaping (Substring) throws -> NewCapture
-) -> Regex<(Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6, C7, C8)> where R.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
-  .init(node: .groupTransform(
-    .capture,
-    component.regex.root,
-    CaptureTransform(resultType: NewCapture.self) {
-      try transform($0) as Any
-    }))
-}
-
-public func tryCapture<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, C8, NewCapture>(
-  _ component: R,
-  as reference: Reference<NewCapture>,
-  transform: @escaping (Substring) throws -> NewCapture
-) -> Regex<(Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6, C7, C8)> where R.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
-  .init(node: .groupTransform(
-    .capture,
-    component.regex.root,
-    CaptureTransform(resultType: NewCapture.self) {
-      try transform($0) as Any
-    },
-    reference.id))
-}
-
-public func tryCapture<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, C8, NewCapture>(
-  _ component: R,
-  transform: @escaping (Substring) -> NewCapture?
-) -> Regex<(Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6, C7, C8)> where R.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
-  .init(node: .groupTransform(
-    .capture,
-    component.regex.root,
-    CaptureTransform(resultType: NewCapture.self) {
-      transform($0) as Any?
-    }))
-}
-
-public func tryCapture<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, C8, NewCapture>(
-  _ component: R,
-  as reference: Reference<NewCapture>,
-  transform: @escaping (Substring) -> NewCapture?
-) -> Regex<(Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6, C7, C8)> where R.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
-  .init(node: .groupTransform(
-    .capture,
-    component.regex.root,
-    CaptureTransform(resultType: NewCapture.self) {
-      transform($0) as Any?
-    },
-    reference.id))
+    public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, C8, NewCapture>(
+    _ component: R,
+    as reference: Reference<NewCapture>,
+    transform: @escaping (Substring) -> NewCapture?
+  ) where Match == (Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6, C7, C8), R.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
+    self.init(node: .groupTransform(
+      .capture,
+      component.regex.root,
+      CaptureTransform(resultType: NewCapture.self) {
+        transform($0) as Any?
+      },
+      reference.id))
+  }
 }
 
 // MARK: - Builder capture arity 9
 
-public func capture<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, C8>(
-  @RegexComponentBuilder _ component: () -> R
-) -> Regex<(Substring, W, C0, C1, C2, C3, C4, C5, C6, C7, C8)> where R.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
-  .init(node: .group(.capture, component().regex.root))
+extension Capture {
+    public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, C8>(
+    @RegexComponentBuilder _ component: () -> R
+  ) where Match == (Substring, W, C0, C1, C2, C3, C4, C5, C6, C7, C8), R.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
+    self.init(node: .group(.capture, component().regex.root))
+  }
+
+    public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, C8>(
+    as reference: Reference<W>,
+    @RegexComponentBuilder _ component: () -> R
+  ) where Match == (Substring, W, C0, C1, C2, C3, C4, C5, C6, C7, C8), R.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
+    self.init(node: .group(.capture, component().regex.root, reference.id))
+  }
+
+    public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, C8, NewCapture>(
+    @RegexComponentBuilder _ component: () -> R,
+    transform: @escaping (Substring) -> NewCapture
+  ) where Match == (Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6, C7, C8), R.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
+    self.init(node: .groupTransform(
+      .capture,
+      component().regex.root,
+      CaptureTransform(resultType: NewCapture.self) {
+        transform($0) as Any
+      }))
+  }
+
+    public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, C8, NewCapture>(
+    as reference: Reference<NewCapture>,
+    @RegexComponentBuilder _ component: () -> R,
+    transform: @escaping (Substring) -> NewCapture
+  ) where Match == (Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6, C7, C8), R.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
+    self.init(node: .groupTransform(
+      .capture,
+      component().regex.root,
+      CaptureTransform(resultType: NewCapture.self) {
+        transform($0) as Any
+      },
+      reference.id))
+  }
 }
 
-public func capture<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, C8>(
-  as reference: Reference<W>,
-  @RegexComponentBuilder _ component: () -> R
-) -> Regex<(Substring, W, C0, C1, C2, C3, C4, C5, C6, C7, C8)> where R.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
-  .init(node: .group(.capture, component().regex.root, reference.id))
+extension TryCapture {
+    public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, C8, NewCapture>(
+    @RegexComponentBuilder _ component: () -> R,
+    transform: @escaping (Substring) throws -> NewCapture
+  ) where Match == (Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6, C7, C8), R.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
+    self.init(node: .groupTransform(
+      .capture,
+      component().regex.root,
+      CaptureTransform(resultType: NewCapture.self) {
+        try transform($0) as Any
+      }))
+  }
+
+    public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, C8, NewCapture>(
+    as reference: Reference<NewCapture>,
+    @RegexComponentBuilder _ component: () -> R,
+    transform: @escaping (Substring) throws -> NewCapture
+  ) where Match == (Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6, C7, C8), R.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
+    self.init(node: .groupTransform(
+      .capture,
+      component().regex.root,
+      CaptureTransform(resultType: NewCapture.self) {
+        try transform($0) as Any
+      },
+      reference.id))
+  }
+
+    public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, C8, NewCapture>(
+    @RegexComponentBuilder _ component: () -> R,
+    transform: @escaping (Substring) -> NewCapture?
+  ) where Match == (Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6, C7, C8), R.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
+    self.init(node: .groupTransform(
+      .capture,
+      component().regex.root,
+      CaptureTransform(resultType: NewCapture.self) {
+        transform($0) as Any?
+      }))
+  }
+
+    public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, C8, NewCapture>(
+    as reference: Reference<NewCapture>,
+    @RegexComponentBuilder _ component: () -> R,
+    transform: @escaping (Substring) -> NewCapture?
+  ) where Match == (Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6, C7, C8), R.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
+    self.init(node: .groupTransform(
+      .capture,
+      component().regex.root,
+      CaptureTransform(resultType: NewCapture.self) {
+        transform($0) as Any?
+      },
+      reference.id))
+  }
 }
 
-public func capture<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, C8, NewCapture>(
-  @RegexComponentBuilder _ component: () -> R,
-  transform: @escaping (Substring) -> NewCapture
-) -> Regex<(Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6, C7, C8)> where R.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
-  .init(node: .groupTransform(
-    .capture,
-    component().regex.root,
-    CaptureTransform(resultType: NewCapture.self) {
-      transform($0) as Any
-    }))
+// MARK: - Non-builder capture arity 10
+
+extension Capture {
+    public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9>(
+    _ component: R
+  ) where Match == (Substring, W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9), R.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
+    self.init(node: .group(.capture, component.regex.root))
+  }
+
+    public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9>(
+    _ component: R, as reference: Reference<W>
+  ) where Match == (Substring, W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9), R.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
+    self.init(node: .group(.capture, component.regex.root, reference.id))
+  }
+
+    public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9, NewCapture>(
+    _ component: R,
+    transform: @escaping (Substring) -> NewCapture
+  ) where Match == (Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9), R.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
+    self.init(node: .groupTransform(
+      .capture,
+      component.regex.root,
+      CaptureTransform(resultType: NewCapture.self) {
+        transform($0) as Any
+      }))
+  }
+
+    public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9, NewCapture>(
+    _ component: R,
+    as reference: Reference<NewCapture>,
+    transform: @escaping (Substring) -> NewCapture
+  ) where Match == (Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9), R.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
+    self.init(node: .groupTransform(
+      .capture,
+      component.regex.root,
+      CaptureTransform(resultType: NewCapture.self) {
+        transform($0) as Any
+      },
+      reference.id))
+  }
 }
 
-public func tryCapture<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, C8, NewCapture>(
-  as reference: Reference<NewCapture>,
-  @RegexComponentBuilder _ component: () -> R,
-  transform: @escaping (Substring) throws -> NewCapture
-) -> Regex<(Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6, C7, C8)> where R.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
-  .init(node: .groupTransform(
-    .capture,
-    component().regex.root,
-    CaptureTransform(resultType: NewCapture.self) {
-      try transform($0) as Any
-    },
-    reference.id))
+extension TryCapture {
+    public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9, NewCapture>(
+    _ component: R,
+    transform: @escaping (Substring) throws -> NewCapture
+  ) where Match == (Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9), R.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
+    self.init(node: .groupTransform(
+      .capture,
+      component.regex.root,
+      CaptureTransform(resultType: NewCapture.self) {
+        try transform($0) as Any
+      }))
+  }
+
+    public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9, NewCapture>(
+    _ component: R,
+    as reference: Reference<NewCapture>,
+    transform: @escaping (Substring) throws -> NewCapture
+  ) where Match == (Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9), R.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
+    self.init(node: .groupTransform(
+      .capture,
+      component.regex.root,
+      CaptureTransform(resultType: NewCapture.self) {
+        try transform($0) as Any
+      },
+      reference.id))
+  }
+
+    public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9, NewCapture>(
+    _ component: R,
+    transform: @escaping (Substring) -> NewCapture?
+  ) where Match == (Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9), R.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
+    self.init(node: .groupTransform(
+      .capture,
+      component.regex.root,
+      CaptureTransform(resultType: NewCapture.self) {
+        transform($0) as Any?
+      }))
+  }
+
+    public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9, NewCapture>(
+    _ component: R,
+    as reference: Reference<NewCapture>,
+    transform: @escaping (Substring) -> NewCapture?
+  ) where Match == (Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9), R.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
+    self.init(node: .groupTransform(
+      .capture,
+      component.regex.root,
+      CaptureTransform(resultType: NewCapture.self) {
+        transform($0) as Any?
+      },
+      reference.id))
+  }
 }
 
-public func tryCapture<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, C8, NewCapture>(
-  @RegexComponentBuilder _ component: () -> R,
-  transform: @escaping (Substring) -> NewCapture?
-) -> Regex<(Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6, C7, C8)> where R.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
-  .init(node: .groupTransform(
-    .capture,
-    component().regex.root,
-    CaptureTransform(resultType: NewCapture.self) {
-      transform($0) as Any?
-    }))
+// MARK: - Builder capture arity 10
+
+extension Capture {
+    public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9>(
+    @RegexComponentBuilder _ component: () -> R
+  ) where Match == (Substring, W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9), R.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
+    self.init(node: .group(.capture, component().regex.root))
+  }
+
+    public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9>(
+    as reference: Reference<W>,
+    @RegexComponentBuilder _ component: () -> R
+  ) where Match == (Substring, W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9), R.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
+    self.init(node: .group(.capture, component().regex.root, reference.id))
+  }
+
+    public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9, NewCapture>(
+    @RegexComponentBuilder _ component: () -> R,
+    transform: @escaping (Substring) -> NewCapture
+  ) where Match == (Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9), R.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
+    self.init(node: .groupTransform(
+      .capture,
+      component().regex.root,
+      CaptureTransform(resultType: NewCapture.self) {
+        transform($0) as Any
+      }))
+  }
+
+    public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9, NewCapture>(
+    as reference: Reference<NewCapture>,
+    @RegexComponentBuilder _ component: () -> R,
+    transform: @escaping (Substring) -> NewCapture
+  ) where Match == (Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9), R.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
+    self.init(node: .groupTransform(
+      .capture,
+      component().regex.root,
+      CaptureTransform(resultType: NewCapture.self) {
+        transform($0) as Any
+      },
+      reference.id))
+  }
 }
 
-public func tryCapture<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, C8, NewCapture>(
-  as reference: Reference<NewCapture>,
-  @RegexComponentBuilder _ component: () -> R,
-  transform: @escaping (Substring) -> NewCapture?
-) -> Regex<(Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6, C7, C8)> where R.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
-  .init(node: .groupTransform(
-    .capture,
-    component().regex.root,
-    CaptureTransform(resultType: NewCapture.self) {
-      transform($0) as Any?
-    },
-    reference.id))
+extension TryCapture {
+    public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9, NewCapture>(
+    @RegexComponentBuilder _ component: () -> R,
+    transform: @escaping (Substring) throws -> NewCapture
+  ) where Match == (Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9), R.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
+    self.init(node: .groupTransform(
+      .capture,
+      component().regex.root,
+      CaptureTransform(resultType: NewCapture.self) {
+        try transform($0) as Any
+      }))
+  }
+
+    public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9, NewCapture>(
+    as reference: Reference<NewCapture>,
+    @RegexComponentBuilder _ component: () -> R,
+    transform: @escaping (Substring) throws -> NewCapture
+  ) where Match == (Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9), R.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
+    self.init(node: .groupTransform(
+      .capture,
+      component().regex.root,
+      CaptureTransform(resultType: NewCapture.self) {
+        try transform($0) as Any
+      },
+      reference.id))
+  }
+
+    public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9, NewCapture>(
+    @RegexComponentBuilder _ component: () -> R,
+    transform: @escaping (Substring) -> NewCapture?
+  ) where Match == (Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9), R.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
+    self.init(node: .groupTransform(
+      .capture,
+      component().regex.root,
+      CaptureTransform(resultType: NewCapture.self) {
+        transform($0) as Any?
+      }))
+  }
+
+    public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9, NewCapture>(
+    as reference: Reference<NewCapture>,
+    @RegexComponentBuilder _ component: () -> R,
+    transform: @escaping (Substring) -> NewCapture?
+  ) where Match == (Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9), R.Match == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
+    self.init(node: .groupTransform(
+      .capture,
+      component().regex.root,
+      CaptureTransform(resultType: NewCapture.self) {
+        transform($0) as Any?
+      },
+      reference.id))
+  }
 }
 
 

--- a/Tests/RegexTests/AlgorithmsTests.swift
+++ b/Tests/RegexTests/AlgorithmsTests.swift
@@ -116,7 +116,7 @@ class RegexConsumerTests: XCTestCase {
   }
   
   func testMatches() {
-    let regex = capture(oneOrMore(.digit)) { 2 * Int($0)! }
+    let regex = Capture(OneOrMore(.digit)) { 2 * Int($0)! }
     let str = "foo 160 bar 99 baz"
     XCTAssertEqual(str.matches(of: regex).map(\.result.1), [320, 198])
   }
@@ -133,7 +133,7 @@ class RegexConsumerTests: XCTestCase {
       XCTAssertEqual(input.replacing(regex, with: replace), result)
     }
     
-    let int = capture(oneOrMore(.digit)) { Int($0)! }
+    let int = Capture(OneOrMore(.digit)) { Int($0)! }
     
     replaceTest(
       int,
@@ -149,13 +149,13 @@ class RegexConsumerTests: XCTestCase {
 
     // TODO: Need to support capture history
     // replaceTest(
-    //   oneOrMore { int; "," },
+    //   OneOrMore { int; "," },
     //   input: "3,5,8,0, 1,0,2,-5,x8,8,",
     //   result: "16 3-5x16",
     //   { match in "\(match.result.1.reduce(0, +))" })
     
     replaceTest(
-      Regex { int; "x"; int; optionally { "x"; int } },
+      Regex { int; "x"; int; Optionally { "x"; int } },
       input: "2x3 5x4x3 6x0 1x2x3x4",
       result: "6 60 0 6x4",
       { match in "\(match.result.1 * match.result.2 * (match.result.3 ?? 1))" })

--- a/Tests/RegexTests/CustomTests.swift
+++ b/Tests/RegexTests/CustomTests.swift
@@ -76,7 +76,7 @@ extension RegexTests {
 
     customTest(
       Regex {
-        oneOrMore { Numbler() }
+        OneOrMore { Numbler() }
       },
       ("ab123c", .firstMatch, "123"),
       ("abc", .firstMatch, nil),
@@ -97,8 +97,8 @@ extension RegexTests {
     // `Equatable` which tuples cannot be.
 
     let regex3 = Regex {
-      capture {
-        oneOrMore {
+      Capture {
+        OneOrMore {
           Numbler()
         }
       }
@@ -114,8 +114,8 @@ extension RegexTests {
     XCTAssertEqual(res3.result.1, "123")
 
     let regex4 = Regex {
-      oneOrMore {
-        capture { Numbler() }
+      OneOrMore {
+        Capture { Numbler() }
       }
     }
 


### PR DESCRIPTION
Replace free functions such as `oneOrMore` with types such as `OneOrMore`. This hides overloads of free functions as initializers within those types. It also makes the DSL consistent with SwiftUI.

- `oneOrMore` -> `OneOrMore`
- `zeroOrMore` -> `ZeroOrMore`
- `optionally` -> `Optionally`
- `repeating` -> `Repeat`
- `choiceOf` -> `ChoiceOf`
- `capture` -> `Capture`
- `tryCapture` -> `TryCapture`

Note: The reason we didn't realize this was possible (e.g. in #126) was because we were narrowly focused on including the subpattern type in the quantifier/combinator's generic parameter, i.e. `OneOrMore<Component: RegexComponent>`, which made it impossible to deduce each type's `typealias Match` from `Component`. Now we have an unconstrained generic parameter (e.g. `OneOrMore<Match>`) which gives us the full flexibility to hide `Match` deduction rules in initializers' type signatures.

Result: All non-operator top-level functions have been eliminated.