### PR TITLE
Allow POSIX character properties outside of custom character classes

### DIFF
--- a/Sources/_RegexParser/Regex/Parse/Parse.swift
+++ b/Sources/_RegexParser/Regex/Parse/Parse.swift
@@ -403,7 +403,7 @@ extension Parser {
     }
 
     // Check if we have the start of a custom character class '['.
-    if let cccStart = try source.lexCustomCCStart(context: context) {
+    if let cccStart = try source.lexCustomCCStart() {
       return .customCharacterClass(
         try parseCustomCharacterClass(cccStart))
     }
@@ -487,7 +487,7 @@ extension Parser {
     while source.peek() != "]" && source.peekCCBinOp() == nil {
 
       // Nested custom character class.
-      if let cccStart = try source.lexCustomCCStart(context: context) {
+      if let cccStart = try source.lexCustomCCStart() {
         members.append(.custom(try parseCustomCharacterClass(cccStart)))
         continue
       }

--- a/Sources/_StringProcessing/Utility/ASTBuilder.swift
+++ b/Sources/_StringProcessing/Utility/ASTBuilder.swift
@@ -354,6 +354,11 @@ func prop(
 ) -> AST.Node {
   atom(.property(.init(kind, isInverted: inverted, isPOSIX: false)))
 }
+func posixProp(
+  _ kind: AST.Atom.CharacterProperty.Kind, inverted: Bool = false
+) -> AST.Node {
+  atom(.property(.init(kind, isInverted: inverted, isPOSIX: true)))
+}
 
 // Raw atom constructing variant
 func atom_a(

--- a/Tests/RegexTests/ParseTests.swift
+++ b/Tests/RegexTests/ParseTests.swift
@@ -477,12 +477,9 @@ extension RegexTests {
     // These are custom character classes, not invalid POSIX character classes.
     // TODO: This behavior is subtle, we ought to warn.
     parseTest("[[:space]]", charClass(charClass(":", "s", "p", "a", "c", "e")))
-    parseTest("[:space:]", charClass(":", "s", "p", "a", "c", "e", ":"))
     parseTest("[:a]", charClass(":", "a"))
     parseTest("[a:]", charClass("a", ":"))
     parseTest("[:]", charClass(":"))
-    parseTest("[::]", charClass(":", ":"))
-    parseTest("[:=:]", charClass(":", "=", ":"))
     parseTest("[[:]]", charClass(charClass(":")))
     parseTest("[[:a=b=c:]]", charClass(charClass(":", "a", "=", "b", "=", "c", ":")))
 
@@ -521,6 +518,12 @@ extension RegexTests {
                         atom_m(.escaped(.decimalDigit)),
                         posixProp_m(.binary(.uppercase), inverted: true),
                         "c", "d"))
+
+    // Like ICU, we allow POSIX character properties outside of custom character
+    // classes. This also appears to be suggested by UTS#18.
+    // TODO: We should likely emit a warning.
+    parseTest("[:space:]", posixProp(.binary(.whitespace)))
+    parseTest("[:script=Greek:]", posixProp(.script(.greek)))
 
     parseTest("[[[:space:]]]", charClass(charClass(
       posixProp_m(.binary(.whitespace))
@@ -2252,6 +2255,8 @@ extension RegexTests {
     diagnosticTest("[[:a:", .expected("]"))
     diagnosticTest("[[:a[:]", .expected("]"))
 
+    diagnosticTest("[::]", .emptyProperty)
+    diagnosticTest("[:=:]", .emptyProperty)
     diagnosticTest("[[::]]", .emptyProperty)
     diagnosticTest("[[:=:]]", .emptyProperty)
 


### PR DESCRIPTION
This matches the ICU behavior, and appears to be suggested by UTS#18.