### PR TITLE
Remove extra const from gestScriptExtensions

### DIFF
--- a/Sources/_CUnicode/UnicodeScalarProps.c
+++ b/Sources/_CUnicode/UnicodeScalarProps.c
@@ -68,8 +68,8 @@ uint8_t _swift_stdlib_getScript(uint32_t scalar) {
 }
 
 SWIFT_CC
-const uint8_t * const _swift_stdlib_getScriptExtensions(uint32_t scalar,
-                                                        uint8_t *count) {
+const uint8_t *_swift_stdlib_getScriptExtensions(uint32_t scalar,
+                                                 uint8_t *count) {
   intptr_t dataIdx = _swift_stdlib_getScalarBitArrayIdx(scalar,
                                                 _swift_stdlib_script_extensions,
                                          _swift_stdlib_script_extensions_ranks);

--- a/Sources/_CUnicode/include/UnicodeData.h
+++ b/Sources/_CUnicode/include/UnicodeData.h
@@ -66,6 +66,7 @@ SWIFT_CC
 uint8_t _swift_stdlib_getScript(uint32_t scalar);
 
 SWIFT_CC
-const uint8_t * const _swift_stdlib_getScriptExtensions(uint32_t scalar, uint8_t *count);
+const uint8_t *_swift_stdlib_getScriptExtensions(uint32_t scalar,
+                                                 uint8_t *count);
 
 #endif // SWIFT_STDLIB_SHIMS_UNICODEDATA_H


### PR DESCRIPTION
Returning a constant pointer is extraneous and leads to a bunch of
warnings. Since you don't control where the pointer is assigned you
can't really control whether the pointer is const or not. The uint8_t
inside can be const though.