### PR TITLE
Move RegexComponent conformances to RegexBuilder

### DIFF
--- a/Sources/RegexBuilder/DSL.swift
+++ b/Sources/RegexBuilder/DSL.swift
@@ -32,6 +32,40 @@ extension _BuiltinRegexComponent {
   }
 }
 
+// MARK: - Primitive regex components
+
+extension String: RegexComponent {
+  public typealias Output = Substring
+
+  public var regex: Regex<Output> {
+    .init(node: .quotedLiteral(self))
+  }
+}
+
+extension Substring: RegexComponent {
+  public typealias Output = Substring
+
+  public var regex: Regex<Output> {
+    .init(node: .quotedLiteral(String(self)))
+  }
+}
+
+extension Character: RegexComponent {
+  public typealias Output = Substring
+
+  public var regex: Regex<Output> {
+    .init(node: .atom(.char(self)))
+  }
+}
+
+extension UnicodeScalar: RegexComponent {
+  public typealias Output = Substring
+
+  public var regex: Regex<Output> {
+    .init(node: .atom(.scalar(self)))
+  }
+}
+
 // MARK: - Combinators
 
 // MARK: Concatenation

--- a/Sources/_StringProcessing/Regex/Core.swift
+++ b/Sources/_StringProcessing/Regex/Core.swift
@@ -95,37 +95,3 @@ extension Regex {
   }
 
 }
-
-// MARK: - Primitive regex components
-
-extension String: RegexComponent {
-  public typealias Output = Substring
-
-  public var regex: Regex<Output> {
-    .init(node: .quotedLiteral(self))
-  }
-}
-
-extension Substring: RegexComponent {
-  public typealias Output = Substring
-
-  public var regex: Regex<Output> {
-    .init(node: .quotedLiteral(String(self)))
-  }
-}
-
-extension Character: RegexComponent {
-  public typealias Output = Substring
-
-  public var regex: Regex<Output> {
-    .init(node: .atom(.char(self)))
-  }
-}
-
-extension UnicodeScalar: RegexComponent {
-  public typealias Output = Substring
-
-  public var regex: Regex<Output> {
-    .init(node: .atom(.scalar(self)))
-  }
-}


### PR DESCRIPTION
This moves the RegexComponent conformances for String, Substring, etc to the RegexBuilder module. This will remove extra API from strings, such as the option-setting methods, when not writing DSL regexes, and also cut down on confusing usage of regex-oriented APIs with strings or characters.