### PR TITLE
Expanded options

### DIFF
--- a/Sources/_StringProcessing/ByteCodeGen.swift
+++ b/Sources/_StringProcessing/ByteCodeGen.swift
@@ -111,30 +111,41 @@ extension Compiler.ByteCodeGen {
       }
 
     case .startOfLine:
-      builder.buildAssert { (input, pos, bounds) in
-        pos == input.startIndex ||
-        input[input.index(before: pos)].isNewline
+      if options.anchorsMatchNewlines {
+        builder.buildAssert { (input, pos, bounds) in
+          pos == input.startIndex || input[input.index(before: pos)].isNewline
+        }
+      } else {
+        builder.buildAssert { (input, pos, bounds) in
+          pos == input.startIndex
+        }
       }
-
+      
     case .endOfLine:
-      builder.buildAssert { (input, pos, bounds) in
-        pos == input.endIndex || input[pos].isNewline
+      if options.anchorsMatchNewlines {
+        builder.buildAssert { (input, pos, bounds) in
+          pos == input.endIndex || input[pos].isNewline
+        }
+      } else {
+        builder.buildAssert { (input, pos, bounds) in
+          pos == input.endIndex
+        }
       }
 
     case .wordBoundary:
       // TODO: May want to consider Unicode level
-      builder.buildAssert { (input, pos, bounds) in
+      builder.buildAssert { [options] (input, pos, bounds) in
         // TODO: How should we handle bounds?
         CharacterClass.word.isBoundary(
-          input, at: pos, bounds: bounds)
+          input, at: pos, bounds: bounds, with: options)
       }
 
     case .notWordBoundary:
       // TODO: May want to consider Unicode level
-      builder.buildAssert { (input, pos, bounds) in
+      builder.buildAssert { [options] (input, pos, bounds) in
         // TODO: How should we handle bounds?
         !CharacterClass.word.isBoundary(
-          input, at: pos, bounds: bounds)
+          input, at: pos, bounds: bounds, with: options)
       }
     }
   }

--- a/Sources/_StringProcessing/ConsumerInterface.swift
+++ b/Sources/_StringProcessing/ConsumerInterface.swift
@@ -136,7 +136,7 @@ extension AST.Atom {
     ) {
       return { input, bounds in
         // FIXME: should we worry about out of bounds?
-        cc.matches(in: input, at: bounds.lowerBound)
+        cc.matches(in: input, at: bounds.lowerBound, with: opts)
       }
     }
 

--- a/Sources/_StringProcessing/MatchingOptions.swift
+++ b/Sources/_StringProcessing/MatchingOptions.swift
@@ -13,7 +13,7 @@ import _RegexParser
 
 /// A type that represents the current state of regex matching options, with
 /// stack-based scoping.
