### PR TITLE
Escape sequence + empty char class tweaks

### DIFF
--- a/Sources/_RegexParser/Regex/Parse/Diagnostics.swift
+++ b/Sources/_RegexParser/Regex/Parse/Diagnostics.swift
@@ -39,6 +39,7 @@ enum ParseError: Error, Hashable {
 
   case expectedNonEmptyContents
   case expectedEscape
+  case invalidEscape(Character)
 
   case cannotReferToWholePattern
 
@@ -107,6 +108,8 @@ extension ParseError: CustomStringConvertible {
       return "expected non-empty contents"
     case .expectedEscape:
       return "expected escape sequence"
+    case .invalidEscape(let c):
+      return "invalid escape sequence '\\\(c)'"
     case .cannotReferToWholePattern:
       return "cannot refer to whole pattern here"
     case .notQuantifiable:

--- a/Sources/_RegexParser/Regex/Parse/LexicalAnalysis.swift
+++ b/Sources/_RegexParser/Regex/Parse/LexicalAnalysis.swift
@@ -1489,8 +1489,17 @@ extension Source {
         return try .scalar(
           src.expectUnicodeScalar(escapedCharacter: char).value)
       default:
-        return .char(char)
+        break
       }
+
+      // We only allow unknown escape sequences for non-letter ASCII, and
+      // non-ASCII whitespace.
+      guard (char.isASCII && !char.isLetter) ||
+              (!char.isASCII && char.isWhitespace)
+      else {
+        throw ParseError.invalidEscape(char)
+      }
+      return .char(char)
     }
   }
 

