### PR TITLE
Store source locations of builder expressions for regex compilation errors

### DIFF
--- a/Sources/_StringProcessing/Compiler.swift
+++ b/Sources/_StringProcessing/Compiler.swift
@@ -44,14 +44,20 @@ func _compileRegex(
 }
 
 // An error produced when compiling a regular expression.
-public enum RegexCompilationError: Error, CustomStringConvertible {
-  // TODO: Source location?
-  case uncapturedReference
+enum RegexCompilationError: Error, CustomStringConvertible {
+  case uncapturedReference([DSLSourceLocation])
 
   public var description: String {
     switch self {
-    case .uncapturedReference:
-      return "Found a reference used before it captured any match."
+    case .uncapturedReference(let locs):
+      var message = """
+         Found a reference used before it captured any match. Used at:
+
+         """
+      for loc in locs {
+        message += "- \(loc.description)\n"
+      }
+      return message
     }
   }
 }

--- a/Sources/_StringProcessing/ConsumerInterface.swift
+++ b/Sources/_StringProcessing/ConsumerInterface.swift
@@ -33,7 +33,7 @@ extension DSLTree.Node {
       fatalError(
         "unreachable: We should only ask atoms")
 
-    case let .convertedRegexLiteral(n, _):
+    case let .convertedRegexLiteral(n, _), let .located(n, _):
       return try n.generateConsumer(opts)
 
     case .alternation, .conditional, .concatenation, .group,

--- a/Sources/_StringProcessing/PrintAsPattern.swift
+++ b/Sources/_StringProcessing/PrintAsPattern.swift
@@ -163,6 +163,11 @@ extension PrettyPrinter {
 
     case .absentFunction:
       print("/* TODO: absent function */")
+
+    case let .located(node, loc):
+      printBlock("Located(\(loc))") { printer in
+        printer.printAsPattern(convertedFromAST: node)
+      }
     }
   }
 

--- a/Sources/_StringProcessing/RegexDSL/Builder.swift
+++ b/Sources/_StringProcessing/RegexDSL/Builder.swift
@@ -15,12 +15,37 @@ public enum RegexComponentBuilder {
     .init(node: .empty)
   }
 
-  public static func buildPartialBlock<R: RegexComponent>(first: R ) -> R {
+  /// A builder component that stores a regex component and its source location
+  /// for debugging purposes.
+  public struct Component<Value: RegexComponent>: RegexComponent {
+    public var value: Value
+    public var file: String
+    public var function: String
+    public var line: Int
+    public var column: Int
+
+    var location: DSLSourceLocation {
+      .init(file: file, function: function, line: line, column: column)
+    }
+
+    public var regex: Regex<Value.Match> {
+      .init(node: .located(value.regex.root, location))
+    }
+  }
+
+  public static func buildPartialBlock<R: RegexComponent>(first: R) -> R {
     first
   }
 
-  public static func buildExpression<R: RegexComponent>(_ regex: R) -> R {
-    regex
+  public static func buildExpression<R: RegexComponent>(
+    _ regex: R,
+    file: String = #file,
+    function: String = #function,
+    line: Int = #line,
+    column: Int = #column
+  ) -> Component<R> {
+    .init(
+      value: regex, file: file, function: function, line: line, column: column)
   }
 
   public static func buildEither<R: RegexComponent>(first component: R) -> R {

--- a/Sources/_StringProcessing/RegexDSL/Core.swift
+++ b/Sources/_StringProcessing/RegexDSL/Core.swift
@@ -11,7 +11,6 @@
 
 import _MatchingEngine
 
-
 /// A type that represents a regular expression.
 public protocol RegexComponent {
   associatedtype Match
@@ -31,7 +30,13 @@ public struct Regex<Match>: RegexComponent {
     let tree: DSLTree
 
     /// The program for execution with the matching engine.
-    lazy private(set) var loweredProgram = try! Compiler(tree: tree).emit()
+    lazy private(set) var loweredProgram: MEProgram<String> = {
+      do {
+        return try Compiler(tree: tree).emit()
+      } catch {
+        fatalError("Regex compilation failed: \(error)")
+      }
+    }()
 
     init(ast: AST) {
       self.tree = ast.dslTree

--- a/Sources/_StringProcessing/RegexDSL/DSL.swift
+++ b/Sources/_StringProcessing/RegexDSL/DSL.swift
@@ -198,8 +198,15 @@ public struct AlternationBuilder {
     .init(component.regex)
   }
 
-  public static func buildExpression<R: RegexComponent>(_ regex: R) -> R {
-    regex
+  public static func buildExpression<R: RegexComponent>(
+    _ regex: R,
+    file: String = #file,
+    function: String = #function,
+    line: Int = #line,
+    column: Int = #column
+  ) -> RegexComponentBuilder.Component<R> {
+    .init(
+      value: regex, file: file, function: function, line: line, column: column)
   }
 
   public static func buildEither<R: RegexComponent>(first component: R) -> R {

--- a/Sources/_StringProcessing/RegexDSL/DSLSourceLocation.swift
+++ b/Sources/_StringProcessing/RegexDSL/DSLSourceLocation.swift
@@ -1,0 +1,28 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2021-2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+struct DSLSourceLocation {
+  var file: String
+  var function: String
+  var line: Int
+  var column: Int
+}
+
+extension DSLSourceLocation: CustomStringConvertible {
+  var description: String {
+    "\(file)@\(function):\(line):\(column)"
+  }
+}
+
+struct DSLLocated<Value> {
+  var value: Value
+  var location: DSLSourceLocation?
+}

--- a/Sources/_StringProcessing/RegexDSL/DSLTree.swift
+++ b/Sources/_StringProcessing/RegexDSL/DSLTree.swift
@@ -90,6 +90,8 @@ extension DSLTree {
 
     // TODO: Would this just boil down to a consumer?
     case characterPredicate(_CharacterPredicateInterface)
+
+    case located(Node, DSLSourceLocation)
   }
 }
 
@@ -177,6 +179,8 @@ extension DSLTree.Node {
 
     case let .absentFunction(a):
       return a.children.map(\.dslTreeNode)
+
+    case let .located(n, _): return [n]
     }
   }
 }
@@ -287,7 +291,7 @@ extension DSLTree.Node {
     case let .absentFunction(abs):
       return constructor.absent(abs.kind)
 
-    case let .convertedRegexLiteral(n, _):
+    case let .convertedRegexLiteral(n, _), let .located(n, _):
       // TODO: Switch nesting strategy?
       return n._captureStructure(&constructor)
 

--- a/Tests/RegexTests/RegexDSLTests.swift
+++ b/Tests/RegexTests/RegexDSLTests.swift
@@ -659,6 +659,22 @@ class RegexDSLTests: XCTestCase {
         }
       }
     }
+
+    // TODO: Test runtime error.
+    #if false
+    do {
+      let a = Reference(Substring.self)
+      let regex = Regex {
+        "abc"
+        a
+        OneOrMore(a)
+      }
+      _ = "abc".match(regex)
+      // Fatal error: Regex compilation failed: Found a reference used before it captured any match. Used at:
+      //  - .../RegexDSLTests.swift@testBackreference():667:9
+      //  - .../RegexDSLTests.swift@testBackreference():668:9
+    }
+    #endif
   }
   
   func testSemanticVersionExample() {


### PR DESCRIPTION
Store source locations using `buildExpression` and print locations upon regex compilation errors. The builder design (i.e. whether `RegexComponentBuilder.Component` should conform to `RegexComponent`) and the ME implementation should be revisited.

Example:

```swift
let a = Reference(Substring.self)
let regex = Regex {
  "abc"
  a
  OneOrMore(a)
}
_ = "abc".match(regex)
// Fatal error: Regex compilation failed: Found a reference used before it captured any match. Used at:
//  - .../RegexDSLTests.swift@testBackreference():667:9
//  - .../RegexDSLTests.swift@testBackreference():668:9
```