### PR TITLE
Avoid conforming String to Error in this module

### DIFF
--- a/Sources/Exercises/Participant.swift
+++ b/Sources/Exercises/Participant.swift
@@ -29,24 +29,25 @@ public protocol Participant {
   // ...
 }
 
+// Errors that may be thrown from default implementations
+private enum ParticipantError: Error {
+  case unsupported
+}
+
 // Default impls
 extension Participant {
-  enum Error: Swift.Error {
-    case unsupported
-  }
-
   // Produce a function that will parse a grapheme break entry from a line
   public static func graphemeBreakProperty() throws -> (String) -> GraphemeBreakEntry? {
-    throw Error.unsupported
+    throw ParticipantError.unsupported
   }
 
   // Produce a function that will extract the bodies of C-style comments from its input
   public static func cComments() throws -> (String) -> [Substring] {
-    throw Error.unsupported
+    throw ParticipantError.unsupported
   }
 
   // Produce a function that will extract the bodies of Swift-style comments from its input
   public static func swiftComments() throws -> (String) -> [Substring] {
-    throw Error.unsupported
+    throw ParticipantError.unsupported
   }
 }

--- a/Sources/Exercises/Participant.swift
+++ b/Sources/Exercises/Participant.swift
@@ -31,20 +31,22 @@ public protocol Participant {
 
 // Default impls
 extension Participant {
-  static var unsupported: Error { "Unsupported" }
+  enum Error: Swift.Error {
+    case unsupported
+  }
 
   // Produce a function that will parse a grapheme break entry from a line
   public static func graphemeBreakProperty() throws -> (String) -> GraphemeBreakEntry? {
-    throw unsupported
+    throw Error.unsupported
   }
 
   // Produce a function that will extract the bodies of C-style comments from its input
   public static func cComments() throws -> (String) -> [Substring] {
-    throw unsupported
+    throw Error.unsupported
   }
 
   // Produce a function that will extract the bodies of Swift-style comments from its input
   public static func swiftComments() throws -> (String) -> [Substring] {
-    throw unsupported
+    throw Error.unsupported
   }
 }

--- a/Sources/_MatchingEngine/Regex/Parse/Parse.swift
+++ b/Sources/_MatchingEngine/Regex/Parse/Parse.swift
@@ -122,15 +122,6 @@ extension ParsingContext {
 
 // Diagnostics
 extension Parser {
-  mutating func report(
-    _ str: String, _ function: String = #function, _ line: Int = #line
-  ) throws -> Never {
-    throw """
-        ERROR: \(str)
-        (error detected in parser at \(function):\(line))
-        """
-  }
-
   fileprivate func loc(
     _ start: Source.Position
   ) -> SourceLocation {
@@ -529,5 +520,3 @@ public func parseWithDelimiters<S: StringProtocol>(
   let (contents, delim) = droppingRegexDelimiters(String(regex))
   return try parse(contents, delim.defaultSyntaxOptions)
 }
-
-extension String: Error {}

--- a/Tests/RegexTests/MatchTests.swift
+++ b/Tests/RegexTests/MatchTests.swift
@@ -13,6 +13,13 @@ import XCTest
 @testable import _MatchingEngine
 @testable import _StringProcessing
 
+struct MatchError: Error {
+    var message: String
+    init(_ message: String) {
+        self.message = message
+    }
+}
+
 extension Executor {
   func _firstMatch(
     _ regex: String, input: String,
@@ -31,7 +38,7 @@ extension Executor {
         let caps = result.rawCaptures.slices(from: input)
         return (input[result.range], caps)
       } else if start == input.endIndex {
-        throw "match not found for \(regex) in \(input)"
+        throw MatchError("match not found for \(regex) in \(input)")
       } else {
         input.formIndex(after: &start)
       }
@@ -76,27 +83,29 @@ func flatCaptureTest(
         if expect == nil {
           continue
         } else {
-          throw "Match failed"
+          throw MatchError("Match failed")
         }
       }
       guard let expect = expect else {
-        throw "Match of \(test) succeeded where failure expected in \(regex)"
+        throw MatchError("""
+            Match of \(test) succeeded where failure expected in \(regex)
+            """)
       }
       let capStrs = caps.map { $0 == nil ? nil : String($0!) }
       guard expect.count == capStrs.count else {
-        throw """
+        throw MatchError("""
           Capture count mismatch:
             \(expect)
             \(capStrs)
-          """
+          """)
       }
 
       guard expect.elementsEqual(capStrs) else {
-        throw """
+        throw MatchError("""
           Capture mismatch:
             \(expect)
             \(capStrs)
-          """
+          """)
       }
     } catch {
       if !xfail {


### PR DESCRIPTION
This seems like an overly-broad conformance to add to
swift-experimental-string-processing. Do we need this?

I noticed this while testing https://github.com/apple/swift/pull/36068, this trips the resilient retroactive conformance warning since we're building this with library evolution.