### PR TITLE
Multi-line and extended delimiter literal lexing

### DIFF
--- a/Sources/_RegexParser/Regex/AST/MatchingOptions.swift
+++ b/Sources/_RegexParser/Regex/AST/MatchingOptions.swift
@@ -137,7 +137,8 @@ extension AST {
   /// Global matching option specifiers. Unlike `MatchingOptionSequence`,
   /// these must appear at the start of the pattern, and apply globally.
   public struct GlobalMatchingOption: _ASTNode, Hashable {
-    /// Determines the definition of a newline for the '.' character class.
+    /// Determines the definition of a newline for the '.' character class and
+    /// when parsing end-of-line comments.
     public enum NewlineMatching: Hashable {
       /// (*CR*)
       case carriageReturnOnly

--- a/Sources/_RegexParser/Regex/Parse/Diagnostics.swift
+++ b/Sources/_RegexParser/Regex/Parse/Diagnostics.swift
@@ -70,6 +70,8 @@ enum ParseError: Error, Hashable {
 
   case cannotRemoveTextSegmentOptions
   case cannotRemoveSemanticsOptions
+  case cannotRemoveExtendedSyntaxInMultilineMode
+
   case expectedCalloutArgument
 }
 
@@ -158,6 +160,8 @@ extension ParseError: CustomStringConvertible {
       return "text segment mode cannot be unset, only changed"
     case .cannotRemoveSemanticsOptions:
       return "semantic level cannot be unset, only changed"
+    case .cannotRemoveExtendedSyntaxInMultilineMode:
+      return "extended syntax may not be disabled in multi-line mode"
     case .expectedCalloutArgument:
       return "expected argument to callout"
     }

--- a/Sources/_RegexParser/Regex/Parse/LexicalAnalysis.swift
+++ b/Sources/_RegexParser/Regex/Parse/LexicalAnalysis.swift
@@ -550,28 +550,12 @@ extension Source {
   ) throws -> AST.Trivia? {
     guard context.ignoreWhitespace else { return nil }
 
-    func isWhitespace(_ c: Character) -> Bool {
-      // This is a list of characters that PCRE treats as whitespace when
-      // compiled with Unicode support. It is a subset of the characters with
-      // the `.isWhitespace` property. ICU appears to also follow this list.
-      // Oniguruma and .NET follow a subset of this list.
-      //
-      // FIXME: PCRE only treats space and tab characters as whitespace when
-      // inside a custom character class (and only treats whitespace as
-      // non-semantic there for the extra-extended `(?xx)` mode). If we get a
-      // strict-PCRE mode, we'll need to add a case for that.
-      switch c {
-      case " ", "\u{9}"..."\u{D}", // space, \t, \n, vertical tab, \f, \r
-           "\u{85}", "\u{200E}",   // next line, left-to-right mark
-           "\u{200F}", "\u{2028}", // right-to-left-mark, line separator
-           "\u{2029}":             // paragraph separator
-        return true
-      default:
-        return false
-      }
-    }
+    // FIXME: PCRE only treats space and tab characters as whitespace when
+    // inside a custom character class (and only treats whitespace as
+    // non-semantic there for the extra-extended `(?xx)` mode). If we get a
+    // strict-PCRE mode, we'll need to add a case for that.
     let trivia: Located<String>? = recordLoc { src in
-      src.tryEatPrefix(isWhitespace)?.string
+      src.tryEatPrefix(\.isPatternWhitespace)?.string
     }
     guard let trivia = trivia else { return nil }
     return AST.Trivia(trivia)

--- a/Sources/_RegexParser/Regex/Parse/Mocking.swift
+++ b/Sources/_RegexParser/Regex/Parse/Mocking.swift
@@ -62,8 +62,8 @@ func libswiftLexRegexLiteral(
     curPtrPtr.pointee = error.resumePtr.assumingMemoryBound(to: CChar.self)
 
     switch error.kind {
-    case .unterminated:
-      // Missing closing delimiter can be recovered from.
+    case .unterminated, .multilineClosingNotOnNewline:
+      // These can be recovered from.
       return false
     case .unprintableASCII, .invalidUTF8:
       // We don't currently have good recovery behavior for these.

--- a/Sources/_RegexParser/Regex/Parse/Mocking.swift
+++ b/Sources/_RegexParser/Regex/Parse/Mocking.swift
@@ -62,7 +62,7 @@ func libswiftLexRegexLiteral(
     curPtrPtr.pointee = error.resumePtr.assumingMemoryBound(to: CChar.self)
 
     switch error.kind {
-    case .endOfString:
+    case .unterminated:
       // Missing closing delimiter can be recovered from.
       return false
     case .unprintableASCII, .invalidUTF8:

--- a/Sources/_RegexParser/Regex/Parse/Source.swift
+++ b/Sources/_RegexParser/Regex/Parse/Source.swift
@@ -68,6 +68,12 @@ extension Source {
     return true
   }
 
+  mutating func tryEat(where pred: (Char) throws -> Bool) rethrows -> Bool {
+    guard let next = peek(), try pred(next) else { return false }
+    advance()
+    return true
+  }
+
   mutating func tryEat<C: Collection>(sequence c: C) -> Bool
   where C.Element == Char {
     guard _slice.starts(with: c) else { return false }

--- a/Sources/_RegexParser/Regex/Parse/SyntaxOptions.swift
+++ b/Sources/_RegexParser/Regex/Parse/SyntaxOptions.swift
@@ -58,6 +58,11 @@ public struct SyntaxOptions: OptionSet {
   ///  `(_: .*)` == `(?:.*)`
   public static var experimentalCaptures: Self { Self(1 << 5) }
 
+  /// The default syntax for a multi-line regex literal.
+  public static var multilineExtendedSyntax: Self {
+    return [Self(1 << 6), .extendedSyntax]
+  }
+
   /*
 
     /// `<digit>*` == `[[:digit:]]*` == `\d*`

--- a/Sources/_RegexParser/Regex/Printing/DumpAST.swift
+++ b/Sources/_RegexParser/Regex/Printing/DumpAST.swift
@@ -44,18 +44,23 @@ extension _ASTPrintable {
     guard let children = _children else {
       return _dumpBase
     }
-    let sub = children.lazy.compactMap {
+    let childDump = children.compactMap { child -> String? in
       // Exclude trivia for now, as we don't want it to appear when performing
       // comparisons of dumped output in tests.
       // TODO: We should eventually have some way of filtering out trivia for
       // tests, so that it can appear in regular dumps.
-      if $0.isTrivia { return nil }
-      return $0._dump()
-    }.joined(separator: ",")
-    if sub.isEmpty {
-      return "\(_dumpBase)"
+      if child.isTrivia { return nil }
+      let dump = child._dump()
+      return !dump.isEmpty ? dump : nil
     }
-    return "\(_dumpBase)(\(sub))"
+    let base = "\(_dumpBase)"
+    if childDump.isEmpty {
+      return base
+    }
+    if childDump.count == 1, base.isEmpty {
+      return "\(childDump[0])"
+    }
+    return "\(base)(\(childDump.joined(separator: ",")))"
   }
 }
 
@@ -77,7 +82,7 @@ extension AST.Node: _ASTPrintable {
 }
 
 extension AST.Alternation {
-  public var _dumpBase: String { "alternation" }
+  public var _dumpBase: String { "alternation<\(children.count)>" }
 }
 
 extension AST.Concatenation {

--- a/Sources/_RegexParser/Utility/MissingUnicode.swift
+++ b/Sources/_RegexParser/Utility/MissingUnicode.swift
@@ -660,6 +660,12 @@ extension Character {
   public var isOctalDigit: Bool { ("0"..."7").contains(self) }
 
   public var isWordCharacter: Bool { isLetter || isNumber || self == "_" }
+
+  /// Whether this character represents whitespace for the purposes of pattern
+  /// parsing.
+  public var isPatternWhitespace: Bool {
+    return unicodeScalars.first!.properties.isPatternWhitespace
+  }
 }
 
 extension UnicodeScalar {

--- a/Tests/RegexTests/LexTests.swift
+++ b/Tests/RegexTests/LexTests.swift
@@ -110,6 +110,11 @@ extension RegexTests {
       ("###/abc/###", ("abc", delim(.forwardSlash, poundCount: 3))),
       ("#|abc|#", ("abc", delim(.experimental))),
 
+      // Multiline
+      ("#/\na\nb\n/#", ("\na\nb\n", delim(.forwardSlash, poundCount: 1))),
+      ("#/ \na\nb\n  /#", (" \na\nb\n  ", delim(.forwardSlash, poundCount: 1))),
+      ("##/ \na\nb\n  /##", (" \na\nb\n  ", delim(.forwardSlash, poundCount: 2))),
+
       // TODO: Null characters are lexically valid, similar to string literals,
       // but we ought to warn the user about them.
       ("#|ab\0c|#", ("ab\0c", delim(.experimental))),

--- a/Tests/RegexTests/LexTests.swift
+++ b/Tests/RegexTests/LexTests.swift
@@ -100,7 +100,7 @@ extension RegexTests {
   }
 
 
-  func testCompilerInterface() {
+  func testCompilerInterface() throws {
     func delim(_ kind: Delimiter.Kind, poundCount: Int = 0) -> Delimiter {
       Delimiter(kind, poundCount: poundCount)
     }
@@ -138,7 +138,9 @@ extension RegexTests {
       input.withCString {
         let endPtr = $0 + input.utf8.count
         assert(endPtr.pointee == 0)
-        guard let out = try? lexRegex(start: $0, end: endPtr) else {
+        guard let out = try? lexRegex(
+          start: $0, end: endPtr, delimiters: Delimiter.allDelimiters)
+        else {
           XCTAssertNil(expected)
           return
         }
@@ -148,6 +150,24 @@ extension RegexTests {
         let droppedDelimiters = droppingRegexDelimiters(input)
         XCTAssertEqual(expected?.0, droppedDelimiters.0)
         XCTAssertEqual(expected?.1, droppedDelimiters.1)
+      }
+    }
+
+    // TODO: Remove the lexing code for these if we no longer need them.
+    let disabledDelimiters: [String] = [
+      "#|x|#", "re'x'", "rx'y'"
+    ]
+
+    for input in disabledDelimiters {
+      try input.withCString {
+        let endPtr = $0 + input.utf8.count
+        assert(endPtr.pointee == 0)
+        do {
+          _ = try lexRegex(start: $0, end: endPtr)
+          XCTFail()
+        } catch let e as DelimiterLexError {
+          XCTAssertEqual(e.kind, .unknownDelimiter)
+        }
       }
     }
   }

--- a/Tests/RegexTests/LexTests.swift
+++ b/Tests/RegexTests/LexTests.swift
@@ -101,26 +101,31 @@ extension RegexTests {
 
 
   func testCompilerInterface() {
+    func delim(_ kind: Delimiter.Kind, poundCount: Int = 0) -> Delimiter {
+      Delimiter(kind, poundCount: poundCount)
+    }
     let testCases: [(String, (String, Delimiter)?)] = [
-      ("#/abc/#", ("abc", .traditional)),
-      ("#|abc|#", ("abc", .experimental)),
+      ("/abc/", ("abc", delim(.forwardSlash))),
+      ("#/abc/#", ("abc", delim(.forwardSlash, poundCount: 1))),
+      ("###/abc/###", ("abc", delim(.forwardSlash, poundCount: 3))),
+      ("#|abc|#", ("abc", delim(.experimental))),
 
       // TODO: Null characters are lexically valid, similar to string literals,
       // but we ought to warn the user about them.
-      ("#|ab\0c|#", ("ab\0c", .experimental)),
+      ("#|ab\0c|#", ("ab\0c", delim(.experimental))),
       ("'abc'", nil),
-      ("#/abc/def/#", ("abc/def", .traditional)),
-      ("#|abc|def|#", ("abc|def", .experimental)),
-      ("#/abc\\/#def/#", ("abc\\/#def", .traditional)),
-      ("#|abc\\|#def|#", ("abc\\|#def", .experimental)),
-      ("#/abc|#def/#", ("abc|#def", .traditional)),
-      ("#|abc/#def|#", ("abc/#def", .experimental)),
+      ("#/abc/def/#", ("abc/def", delim(.forwardSlash, poundCount: 1))),
+      ("#|abc|def|#", ("abc|def", delim(.experimental))),
+      ("#/abc\\/#def/#", ("abc\\/#def", delim(.forwardSlash, poundCount: 1))),
+      ("#|abc\\|#def|#", ("abc\\|#def", delim(.experimental))),
+      ("#/abc|#def/#", ("abc|#def", delim(.forwardSlash, poundCount: 1))),
+      ("#|abc/#def|#", ("abc/#def", delim(.experimental))),
       ("#/abc|#def/", nil),
       ("#|abc/#def#", nil),
       ("#/abc\n/#", nil),
       ("#/abc\r/#", nil),
 
-      (#"re'abcre\''"#, (#"abcre\'"#, .reSingleQuote)),
+      (#"re'abcre\''"#, (#"abcre\'"#, delim(.reSingleQuote))),
       (#"re'\'"#, nil)
     ]
 

--- a/Tests/RegexTests/ParseTests.swift
+++ b/Tests/RegexTests/ParseTests.swift
@@ -1736,7 +1736,9 @@ extension RegexTests {
 
     // MARK: Parse with delimiters
 
+    parseWithDelimitersTest("/a b/", concat("a", " ", "b"))
     parseWithDelimitersTest("#/a b/#", concat("a", " ", "b"))
+    parseWithDelimitersTest("##/a b/##", concat("a", " ", "b"))
     parseWithDelimitersTest("#|a b|#", concat("a", "b"))
 
     parseWithDelimitersTest("re'a b'", concat("a", " ", "b"))
@@ -1772,6 +1774,11 @@ extension RegexTests {
 
     // Printable ASCII characters.
     delimiterLexingTest(##"re' !"#$%&\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefghijklmnopqrstuvwxyz{|}~'"##)
+
+    // Make sure we can handle a combining accent as first character.
+    parseWithDelimitersTest("/\u{301}/", "\u{301}")
+
+    delimiterLexingTest("/a/#", ignoreTrailing: true)
 
     // MARK: Delimiter skipping: Make sure we can skip over the ending delimiter
     // if it's clear that it's part of the regex syntax.
@@ -2302,6 +2309,11 @@ extension RegexTests {
     delimiterLexingDiagnosticTest("re'(?('abc'", .unterminated)
     delimiterLexingDiagnosticTest(#"re'\k'ab_c0+-'"#, .unterminated)
     delimiterLexingDiagnosticTest(#"re'\g'ab_c0+-'"#, .unterminated)
+
+    // MARK: Unbalanced extended syntax
+    delimiterLexingDiagnosticTest("#/a/", .unterminated)
+    delimiterLexingDiagnosticTest("##/a/#", .unterminated)
+
   }
 
   func testlibswiftDiagnostics() {

--- a/Tests/RegexTests/ParseTests.swift
+++ b/Tests/RegexTests/ParseTests.swift
@@ -117,7 +117,8 @@ func delimiterLexingTest(
 ) -> String {
   input.withCString(encodedAs: UTF8.self) { ptr in
     let endPtr = ptr + input.utf8.count
-    let (contents, delim, end) = try! lexRegex(start: ptr, end: endPtr)
+    let (contents, delim, end) = try! lexRegex(
+      start: ptr, end: endPtr, delimiters: Delimiter.allDelimiters)
     if ignoreTrailing {
       XCTAssertNotEqual(end, endPtr, file: file, line: line)
     } else {
@@ -260,7 +261,8 @@ func delimiterLexingDiagnosticTest(
 ) {
   do {
     _ = try input.withCString { ptr in
-      try lexRegex(start: ptr, end: ptr + input.count)
+      try lexRegex(
+        start: ptr, end: ptr + input.count, delimiters: Delimiter.allDelimiters)
     }
     XCTFail("""
       Passed, but expected error: \(expected)

--- a/Tests/RegexTests/ParseTests.swift
+++ b/Tests/RegexTests/ParseTests.swift
@@ -1526,6 +1526,214 @@ extension RegexTests {
         matchingOptions(adding: .extended), isIsolated: true, charClass("a", "b"))
     )
 
+    // Test multi-line comment handling.
+    parseTest(
+      """
+      # a
+      bc # d
+      ef# g
+      # h
+      """,
+      concat("b", "c", "e", "f"),
+      syntax: .extendedSyntax
+    )
+    parseTest(
+      """
+      # a\r\
+      bc # d\r\
+      ef# g\r\
+      # h\r
+      """,
+      concat("b", "c", "e", "f"),
+      syntax: .extendedSyntax
+    )
+    parseTest(
+      """
+      # a\r\
+      bc # d\r\
+      ef# g\r\
+      # h\r
+      """,
+      concat("b", "c", "e", "f"),
+      syntax: .extendedSyntax
+    )
+    parseTest(
+      """
+      # a\r
+      bc # d\r
+      ef# g\r
+      # h\r
+      """,
+      concat("b", "c", "e", "f"),
+      syntax: .extendedSyntax
+    )
+    parseTest(
+      """
+      # a\n\r\
+      bc # d\n\r\
+      ef# g\n\r\
+      # h\n\r
+      """,
+      concat("b", "c", "e", "f"),
+      syntax: .extendedSyntax
+    )
+    parseTest(
+      """
+      (*CR)
+      # a
+      bc # d
+      ef# g
+      # h
+      """,
+      ast(empty(), opts: .newlineMatching(.carriageReturnOnly)),
+      syntax: .extendedSyntax
+    )
+    parseTest(
+      """
+      (*CR)\r\
+      # a\r\
+      bc # d\r\
+      ef# g\r\
+      # h
+      """,
+      ast(concat("b", "c", "e", "f"), opts: .newlineMatching(.carriageReturnOnly)),
+      syntax: .extendedSyntax
+    )
+    parseTest(
+      """
+      (*LF)
+      # a
+      bc # d
+      ef# g
+      # h
+      """,
+      ast(concat("b", "c", "e", "f"), opts: .newlineMatching(.linefeedOnly)),
+      syntax: .extendedSyntax
+    )
+    parseTest(
+      """
+      (*CRLF)
+      # a
+      bc # d
+      ef# g
+      # h
+      """,
+      ast(empty(), opts: .newlineMatching(.carriageAndLinefeedOnly)),
+      syntax: .extendedSyntax
+    )
+    parseTest(
+      """
+      (*CRLF)
+      # a\r
+      bc # d\r
+      ef# g\r
+      # h
+      """,
+      ast(concat("b", "c", "e", "f"), opts: .newlineMatching(.carriageAndLinefeedOnly)),
+      syntax: .extendedSyntax
+    )
+    parseTest(
+      """
+      (*ANYCRLF)
+      # a
+      bc # d
+      ef# g
+      # h
+      """,
+      ast(concat("b", "c", "e", "f"), opts: .newlineMatching(.anyCarriageReturnOrLinefeed)),
+      syntax: .extendedSyntax
+    )
+    parseTest(
+      """
+      (*ANYCRLF)
+      # a\r\
+      bc # d\r\
+      ef# g\r\
+      # h
+      """,
+      ast(concat("b", "c", "e", "f"), opts: .newlineMatching(.anyCarriageReturnOrLinefeed)),
+      syntax: .extendedSyntax
+    )
+    parseTest(
+      """
+      (*ANYCRLF)
+      # a\r
+      bc # d\r
+      ef# g\r
+      # h
+      """,
+      ast(concat("b", "c", "e", "f"), opts: .newlineMatching(.anyCarriageReturnOrLinefeed)),
+      syntax: .extendedSyntax
+    )
+    parseTest(
+      """
+      (*ANY)
+      # a
+      bc # d
+      ef# g
+      # h
+      """,
+      ast(concat("b", "c", "e", "f"), opts: .newlineMatching(.anyUnicode)),
+      syntax: .extendedSyntax
+    )
+    parseTest(
+      """
+      # a\u{2028}\
+      bc # d
+      ef# g\u{2028}\
+      # h
+      """,
+      concat("e", "f"),
+      syntax: .extendedSyntax
+    )
+    parseTest(
+      """
+      (*ANY)
+      # a\u{2028}\
+      bc # d\u{2028}\
+      ef# g\u{2028}\
+      # h
+      """,
+      ast(concat("b", "c", "e", "f"), opts: .newlineMatching(.anyUnicode)),
+      syntax: .extendedSyntax
+    )
+    parseTest(
+      """
+      (*NUL)
+      # a
+      bc # d\0\
+      ef# g
+      # h
+      """,
+      ast(concat("e", "f"), opts: .newlineMatching(.nulCharacter)),
+      syntax: .extendedSyntax
+    )
+    parseTest(
+      """
+      (*NUL)
+      # a\0\
+      bc # d\0\
+      ef# g\0\
+      # h
+      """,
+      ast(concat("b", "c", "e", "f"), opts: .newlineMatching(.nulCharacter)),
+      syntax: .extendedSyntax
+    )
+    parseTest(
+      """
+      (*CR)(*NUL)
+      # a\0\
+      bc # d\0\
+      ef# g\0\
+      # h
+      """,
+      ast(concat("b", "c", "e", "f"),
+          opts: .newlineMatching(.carriageReturnOnly),
+                .newlineMatching(.nulCharacter)
+         ),
+      syntax: .extendedSyntax
+    )
+
     // MARK: Parse with delimiters
 
     parseWithDelimitersTest("#/a b/#", concat("a", " ", "b"))

--- a/Tests/RegexTests/ParseTests.swift
+++ b/Tests/RegexTests/ParseTests.swift
@@ -2079,21 +2079,21 @@ extension RegexTests {
 
     // MARK: Printable ASCII
 
-    delimiterLexingDiagnosticTest(#"re'\\#n'"#, .endOfString)
+    delimiterLexingDiagnosticTest(#"re'\\#n'"#, .unterminated)
     for i: UInt8 in 0x1 ..< 0x20 where i != 0xA && i != 0xD { // U+A & U+D are \n and \r.
       delimiterLexingDiagnosticTest("re'\(UnicodeScalar(i))'", .unprintableASCII)
     }
-    delimiterLexingDiagnosticTest("re'\n'", .endOfString)
-    delimiterLexingDiagnosticTest("re'\r'", .endOfString)
+    delimiterLexingDiagnosticTest("re'\n'", .unterminated)
+    delimiterLexingDiagnosticTest("re'\r'", .unterminated)
     delimiterLexingDiagnosticTest("re'\u{7F}'", .unprintableASCII)
 
     // MARK: Delimiter skipping
 
-    delimiterLexingDiagnosticTest("re'(?''", .endOfString)
-    delimiterLexingDiagnosticTest("re'(?'abc'", .endOfString)
-    delimiterLexingDiagnosticTest("re'(?('abc'", .endOfString)
-    delimiterLexingDiagnosticTest(#"re'\k'ab_c0+-'"#, .endOfString)
-    delimiterLexingDiagnosticTest(#"re'\g'ab_c0+-'"#, .endOfString)
+    delimiterLexingDiagnosticTest("re'(?''", .unterminated)
+    delimiterLexingDiagnosticTest("re'(?'abc'", .unterminated)
+    delimiterLexingDiagnosticTest("re'(?('abc'", .unterminated)
+    delimiterLexingDiagnosticTest(#"re'\k'ab_c0+-'"#, .unterminated)
+    delimiterLexingDiagnosticTest(#"re'\g'ab_c0+-'"#, .unterminated)
   }
 
   func testlibswiftDiagnostics() {


### PR DESCRIPTION
Update the delimiter lexing logic to handle `/.../`, an extended variant that allows an arbitrary number of balanced pounds, e.g `##/.../##`, and a multi-line mode when the extended variant starts with a newline. The multi-line mode uses extended regex syntax by default, allowing for non-semantic whitespace and end-of-line comments.

Additionally, disable the `#|...|#`, `re'...'`, and `rx'...'` spellings for now.