--- a/Sources/_RegexParser/Regex/Parse/Parse.swift
+++ b/Sources/_RegexParser/Regex/Parse/Parse.swift
@@ -425,6 +425,12 @@ extension Parser {
     try source.expectNonEmpty()
 
     var members: Array<Member> = []
+
+    // We can eat an initial ']', as PCRE, Oniguruma, and ICU forbid empty
+    // character classes, and assume an initial ']' is literal.
+    if let loc = source.tryEatWithLoc("]") {
+      members.append(.atom(.init(.char("]"), loc)))
+    }
     try parseCCCMembers(into: &members)
 
     // If we have a binary set operator, parse it and the next members. Note

--- a/Sources/_RegexParser/Regex/Parse/Parse.swift
+++ b/Sources/_RegexParser/Regex/Parse/Parse.swift
@@ -489,10 +489,11 @@ extension Parser {
       // Range between atoms.
       if let (dashLoc, rhs) =
           try source.lexCustomCharClassRangeEnd(context: context) {
-        guard atom.literalCharacterValue != nil &&
-              rhs.literalCharacterValue != nil else {
+        guard atom.isValidCharacterClassRangeBound &&
+              rhs.isValidCharacterClassRangeBound else {
           throw ParseError.invalidCharacterClassRangeOperand
         }
+        // TODO: Validate lower <= upper?
         members.append(.range(.init(atom, dashLoc, rhs)))
         continue
       }

--- a/Sources/_StringProcessing/CharacterClass.swift
+++ b/Sources/_StringProcessing/CharacterClass.swift
@@ -319,21 +319,6 @@ extension CharacterClass {
   }
 }
 
-extension AST.Node {
-  /// If this has a character class representation, whether built-in or custom, return it.
-  ///
-  /// TODO: Not sure if this the right model type, but I suspect we'll want to produce
-  /// something like this on demand
-  var characterClass: CharacterClass? {
-    switch self {
-    case let .customCharacterClass(cc): return cc.modelCharacterClass
-    case let .atom(a): return a.characterClass
-
-    default: return nil
-    }
-  }
-}
-
 extension DSLTree.Node {
   var characterClass: CharacterClass? {
     switch self {
@@ -499,66 +484,6 @@ extension DSLTree.CustomCharacterClass {
     }
     let cc = CharacterClass.custom(result)
     return isInverted ? cc.inverted : cc
-  }
-}
-
-extension AST.CustomCharacterClass {
-  /// The model character class for this custom character class.
-  var modelCharacterClass: CharacterClass? {
-    typealias Component = CharacterClass.CharacterSetComponent
-    func getComponents(_ members: [Member]) -> [Component]? {
-      var result = Array<Component>()
-      for m in members {
-        switch m {
-        case .custom(let cc):
-          guard let cc = cc.modelCharacterClass else {
-            return nil
-          }
-          result.append(.characterClass(cc))
-        case .range(let r):
-          result.append(.range(
-            r.lhs.literalCharacterValue! ...
-            r.rhs.literalCharacterValue!))
-
-        case .atom(let a):
-          if let cc = a.characterClass {
-            result.append(.characterClass(cc))
-          } else if let lit = a.literalCharacterValue {
-            result.append(.character(lit))
-          } else {
-            return nil
-          }
-
-        case .quote(let q):
-          // Decompose quoted literal into literal characters.
-          result += q.literal.map { .character($0) }
-
-        case .trivia:
-          // Not semantically important.
-          break
-
-        case .setOperation(let lhs, let op, let rhs):
-          // FIXME: CharacterClass wasn't designed for set operations with
-          // multiple components in each operand, we should fix that. For now,
-          // just produce custom components.
-          guard let lhs = getComponents(lhs),
-                let rhs = getComponents(rhs)
-          else {
-            return nil
-          }
-          result.append(.setOperation(.init(
-            lhs: .characterClass(.custom(lhs)),
-            op: op.value,
-            rhs: .characterClass(.custom(rhs)))))
-        }
-      }
-      return result
-    }
-    guard let comps = getComponents(members) else {
-      return nil
-    }
-    let cc = CharacterClass.custom(comps)
-    return self.isInverted ? cc.inverted : cc
   }
 }
 

--- a/Tests/RegexTests/MatchTests.swift
+++ b/Tests/RegexTests/MatchTests.swift
@@ -594,6 +594,35 @@ extension RegexTests {
 
     firstMatchTest("[[:script=Greek:]]", input: "123αβγxyz", match: "α")
 
+    func scalar(_ u: UnicodeScalar) -> UInt32 { u.value }
+
+    // Currently not supported in the matching engine.
+    for s in scalar("\u{C}") ... scalar("\u{1B}") {
+      let u = UnicodeScalar(s)!
+      firstMatchTest(#"[\f-\e]"#, input: "\u{B}\u{1C}\(u)", match: "\(u)",
+                     xfail: true)
+    }
+    for u: UnicodeScalar in ["\u{7}", "\u{8}"] {
+      firstMatchTest(#"[\a-\b]"#, input: "\u{6}\u{9}\(u)", match: "\(u)",
+                     xfail: true)
+    }
+    for s in scalar("\u{A}") ... scalar("\u{D}") {
+      let u = UnicodeScalar(s)!
+      firstMatchTest(#"[\n-\r]"#, input: "\u{9}\u{E}\(u)", match: "\(u)",
+                     xfail: true)
+    }
+    firstMatchTest(#"[\t-\t]"#, input: "\u{8}\u{A}\u{9}", match: "\u{9}",
+                   xfail: true)
+
+    for c: UnicodeScalar in ["a", "b", "c"] {
+      firstMatchTest(#"[\c!-\C-#]"#, input: "def\(c)", match: "\(c)",
+                     xfail: true)
+    }
+    for c: UnicodeScalar in ["$", "%", "&", "'"] {
+      firstMatchTest(#"[\N{DOLLAR SIGN}-\N{APOSTROPHE}]"#,
+                     input: "#()\(c)", match: "\(c)", xfail: true)
+    }
+
     // MARK: Operators
 
     firstMatchTest(

--- a/Tests/RegexTests/ParseTests.swift
+++ b/Tests/RegexTests/ParseTests.swift
@@ -544,9 +544,8 @@ extension RegexTests {
       #"a\Q \Q \\.\Eb"#,
       concat("a", quote(#" \Q \\."#), "b"))
 
-    // These follow the PCRE behavior.
+    // This follows the PCRE behavior.
     parseTest(#"\Q\\E"#, quote("\\"))
-    parseTest(#"\E"#, "E")
 
     parseTest(#"a" ."b"#, concat("a", quote(" ."), "b"),
               syntax: .experimental)
@@ -565,6 +564,16 @@ extension RegexTests {
               syntax: .experimental)
 
     parseTest(#"["-"]"#, charClass(range_m("\"", "\"")))
+
+    // MARK: Escapes
+
+    // Not metachars, but we allow their escape as ASCII.
+    parseTest(#"\<"#, "<")
+    parseTest(#"\ "#, " ")
+    parseTest(#"\\"#, "\\")
+
+    // Escaped U+3000 IDEOGRAPHIC SPACE.
+    parseTest(#"\\#u{3000}"#, "\u{3000}")
 
     // MARK: Comments
 
@@ -989,13 +998,6 @@ extension RegexTests {
     // Backreferences are not valid in custom character classes.
     parseTest(#"[\8]"#, charClass("8"))
     parseTest(#"[\9]"#, charClass("9"))
-    parseTest(#"[\g]"#, charClass("g"))
-    parseTest(#"[\g+30]"#, charClass("g", "+", "3", "0"))
-    parseTest(#"[\g{1}]"#, charClass("g", "{", "1", "}"))
-    parseTest(#"[\k'a']"#, charClass("k", "'", "a", "'"))
-
-    parseTest(#"\g"#, atom(.char("g")))
-    parseTest(#"\k"#, atom(.char("k")))
 
     // MARK: Character names.
 
@@ -1526,7 +1528,7 @@ extension RegexTests {
     parseWithDelimitersTest("re'x*'", zeroOrMore(of: "x"))
 
     parseWithDelimitersTest(#"re'🔥🇩🇰'"#, concat("🔥", "🇩🇰"))
-    parseWithDelimitersTest(#"re'\🔥✅'"#, concat("🔥", "✅"))
+    parseWithDelimitersTest(#"re'🔥✅'"#, concat("🔥", "✅"))
 
     // Printable ASCII characters.
     delimiterLexingTest(##"re' !"#$%&\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefghijklmnopqrstuvwxyz{|}~'"##)
@@ -1874,6 +1876,26 @@ extension RegexTests {
     // MARK: Bad escapes
 
     diagnosticTest("\\", .expectedEscape)
+
+    // TODO: Custom diagnostic for expected backref
+    diagnosticTest(#"\g"#, .invalidEscape("g"))
+    diagnosticTest(#"\k"#, .invalidEscape("k"))
+
+    // TODO: Custom diagnostic for backref in custom char class
+    diagnosticTest(#"[\g]"#, .invalidEscape("g"))
+    diagnosticTest(#"[\g+30]"#, .invalidEscape("g"))
+    diagnosticTest(#"[\g{1}]"#, .invalidEscape("g"))
+    diagnosticTest(#"[\k'a']"#, .invalidEscape("k"))
+
+    // TODO: Custom diagnostic for missing '\Q'
+    diagnosticTest(#"\E"#, .invalidEscape("E"))
+
+    // Non-ASCII non-whitespace cases.
+    diagnosticTest(#"\🔥"#, .invalidEscape("🔥"))
+    diagnosticTest(#"\🇩🇰"#, .invalidEscape("🇩🇰"))
+    diagnosticTest(#"\e\#u{301}"#, .invalidEscape("e\u{301}"))
+    diagnosticTest(#"\\#u{E9}"#, .invalidEscape("é"))
+    diagnosticTest(#"\˂"#, .invalidEscape("˂"))
 
     // MARK: Text Segment options
 

--- a/Tests/RegexTests/ParseTests.swift
+++ b/Tests/RegexTests/ParseTests.swift
@@ -428,6 +428,10 @@ extension RegexTests {
 
     parseTest("[-]", charClass("-"))
 
+    // Empty character classes are forbidden, therefore this is a character
+    // class of literal ']'.
+    parseTest("[]]", charClass("]"))
+
     // These are metacharacters in certain contexts, but normal characters
     // otherwise.
     parseTest(
@@ -1900,6 +1904,10 @@ extension RegexTests {
     diagnosticTest("(?<a--", .identifierMustBeAlphaNumeric(.groupName))
     diagnosticTest("(?<a-b", .expected(">"))
     diagnosticTest("(?<a-b>", .expected(")"))
+
+    // The first ']' of a custom character class is literal, so this is missing
+    // the closing bracket.
+    diagnosticTest("[]", .expected("]"))
 
     // MARK: Bad escapes
 


### PR DESCRIPTION
- Start throwing an error on unknown `a-zA-Z` and non-ASCII non-whitespace escape sequences.
- Start allowing more escape sequences that denote Unicode scalars in custom character class ranges.
- Forbid empty character classes, `]` as the first character is instead treated as literal, for consistency with PCRE, Oniguruma, and ICU.