-struct MatchingOptions {
+public struct MatchingOptions {
   fileprivate var stack: [Representation]
   
   fileprivate func _invariantCheck() {
@@ -67,11 +67,32 @@ extension MatchingOptions {
     stack.last!.contains(.singleLine)
   }
   
+  var anchorsMatchNewlines: Bool {
+    stack.last!.contains(.multiline)
+  }
+  
+  var usesASCIIWord: Bool {
+    stack.last!.contains(.asciiOnlyWord)
+      || stack.last!.contains(.asciiOnlyPOSIXProps)
+  }
+  
+  var usesASCIIDigits: Bool {
+    stack.last!.contains(.asciiOnlyDigit)
+      || stack.last!.contains(.asciiOnlyPOSIXProps)
+  }
+  
+  var usesASCIISpaces: Bool {
+    stack.last!.contains(.asciiOnlySpace)
+      || stack.last!.contains(.asciiOnlyPOSIXProps)
+  }
+  
+  var usesSimpleUnicodeBoundaries: Bool {
+    !stack.last!.contains(.unicodeWordBoundaries)
+  }
+  
   enum SemanticLevel {
     case graphemeCluster
     case unicodeScalar
-    // TODO: include?
-    // case byte
   }
   
   var semanticLevel: SemanticLevel {

--- a/Sources/_StringProcessing/Regex/Options.swift
+++ b/Sources/_StringProcessing/Regex/Options.swift
@@ -40,13 +40,26 @@ extension RegexComponent {
     wrapInOption(.asciiOnlyPOSIXProps, addingIf: useASCII)
   }
   
-  /// Returns a regular expression that uses a simpler set of Unicode scalar
-  /// values to detect word boundaries.
-  public func usingSimpleWordBoundaries(_ useASCII: Bool = true) -> Regex<Output> {
-    wrapInOption(.unicodeWordBoundaries, addingIf: !useASCII)
+  /// Returns a regular expression that uses the Unicode word boundary
+  /// algorithm.
+  ///
+  /// This option is enabled by default; pass `false` to disable use of
+  /// Unicode's word boundary algorithm.
+  public func usingUnicodeWordBoundaries(_ useUnicodeWordBoundaries: Bool = true) -> Regex<Output> {
+    wrapInOption(.unicodeWordBoundaries, addingIf: useUnicodeWordBoundaries)
   }
   
-  /// Match with the specified semantic level.
+  /// Returns a regular expression where the start and end of input
+  /// anchors (`^` and `$`) also match against the start and end of a line.
+  ///
+  /// - Parameter dotMatchesNewlines: A Boolean value indicating whether `.`
+  ///   should match a newline character.
+  public func dotMatchesNewlines(_ dotMatchesNewlines: Bool = true) -> Regex<Output> {
+    wrapInOption(.singleLine, addingIf: dotMatchesNewlines)
+  }
+  
+  /// Returns a regular expression that matches with the specified semantic
+  /// level.
   ///
   /// When matching with grapheme cluster semantics (the default),
   /// metacharacters like `.` and `\w`, custom character classes, and character
@@ -130,20 +143,6 @@ extension RegexComponent {
     wrapInOption(.multiline, addingIf: matchLineEndings)
   }
   
-  /// Returns a regular expression where the start and end of input
-  /// anchors (`^` and `$`) also match against the start and end of a line.
-  ///
-  /// This method corresponds to applying the `s` option in a regular
-  /// expression literal, and only applies to regular expressions specified as
-  /// literals. To use this distinction in the `RegexBuilder` syntax, see
-  /// ``CharacterClass.any`` and ``CharacterClass.anyNonNewline``.
-  ///
-  /// - Parameter dotMatchesNewlines: A Boolean value indicating whether `.`
-  ///   should match a newline character.
-  public func dotMatchesNewlines(_ dotMatchesNewlines: Bool = true) -> Regex<Output> {
-    wrapInOption(.singleLine, addingIf: dotMatchesNewlines)
-  }
-  
   /// Returns a regular expression where quantifiers are reluctant by default
   /// instead of eager.
   ///
@@ -156,63 +155,6 @@ extension RegexComponent {
   ///   quantifiers should be reluctant by default.
   public func reluctantCaptures(_ useReluctantCaptures: Bool = true) -> Regex<Output> {
     wrapInOption(.reluctantByDefault, addingIf: useReluctantCaptures)
-  }
-  
-  /// Returns a regular expression where the `\X`, `\y`, and `\Y` metacharacters
-  /// operate at the word boundary level instead of the grapheme cluster level.
-  ///
-  /// This method corresponds to applying the `y{w}` or `y{g}` option in a
-  /// regular expression literal, and only applies to regular expressions
-  /// specified as literals.
-  ///
-  /// - Parameter useWordBoundaries: A Boolean value indicating whether `\X`,
-  ///   `\y`, and `\Y` should use word boundaries instead of grapheme cluster
-  ///   boundaries.
-  public func segmentTextByWords(_ useWordBoundaries: Bool = true) -> Regex<Output> {
-    wrapInOption(.textSegmentWordMode, addingIf: useWordBoundaries)
-  }
-}
-
-// Options that affect parsing, and therefore likely can't be API
-@available(*, unavailable)
-extension RegexComponent {
-  /// Returns a regular expression where whitespace is not significant for
-  /// matching.
-  ///
-  /// This method corresponds to applying the `xx` option in a regular
-  /// expression literal, and only applies to regular expressions specified as
-  /// literals.
-  ///
-  /// - Parameter useExtendedSyntax: A Boolean value indicating whether
-  ///   whitespace in a regex literal should be ignored.
-  public func extendedSyntax(_ useExtendedSyntax: Bool = true) -> Regex<Output> {
-    wrapInOption(.extraExtended, addingIf: useExtendedSyntax)
-  }
-  
-  /// Returns a regular expression where only named groups are captured.
-  ///
-  /// This method corresponds to applying the `n` option in a regular
-  /// expression literal, and only applies to regular expressions specified as
-  /// literals. In the `RegexBuilder` syntax, use the `Capture` method only
-  /// when you want to capture a portion of a match.
-  ///
-  /// - Parameter namedCapturesOnly: A Boolean value indicating whether only
-  ///   named groups should be captured.
-  public func namedCapturesOnly(_ namedCapturesOnly: Bool = true) -> Regex<Output> {
-    wrapInOption(.noAutoCapture, addingIf: namedCapturesOnly)
-  }
-  
-  /// Returns a regular expression where multiple groups are allowed to share
-  /// the same name.
-  ///
-  /// This method corresponds to applying the `J` option in a regular
-  /// expression literal, and only applies to regular expressions specified as
-  /// literals.
-  ///
-  /// - Parameter allowDuplicateNames: A Boolean value indicating whether groups
-  ///   are allowed to share names.
-  public func allowDuplicateNames(_ allowDuplicateNames: Bool = true) -> Regex<Output> {
-    wrapInOption(.allowDuplicateGroupNames, addingIf: allowDuplicateNames)
   }
 }
 

--- a/Sources/_StringProcessing/Regex/Options.swift
+++ b/Sources/_StringProcessing/Regex/Options.swift
@@ -12,17 +12,221 @@
 import _RegexParser
 
 extension RegexComponent {
-  public func caseSensitive(_ isCaseSensitive: Bool) -> Regex<Output> {
-    // The API is "case sensitive = true or false", so as to avoid the
-    // double negatives inherent in setting "case insensitive" to a Boolean
-    // value. The internal version of this option, on the other hand, is
-    // `.caseInsensitive`, derived from the `(?i)` regex literal option.
-    let sequence = isCaseSensitive
-      ? AST.MatchingOptionSequence(removing: [.init(.caseInsensitive, location: .fake)])
-      : AST.MatchingOptionSequence(adding: [.init(.caseInsensitive, location: .fake)])
+  /// Returns a regular expression that ignores casing when matching.
+  public func ignoringCase(_ ignoreCase: Bool = true) -> Regex<Output> {
+    wrapInOption(.caseInsensitive, addingIf: ignoreCase)
+  }
+
+  /// Returns a regular expression that only matches ASCII characters as "word
+  /// characters".
+  public func usingASCIIWordCharacters(_ useASCII: Bool = true) -> Regex<Output> {
+    wrapInOption(.asciiOnlyDigit, addingIf: useASCII)
+  }
+
+  /// Returns a regular expression that only matches ASCII characters as digits.
+  public func usingASCIIDigits(_ useASCII: Bool = true) -> Regex<Output> {
+    wrapInOption(.asciiOnlyDigit, addingIf: useASCII)
+  }
+
+  /// Returns a regular expression that only matches ASCII characters as space
+  /// characters.
+  public func usingASCIISpaces(_ useASCII: Bool = true) -> Regex<Output> {
+    wrapInOption(.asciiOnlySpace, addingIf: useASCII)
+  }
+
+  /// Returns a regular expression that only matches ASCII characters when
+  /// matching character classes.
+  public func usingASCIICharacterClasses(_ useASCII: Bool = true) -> Regex<Output> {
+    wrapInOption(.asciiOnlyPOSIXProps, addingIf: useASCII)
+  }
+  
+  /// Returns a regular expression that uses a simpler set of Unicode scalar
+  /// values to detect word boundaries.
+  public func usingSimpleWordBoundaries(_ useASCII: Bool = true) -> Regex<Output> {
+    wrapInOption(.unicodeWordBoundaries, addingIf: !useASCII)
+  }
+  
+  /// Match with the specified semantic level.
+  ///
+  /// When matching with grapheme cluster semantics (the default),
+  /// metacharacters like `.` and `\w`, custom character classes, and character
+  /// class instances like `.any` match a grapheme cluster when possible,
+  /// corresponding with the default string representation. In addition,
+  /// matching with grapheme cluster semantics compares characters using their
+  /// canonical representation, corresponding with how strings comparison works.
+  ///
+  /// When matching with Unicode scalar semantics, metacharacters and character
+  /// classes always match a single Unicode scalar value, even if that scalar
+  /// comprises part of a grapheme cluster.
+  ///
+  /// These semantic levels can lead to different results, especially when
+  /// working with strings that have decomposed characters. In the following
+  /// example, `queRegex` matches any 3-character string that begins with `"q"`.
+  ///
+  ///     let composed = "qué"
+  ///     let decomposed = "que\u{301}"
+  ///
+  ///     let queRegex = /^q..$/
+  ///
+  ///     print(composed.contains(queRegex))
+  ///     // Prints "true"
+  ///     print(decomposed.contains(queRegex))
+  ///     // Prints "true"
+  ///
+  /// When using Unicode scalar semantics, however, the regular expression only
+  /// matches the composed version of the string, because each `.` matches a
+  /// single Unicode scalar value.
+  ///
+  ///     let queRegexScalar = queRegex.matchingSemantics(.unicodeScalar)
+  ///     print(composed.contains(queRegexScalar))
+  ///     // Prints "true"
+  ///     print(decomposed.contains(queRegexScalar))
+  ///     // Prints "false"
+  public func matchingSemantics(_ semanticLevel: RegexSemanticLevel) -> Regex<Output> {
+    switch semanticLevel.base {
+    case .graphemeCluster:
+      return wrapInOption(.graphemeClusterSemantics, addingIf: true)
+    case .unicodeScalar:
+      return wrapInOption(.unicodeScalarSemantics, addingIf: true)
+    }
+  }
+}
+
+public struct RegexSemanticLevel: Hashable {
+  internal enum Representation {
+    case graphemeCluster
+    case unicodeScalar
+  }
+  
+  internal var base: Representation
+  
+  /// Match at the default semantic level of a string, where each matched
+  /// element is a `Character`.
+  public static var graphemeCluster: RegexSemanticLevel {
+    .init(base: .graphemeCluster)
+  }
+  
+  /// Match at the semantic level of a string's `UnicodeScalarView`, where each
+  /// matched element is a `UnicodeScalar` value.
+  public static var unicodeScalar: RegexSemanticLevel {
+    .init(base: .unicodeScalar)
+  }
+}
+
+// Options that only affect literals
+extension RegexComponent {
+  /// Returns a regular expression where the start and end of input
+  /// anchors (`^` and `$`) also match against the start and end of a line.
+  ///
+  /// This method corresponds to applying the `m` option in a regular
+  /// expression literal, and only applies to regular expressions specified as
+  /// literals. For this behavior in the `RegexBuilder` syntax, see
+  /// ``Anchor.startOfLine``, ``Anchor.endOfLine``, ``Anchor.startOfInput``,
+  /// and ``Anchor.endOfInput``.
+  ///
+  /// - Parameter matchLineEndings: A Boolean value indicating whether `^` and
+  ///   `$` should match the start and end of lines, respectively.
+  public func anchorsMatchLineEndings(_ matchLineEndings: Bool = true) -> Regex<Output> {
+    wrapInOption(.multiline, addingIf: matchLineEndings)
+  }
+  
+  /// Returns a regular expression where the start and end of input
+  /// anchors (`^` and `$`) also match against the start and end of a line.
+  ///
+  /// This method corresponds to applying the `s` option in a regular
+  /// expression literal, and only applies to regular expressions specified as
+  /// literals. To use this distinction in the `RegexBuilder` syntax, see
+  /// ``CharacterClass.any`` and ``CharacterClass.anyNonNewline``.
+  ///
+  /// - Parameter dotMatchesNewlines: A Boolean value indicating whether `.`
+  ///   should match a newline character.
+  public func dotMatchesNewlines(_ dotMatchesNewlines: Bool = true) -> Regex<Output> {
+    wrapInOption(.singleLine, addingIf: dotMatchesNewlines)
+  }
+  
+  /// Returns a regular expression where quantifiers are reluctant by default
+  /// instead of eager.
+  ///
+  /// This method corresponds to applying the `U` option in a regular
+  /// expression literal, and only applies to regular expressions specified as
+  /// literals. In the `RegexBuilder` syntax, pass a ``QuantificationBehavior``
+  /// value to any quantification method to change its behavior.
+  ///
+  /// - Parameter useReluctantCaptures: A Boolean value indicating whether
+  ///   quantifiers should be reluctant by default.
+  public func reluctantCaptures(_ useReluctantCaptures: Bool = true) -> Regex<Output> {
+    wrapInOption(.reluctantByDefault, addingIf: useReluctantCaptures)
+  }
+  
+  /// Returns a regular expression where the `\X`, `\y`, and `\Y` metacharacters
+  /// operate at the word boundary level instead of the grapheme cluster level.
+  ///
+  /// This method corresponds to applying the `y{w}` or `y{g}` option in a
+  /// regular expression literal, and only applies to regular expressions
+  /// specified as literals.
+  ///
+  /// - Parameter useWordBoundaries: A Boolean value indicating whether `\X`,
+  ///   `\y`, and `\Y` should use word boundaries instead of grapheme cluster
+  ///   boundaries.
+  public func segmentTextByWords(_ useWordBoundaries: Bool = true) -> Regex<Output> {
+    wrapInOption(.textSegmentWordMode, addingIf: useWordBoundaries)
+  }
+}
+
+// Options that affect parsing, and therefore likely can't be API
+@available(*, unavailable)
+extension RegexComponent {
+  /// Returns a regular expression where whitespace is not significant for
+  /// matching.
+  ///
+  /// This method corresponds to applying the `xx` option in a regular
+  /// expression literal, and only applies to regular expressions specified as
+  /// literals.
+  ///
+  /// - Parameter useExtendedSyntax: A Boolean value indicating whether
+  ///   whitespace in a regex literal should be ignored.
+  public func extendedSyntax(_ useExtendedSyntax: Bool = true) -> Regex<Output> {
+    wrapInOption(.extraExtended, addingIf: useExtendedSyntax)
+  }
+  
+  /// Returns a regular expression where only named groups are captured.
+  ///
+  /// This method corresponds to applying the `n` option in a regular
+  /// expression literal, and only applies to regular expressions specified as
+  /// literals. In the `RegexBuilder` syntax, use the `Capture` method only
+  /// when you want to capture a portion of a match.
+  ///
+  /// - Parameter namedCapturesOnly: A Boolean value indicating whether only
+  ///   named groups should be captured.
+  public func namedCapturesOnly(_ namedCapturesOnly: Bool = true) -> Regex<Output> {
+    wrapInOption(.noAutoCapture, addingIf: namedCapturesOnly)
+  }
+  
+  /// Returns a regular expression where multiple groups are allowed to share
+  /// the same name.
+  ///
+  /// This method corresponds to applying the `J` option in a regular
+  /// expression literal, and only applies to regular expressions specified as
+  /// literals.
+  ///
+  /// - Parameter allowDuplicateNames: A Boolean value indicating whether groups
+  ///   are allowed to share names.
+  public func allowDuplicateNames(_ allowDuplicateNames: Bool = true) -> Regex<Output> {
+    wrapInOption(.allowDuplicateGroupNames, addingIf: allowDuplicateNames)
+  }
+}
+
+// MARK: - Helper method
+extension RegexComponent {
+  fileprivate func wrapInOption(
+    _ option: AST.MatchingOption.Kind,
+    addingIf shouldAdd: Bool) -> Regex<Output>
+  {
+    let sequence = shouldAdd
+      ? AST.MatchingOptionSequence(adding: [.init(option, location: .fake)])
+      : AST.MatchingOptionSequence(removing: [.init(option, location: .fake)])
     return Regex(node: .nonCapturingGroup(
       .changeMatchingOptions(sequence, isIsolated: false),
       regex.root))
   }
 }
-

--- a/Tests/RegexBuilderTests/RegexDSLTests.swift
+++ b/Tests/RegexBuilderTests/RegexDSLTests.swift
@@ -175,7 +175,7 @@ class RegexDSLTests: XCTestCase {
       matchType: Substring.self, ==) {
         OneOrMore {
           "abc"
-        }.caseSensitive(false)
+        }.ignoringCase(true)
       }
     
     // Multiple options on one component wrap successively, but do not
@@ -189,8 +189,8 @@ class RegexDSLTests: XCTestCase {
         OneOrMore {
           "abc"
         }
-        .caseSensitive(false)
-        .caseSensitive(true)
+        .ignoringCase(true)
+        .ignoringCase(false)
       }
 
     // An option on an outer component doesn't override an option set on an
@@ -204,10 +204,10 @@ class RegexDSLTests: XCTestCase {
       ("abcdeABCdeaBcde", "abcdeABCdeaBcde"),
       matchType: Substring.self, ==) {
         OneOrMore {
-          "abc".caseSensitive(false)
+          "abc".ignoringCase(true)
           Optionally("de")
         }
-        .caseSensitive(true)
+        .ignoringCase(false)
       }
   }
   

--- a/Tests/RegexBuilderTests/RegexDSLTests.swift
+++ b/Tests/RegexBuilderTests/RegexDSLTests.swift
@@ -216,32 +216,42 @@ class RegexDSLTests: XCTestCase {
       ("abc1def2", ("abc1def2", "2")),
       matchType: (Substring, Substring).self, ==)
     {
-      OneOrMore {
-        OneOrMore(.word)
-        Capture(.digit)
+      OneOrMore(.word)
+      Capture(.digit)
+      ZeroOrMore(.any)
+    }
+
+    try _testDSLCaptures(
+      ("abc1def2", ("abc1def2", "1")),
+      matchType: (Substring, Substring).self, ==)
+    {
+      OneOrMore(.word, .reluctantly)
+      Capture(.digit)
+      ZeroOrMore(.any)
+    }
+    
+    try XCTExpectFailure("'relucantCaptures()' API should only affect regex literals") {
+      try _testDSLCaptures(
+        ("abc1def2", ("abc1def2", "2")),
+        matchType: (Substring, Substring).self, ==)
+      {
+        Regex {
+          OneOrMore(.word)
+          Capture(.digit)
+          ZeroOrMore(.any)
+        }.reluctantCaptures()
       }
     }
 
     try _testDSLCaptures(
-      ("abc1def2", ("abc1def2", "2")),
+      ("abc1def2", ("abc1def2", "1")),
       matchType: (Substring, Substring).self, ==)
     {
-      OneOrMore {
-        OneOrMore(.word, .reluctantly)
-        Capture(.digit)
+      OneOrMore(.reluctantly) {
+        .word
       }
-    }
-
-    try _testDSLCaptures(
-      ("abc1def2", ("abc1def2", "2")),
-      matchType: (Substring, Substring).self, ==)
-    {
-      OneOrMore {
-        OneOrMore(.reluctantly) {
-          .word
-        }
-        Capture(.digit)
-      }
+      Capture(.digit)
+      ZeroOrMore(.any)
     }
     
     try _testDSLCaptures(

--- a/Tests/RegexBuilderTests/RegexDSLTests.swift
+++ b/Tests/RegexBuilderTests/RegexDSLTests.swift
@@ -230,6 +230,7 @@ class RegexDSLTests: XCTestCase {
       ZeroOrMore(.any)
     }
     
+#if os(macOS)
     try XCTExpectFailure("'relucantCaptures()' API should only affect regex literals") {
       try _testDSLCaptures(
         ("abc1def2", ("abc1def2", "2")),
@@ -242,7 +243,8 @@ class RegexDSLTests: XCTestCase {
         }.reluctantCaptures()
       }
     }
-
+#endif
+    
     try _testDSLCaptures(
       ("abc1def2", ("abc1def2", "1")),
       matchType: (Substring, Substring).self, ==)


### PR DESCRIPTION
This adds methods to `RegexComponent` for the remainder of the regex options, and passes the current `MatchingOptions` further down into the consumers so that the correct behavior can be used.