### PR TITLE
Remove `Regex.init<R: RegexComponent>(_: R)`.

### DIFF
--- a/Sources/RegexBuilder/DSL.swift
+++ b/Sources/RegexBuilder/DSL.swift
@@ -16,7 +16,7 @@ extension Regex {
   public init<Content: RegexComponent>(
     @RegexComponentBuilder _ content: () -> Content
   ) where Content.Output == Output {
-    self.init(content())
+    self = content().regex
   }
 }
 

--- a/Sources/_StringProcessing/Regex/Core.swift
+++ b/Sources/_StringProcessing/Regex/Core.swift
@@ -81,12 +81,6 @@ public struct Regex<Output>: RegexComponent {
     self.init(ast: try! parseWithDelimiters(pattern))
   }
 
-  public init<Content: RegexComponent>(
-    _ content: Content
-  ) where Content.Output == Output {
-    self = content.regex
-  }
-
   public var regex: Regex<Output> {
     self
   }

--- a/Tests/RegexBuilderTests/RegexDSLTests.swift
+++ b/Tests/RegexBuilderTests/RegexDSLTests.swift
@@ -22,7 +22,7 @@ class RegexDSLTests: XCTestCase {
     line: UInt = #line,
     @RegexComponentBuilder _ content: () -> Content
   ) throws {
-    let regex = Regex(content())
+    let regex = content()
     for (input, maybeExpectedCaptures) in tests {
       let maybeMatch = input.match(regex)
       if let expectedCaptures = maybeExpectedCaptures {


### PR DESCRIPTION
`Regex.init<R: RegexComponent>(_: R)` has existed as a way to convert any `RegexComponent` to a `Regex`. However, it is not super useful for the end user. More importantly, its existence seems to cause bad error messages in regex builder closures.

<img width="583" alt="with-init" src="https://user-images.githubusercontent.com/856507/160708135-8f43e104-3df0-43d1-8467-22a51eb59ed9.png">


When this initializer is deleted, error messages become better and more localized. The user can still obtain a `Regex` from any `RegexComponent` just by calling the `regex` property.

<img width="589" alt="without-init" src="https://user-images.githubusercontent.com/856507/160708142-baa10ab4-a83c-4522-a393-f30472c27c36.png">