### PR TITLE
Error on unknown character properties

### DIFF
--- a/Sources/_RegexParser/Regex/AST/Atom.swift
+++ b/Sources/_RegexParser/Regex/AST/Atom.swift
@@ -401,9 +401,6 @@ extension AST.Atom.CharacterProperty {
     /// Some special properties implemented by PCRE and Oniguruma.
     case pcreSpecial(PCRESpecialCategory)
     case onigurumaSpecial(OnigurumaSpecialProperty)
-
-    /// Unhandled properties.
-    case other(key: String?, value: String)
   }
 
   // TODO: erm, separate out or fold into something? splat it in?

--- a/Sources/_RegexParser/Regex/Parse/CharacterPropertyClassification.swift
+++ b/Sources/_RegexParser/Regex/Parse/CharacterPropertyClassification.swift
@@ -397,8 +397,9 @@ extension Source {
       return .pcreSpecial(pcreSpecial)
     }
 
-    // Otherwise we don't know what this is.
-    return .other(key: nil, value: value)
+    // TODO: This should be versioned, and do we want a more lax behavior for
+    // the runtime?
+    throw ParseError.unknownProperty(key: nil, value: value)
   }
 
   static func classifyCharacterProperty(
@@ -435,6 +436,8 @@ extension Source {
     if let match = match {
       return match
     }
-    return .other(key: key, value: value)
+    // TODO: This should be versioned, and do we want a more lax behavior for
+    // the runtime?
+    throw ParseError.unknownProperty(key: key, value: value)
   }
 }

--- a/Sources/_RegexParser/Regex/Parse/Diagnostics.swift
+++ b/Sources/_RegexParser/Regex/Parse/Diagnostics.swift
@@ -57,8 +57,8 @@ enum ParseError: Error, Hashable {
   case expectedCustomCharacterClassMembers
   case invalidCharacterClassRangeOperand
 
-  case invalidPOSIXSetName(String)
   case emptyProperty
+  case unknownProperty(key: String?, value: String)
 
   case expectedGroupSpecifier
   case unbalancedEndOfGroup
@@ -142,10 +142,13 @@ extension ParseError: CustomStringConvertible {
       return "expected custom character class members"
     case .invalidCharacterClassRangeOperand:
       return "invalid character class range"
-    case let .invalidPOSIXSetName(n):
-      return "invalid character set name: '\(n)'"
     case .emptyProperty:
       return "empty property"
+    case .unknownProperty(let key, let value):
+      if let key = key {
+        return "unknown character property '\(key)=\(value)'"
+      }
+      return "unknown character property '\(value)'"
     case .expectedGroupSpecifier:
       return "expected group specifier"
     case .unbalancedEndOfGroup:

--- a/Sources/_StringProcessing/ConsumerInterface.swift
+++ b/Sources/_StringProcessing/ConsumerInterface.swift
@@ -423,10 +423,6 @@ extension AST.Atom.CharacterProperty {
 
       case .onigurumaSpecial(let s):
         throw Unsupported("TODO: map Oniguruma special: \(s)")
-
-      case let .other(key, value):
-        throw Unsupported(
-          "TODO: map other \(key ?? "")=\(value)")
       }
     }()
 


### PR DESCRIPTION
Previously we would form an `.other` character property kind for any unclassified properties, which crash at runtime as unsupported. Instead, switch to erroring on them. Eventually it would be nice if we could version this based on what the runtime being targeted supports.