### PR TITLE
Clarify integration process.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,9 @@ A pair of corresponding branches are expected to build successfully together and
 To integrate the latest changes in apple/swift-experimental-string-processing to apple/swift, carefully follow the workflow: 
 
 - Create pull requests.
-  - Create a pull request in apple/swift-experimental-string-processing from `main` to `swift/main`, e.g. "[Integration] main -> swift/main".
-  - If apple/swift needs to be modified to work with the latest `main` in apple/swift-experimental-string-processing, create a pull request in apple/swift.
+  - Create a branch from a commit on `main` that you would like to integrate into `swift/main`.
+  - Create a pull request in apple/swift-experimental-string-processing from that branch to `swift/main`, e.g. "[Integration] main (<commit>) -> swift/main".
+  - If apple/swift needs to be modified to work with the latest `main` in apple/swift-experimental-string-processing, create a pull request in apple/swift.  **Note:** Since CI in apple/swift-experimental-string-processing has not yet been set up to run full toolchain tests, you should create a PR in apple/swift regardless; if the integartion does not require changing apple/swift, create a dummy PR in apple/swift by changing the README and just not merge it in the end.
 - Trigger CI.
   - In the apple/swift-experimental-string-processing pull request, trigger CI using the following command (replacing `<PR NUMBER>` with the apple/swift pull request number, if any):
     ```


### PR DESCRIPTION
- Require creating an branch from a commit on main instead of merging from main, as main is moving constantly.
- Require creating a dummy PR in apple/swift before we have full CI in this repo.