### PR TITLE
Rename RegexComponent.Output

### DIFF
--- a/Sources/Exercises/Participants/RegexParticipant.swift
+++ b/Sources/Exercises/Participants/RegexParticipant.swift
@@ -62,7 +62,7 @@ private func extractFromCaptures(
 private func graphemeBreakPropertyData<RP: RegexComponent>(
   forLine line: String,
   using regex: RP
-) -> GraphemeBreakEntry? where RP.Output == (Substring, Substring, Substring?, Substring) {
+) -> GraphemeBreakEntry? where RP.RegexOutput == (Substring, Substring, Substring?, Substring) {
   line.wholeMatch(of: regex).map(\.output).flatMap(extractFromCaptures)
 }
 

--- a/Sources/RegexBuilder/Anchor.swift
+++ b/Sources/RegexBuilder/Anchor.swift
@@ -117,7 +117,7 @@ public struct Lookahead<Output>: _BuiltinRegexComponent {
   public init<R: RegexComponent>(
     _ component: R,
     negative: Bool = false
-  ) where R.Output == Output {
+  ) where R.RegexOutput == Output {
     self.init(node: .nonCapturingGroup(
       negative ? .negativeLookahead : .lookahead, component.regex.root))
   }
@@ -125,7 +125,7 @@ public struct Lookahead<Output>: _BuiltinRegexComponent {
   public init<R: RegexComponent>(
     negative: Bool = false,
     @RegexComponentBuilder _ component: () -> R
-  ) where R.Output == Output {
+  ) where R.RegexOutput == Output {
     self.init(node: .nonCapturingGroup(
       negative ? .negativeLookahead : .lookahead, component().regex.root))
   }

--- a/Sources/RegexBuilder/DSL.swift
+++ b/Sources/RegexBuilder/DSL.swift
@@ -15,7 +15,7 @@ import _RegexParser
 extension Regex {
   public init<Content: RegexComponent>(
     @RegexComponentBuilder _ content: () -> Content
-  ) where Content.Output == Output {
+  ) where Content.RegexOutput == Output {
     self = content().regex
   }
 }
@@ -23,7 +23,7 @@ extension Regex {
 // A convenience protocol for builtin regex components that are initialized with
 // a `DSLTree` node.
 internal protocol _BuiltinRegexComponent: RegexComponent {
-  init(_ regex: Regex<Output>)
+  init(_ regex: Regex<RegexOutput>)
 }
 
 extension _BuiltinRegexComponent {
@@ -184,7 +184,7 @@ public struct AlternationBuilder {
   @_disfavoredOverload
   public static func buildPartialBlock<R: RegexComponent>(
     first component: R
-  ) -> ChoiceOf<R.Output> {
+  ) -> ChoiceOf<R.RegexOutput> {
     .init(component.regex)
   }
 

--- a/Sources/RegexBuilder/Match.swift
+++ b/Sources/RegexBuilder/Match.swift
@@ -14,13 +14,13 @@ import _StringProcessing
 extension String {
   public func wholeMatch<R: RegexComponent>(
     @RegexComponentBuilder of content: () -> R
-  ) -> Regex<R.Output>.Match? {
+  ) -> Regex<R.RegexOutput>.Match? {
     wholeMatch(of: content())
   }
 
   public func prefixMatch<R: RegexComponent>(
     @RegexComponentBuilder of content: () -> R
-  ) -> Regex<R.Output>.Match? {
+  ) -> Regex<R.RegexOutput>.Match? {
     prefixMatch(of: content())
   }
 }
@@ -28,13 +28,13 @@ extension String {
 extension Substring {
   public func wholeMatch<R: RegexComponent>(
     @RegexComponentBuilder of content: () -> R
-  ) -> Regex<R.Output>.Match? {
+  ) -> Regex<R.RegexOutput>.Match? {
     wholeMatch(of: content())
   }
 
   public func prefixMatch<R: RegexComponent>(
     @RegexComponentBuilder of content: () -> R
-  ) -> Regex<R.Output>.Match? {
+  ) -> Regex<R.RegexOutput>.Match? {
     prefixMatch(of: content())
   }
 }

--- a/Sources/RegexBuilder/Variadics.swift
+++ b/Sources/RegexBuilder/Variadics.swift
@@ -17,462 +17,462 @@ import _RegexParser
 extension RegexComponentBuilder {
   public static func buildPartialBlock<W0, W1, C0, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
-  ) -> Regex<(Substring, C0)>  where R0.Output == W0, R1.Output == (W1, C0) {
+  ) -> Regex<(Substring, C0)>  where R0.RegexOutput == W0, R1.RegexOutput == (W1, C0) {
     .init(node: accumulated.regex.root.appending(next.regex.root))
   }
 }
 extension RegexComponentBuilder {
   public static func buildPartialBlock<W0, W1, C0, C1, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
-  ) -> Regex<(Substring, C0, C1)>  where R0.Output == W0, R1.Output == (W1, C0, C1) {
+  ) -> Regex<(Substring, C0, C1)>  where R0.RegexOutput == W0, R1.RegexOutput == (W1, C0, C1) {
     .init(node: accumulated.regex.root.appending(next.regex.root))
   }
 }
 extension RegexComponentBuilder {
   public static func buildPartialBlock<W0, W1, C0, C1, C2, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
-  ) -> Regex<(Substring, C0, C1, C2)>  where R0.Output == W0, R1.Output == (W1, C0, C1, C2) {
+  ) -> Regex<(Substring, C0, C1, C2)>  where R0.RegexOutput == W0, R1.RegexOutput == (W1, C0, C1, C2) {
     .init(node: accumulated.regex.root.appending(next.regex.root))
   }
 }
 extension RegexComponentBuilder {
   public static func buildPartialBlock<W0, W1, C0, C1, C2, C3, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
-  ) -> Regex<(Substring, C0, C1, C2, C3)>  where R0.Output == W0, R1.Output == (W1, C0, C1, C2, C3) {
+  ) -> Regex<(Substring, C0, C1, C2, C3)>  where R0.RegexOutput == W0, R1.RegexOutput == (W1, C0, C1, C2, C3) {
     .init(node: accumulated.regex.root.appending(next.regex.root))
   }
 }
 extension RegexComponentBuilder {
   public static func buildPartialBlock<W0, W1, C0, C1, C2, C3, C4, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
-  ) -> Regex<(Substring, C0, C1, C2, C3, C4)>  where R0.Output == W0, R1.Output == (W1, C0, C1, C2, C3, C4) {
+  ) -> Regex<(Substring, C0, C1, C2, C3, C4)>  where R0.RegexOutput == W0, R1.RegexOutput == (W1, C0, C1, C2, C3, C4) {
     .init(node: accumulated.regex.root.appending(next.regex.root))
   }
 }
 extension RegexComponentBuilder {
   public static func buildPartialBlock<W0, W1, C0, C1, C2, C3, C4, C5, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
-  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5)>  where R0.Output == W0, R1.Output == (W1, C0, C1, C2, C3, C4, C5) {
+  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5)>  where R0.RegexOutput == W0, R1.RegexOutput == (W1, C0, C1, C2, C3, C4, C5) {
     .init(node: accumulated.regex.root.appending(next.regex.root))
   }
 }
 extension RegexComponentBuilder {
   public static func buildPartialBlock<W0, W1, C0, C1, C2, C3, C4, C5, C6, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
-  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6)>  where R0.Output == W0, R1.Output == (W1, C0, C1, C2, C3, C4, C5, C6) {
+  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6)>  where R0.RegexOutput == W0, R1.RegexOutput == (W1, C0, C1, C2, C3, C4, C5, C6) {
     .init(node: accumulated.regex.root.appending(next.regex.root))
   }
 }
 extension RegexComponentBuilder {
   public static func buildPartialBlock<W0, W1, C0, C1, C2, C3, C4, C5, C6, C7, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
-  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7)>  where R0.Output == W0, R1.Output == (W1, C0, C1, C2, C3, C4, C5, C6, C7) {
+  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7)>  where R0.RegexOutput == W0, R1.RegexOutput == (W1, C0, C1, C2, C3, C4, C5, C6, C7) {
     .init(node: accumulated.regex.root.appending(next.regex.root))
   }
 }
 extension RegexComponentBuilder {
   public static func buildPartialBlock<W0, W1, C0, C1, C2, C3, C4, C5, C6, C7, C8, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
-  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8)>  where R0.Output == W0, R1.Output == (W1, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
+  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8)>  where R0.RegexOutput == W0, R1.RegexOutput == (W1, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
     .init(node: accumulated.regex.root.appending(next.regex.root))
   }
 }
 extension RegexComponentBuilder {
   public static func buildPartialBlock<W0, W1, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
-  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9)>  where R0.Output == W0, R1.Output == (W1, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
+  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9)>  where R0.RegexOutput == W0, R1.RegexOutput == (W1, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
     .init(node: accumulated.regex.root.appending(next.regex.root))
   }
 }
 extension RegexComponentBuilder {
   public static func buildPartialBlock<W0, W1, C0, C1, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
-  ) -> Regex<(Substring, C0, C1)>  where R0.Output == (W0, C0), R1.Output == (W1, C1) {
+  ) -> Regex<(Substring, C0, C1)>  where R0.RegexOutput == (W0, C0), R1.RegexOutput == (W1, C1) {
     .init(node: accumulated.regex.root.appending(next.regex.root))
   }
 }
 extension RegexComponentBuilder {
   public static func buildPartialBlock<W0, W1, C0, C1, C2, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
-  ) -> Regex<(Substring, C0, C1, C2)>  where R0.Output == (W0, C0), R1.Output == (W1, C1, C2) {
+  ) -> Regex<(Substring, C0, C1, C2)>  where R0.RegexOutput == (W0, C0), R1.RegexOutput == (W1, C1, C2) {
     .init(node: accumulated.regex.root.appending(next.regex.root))
   }
 }
 extension RegexComponentBuilder {
   public static func buildPartialBlock<W0, W1, C0, C1, C2, C3, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
-  ) -> Regex<(Substring, C0, C1, C2, C3)>  where R0.Output == (W0, C0), R1.Output == (W1, C1, C2, C3) {
+  ) -> Regex<(Substring, C0, C1, C2, C3)>  where R0.RegexOutput == (W0, C0), R1.RegexOutput == (W1, C1, C2, C3) {
     .init(node: accumulated.regex.root.appending(next.regex.root))
   }
 }
 extension RegexComponentBuilder {
   public static func buildPartialBlock<W0, W1, C0, C1, C2, C3, C4, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
-  ) -> Regex<(Substring, C0, C1, C2, C3, C4)>  where R0.Output == (W0, C0), R1.Output == (W1, C1, C2, C3, C4) {
+  ) -> Regex<(Substring, C0, C1, C2, C3, C4)>  where R0.RegexOutput == (W0, C0), R1.RegexOutput == (W1, C1, C2, C3, C4) {
     .init(node: accumulated.regex.root.appending(next.regex.root))
   }
 }
 extension RegexComponentBuilder {
   public static func buildPartialBlock<W0, W1, C0, C1, C2, C3, C4, C5, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
-  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5)>  where R0.Output == (W0, C0), R1.Output == (W1, C1, C2, C3, C4, C5) {
+  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5)>  where R0.RegexOutput == (W0, C0), R1.RegexOutput == (W1, C1, C2, C3, C4, C5) {
     .init(node: accumulated.regex.root.appending(next.regex.root))
   }
 }
 extension RegexComponentBuilder {
   public static func buildPartialBlock<W0, W1, C0, C1, C2, C3, C4, C5, C6, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
-  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6)>  where R0.Output == (W0, C0), R1.Output == (W1, C1, C2, C3, C4, C5, C6) {
+  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6)>  where R0.RegexOutput == (W0, C0), R1.RegexOutput == (W1, C1, C2, C3, C4, C5, C6) {
     .init(node: accumulated.regex.root.appending(next.regex.root))
   }
 }
 extension RegexComponentBuilder {
   public static func buildPartialBlock<W0, W1, C0, C1, C2, C3, C4, C5, C6, C7, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
-  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7)>  where R0.Output == (W0, C0), R1.Output == (W1, C1, C2, C3, C4, C5, C6, C7) {
+  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7)>  where R0.RegexOutput == (W0, C0), R1.RegexOutput == (W1, C1, C2, C3, C4, C5, C6, C7) {
     .init(node: accumulated.regex.root.appending(next.regex.root))
   }
 }
 extension RegexComponentBuilder {
   public static func buildPartialBlock<W0, W1, C0, C1, C2, C3, C4, C5, C6, C7, C8, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
-  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8)>  where R0.Output == (W0, C0), R1.Output == (W1, C1, C2, C3, C4, C5, C6, C7, C8) {
+  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8)>  where R0.RegexOutput == (W0, C0), R1.RegexOutput == (W1, C1, C2, C3, C4, C5, C6, C7, C8) {
     .init(node: accumulated.regex.root.appending(next.regex.root))
   }
 }
 extension RegexComponentBuilder {
   public static func buildPartialBlock<W0, W1, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
-  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9)>  where R0.Output == (W0, C0), R1.Output == (W1, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
+  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9)>  where R0.RegexOutput == (W0, C0), R1.RegexOutput == (W1, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
     .init(node: accumulated.regex.root.appending(next.regex.root))
   }
 }
 extension RegexComponentBuilder {
   public static func buildPartialBlock<W0, W1, C0, C1, C2, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
-  ) -> Regex<(Substring, C0, C1, C2)>  where R0.Output == (W0, C0, C1), R1.Output == (W1, C2) {
+  ) -> Regex<(Substring, C0, C1, C2)>  where R0.RegexOutput == (W0, C0, C1), R1.RegexOutput == (W1, C2) {
     .init(node: accumulated.regex.root.appending(next.regex.root))
   }
 }
 extension RegexComponentBuilder {
   public static func buildPartialBlock<W0, W1, C0, C1, C2, C3, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
-  ) -> Regex<(Substring, C0, C1, C2, C3)>  where R0.Output == (W0, C0, C1), R1.Output == (W1, C2, C3) {
+  ) -> Regex<(Substring, C0, C1, C2, C3)>  where R0.RegexOutput == (W0, C0, C1), R1.RegexOutput == (W1, C2, C3) {
     .init(node: accumulated.regex.root.appending(next.regex.root))
   }
 }
 extension RegexComponentBuilder {
   public static func buildPartialBlock<W0, W1, C0, C1, C2, C3, C4, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
-  ) -> Regex<(Substring, C0, C1, C2, C3, C4)>  where R0.Output == (W0, C0, C1), R1.Output == (W1, C2, C3, C4) {
+  ) -> Regex<(Substring, C0, C1, C2, C3, C4)>  where R0.RegexOutput == (W0, C0, C1), R1.RegexOutput == (W1, C2, C3, C4) {
     .init(node: accumulated.regex.root.appending(next.regex.root))
   }
 }
 extension RegexComponentBuilder {
   public static func buildPartialBlock<W0, W1, C0, C1, C2, C3, C4, C5, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
-  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5)>  where R0.Output == (W0, C0, C1), R1.Output == (W1, C2, C3, C4, C5) {
+  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5)>  where R0.RegexOutput == (W0, C0, C1), R1.RegexOutput == (W1, C2, C3, C4, C5) {
     .init(node: accumulated.regex.root.appending(next.regex.root))
   }
 }
 extension RegexComponentBuilder {
   public static func buildPartialBlock<W0, W1, C0, C1, C2, C3, C4, C5, C6, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
-  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6)>  where R0.Output == (W0, C0, C1), R1.Output == (W1, C2, C3, C4, C5, C6) {
+  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6)>  where R0.RegexOutput == (W0, C0, C1), R1.RegexOutput == (W1, C2, C3, C4, C5, C6) {
     .init(node: accumulated.regex.root.appending(next.regex.root))
   }
 }
 extension RegexComponentBuilder {
   public static func buildPartialBlock<W0, W1, C0, C1, C2, C3, C4, C5, C6, C7, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
-  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7)>  where R0.Output == (W0, C0, C1), R1.Output == (W1, C2, C3, C4, C5, C6, C7) {
+  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7)>  where R0.RegexOutput == (W0, C0, C1), R1.RegexOutput == (W1, C2, C3, C4, C5, C6, C7) {
     .init(node: accumulated.regex.root.appending(next.regex.root))
   }
 }
 extension RegexComponentBuilder {
   public static func buildPartialBlock<W0, W1, C0, C1, C2, C3, C4, C5, C6, C7, C8, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
-  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8)>  where R0.Output == (W0, C0, C1), R1.Output == (W1, C2, C3, C4, C5, C6, C7, C8) {
+  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8)>  where R0.RegexOutput == (W0, C0, C1), R1.RegexOutput == (W1, C2, C3, C4, C5, C6, C7, C8) {
     .init(node: accumulated.regex.root.appending(next.regex.root))
   }
 }
 extension RegexComponentBuilder {
   public static func buildPartialBlock<W0, W1, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
-  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9)>  where R0.Output == (W0, C0, C1), R1.Output == (W1, C2, C3, C4, C5, C6, C7, C8, C9) {
+  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9)>  where R0.RegexOutput == (W0, C0, C1), R1.RegexOutput == (W1, C2, C3, C4, C5, C6, C7, C8, C9) {
     .init(node: accumulated.regex.root.appending(next.regex.root))
   }
 }
 extension RegexComponentBuilder {
   public static func buildPartialBlock<W0, W1, C0, C1, C2, C3, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
-  ) -> Regex<(Substring, C0, C1, C2, C3)>  where R0.Output == (W0, C0, C1, C2), R1.Output == (W1, C3) {
+  ) -> Regex<(Substring, C0, C1, C2, C3)>  where R0.RegexOutput == (W0, C0, C1, C2), R1.RegexOutput == (W1, C3) {
     .init(node: accumulated.regex.root.appending(next.regex.root))
   }
 }
 extension RegexComponentBuilder {
   public static func buildPartialBlock<W0, W1, C0, C1, C2, C3, C4, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
-  ) -> Regex<(Substring, C0, C1, C2, C3, C4)>  where R0.Output == (W0, C0, C1, C2), R1.Output == (W1, C3, C4) {
+  ) -> Regex<(Substring, C0, C1, C2, C3, C4)>  where R0.RegexOutput == (W0, C0, C1, C2), R1.RegexOutput == (W1, C3, C4) {
     .init(node: accumulated.regex.root.appending(next.regex.root))
   }
 }
 extension RegexComponentBuilder {
   public static func buildPartialBlock<W0, W1, C0, C1, C2, C3, C4, C5, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
-  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5)>  where R0.Output == (W0, C0, C1, C2), R1.Output == (W1, C3, C4, C5) {
+  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5)>  where R0.RegexOutput == (W0, C0, C1, C2), R1.RegexOutput == (W1, C3, C4, C5) {
     .init(node: accumulated.regex.root.appending(next.regex.root))
   }
 }
 extension RegexComponentBuilder {
   public static func buildPartialBlock<W0, W1, C0, C1, C2, C3, C4, C5, C6, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
-  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6)>  where R0.Output == (W0, C0, C1, C2), R1.Output == (W1, C3, C4, C5, C6) {
+  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6)>  where R0.RegexOutput == (W0, C0, C1, C2), R1.RegexOutput == (W1, C3, C4, C5, C6) {
     .init(node: accumulated.regex.root.appending(next.regex.root))
   }
 }
 extension RegexComponentBuilder {
   public static func buildPartialBlock<W0, W1, C0, C1, C2, C3, C4, C5, C6, C7, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
-  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7)>  where R0.Output == (W0, C0, C1, C2), R1.Output == (W1, C3, C4, C5, C6, C7) {
+  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7)>  where R0.RegexOutput == (W0, C0, C1, C2), R1.RegexOutput == (W1, C3, C4, C5, C6, C7) {
     .init(node: accumulated.regex.root.appending(next.regex.root))
   }
 }
 extension RegexComponentBuilder {
   public static func buildPartialBlock<W0, W1, C0, C1, C2, C3, C4, C5, C6, C7, C8, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
-  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8)>  where R0.Output == (W0, C0, C1, C2), R1.Output == (W1, C3, C4, C5, C6, C7, C8) {
+  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8)>  where R0.RegexOutput == (W0, C0, C1, C2), R1.RegexOutput == (W1, C3, C4, C5, C6, C7, C8) {
     .init(node: accumulated.regex.root.appending(next.regex.root))
   }
 }
 extension RegexComponentBuilder {
   public static func buildPartialBlock<W0, W1, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
-  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9)>  where R0.Output == (W0, C0, C1, C2), R1.Output == (W1, C3, C4, C5, C6, C7, C8, C9) {
+  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9)>  where R0.RegexOutput == (W0, C0, C1, C2), R1.RegexOutput == (W1, C3, C4, C5, C6, C7, C8, C9) {
     .init(node: accumulated.regex.root.appending(next.regex.root))
   }
 }
 extension RegexComponentBuilder {
   public static func buildPartialBlock<W0, W1, C0, C1, C2, C3, C4, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
-  ) -> Regex<(Substring, C0, C1, C2, C3, C4)>  where R0.Output == (W0, C0, C1, C2, C3), R1.Output == (W1, C4) {
+  ) -> Regex<(Substring, C0, C1, C2, C3, C4)>  where R0.RegexOutput == (W0, C0, C1, C2, C3), R1.RegexOutput == (W1, C4) {
     .init(node: accumulated.regex.root.appending(next.regex.root))
   }
 }
 extension RegexComponentBuilder {
   public static func buildPartialBlock<W0, W1, C0, C1, C2, C3, C4, C5, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
-  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5)>  where R0.Output == (W0, C0, C1, C2, C3), R1.Output == (W1, C4, C5) {
+  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5)>  where R0.RegexOutput == (W0, C0, C1, C2, C3), R1.RegexOutput == (W1, C4, C5) {
     .init(node: accumulated.regex.root.appending(next.regex.root))
   }
 }
 extension RegexComponentBuilder {
   public static func buildPartialBlock<W0, W1, C0, C1, C2, C3, C4, C5, C6, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
-  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6)>  where R0.Output == (W0, C0, C1, C2, C3), R1.Output == (W1, C4, C5, C6) {
+  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6)>  where R0.RegexOutput == (W0, C0, C1, C2, C3), R1.RegexOutput == (W1, C4, C5, C6) {
     .init(node: accumulated.regex.root.appending(next.regex.root))
   }
 }
 extension RegexComponentBuilder {
   public static func buildPartialBlock<W0, W1, C0, C1, C2, C3, C4, C5, C6, C7, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
-  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7)>  where R0.Output == (W0, C0, C1, C2, C3), R1.Output == (W1, C4, C5, C6, C7) {
+  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7)>  where R0.RegexOutput == (W0, C0, C1, C2, C3), R1.RegexOutput == (W1, C4, C5, C6, C7) {
     .init(node: accumulated.regex.root.appending(next.regex.root))
   }
 }
 extension RegexComponentBuilder {
   public static func buildPartialBlock<W0, W1, C0, C1, C2, C3, C4, C5, C6, C7, C8, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
-  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8)>  where R0.Output == (W0, C0, C1, C2, C3), R1.Output == (W1, C4, C5, C6, C7, C8) {
+  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8)>  where R0.RegexOutput == (W0, C0, C1, C2, C3), R1.RegexOutput == (W1, C4, C5, C6, C7, C8) {
     .init(node: accumulated.regex.root.appending(next.regex.root))
   }
 }
 extension RegexComponentBuilder {
   public static func buildPartialBlock<W0, W1, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
-  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9)>  where R0.Output == (W0, C0, C1, C2, C3), R1.Output == (W1, C4, C5, C6, C7, C8, C9) {
+  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9)>  where R0.RegexOutput == (W0, C0, C1, C2, C3), R1.RegexOutput == (W1, C4, C5, C6, C7, C8, C9) {
     .init(node: accumulated.regex.root.appending(next.regex.root))
   }
 }
 extension RegexComponentBuilder {
   public static func buildPartialBlock<W0, W1, C0, C1, C2, C3, C4, C5, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
-  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5)>  where R0.Output == (W0, C0, C1, C2, C3, C4), R1.Output == (W1, C5) {
+  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5)>  where R0.RegexOutput == (W0, C0, C1, C2, C3, C4), R1.RegexOutput == (W1, C5) {
     .init(node: accumulated.regex.root.appending(next.regex.root))
   }
 }
 extension RegexComponentBuilder {
   public static func buildPartialBlock<W0, W1, C0, C1, C2, C3, C4, C5, C6, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
-  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6)>  where R0.Output == (W0, C0, C1, C2, C3, C4), R1.Output == (W1, C5, C6) {
+  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6)>  where R0.RegexOutput == (W0, C0, C1, C2, C3, C4), R1.RegexOutput == (W1, C5, C6) {
     .init(node: accumulated.regex.root.appending(next.regex.root))
   }
 }
 extension RegexComponentBuilder {
   public static func buildPartialBlock<W0, W1, C0, C1, C2, C3, C4, C5, C6, C7, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
-  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7)>  where R0.Output == (W0, C0, C1, C2, C3, C4), R1.Output == (W1, C5, C6, C7) {
+  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7)>  where R0.RegexOutput == (W0, C0, C1, C2, C3, C4), R1.RegexOutput == (W1, C5, C6, C7) {
     .init(node: accumulated.regex.root.appending(next.regex.root))
   }
 }
 extension RegexComponentBuilder {
   public static func buildPartialBlock<W0, W1, C0, C1, C2, C3, C4, C5, C6, C7, C8, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
-  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8)>  where R0.Output == (W0, C0, C1, C2, C3, C4), R1.Output == (W1, C5, C6, C7, C8) {
+  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8)>  where R0.RegexOutput == (W0, C0, C1, C2, C3, C4), R1.RegexOutput == (W1, C5, C6, C7, C8) {
     .init(node: accumulated.regex.root.appending(next.regex.root))
   }
 }
 extension RegexComponentBuilder {
   public static func buildPartialBlock<W0, W1, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
-  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9)>  where R0.Output == (W0, C0, C1, C2, C3, C4), R1.Output == (W1, C5, C6, C7, C8, C9) {
+  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9)>  where R0.RegexOutput == (W0, C0, C1, C2, C3, C4), R1.RegexOutput == (W1, C5, C6, C7, C8, C9) {
     .init(node: accumulated.regex.root.appending(next.regex.root))
   }
 }
 extension RegexComponentBuilder {
   public static func buildPartialBlock<W0, W1, C0, C1, C2, C3, C4, C5, C6, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
-  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6)>  where R0.Output == (W0, C0, C1, C2, C3, C4, C5), R1.Output == (W1, C6) {
+  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6)>  where R0.RegexOutput == (W0, C0, C1, C2, C3, C4, C5), R1.RegexOutput == (W1, C6) {
     .init(node: accumulated.regex.root.appending(next.regex.root))
   }
 }
 extension RegexComponentBuilder {
   public static func buildPartialBlock<W0, W1, C0, C1, C2, C3, C4, C5, C6, C7, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
-  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7)>  where R0.Output == (W0, C0, C1, C2, C3, C4, C5), R1.Output == (W1, C6, C7) {
+  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7)>  where R0.RegexOutput == (W0, C0, C1, C2, C3, C4, C5), R1.RegexOutput == (W1, C6, C7) {
     .init(node: accumulated.regex.root.appending(next.regex.root))
   }
 }
 extension RegexComponentBuilder {
   public static func buildPartialBlock<W0, W1, C0, C1, C2, C3, C4, C5, C6, C7, C8, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
-  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8)>  where R0.Output == (W0, C0, C1, C2, C3, C4, C5), R1.Output == (W1, C6, C7, C8) {
+  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8)>  where R0.RegexOutput == (W0, C0, C1, C2, C3, C4, C5), R1.RegexOutput == (W1, C6, C7, C8) {
     .init(node: accumulated.regex.root.appending(next.regex.root))
   }
 }
 extension RegexComponentBuilder {
   public static func buildPartialBlock<W0, W1, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
-  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9)>  where R0.Output == (W0, C0, C1, C2, C3, C4, C5), R1.Output == (W1, C6, C7, C8, C9) {
+  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9)>  where R0.RegexOutput == (W0, C0, C1, C2, C3, C4, C5), R1.RegexOutput == (W1, C6, C7, C8, C9) {
     .init(node: accumulated.regex.root.appending(next.regex.root))
   }
 }
 extension RegexComponentBuilder {
   public static func buildPartialBlock<W0, W1, C0, C1, C2, C3, C4, C5, C6, C7, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
-  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7)>  where R0.Output == (W0, C0, C1, C2, C3, C4, C5, C6), R1.Output == (W1, C7) {
+  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7)>  where R0.RegexOutput == (W0, C0, C1, C2, C3, C4, C5, C6), R1.RegexOutput == (W1, C7) {
     .init(node: accumulated.regex.root.appending(next.regex.root))
   }
 }
 extension RegexComponentBuilder {
   public static func buildPartialBlock<W0, W1, C0, C1, C2, C3, C4, C5, C6, C7, C8, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
-  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8)>  where R0.Output == (W0, C0, C1, C2, C3, C4, C5, C6), R1.Output == (W1, C7, C8) {
+  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8)>  where R0.RegexOutput == (W0, C0, C1, C2, C3, C4, C5, C6), R1.RegexOutput == (W1, C7, C8) {
     .init(node: accumulated.regex.root.appending(next.regex.root))
   }
 }
 extension RegexComponentBuilder {
   public static func buildPartialBlock<W0, W1, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
-  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9)>  where R0.Output == (W0, C0, C1, C2, C3, C4, C5, C6), R1.Output == (W1, C7, C8, C9) {
+  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9)>  where R0.RegexOutput == (W0, C0, C1, C2, C3, C4, C5, C6), R1.RegexOutput == (W1, C7, C8, C9) {
     .init(node: accumulated.regex.root.appending(next.regex.root))
   }
 }
 extension RegexComponentBuilder {
   public static func buildPartialBlock<W0, W1, C0, C1, C2, C3, C4, C5, C6, C7, C8, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
-  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8)>  where R0.Output == (W0, C0, C1, C2, C3, C4, C5, C6, C7), R1.Output == (W1, C8) {
+  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8)>  where R0.RegexOutput == (W0, C0, C1, C2, C3, C4, C5, C6, C7), R1.RegexOutput == (W1, C8) {
     .init(node: accumulated.regex.root.appending(next.regex.root))
   }
 }
 extension RegexComponentBuilder {
   public static func buildPartialBlock<W0, W1, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
-  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9)>  where R0.Output == (W0, C0, C1, C2, C3, C4, C5, C6, C7), R1.Output == (W1, C8, C9) {
+  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9)>  where R0.RegexOutput == (W0, C0, C1, C2, C3, C4, C5, C6, C7), R1.RegexOutput == (W1, C8, C9) {
     .init(node: accumulated.regex.root.appending(next.regex.root))
   }
 }
 extension RegexComponentBuilder {
   public static func buildPartialBlock<W0, W1, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
-  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9)>  where R0.Output == (W0, C0, C1, C2, C3, C4, C5, C6, C7, C8), R1.Output == (W1, C9) {
+  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9)>  where R0.RegexOutput == (W0, C0, C1, C2, C3, C4, C5, C6, C7, C8), R1.RegexOutput == (W1, C9) {
     .init(node: accumulated.regex.root.appending(next.regex.root))
   }
 }
 extension RegexComponentBuilder {
   public static func buildPartialBlock<W0, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
-  ) -> Regex<Substring> where R0.Output == W0  {
+  ) -> Regex<Substring> where R0.RegexOutput == W0  {
     .init(node: accumulated.regex.root.appending(next.regex.root))
   }
 }
 extension RegexComponentBuilder {
   public static func buildPartialBlock<W0, C0, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
-  ) -> Regex<(Substring, C0)> where R0.Output == (W0, C0)  {
+  ) -> Regex<(Substring, C0)> where R0.RegexOutput == (W0, C0)  {
     .init(node: accumulated.regex.root.appending(next.regex.root))
   }
 }
 extension RegexComponentBuilder {
   public static func buildPartialBlock<W0, C0, C1, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
-  ) -> Regex<(Substring, C0, C1)> where R0.Output == (W0, C0, C1)  {
+  ) -> Regex<(Substring, C0, C1)> where R0.RegexOutput == (W0, C0, C1)  {
     .init(node: accumulated.regex.root.appending(next.regex.root))
   }
 }
 extension RegexComponentBuilder {
   public static func buildPartialBlock<W0, C0, C1, C2, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
-  ) -> Regex<(Substring, C0, C1, C2)> where R0.Output == (W0, C0, C1, C2)  {
+  ) -> Regex<(Substring, C0, C1, C2)> where R0.RegexOutput == (W0, C0, C1, C2)  {
     .init(node: accumulated.regex.root.appending(next.regex.root))
   }
 }
 extension RegexComponentBuilder {
   public static func buildPartialBlock<W0, C0, C1, C2, C3, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
-  ) -> Regex<(Substring, C0, C1, C2, C3)> where R0.Output == (W0, C0, C1, C2, C3)  {
+  ) -> Regex<(Substring, C0, C1, C2, C3)> where R0.RegexOutput == (W0, C0, C1, C2, C3)  {
     .init(node: accumulated.regex.root.appending(next.regex.root))
   }
 }
 extension RegexComponentBuilder {
   public static func buildPartialBlock<W0, C0, C1, C2, C3, C4, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
-  ) -> Regex<(Substring, C0, C1, C2, C3, C4)> where R0.Output == (W0, C0, C1, C2, C3, C4)  {
+  ) -> Regex<(Substring, C0, C1, C2, C3, C4)> where R0.RegexOutput == (W0, C0, C1, C2, C3, C4)  {
     .init(node: accumulated.regex.root.appending(next.regex.root))
   }
 }
 extension RegexComponentBuilder {
   public static func buildPartialBlock<W0, C0, C1, C2, C3, C4, C5, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
-  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5)> where R0.Output == (W0, C0, C1, C2, C3, C4, C5)  {
+  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5)> where R0.RegexOutput == (W0, C0, C1, C2, C3, C4, C5)  {
     .init(node: accumulated.regex.root.appending(next.regex.root))
   }
 }
 extension RegexComponentBuilder {
   public static func buildPartialBlock<W0, C0, C1, C2, C3, C4, C5, C6, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
-  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6)> where R0.Output == (W0, C0, C1, C2, C3, C4, C5, C6)  {
+  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6)> where R0.RegexOutput == (W0, C0, C1, C2, C3, C4, C5, C6)  {
     .init(node: accumulated.regex.root.appending(next.regex.root))
   }
 }
 extension RegexComponentBuilder {
   public static func buildPartialBlock<W0, C0, C1, C2, C3, C4, C5, C6, C7, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
-  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7)> where R0.Output == (W0, C0, C1, C2, C3, C4, C5, C6, C7)  {
+  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7)> where R0.RegexOutput == (W0, C0, C1, C2, C3, C4, C5, C6, C7)  {
     .init(node: accumulated.regex.root.appending(next.regex.root))
   }
 }
 extension RegexComponentBuilder {
   public static func buildPartialBlock<W0, C0, C1, C2, C3, C4, C5, C6, C7, C8, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
-  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8)> where R0.Output == (W0, C0, C1, C2, C3, C4, C5, C6, C7, C8)  {
+  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8)> where R0.RegexOutput == (W0, C0, C1, C2, C3, C4, C5, C6, C7, C8)  {
     .init(node: accumulated.regex.root.appending(next.regex.root))
   }
 }
 extension RegexComponentBuilder {
   public static func buildPartialBlock<W0, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
-  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9)> where R0.Output == (W0, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9)  {
+  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9)> where R0.RegexOutput == (W0, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9)  {
     .init(node: accumulated.regex.root.appending(next.regex.root))
   }
 }
@@ -483,7 +483,7 @@ extension Optionally {
   public init<Component: RegexComponent>(
     _ component: Component,
     _ behavior: QuantificationBehavior = .eagerly
-  ) where Output == Substring {
+  ) where RegexOutput == Substring {
     self.init(node: .quantification(.zeroOrOne, behavior.astKind, component.regex.root))
   }
 }
@@ -493,7 +493,7 @@ extension Optionally {
   public init<Component: RegexComponent>(
     _ behavior: QuantificationBehavior = .eagerly,
     @RegexComponentBuilder _ component: () -> Component
-  ) where Output == Substring {
+  ) where RegexOutput == Substring {
     self.init(node: .quantification(.zeroOrOne, behavior.astKind, component().regex.root))
   }
 }
@@ -510,7 +510,7 @@ extension ZeroOrMore {
   public init<Component: RegexComponent>(
     _ component: Component,
     _ behavior: QuantificationBehavior = .eagerly
-  ) where Output == Substring {
+  ) where RegexOutput == Substring {
     self.init(node: .quantification(.zeroOrMore, behavior.astKind, component.regex.root))
   }
 }
@@ -520,7 +520,7 @@ extension ZeroOrMore {
   public init<Component: RegexComponent>(
     _ behavior: QuantificationBehavior = .eagerly,
     @RegexComponentBuilder _ component: () -> Component
-  ) where Output == Substring {
+  ) where RegexOutput == Substring {
     self.init(node: .quantification(.zeroOrMore, behavior.astKind, component().regex.root))
   }
 }
@@ -531,7 +531,7 @@ extension OneOrMore {
   public init<Component: RegexComponent>(
     _ component: Component,
     _ behavior: QuantificationBehavior = .eagerly
-  ) where Output == Substring {
+  ) where RegexOutput == Substring {
     self.init(node: .quantification(.oneOrMore, behavior.astKind, component.regex.root))
   }
 }
@@ -541,7 +541,7 @@ extension OneOrMore {
   public init<Component: RegexComponent>(
     _ behavior: QuantificationBehavior = .eagerly,
     @RegexComponentBuilder _ component: () -> Component
-  ) where Output == Substring {
+  ) where RegexOutput == Substring {
     self.init(node: .quantification(.oneOrMore, behavior.astKind, component().regex.root))
   }
 }
@@ -552,7 +552,7 @@ extension Repeat {
   public init<Component: RegexComponent>(
     _ component: Component,
     count: Int
-  ) where Output == Substring {
+  ) where RegexOutput == Substring {
     assert(count > 0, "Must specify a positive count")
     // TODO: Emit a warning about `repeatMatch(count: 0)` or `repeatMatch(count: 1)`
     self.init(node: .quantification(.exactly(.init(faking: count)), .eager, component.regex.root))
@@ -562,7 +562,7 @@ extension Repeat {
   public init<Component: RegexComponent>(
     count: Int,
     @RegexComponentBuilder _ component: () -> Component
-  ) where Output == Substring {
+  ) where RegexOutput == Substring {
     assert(count > 0, "Must specify a positive count")
     // TODO: Emit a warning about `repeatMatch(count: 0)` or `repeatMatch(count: 1)`
     self.init(node: .quantification(.exactly(.init(faking: count)), .eager, component().regex.root))
@@ -573,7 +573,7 @@ extension Repeat {
     _ component: Component,
     _ expression: R,
     _ behavior: QuantificationBehavior = .eagerly
-  ) where Output == Substring, R.Bound == Int {
+  ) where RegexOutput == Substring, R.Bound == Int {
     self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component.regex.root))
   }
 
@@ -582,7 +582,7 @@ extension Repeat {
     _ expression: R,
     _ behavior: QuantificationBehavior = .eagerly,
     @RegexComponentBuilder _ component: () -> Component
-  ) where Output == Substring, R.Bound == Int {
+  ) where RegexOutput == Substring, R.Bound == Int {
     self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component().regex.root))
   }
 }
@@ -590,7 +590,7 @@ extension Optionally {
     public init<W, C0, Component: RegexComponent>(
     _ component: Component,
     _ behavior: QuantificationBehavior = .eagerly
-  ) where Output == (Substring, C0?), Component.Output == (W, C0) {
+  ) where RegexOutput == (Substring, C0?), Component.RegexOutput == (W, C0) {
     self.init(node: .quantification(.zeroOrOne, behavior.astKind, component.regex.root))
   }
 }
@@ -599,7 +599,7 @@ extension Optionally {
     public init<W, C0, Component: RegexComponent>(
     _ behavior: QuantificationBehavior = .eagerly,
     @RegexComponentBuilder _ component: () -> Component
-  ) where Output == (Substring, C0?), Component.Output == (W, C0) {
+  ) where RegexOutput == (Substring, C0?), Component.RegexOutput == (W, C0) {
     self.init(node: .quantification(.zeroOrOne, behavior.astKind, component().regex.root))
   }
 }
@@ -607,7 +607,7 @@ extension Optionally {
 extension RegexComponentBuilder {
   public static func buildLimitedAvailability<W, C0, Component: RegexComponent>(
     _ component: Component
-  ) -> Regex<(Substring, C0?)> where Component.Output == (W, C0) {
+  ) -> Regex<(Substring, C0?)> where Component.RegexOutput == (W, C0) {
     .init(node: .quantification(.zeroOrOne, .eager, component.regex.root))
   }
 }
@@ -615,7 +615,7 @@ extension ZeroOrMore {
     public init<W, C0, Component: RegexComponent>(
     _ component: Component,
     _ behavior: QuantificationBehavior = .eagerly
-  ) where Output == (Substring, C0?), Component.Output == (W, C0) {
+  ) where RegexOutput == (Substring, C0?), Component.RegexOutput == (W, C0) {
     self.init(node: .quantification(.zeroOrMore, behavior.astKind, component.regex.root))
   }
 }
@@ -624,7 +624,7 @@ extension ZeroOrMore {
     public init<W, C0, Component: RegexComponent>(
     _ behavior: QuantificationBehavior = .eagerly,
     @RegexComponentBuilder _ component: () -> Component
-  ) where Output == (Substring, C0?), Component.Output == (W, C0) {
+  ) where RegexOutput == (Substring, C0?), Component.RegexOutput == (W, C0) {
     self.init(node: .quantification(.zeroOrMore, behavior.astKind, component().regex.root))
   }
 }
@@ -634,7 +634,7 @@ extension OneOrMore {
     public init<W, C0, Component: RegexComponent>(
     _ component: Component,
     _ behavior: QuantificationBehavior = .eagerly
-  ) where Output == (Substring, C0), Component.Output == (W, C0) {
+  ) where RegexOutput == (Substring, C0), Component.RegexOutput == (W, C0) {
     self.init(node: .quantification(.oneOrMore, behavior.astKind, component.regex.root))
   }
 }
@@ -643,7 +643,7 @@ extension OneOrMore {
     public init<W, C0, Component: RegexComponent>(
     _ behavior: QuantificationBehavior = .eagerly,
     @RegexComponentBuilder _ component: () -> Component
-  ) where Output == (Substring, C0), Component.Output == (W, C0) {
+  ) where RegexOutput == (Substring, C0), Component.RegexOutput == (W, C0) {
     self.init(node: .quantification(.oneOrMore, behavior.astKind, component().regex.root))
   }
 }
@@ -653,7 +653,7 @@ extension Repeat {
     public init<W, C0, Component: RegexComponent>(
     _ component: Component,
     count: Int
-  ) where Output == (Substring, C0?), Component.Output == (W, C0) {
+  ) where RegexOutput == (Substring, C0?), Component.RegexOutput == (W, C0) {
     assert(count > 0, "Must specify a positive count")
     // TODO: Emit a warning about `repeatMatch(count: 0)` or `repeatMatch(count: 1)`
     self.init(node: .quantification(.exactly(.init(faking: count)), .eager, component.regex.root))
@@ -662,7 +662,7 @@ extension Repeat {
     public init<W, C0, Component: RegexComponent>(
     count: Int,
     @RegexComponentBuilder _ component: () -> Component
-  ) where Output == (Substring, C0?), Component.Output == (W, C0) {
+  ) where RegexOutput == (Substring, C0?), Component.RegexOutput == (W, C0) {
     assert(count > 0, "Must specify a positive count")
     // TODO: Emit a warning about `repeatMatch(count: 0)` or `repeatMatch(count: 1)`
     self.init(node: .quantification(.exactly(.init(faking: count)), .eager, component().regex.root))
@@ -672,7 +672,7 @@ extension Repeat {
     _ component: Component,
     _ expression: R,
     _ behavior: QuantificationBehavior = .eagerly
-  ) where Output == (Substring, C0?), Component.Output == (W, C0), R.Bound == Int {
+  ) where RegexOutput == (Substring, C0?), Component.RegexOutput == (W, C0), R.Bound == Int {
     self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component.regex.root))
   }
 
@@ -680,7 +680,7 @@ extension Repeat {
     _ expression: R,
     _ behavior: QuantificationBehavior = .eagerly,
     @RegexComponentBuilder _ component: () -> Component
-  ) where Output == (Substring, C0?), Component.Output == (W, C0), R.Bound == Int {
+  ) where RegexOutput == (Substring, C0?), Component.RegexOutput == (W, C0), R.Bound == Int {
     self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component().regex.root))
   }
 }
@@ -688,7 +688,7 @@ extension Optionally {
     public init<W, C0, C1, Component: RegexComponent>(
     _ component: Component,
     _ behavior: QuantificationBehavior = .eagerly
-  ) where Output == (Substring, C0?, C1?), Component.Output == (W, C0, C1) {
+  ) where RegexOutput == (Substring, C0?, C1?), Component.RegexOutput == (W, C0, C1) {
     self.init(node: .quantification(.zeroOrOne, behavior.astKind, component.regex.root))
   }
 }
@@ -697,7 +697,7 @@ extension Optionally {
     public init<W, C0, C1, Component: RegexComponent>(
     _ behavior: QuantificationBehavior = .eagerly,
     @RegexComponentBuilder _ component: () -> Component
-  ) where Output == (Substring, C0?, C1?), Component.Output == (W, C0, C1) {
+  ) where RegexOutput == (Substring, C0?, C1?), Component.RegexOutput == (W, C0, C1) {
     self.init(node: .quantification(.zeroOrOne, behavior.astKind, component().regex.root))
   }
 }
@@ -705,7 +705,7 @@ extension Optionally {
 extension RegexComponentBuilder {
   public static func buildLimitedAvailability<W, C0, C1, Component: RegexComponent>(
     _ component: Component
-  ) -> Regex<(Substring, C0?, C1?)> where Component.Output == (W, C0, C1) {
+  ) -> Regex<(Substring, C0?, C1?)> where Component.RegexOutput == (W, C0, C1) {
     .init(node: .quantification(.zeroOrOne, .eager, component.regex.root))
   }
 }
@@ -713,7 +713,7 @@ extension ZeroOrMore {
     public init<W, C0, C1, Component: RegexComponent>(
     _ component: Component,
     _ behavior: QuantificationBehavior = .eagerly
-  ) where Output == (Substring, C0?, C1?), Component.Output == (W, C0, C1) {
+  ) where RegexOutput == (Substring, C0?, C1?), Component.RegexOutput == (W, C0, C1) {
     self.init(node: .quantification(.zeroOrMore, behavior.astKind, component.regex.root))
   }
 }
@@ -722,7 +722,7 @@ extension ZeroOrMore {
     public init<W, C0, C1, Component: RegexComponent>(
     _ behavior: QuantificationBehavior = .eagerly,
     @RegexComponentBuilder _ component: () -> Component
-  ) where Output == (Substring, C0?, C1?), Component.Output == (W, C0, C1) {
+  ) where RegexOutput == (Substring, C0?, C1?), Component.RegexOutput == (W, C0, C1) {
     self.init(node: .quantification(.zeroOrMore, behavior.astKind, component().regex.root))
   }
 }
@@ -732,7 +732,7 @@ extension OneOrMore {
     public init<W, C0, C1, Component: RegexComponent>(
     _ component: Component,
     _ behavior: QuantificationBehavior = .eagerly
-  ) where Output == (Substring, C0, C1), Component.Output == (W, C0, C1) {
+  ) where RegexOutput == (Substring, C0, C1), Component.RegexOutput == (W, C0, C1) {
     self.init(node: .quantification(.oneOrMore, behavior.astKind, component.regex.root))
   }
 }
@@ -741,7 +741,7 @@ extension OneOrMore {
     public init<W, C0, C1, Component: RegexComponent>(
     _ behavior: QuantificationBehavior = .eagerly,
     @RegexComponentBuilder _ component: () -> Component
-  ) where Output == (Substring, C0, C1), Component.Output == (W, C0, C1) {
+  ) where RegexOutput == (Substring, C0, C1), Component.RegexOutput == (W, C0, C1) {
     self.init(node: .quantification(.oneOrMore, behavior.astKind, component().regex.root))
   }
 }
@@ -751,7 +751,7 @@ extension Repeat {
     public init<W, C0, C1, Component: RegexComponent>(
     _ component: Component,
     count: Int
-  ) where Output == (Substring, C0?, C1?), Component.Output == (W, C0, C1) {
+  ) where RegexOutput == (Substring, C0?, C1?), Component.RegexOutput == (W, C0, C1) {
     assert(count > 0, "Must specify a positive count")
     // TODO: Emit a warning about `repeatMatch(count: 0)` or `repeatMatch(count: 1)`
     self.init(node: .quantification(.exactly(.init(faking: count)), .eager, component.regex.root))
@@ -760,7 +760,7 @@ extension Repeat {
     public init<W, C0, C1, Component: RegexComponent>(
     count: Int,
     @RegexComponentBuilder _ component: () -> Component
-  ) where Output == (Substring, C0?, C1?), Component.Output == (W, C0, C1) {
+  ) where RegexOutput == (Substring, C0?, C1?), Component.RegexOutput == (W, C0, C1) {
     assert(count > 0, "Must specify a positive count")
     // TODO: Emit a warning about `repeatMatch(count: 0)` or `repeatMatch(count: 1)`
     self.init(node: .quantification(.exactly(.init(faking: count)), .eager, component().regex.root))
@@ -770,7 +770,7 @@ extension Repeat {
     _ component: Component,
     _ expression: R,
     _ behavior: QuantificationBehavior = .eagerly
-  ) where Output == (Substring, C0?, C1?), Component.Output == (W, C0, C1), R.Bound == Int {
+  ) where RegexOutput == (Substring, C0?, C1?), Component.RegexOutput == (W, C0, C1), R.Bound == Int {
     self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component.regex.root))
   }
 
@@ -778,7 +778,7 @@ extension Repeat {
     _ expression: R,
     _ behavior: QuantificationBehavior = .eagerly,
     @RegexComponentBuilder _ component: () -> Component
-  ) where Output == (Substring, C0?, C1?), Component.Output == (W, C0, C1), R.Bound == Int {
+  ) where RegexOutput == (Substring, C0?, C1?), Component.RegexOutput == (W, C0, C1), R.Bound == Int {
     self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component().regex.root))
   }
 }
@@ -786,7 +786,7 @@ extension Optionally {
     public init<W, C0, C1, C2, Component: RegexComponent>(
     _ component: Component,
     _ behavior: QuantificationBehavior = .eagerly
-  ) where Output == (Substring, C0?, C1?, C2?), Component.Output == (W, C0, C1, C2) {
+  ) where RegexOutput == (Substring, C0?, C1?, C2?), Component.RegexOutput == (W, C0, C1, C2) {
     self.init(node: .quantification(.zeroOrOne, behavior.astKind, component.regex.root))
   }
 }
@@ -795,7 +795,7 @@ extension Optionally {
     public init<W, C0, C1, C2, Component: RegexComponent>(
     _ behavior: QuantificationBehavior = .eagerly,
     @RegexComponentBuilder _ component: () -> Component
-  ) where Output == (Substring, C0?, C1?, C2?), Component.Output == (W, C0, C1, C2) {
+  ) where RegexOutput == (Substring, C0?, C1?, C2?), Component.RegexOutput == (W, C0, C1, C2) {
     self.init(node: .quantification(.zeroOrOne, behavior.astKind, component().regex.root))
   }
 }
@@ -803,7 +803,7 @@ extension Optionally {
 extension RegexComponentBuilder {
   public static func buildLimitedAvailability<W, C0, C1, C2, Component: RegexComponent>(
     _ component: Component
-  ) -> Regex<(Substring, C0?, C1?, C2?)> where Component.Output == (W, C0, C1, C2) {
+  ) -> Regex<(Substring, C0?, C1?, C2?)> where Component.RegexOutput == (W, C0, C1, C2) {
     .init(node: .quantification(.zeroOrOne, .eager, component.regex.root))
   }
 }
@@ -811,7 +811,7 @@ extension ZeroOrMore {
     public init<W, C0, C1, C2, Component: RegexComponent>(
     _ component: Component,
     _ behavior: QuantificationBehavior = .eagerly
-  ) where Output == (Substring, C0?, C1?, C2?), Component.Output == (W, C0, C1, C2) {
+  ) where RegexOutput == (Substring, C0?, C1?, C2?), Component.RegexOutput == (W, C0, C1, C2) {
     self.init(node: .quantification(.zeroOrMore, behavior.astKind, component.regex.root))
   }
 }
@@ -820,7 +820,7 @@ extension ZeroOrMore {
     public init<W, C0, C1, C2, Component: RegexComponent>(
     _ behavior: QuantificationBehavior = .eagerly,
     @RegexComponentBuilder _ component: () -> Component
-  ) where Output == (Substring, C0?, C1?, C2?), Component.Output == (W, C0, C1, C2) {
+  ) where RegexOutput == (Substring, C0?, C1?, C2?), Component.RegexOutput == (W, C0, C1, C2) {
     self.init(node: .quantification(.zeroOrMore, behavior.astKind, component().regex.root))
   }
 }
@@ -830,7 +830,7 @@ extension OneOrMore {
     public init<W, C0, C1, C2, Component: RegexComponent>(
     _ component: Component,
     _ behavior: QuantificationBehavior = .eagerly
-  ) where Output == (Substring, C0, C1, C2), Component.Output == (W, C0, C1, C2) {
+  ) where RegexOutput == (Substring, C0, C1, C2), Component.RegexOutput == (W, C0, C1, C2) {
     self.init(node: .quantification(.oneOrMore, behavior.astKind, component.regex.root))
   }
 }
@@ -839,7 +839,7 @@ extension OneOrMore {
     public init<W, C0, C1, C2, Component: RegexComponent>(
     _ behavior: QuantificationBehavior = .eagerly,
     @RegexComponentBuilder _ component: () -> Component
-  ) where Output == (Substring, C0, C1, C2), Component.Output == (W, C0, C1, C2) {
+  ) where RegexOutput == (Substring, C0, C1, C2), Component.RegexOutput == (W, C0, C1, C2) {
     self.init(node: .quantification(.oneOrMore, behavior.astKind, component().regex.root))
   }
 }
@@ -849,7 +849,7 @@ extension Repeat {
     public init<W, C0, C1, C2, Component: RegexComponent>(
     _ component: Component,
     count: Int
-  ) where Output == (Substring, C0?, C1?, C2?), Component.Output == (W, C0, C1, C2) {
+  ) where RegexOutput == (Substring, C0?, C1?, C2?), Component.RegexOutput == (W, C0, C1, C2) {
     assert(count > 0, "Must specify a positive count")
     // TODO: Emit a warning about `repeatMatch(count: 0)` or `repeatMatch(count: 1)`
     self.init(node: .quantification(.exactly(.init(faking: count)), .eager, component.regex.root))
@@ -858,7 +858,7 @@ extension Repeat {
     public init<W, C0, C1, C2, Component: RegexComponent>(
     count: Int,
     @RegexComponentBuilder _ component: () -> Component
-  ) where Output == (Substring, C0?, C1?, C2?), Component.Output == (W, C0, C1, C2) {
+  ) where RegexOutput == (Substring, C0?, C1?, C2?), Component.RegexOutput == (W, C0, C1, C2) {
     assert(count > 0, "Must specify a positive count")
     // TODO: Emit a warning about `repeatMatch(count: 0)` or `repeatMatch(count: 1)`
     self.init(node: .quantification(.exactly(.init(faking: count)), .eager, component().regex.root))
@@ -868,7 +868,7 @@ extension Repeat {
     _ component: Component,
     _ expression: R,
     _ behavior: QuantificationBehavior = .eagerly
-  ) where Output == (Substring, C0?, C1?, C2?), Component.Output == (W, C0, C1, C2), R.Bound == Int {
+  ) where RegexOutput == (Substring, C0?, C1?, C2?), Component.RegexOutput == (W, C0, C1, C2), R.Bound == Int {
     self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component.regex.root))
   }
 
@@ -876,7 +876,7 @@ extension Repeat {
     _ expression: R,
     _ behavior: QuantificationBehavior = .eagerly,
     @RegexComponentBuilder _ component: () -> Component
-  ) where Output == (Substring, C0?, C1?, C2?), Component.Output == (W, C0, C1, C2), R.Bound == Int {
+  ) where RegexOutput == (Substring, C0?, C1?, C2?), Component.RegexOutput == (W, C0, C1, C2), R.Bound == Int {
     self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component().regex.root))
   }
 }
@@ -884,7 +884,7 @@ extension Optionally {
     public init<W, C0, C1, C2, C3, Component: RegexComponent>(
     _ component: Component,
     _ behavior: QuantificationBehavior = .eagerly
-  ) where Output == (Substring, C0?, C1?, C2?, C3?), Component.Output == (W, C0, C1, C2, C3) {
+  ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?), Component.RegexOutput == (W, C0, C1, C2, C3) {
     self.init(node: .quantification(.zeroOrOne, behavior.astKind, component.regex.root))
   }
 }
@@ -893,7 +893,7 @@ extension Optionally {
     public init<W, C0, C1, C2, C3, Component: RegexComponent>(
     _ behavior: QuantificationBehavior = .eagerly,
     @RegexComponentBuilder _ component: () -> Component
-  ) where Output == (Substring, C0?, C1?, C2?, C3?), Component.Output == (W, C0, C1, C2, C3) {
+  ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?), Component.RegexOutput == (W, C0, C1, C2, C3) {
     self.init(node: .quantification(.zeroOrOne, behavior.astKind, component().regex.root))
   }
 }
@@ -901,7 +901,7 @@ extension Optionally {
 extension RegexComponentBuilder {
   public static func buildLimitedAvailability<W, C0, C1, C2, C3, Component: RegexComponent>(
     _ component: Component
-  ) -> Regex<(Substring, C0?, C1?, C2?, C3?)> where Component.Output == (W, C0, C1, C2, C3) {
+  ) -> Regex<(Substring, C0?, C1?, C2?, C3?)> where Component.RegexOutput == (W, C0, C1, C2, C3) {
     .init(node: .quantification(.zeroOrOne, .eager, component.regex.root))
   }
 }
@@ -909,7 +909,7 @@ extension ZeroOrMore {
     public init<W, C0, C1, C2, C3, Component: RegexComponent>(
     _ component: Component,
     _ behavior: QuantificationBehavior = .eagerly
-  ) where Output == (Substring, C0?, C1?, C2?, C3?), Component.Output == (W, C0, C1, C2, C3) {
+  ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?), Component.RegexOutput == (W, C0, C1, C2, C3) {
     self.init(node: .quantification(.zeroOrMore, behavior.astKind, component.regex.root))
   }
 }
@@ -918,7 +918,7 @@ extension ZeroOrMore {
     public init<W, C0, C1, C2, C3, Component: RegexComponent>(
     _ behavior: QuantificationBehavior = .eagerly,
     @RegexComponentBuilder _ component: () -> Component
-  ) where Output == (Substring, C0?, C1?, C2?, C3?), Component.Output == (W, C0, C1, C2, C3) {
+  ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?), Component.RegexOutput == (W, C0, C1, C2, C3) {
     self.init(node: .quantification(.zeroOrMore, behavior.astKind, component().regex.root))
   }
 }
@@ -928,7 +928,7 @@ extension OneOrMore {
     public init<W, C0, C1, C2, C3, Component: RegexComponent>(
     _ component: Component,
     _ behavior: QuantificationBehavior = .eagerly
-  ) where Output == (Substring, C0, C1, C2, C3), Component.Output == (W, C0, C1, C2, C3) {
+  ) where RegexOutput == (Substring, C0, C1, C2, C3), Component.RegexOutput == (W, C0, C1, C2, C3) {
     self.init(node: .quantification(.oneOrMore, behavior.astKind, component.regex.root))
   }
 }
@@ -937,7 +937,7 @@ extension OneOrMore {
     public init<W, C0, C1, C2, C3, Component: RegexComponent>(
     _ behavior: QuantificationBehavior = .eagerly,
     @RegexComponentBuilder _ component: () -> Component
-  ) where Output == (Substring, C0, C1, C2, C3), Component.Output == (W, C0, C1, C2, C3) {
+  ) where RegexOutput == (Substring, C0, C1, C2, C3), Component.RegexOutput == (W, C0, C1, C2, C3) {
     self.init(node: .quantification(.oneOrMore, behavior.astKind, component().regex.root))
   }
 }
@@ -947,7 +947,7 @@ extension Repeat {
     public init<W, C0, C1, C2, C3, Component: RegexComponent>(
     _ component: Component,
     count: Int
-  ) where Output == (Substring, C0?, C1?, C2?, C3?), Component.Output == (W, C0, C1, C2, C3) {
+  ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?), Component.RegexOutput == (W, C0, C1, C2, C3) {
     assert(count > 0, "Must specify a positive count")
     // TODO: Emit a warning about `repeatMatch(count: 0)` or `repeatMatch(count: 1)`
     self.init(node: .quantification(.exactly(.init(faking: count)), .eager, component.regex.root))
@@ -956,7 +956,7 @@ extension Repeat {
     public init<W, C0, C1, C2, C3, Component: RegexComponent>(
     count: Int,
     @RegexComponentBuilder _ component: () -> Component
-  ) where Output == (Substring, C0?, C1?, C2?, C3?), Component.Output == (W, C0, C1, C2, C3) {
+  ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?), Component.RegexOutput == (W, C0, C1, C2, C3) {
     assert(count > 0, "Must specify a positive count")
     // TODO: Emit a warning about `repeatMatch(count: 0)` or `repeatMatch(count: 1)`
     self.init(node: .quantification(.exactly(.init(faking: count)), .eager, component().regex.root))
@@ -966,7 +966,7 @@ extension Repeat {
     _ component: Component,
     _ expression: R,
     _ behavior: QuantificationBehavior = .eagerly
-  ) where Output == (Substring, C0?, C1?, C2?, C3?), Component.Output == (W, C0, C1, C2, C3), R.Bound == Int {
+  ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?), Component.RegexOutput == (W, C0, C1, C2, C3), R.Bound == Int {
     self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component.regex.root))
   }
 
@@ -974,7 +974,7 @@ extension Repeat {
     _ expression: R,
     _ behavior: QuantificationBehavior = .eagerly,
     @RegexComponentBuilder _ component: () -> Component
-  ) where Output == (Substring, C0?, C1?, C2?, C3?), Component.Output == (W, C0, C1, C2, C3), R.Bound == Int {
+  ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?), Component.RegexOutput == (W, C0, C1, C2, C3), R.Bound == Int {
     self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component().regex.root))
   }
 }
@@ -982,7 +982,7 @@ extension Optionally {
     public init<W, C0, C1, C2, C3, C4, Component: RegexComponent>(
     _ component: Component,
     _ behavior: QuantificationBehavior = .eagerly
-  ) where Output == (Substring, C0?, C1?, C2?, C3?, C4?), Component.Output == (W, C0, C1, C2, C3, C4) {
+  ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?), Component.RegexOutput == (W, C0, C1, C2, C3, C4) {
     self.init(node: .quantification(.zeroOrOne, behavior.astKind, component.regex.root))
   }
 }
@@ -991,7 +991,7 @@ extension Optionally {
     public init<W, C0, C1, C2, C3, C4, Component: RegexComponent>(
     _ behavior: QuantificationBehavior = .eagerly,
     @RegexComponentBuilder _ component: () -> Component
-  ) where Output == (Substring, C0?, C1?, C2?, C3?, C4?), Component.Output == (W, C0, C1, C2, C3, C4) {
+  ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?), Component.RegexOutput == (W, C0, C1, C2, C3, C4) {
     self.init(node: .quantification(.zeroOrOne, behavior.astKind, component().regex.root))
   }
 }
@@ -999,7 +999,7 @@ extension Optionally {
 extension RegexComponentBuilder {
   public static func buildLimitedAvailability<W, C0, C1, C2, C3, C4, Component: RegexComponent>(
     _ component: Component
-  ) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?)> where Component.Output == (W, C0, C1, C2, C3, C4) {
+  ) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?)> where Component.RegexOutput == (W, C0, C1, C2, C3, C4) {
     .init(node: .quantification(.zeroOrOne, .eager, component.regex.root))
   }
 }
@@ -1007,7 +1007,7 @@ extension ZeroOrMore {
     public init<W, C0, C1, C2, C3, C4, Component: RegexComponent>(
     _ component: Component,
     _ behavior: QuantificationBehavior = .eagerly
-  ) where Output == (Substring, C0?, C1?, C2?, C3?, C4?), Component.Output == (W, C0, C1, C2, C3, C4) {
+  ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?), Component.RegexOutput == (W, C0, C1, C2, C3, C4) {
     self.init(node: .quantification(.zeroOrMore, behavior.astKind, component.regex.root))
   }
 }
@@ -1016,7 +1016,7 @@ extension ZeroOrMore {
     public init<W, C0, C1, C2, C3, C4, Component: RegexComponent>(
     _ behavior: QuantificationBehavior = .eagerly,
     @RegexComponentBuilder _ component: () -> Component
-  ) where Output == (Substring, C0?, C1?, C2?, C3?, C4?), Component.Output == (W, C0, C1, C2, C3, C4) {
+  ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?), Component.RegexOutput == (W, C0, C1, C2, C3, C4) {
     self.init(node: .quantification(.zeroOrMore, behavior.astKind, component().regex.root))
   }
 }
@@ -1026,7 +1026,7 @@ extension OneOrMore {
     public init<W, C0, C1, C2, C3, C4, Component: RegexComponent>(
     _ component: Component,
     _ behavior: QuantificationBehavior = .eagerly
-  ) where Output == (Substring, C0, C1, C2, C3, C4), Component.Output == (W, C0, C1, C2, C3, C4) {
+  ) where RegexOutput == (Substring, C0, C1, C2, C3, C4), Component.RegexOutput == (W, C0, C1, C2, C3, C4) {
     self.init(node: .quantification(.oneOrMore, behavior.astKind, component.regex.root))
   }
 }
@@ -1035,7 +1035,7 @@ extension OneOrMore {
     public init<W, C0, C1, C2, C3, C4, Component: RegexComponent>(
     _ behavior: QuantificationBehavior = .eagerly,
     @RegexComponentBuilder _ component: () -> Component
-  ) where Output == (Substring, C0, C1, C2, C3, C4), Component.Output == (W, C0, C1, C2, C3, C4) {
+  ) where RegexOutput == (Substring, C0, C1, C2, C3, C4), Component.RegexOutput == (W, C0, C1, C2, C3, C4) {
     self.init(node: .quantification(.oneOrMore, behavior.astKind, component().regex.root))
   }
 }
@@ -1045,7 +1045,7 @@ extension Repeat {
     public init<W, C0, C1, C2, C3, C4, Component: RegexComponent>(
     _ component: Component,
     count: Int
-  ) where Output == (Substring, C0?, C1?, C2?, C3?, C4?), Component.Output == (W, C0, C1, C2, C3, C4) {
+  ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?), Component.RegexOutput == (W, C0, C1, C2, C3, C4) {
     assert(count > 0, "Must specify a positive count")
     // TODO: Emit a warning about `repeatMatch(count: 0)` or `repeatMatch(count: 1)`
     self.init(node: .quantification(.exactly(.init(faking: count)), .eager, component.regex.root))
@@ -1054,7 +1054,7 @@ extension Repeat {
     public init<W, C0, C1, C2, C3, C4, Component: RegexComponent>(
     count: Int,
     @RegexComponentBuilder _ component: () -> Component
-  ) where Output == (Substring, C0?, C1?, C2?, C3?, C4?), Component.Output == (W, C0, C1, C2, C3, C4) {
+  ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?), Component.RegexOutput == (W, C0, C1, C2, C3, C4) {
     assert(count > 0, "Must specify a positive count")
     // TODO: Emit a warning about `repeatMatch(count: 0)` or `repeatMatch(count: 1)`
     self.init(node: .quantification(.exactly(.init(faking: count)), .eager, component().regex.root))
@@ -1064,7 +1064,7 @@ extension Repeat {
     _ component: Component,
     _ expression: R,
     _ behavior: QuantificationBehavior = .eagerly
-  ) where Output == (Substring, C0?, C1?, C2?, C3?, C4?), Component.Output == (W, C0, C1, C2, C3, C4), R.Bound == Int {
+  ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?), Component.RegexOutput == (W, C0, C1, C2, C3, C4), R.Bound == Int {
     self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component.regex.root))
   }
 
@@ -1072,7 +1072,7 @@ extension Repeat {
     _ expression: R,
     _ behavior: QuantificationBehavior = .eagerly,
     @RegexComponentBuilder _ component: () -> Component
-  ) where Output == (Substring, C0?, C1?, C2?, C3?, C4?), Component.Output == (W, C0, C1, C2, C3, C4), R.Bound == Int {
+  ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?), Component.RegexOutput == (W, C0, C1, C2, C3, C4), R.Bound == Int {
     self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component().regex.root))
   }
 }
@@ -1080,7 +1080,7 @@ extension Optionally {
     public init<W, C0, C1, C2, C3, C4, C5, Component: RegexComponent>(
     _ component: Component,
     _ behavior: QuantificationBehavior = .eagerly
-  ) where Output == (Substring, C0?, C1?, C2?, C3?, C4?, C5?), Component.Output == (W, C0, C1, C2, C3, C4, C5) {
+  ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?, C5?), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5) {
     self.init(node: .quantification(.zeroOrOne, behavior.astKind, component.regex.root))
   }
 }
@@ -1089,7 +1089,7 @@ extension Optionally {
     public init<W, C0, C1, C2, C3, C4, C5, Component: RegexComponent>(
     _ behavior: QuantificationBehavior = .eagerly,
     @RegexComponentBuilder _ component: () -> Component
-  ) where Output == (Substring, C0?, C1?, C2?, C3?, C4?, C5?), Component.Output == (W, C0, C1, C2, C3, C4, C5) {
+  ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?, C5?), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5) {
     self.init(node: .quantification(.zeroOrOne, behavior.astKind, component().regex.root))
   }
 }
@@ -1097,7 +1097,7 @@ extension Optionally {
 extension RegexComponentBuilder {
   public static func buildLimitedAvailability<W, C0, C1, C2, C3, C4, C5, Component: RegexComponent>(
     _ component: Component
-  ) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?)> where Component.Output == (W, C0, C1, C2, C3, C4, C5) {
+  ) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?)> where Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5) {
     .init(node: .quantification(.zeroOrOne, .eager, component.regex.root))
   }
 }
@@ -1105,7 +1105,7 @@ extension ZeroOrMore {
     public init<W, C0, C1, C2, C3, C4, C5, Component: RegexComponent>(
     _ component: Component,
     _ behavior: QuantificationBehavior = .eagerly
-  ) where Output == (Substring, C0?, C1?, C2?, C3?, C4?, C5?), Component.Output == (W, C0, C1, C2, C3, C4, C5) {
+  ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?, C5?), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5) {
     self.init(node: .quantification(.zeroOrMore, behavior.astKind, component.regex.root))
   }
 }
@@ -1114,7 +1114,7 @@ extension ZeroOrMore {
     public init<W, C0, C1, C2, C3, C4, C5, Component: RegexComponent>(
     _ behavior: QuantificationBehavior = .eagerly,
     @RegexComponentBuilder _ component: () -> Component
-  ) where Output == (Substring, C0?, C1?, C2?, C3?, C4?, C5?), Component.Output == (W, C0, C1, C2, C3, C4, C5) {
+  ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?, C5?), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5) {
     self.init(node: .quantification(.zeroOrMore, behavior.astKind, component().regex.root))
   }
 }
@@ -1124,7 +1124,7 @@ extension OneOrMore {
     public init<W, C0, C1, C2, C3, C4, C5, Component: RegexComponent>(
     _ component: Component,
     _ behavior: QuantificationBehavior = .eagerly
-  ) where Output == (Substring, C0, C1, C2, C3, C4, C5), Component.Output == (W, C0, C1, C2, C3, C4, C5) {
+  ) where RegexOutput == (Substring, C0, C1, C2, C3, C4, C5), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5) {
     self.init(node: .quantification(.oneOrMore, behavior.astKind, component.regex.root))
   }
 }
@@ -1133,7 +1133,7 @@ extension OneOrMore {
     public init<W, C0, C1, C2, C3, C4, C5, Component: RegexComponent>(
     _ behavior: QuantificationBehavior = .eagerly,
     @RegexComponentBuilder _ component: () -> Component
-  ) where Output == (Substring, C0, C1, C2, C3, C4, C5), Component.Output == (W, C0, C1, C2, C3, C4, C5) {
+  ) where RegexOutput == (Substring, C0, C1, C2, C3, C4, C5), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5) {
     self.init(node: .quantification(.oneOrMore, behavior.astKind, component().regex.root))
   }
 }
@@ -1143,7 +1143,7 @@ extension Repeat {
     public init<W, C0, C1, C2, C3, C4, C5, Component: RegexComponent>(
     _ component: Component,
     count: Int
-  ) where Output == (Substring, C0?, C1?, C2?, C3?, C4?, C5?), Component.Output == (W, C0, C1, C2, C3, C4, C5) {
+  ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?, C5?), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5) {
     assert(count > 0, "Must specify a positive count")
     // TODO: Emit a warning about `repeatMatch(count: 0)` or `repeatMatch(count: 1)`
     self.init(node: .quantification(.exactly(.init(faking: count)), .eager, component.regex.root))
@@ -1152,7 +1152,7 @@ extension Repeat {
     public init<W, C0, C1, C2, C3, C4, C5, Component: RegexComponent>(
     count: Int,
     @RegexComponentBuilder _ component: () -> Component
-  ) where Output == (Substring, C0?, C1?, C2?, C3?, C4?, C5?), Component.Output == (W, C0, C1, C2, C3, C4, C5) {
+  ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?, C5?), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5) {
     assert(count > 0, "Must specify a positive count")
     // TODO: Emit a warning about `repeatMatch(count: 0)` or `repeatMatch(count: 1)`
     self.init(node: .quantification(.exactly(.init(faking: count)), .eager, component().regex.root))
@@ -1162,7 +1162,7 @@ extension Repeat {
     _ component: Component,
     _ expression: R,
     _ behavior: QuantificationBehavior = .eagerly
-  ) where Output == (Substring, C0?, C1?, C2?, C3?, C4?, C5?), Component.Output == (W, C0, C1, C2, C3, C4, C5), R.Bound == Int {
+  ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?, C5?), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5), R.Bound == Int {
     self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component.regex.root))
   }
 
@@ -1170,7 +1170,7 @@ extension Repeat {
     _ expression: R,
     _ behavior: QuantificationBehavior = .eagerly,
     @RegexComponentBuilder _ component: () -> Component
-  ) where Output == (Substring, C0?, C1?, C2?, C3?, C4?, C5?), Component.Output == (W, C0, C1, C2, C3, C4, C5), R.Bound == Int {
+  ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?, C5?), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5), R.Bound == Int {
     self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component().regex.root))
   }
 }
@@ -1178,7 +1178,7 @@ extension Optionally {
     public init<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexComponent>(
     _ component: Component,
     _ behavior: QuantificationBehavior = .eagerly
-  ) where Output == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?), Component.Output == (W, C0, C1, C2, C3, C4, C5, C6) {
+  ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6) {
     self.init(node: .quantification(.zeroOrOne, behavior.astKind, component.regex.root))
   }
 }
@@ -1187,7 +1187,7 @@ extension Optionally {
     public init<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexComponent>(
     _ behavior: QuantificationBehavior = .eagerly,
     @RegexComponentBuilder _ component: () -> Component
-  ) where Output == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?), Component.Output == (W, C0, C1, C2, C3, C4, C5, C6) {
+  ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6) {
     self.init(node: .quantification(.zeroOrOne, behavior.astKind, component().regex.root))
   }
 }
@@ -1195,7 +1195,7 @@ extension Optionally {
 extension RegexComponentBuilder {
   public static func buildLimitedAvailability<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexComponent>(
     _ component: Component
-  ) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?)> where Component.Output == (W, C0, C1, C2, C3, C4, C5, C6) {
+  ) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?)> where Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6) {
     .init(node: .quantification(.zeroOrOne, .eager, component.regex.root))
   }
 }
@@ -1203,7 +1203,7 @@ extension ZeroOrMore {
     public init<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexComponent>(
     _ component: Component,
     _ behavior: QuantificationBehavior = .eagerly
-  ) where Output == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?), Component.Output == (W, C0, C1, C2, C3, C4, C5, C6) {
+  ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6) {
     self.init(node: .quantification(.zeroOrMore, behavior.astKind, component.regex.root))
   }
 }
@@ -1212,7 +1212,7 @@ extension ZeroOrMore {
     public init<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexComponent>(
     _ behavior: QuantificationBehavior = .eagerly,
     @RegexComponentBuilder _ component: () -> Component
-  ) where Output == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?), Component.Output == (W, C0, C1, C2, C3, C4, C5, C6) {
+  ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6) {
     self.init(node: .quantification(.zeroOrMore, behavior.astKind, component().regex.root))
   }
 }
@@ -1222,7 +1222,7 @@ extension OneOrMore {
     public init<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexComponent>(
     _ component: Component,
     _ behavior: QuantificationBehavior = .eagerly
-  ) where Output == (Substring, C0, C1, C2, C3, C4, C5, C6), Component.Output == (W, C0, C1, C2, C3, C4, C5, C6) {
+  ) where RegexOutput == (Substring, C0, C1, C2, C3, C4, C5, C6), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6) {
     self.init(node: .quantification(.oneOrMore, behavior.astKind, component.regex.root))
   }
 }
@@ -1231,7 +1231,7 @@ extension OneOrMore {
     public init<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexComponent>(
     _ behavior: QuantificationBehavior = .eagerly,
     @RegexComponentBuilder _ component: () -> Component
-  ) where Output == (Substring, C0, C1, C2, C3, C4, C5, C6), Component.Output == (W, C0, C1, C2, C3, C4, C5, C6) {
+  ) where RegexOutput == (Substring, C0, C1, C2, C3, C4, C5, C6), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6) {
     self.init(node: .quantification(.oneOrMore, behavior.astKind, component().regex.root))
   }
 }
@@ -1241,7 +1241,7 @@ extension Repeat {
     public init<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexComponent>(
     _ component: Component,
     count: Int
-  ) where Output == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?), Component.Output == (W, C0, C1, C2, C3, C4, C5, C6) {
+  ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6) {
     assert(count > 0, "Must specify a positive count")
     // TODO: Emit a warning about `repeatMatch(count: 0)` or `repeatMatch(count: 1)`
     self.init(node: .quantification(.exactly(.init(faking: count)), .eager, component.regex.root))
@@ -1250,7 +1250,7 @@ extension Repeat {
     public init<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexComponent>(
     count: Int,
     @RegexComponentBuilder _ component: () -> Component
-  ) where Output == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?), Component.Output == (W, C0, C1, C2, C3, C4, C5, C6) {
+  ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6) {
     assert(count > 0, "Must specify a positive count")
     // TODO: Emit a warning about `repeatMatch(count: 0)` or `repeatMatch(count: 1)`
     self.init(node: .quantification(.exactly(.init(faking: count)), .eager, component().regex.root))
@@ -1260,7 +1260,7 @@ extension Repeat {
     _ component: Component,
     _ expression: R,
     _ behavior: QuantificationBehavior = .eagerly
-  ) where Output == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?), Component.Output == (W, C0, C1, C2, C3, C4, C5, C6), R.Bound == Int {
+  ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6), R.Bound == Int {
     self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component.regex.root))
   }
 
@@ -1268,7 +1268,7 @@ extension Repeat {
     _ expression: R,
     _ behavior: QuantificationBehavior = .eagerly,
     @RegexComponentBuilder _ component: () -> Component
-  ) where Output == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?), Component.Output == (W, C0, C1, C2, C3, C4, C5, C6), R.Bound == Int {
+  ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6), R.Bound == Int {
     self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component().regex.root))
   }
 }
@@ -1276,7 +1276,7 @@ extension Optionally {
     public init<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexComponent>(
     _ component: Component,
     _ behavior: QuantificationBehavior = .eagerly
-  ) where Output == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?), Component.Output == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
+  ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
     self.init(node: .quantification(.zeroOrOne, behavior.astKind, component.regex.root))
   }
 }
@@ -1285,7 +1285,7 @@ extension Optionally {
     public init<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexComponent>(
     _ behavior: QuantificationBehavior = .eagerly,
     @RegexComponentBuilder _ component: () -> Component
-  ) where Output == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?), Component.Output == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
+  ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
     self.init(node: .quantification(.zeroOrOne, behavior.astKind, component().regex.root))
   }
 }
@@ -1293,7 +1293,7 @@ extension Optionally {
 extension RegexComponentBuilder {
   public static func buildLimitedAvailability<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexComponent>(
     _ component: Component
-  ) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?)> where Component.Output == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
+  ) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?)> where Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
     .init(node: .quantification(.zeroOrOne, .eager, component.regex.root))
   }
 }
@@ -1301,7 +1301,7 @@ extension ZeroOrMore {
     public init<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexComponent>(
     _ component: Component,
     _ behavior: QuantificationBehavior = .eagerly
-  ) where Output == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?), Component.Output == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
+  ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
     self.init(node: .quantification(.zeroOrMore, behavior.astKind, component.regex.root))
   }
 }
@@ -1310,7 +1310,7 @@ extension ZeroOrMore {
     public init<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexComponent>(
     _ behavior: QuantificationBehavior = .eagerly,
     @RegexComponentBuilder _ component: () -> Component
-  ) where Output == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?), Component.Output == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
+  ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
     self.init(node: .quantification(.zeroOrMore, behavior.astKind, component().regex.root))
   }
 }
@@ -1320,7 +1320,7 @@ extension OneOrMore {
     public init<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexComponent>(
     _ component: Component,
     _ behavior: QuantificationBehavior = .eagerly
-  ) where Output == (Substring, C0, C1, C2, C3, C4, C5, C6, C7), Component.Output == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
+  ) where RegexOutput == (Substring, C0, C1, C2, C3, C4, C5, C6, C7), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
     self.init(node: .quantification(.oneOrMore, behavior.astKind, component.regex.root))
   }
 }
@@ -1329,7 +1329,7 @@ extension OneOrMore {
     public init<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexComponent>(
     _ behavior: QuantificationBehavior = .eagerly,
     @RegexComponentBuilder _ component: () -> Component
-  ) where Output == (Substring, C0, C1, C2, C3, C4, C5, C6, C7), Component.Output == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
+  ) where RegexOutput == (Substring, C0, C1, C2, C3, C4, C5, C6, C7), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
     self.init(node: .quantification(.oneOrMore, behavior.astKind, component().regex.root))
   }
 }
@@ -1339,7 +1339,7 @@ extension Repeat {
     public init<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexComponent>(
     _ component: Component,
     count: Int
-  ) where Output == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?), Component.Output == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
+  ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
     assert(count > 0, "Must specify a positive count")
     // TODO: Emit a warning about `repeatMatch(count: 0)` or `repeatMatch(count: 1)`
     self.init(node: .quantification(.exactly(.init(faking: count)), .eager, component.regex.root))
@@ -1348,7 +1348,7 @@ extension Repeat {
     public init<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexComponent>(
     count: Int,
     @RegexComponentBuilder _ component: () -> Component
-  ) where Output == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?), Component.Output == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
+  ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
     assert(count > 0, "Must specify a positive count")
     // TODO: Emit a warning about `repeatMatch(count: 0)` or `repeatMatch(count: 1)`
     self.init(node: .quantification(.exactly(.init(faking: count)), .eager, component().regex.root))
@@ -1358,7 +1358,7 @@ extension Repeat {
     _ component: Component,
     _ expression: R,
     _ behavior: QuantificationBehavior = .eagerly
-  ) where Output == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?), Component.Output == (W, C0, C1, C2, C3, C4, C5, C6, C7), R.Bound == Int {
+  ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7), R.Bound == Int {
     self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component.regex.root))
   }
 
@@ -1366,7 +1366,7 @@ extension Repeat {
     _ expression: R,
     _ behavior: QuantificationBehavior = .eagerly,
     @RegexComponentBuilder _ component: () -> Component
-  ) where Output == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?), Component.Output == (W, C0, C1, C2, C3, C4, C5, C6, C7), R.Bound == Int {
+  ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7), R.Bound == Int {
     self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component().regex.root))
   }
 }
@@ -1374,7 +1374,7 @@ extension Optionally {
     public init<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexComponent>(
     _ component: Component,
     _ behavior: QuantificationBehavior = .eagerly
-  ) where Output == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?), Component.Output == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
+  ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
     self.init(node: .quantification(.zeroOrOne, behavior.astKind, component.regex.root))
   }
 }
@@ -1383,7 +1383,7 @@ extension Optionally {
     public init<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexComponent>(
     _ behavior: QuantificationBehavior = .eagerly,
     @RegexComponentBuilder _ component: () -> Component
-  ) where Output == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?), Component.Output == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
+  ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
     self.init(node: .quantification(.zeroOrOne, behavior.astKind, component().regex.root))
   }
 }
@@ -1391,7 +1391,7 @@ extension Optionally {
 extension RegexComponentBuilder {
   public static func buildLimitedAvailability<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexComponent>(
     _ component: Component
-  ) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?)> where Component.Output == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
+  ) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?)> where Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
     .init(node: .quantification(.zeroOrOne, .eager, component.regex.root))
   }
 }
@@ -1399,7 +1399,7 @@ extension ZeroOrMore {
     public init<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexComponent>(
     _ component: Component,
     _ behavior: QuantificationBehavior = .eagerly
-  ) where Output == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?), Component.Output == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
+  ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
     self.init(node: .quantification(.zeroOrMore, behavior.astKind, component.regex.root))
   }
 }
@@ -1408,7 +1408,7 @@ extension ZeroOrMore {
     public init<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexComponent>(
     _ behavior: QuantificationBehavior = .eagerly,
     @RegexComponentBuilder _ component: () -> Component
-  ) where Output == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?), Component.Output == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
+  ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
     self.init(node: .quantification(.zeroOrMore, behavior.astKind, component().regex.root))
   }
 }
@@ -1418,7 +1418,7 @@ extension OneOrMore {
     public init<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexComponent>(
     _ component: Component,
     _ behavior: QuantificationBehavior = .eagerly
-  ) where Output == (Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8), Component.Output == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
+  ) where RegexOutput == (Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
     self.init(node: .quantification(.oneOrMore, behavior.astKind, component.regex.root))
   }
 }
@@ -1427,7 +1427,7 @@ extension OneOrMore {
     public init<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexComponent>(
     _ behavior: QuantificationBehavior = .eagerly,
     @RegexComponentBuilder _ component: () -> Component
-  ) where Output == (Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8), Component.Output == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
+  ) where RegexOutput == (Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
     self.init(node: .quantification(.oneOrMore, behavior.astKind, component().regex.root))
   }
 }
@@ -1437,7 +1437,7 @@ extension Repeat {
     public init<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexComponent>(
     _ component: Component,
     count: Int
-  ) where Output == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?), Component.Output == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
+  ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
     assert(count > 0, "Must specify a positive count")
     // TODO: Emit a warning about `repeatMatch(count: 0)` or `repeatMatch(count: 1)`
     self.init(node: .quantification(.exactly(.init(faking: count)), .eager, component.regex.root))
@@ -1446,7 +1446,7 @@ extension Repeat {
     public init<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexComponent>(
     count: Int,
     @RegexComponentBuilder _ component: () -> Component
-  ) where Output == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?), Component.Output == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
+  ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
     assert(count > 0, "Must specify a positive count")
     // TODO: Emit a warning about `repeatMatch(count: 0)` or `repeatMatch(count: 1)`
     self.init(node: .quantification(.exactly(.init(faking: count)), .eager, component().regex.root))
@@ -1456,7 +1456,7 @@ extension Repeat {
     _ component: Component,
     _ expression: R,
     _ behavior: QuantificationBehavior = .eagerly
-  ) where Output == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?), Component.Output == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8), R.Bound == Int {
+  ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8), R.Bound == Int {
     self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component.regex.root))
   }
 
@@ -1464,7 +1464,7 @@ extension Repeat {
     _ expression: R,
     _ behavior: QuantificationBehavior = .eagerly,
     @RegexComponentBuilder _ component: () -> Component
-  ) where Output == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?), Component.Output == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8), R.Bound == Int {
+  ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8), R.Bound == Int {
     self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component().regex.root))
   }
 }
@@ -1472,7 +1472,7 @@ extension Optionally {
     public init<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9, Component: RegexComponent>(
     _ component: Component,
     _ behavior: QuantificationBehavior = .eagerly
-  ) where Output == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?), Component.Output == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
+  ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
     self.init(node: .quantification(.zeroOrOne, behavior.astKind, component.regex.root))
   }
 }
@@ -1481,7 +1481,7 @@ extension Optionally {
     public init<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9, Component: RegexComponent>(
     _ behavior: QuantificationBehavior = .eagerly,
     @RegexComponentBuilder _ component: () -> Component
-  ) where Output == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?), Component.Output == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
+  ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
     self.init(node: .quantification(.zeroOrOne, behavior.astKind, component().regex.root))
   }
 }
@@ -1489,7 +1489,7 @@ extension Optionally {
 extension RegexComponentBuilder {
   public static func buildLimitedAvailability<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9, Component: RegexComponent>(
     _ component: Component
-  ) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?)> where Component.Output == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
+  ) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?)> where Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
     .init(node: .quantification(.zeroOrOne, .eager, component.regex.root))
   }
 }
@@ -1497,7 +1497,7 @@ extension ZeroOrMore {
     public init<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9, Component: RegexComponent>(
     _ component: Component,
     _ behavior: QuantificationBehavior = .eagerly
-  ) where Output == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?), Component.Output == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
+  ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
     self.init(node: .quantification(.zeroOrMore, behavior.astKind, component.regex.root))
   }
 }
@@ -1506,7 +1506,7 @@ extension ZeroOrMore {
     public init<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9, Component: RegexComponent>(
     _ behavior: QuantificationBehavior = .eagerly,
     @RegexComponentBuilder _ component: () -> Component
-  ) where Output == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?), Component.Output == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
+  ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
     self.init(node: .quantification(.zeroOrMore, behavior.astKind, component().regex.root))
   }
 }
@@ -1516,7 +1516,7 @@ extension OneOrMore {
     public init<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9, Component: RegexComponent>(
     _ component: Component,
     _ behavior: QuantificationBehavior = .eagerly
-  ) where Output == (Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9), Component.Output == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
+  ) where RegexOutput == (Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
     self.init(node: .quantification(.oneOrMore, behavior.astKind, component.regex.root))
   }
 }
@@ -1525,7 +1525,7 @@ extension OneOrMore {
     public init<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9, Component: RegexComponent>(
     _ behavior: QuantificationBehavior = .eagerly,
     @RegexComponentBuilder _ component: () -> Component
-  ) where Output == (Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9), Component.Output == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
+  ) where RegexOutput == (Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
     self.init(node: .quantification(.oneOrMore, behavior.astKind, component().regex.root))
   }
 }
@@ -1535,7 +1535,7 @@ extension Repeat {
     public init<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9, Component: RegexComponent>(
     _ component: Component,
     count: Int
-  ) where Output == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?), Component.Output == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
+  ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
     assert(count > 0, "Must specify a positive count")
     // TODO: Emit a warning about `repeatMatch(count: 0)` or `repeatMatch(count: 1)`
     self.init(node: .quantification(.exactly(.init(faking: count)), .eager, component.regex.root))
@@ -1544,7 +1544,7 @@ extension Repeat {
     public init<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9, Component: RegexComponent>(
     count: Int,
     @RegexComponentBuilder _ component: () -> Component
-  ) where Output == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?), Component.Output == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
+  ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
     assert(count > 0, "Must specify a positive count")
     // TODO: Emit a warning about `repeatMatch(count: 0)` or `repeatMatch(count: 1)`
     self.init(node: .quantification(.exactly(.init(faking: count)), .eager, component().regex.root))
@@ -1554,7 +1554,7 @@ extension Repeat {
     _ component: Component,
     _ expression: R,
     _ behavior: QuantificationBehavior = .eagerly
-  ) where Output == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?), Component.Output == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9), R.Bound == Int {
+  ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9), R.Bound == Int {
     self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component.regex.root))
   }
 
@@ -1562,7 +1562,7 @@ extension Repeat {
     _ expression: R,
     _ behavior: QuantificationBehavior = .eagerly,
     @RegexComponentBuilder _ component: () -> Component
-  ) where Output == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?), Component.Output == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9), R.Bound == Int {
+  ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9), R.Bound == Int {
     self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component().regex.root))
   }
 }
@@ -1570,7 +1570,7 @@ extension Local {
   @_disfavoredOverload
   public init<Component: RegexComponent>(
     _ component: Component
-  ) where Output == Substring {
+  ) where RegexOutput == Substring {
     self.init(node: .nonCapturingGroup(.atomicNonCapturing, component.regex.root))
   }
 }
@@ -1579,14 +1579,14 @@ extension Local {
   @_disfavoredOverload
   public init<Component: RegexComponent>(
     @RegexComponentBuilder _ component: () -> Component
-  ) where Output == Substring {
+  ) where RegexOutput == Substring {
     self.init(node: .nonCapturingGroup(.atomicNonCapturing, component().regex.root))
   }
 }
 extension Local {
     public init<W, C0, Component: RegexComponent>(
     _ component: Component
-  ) where Output == (Substring, C0), Component.Output == (W, C0) {
+  ) where RegexOutput == (Substring, C0), Component.RegexOutput == (W, C0) {
     self.init(node: .nonCapturingGroup(.atomicNonCapturing, component.regex.root))
   }
 }
@@ -1594,14 +1594,14 @@ extension Local {
 extension Local {
     public init<W, C0, Component: RegexComponent>(
     @RegexComponentBuilder _ component: () -> Component
-  ) where Output == (Substring, C0), Component.Output == (W, C0) {
+  ) where RegexOutput == (Substring, C0), Component.RegexOutput == (W, C0) {
     self.init(node: .nonCapturingGroup(.atomicNonCapturing, component().regex.root))
   }
 }
 extension Local {
     public init<W, C0, C1, Component: RegexComponent>(
     _ component: Component
-  ) where Output == (Substring, C0, C1), Component.Output == (W, C0, C1) {
+  ) where RegexOutput == (Substring, C0, C1), Component.RegexOutput == (W, C0, C1) {
     self.init(node: .nonCapturingGroup(.atomicNonCapturing, component.regex.root))
   }
 }
@@ -1609,14 +1609,14 @@ extension Local {
 extension Local {
     public init<W, C0, C1, Component: RegexComponent>(
     @RegexComponentBuilder _ component: () -> Component
-  ) where Output == (Substring, C0, C1), Component.Output == (W, C0, C1) {
+  ) where RegexOutput == (Substring, C0, C1), Component.RegexOutput == (W, C0, C1) {
     self.init(node: .nonCapturingGroup(.atomicNonCapturing, component().regex.root))
   }
 }
 extension Local {
     public init<W, C0, C1, C2, Component: RegexComponent>(
     _ component: Component
-  ) where Output == (Substring, C0, C1, C2), Component.Output == (W, C0, C1, C2) {
+  ) where RegexOutput == (Substring, C0, C1, C2), Component.RegexOutput == (W, C0, C1, C2) {
     self.init(node: .nonCapturingGroup(.atomicNonCapturing, component.regex.root))
   }
 }
@@ -1624,14 +1624,14 @@ extension Local {
 extension Local {
     public init<W, C0, C1, C2, Component: RegexComponent>(
     @RegexComponentBuilder _ component: () -> Component
-  ) where Output == (Substring, C0, C1, C2), Component.Output == (W, C0, C1, C2) {
+  ) where RegexOutput == (Substring, C0, C1, C2), Component.RegexOutput == (W, C0, C1, C2) {
     self.init(node: .nonCapturingGroup(.atomicNonCapturing, component().regex.root))
   }
 }
 extension Local {
     public init<W, C0, C1, C2, C3, Component: RegexComponent>(
     _ component: Component
-  ) where Output == (Substring, C0, C1, C2, C3), Component.Output == (W, C0, C1, C2, C3) {
+  ) where RegexOutput == (Substring, C0, C1, C2, C3), Component.RegexOutput == (W, C0, C1, C2, C3) {
     self.init(node: .nonCapturingGroup(.atomicNonCapturing, component.regex.root))
   }
 }
@@ -1639,14 +1639,14 @@ extension Local {
 extension Local {
     public init<W, C0, C1, C2, C3, Component: RegexComponent>(
     @RegexComponentBuilder _ component: () -> Component
-  ) where Output == (Substring, C0, C1, C2, C3), Component.Output == (W, C0, C1, C2, C3) {
+  ) where RegexOutput == (Substring, C0, C1, C2, C3), Component.RegexOutput == (W, C0, C1, C2, C3) {
     self.init(node: .nonCapturingGroup(.atomicNonCapturing, component().regex.root))
   }
 }
 extension Local {
     public init<W, C0, C1, C2, C3, C4, Component: RegexComponent>(
     _ component: Component
-  ) where Output == (Substring, C0, C1, C2, C3, C4), Component.Output == (W, C0, C1, C2, C3, C4) {
+  ) where RegexOutput == (Substring, C0, C1, C2, C3, C4), Component.RegexOutput == (W, C0, C1, C2, C3, C4) {
     self.init(node: .nonCapturingGroup(.atomicNonCapturing, component.regex.root))
   }
 }
@@ -1654,14 +1654,14 @@ extension Local {
 extension Local {
     public init<W, C0, C1, C2, C3, C4, Component: RegexComponent>(
     @RegexComponentBuilder _ component: () -> Component
-  ) where Output == (Substring, C0, C1, C2, C3, C4), Component.Output == (W, C0, C1, C2, C3, C4) {
+  ) where RegexOutput == (Substring, C0, C1, C2, C3, C4), Component.RegexOutput == (W, C0, C1, C2, C3, C4) {
     self.init(node: .nonCapturingGroup(.atomicNonCapturing, component().regex.root))
   }
 }
 extension Local {
     public init<W, C0, C1, C2, C3, C4, C5, Component: RegexComponent>(
     _ component: Component
-  ) where Output == (Substring, C0, C1, C2, C3, C4, C5), Component.Output == (W, C0, C1, C2, C3, C4, C5) {
+  ) where RegexOutput == (Substring, C0, C1, C2, C3, C4, C5), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5) {
     self.init(node: .nonCapturingGroup(.atomicNonCapturing, component.regex.root))
   }
 }
@@ -1669,14 +1669,14 @@ extension Local {
 extension Local {
     public init<W, C0, C1, C2, C3, C4, C5, Component: RegexComponent>(
     @RegexComponentBuilder _ component: () -> Component
-  ) where Output == (Substring, C0, C1, C2, C3, C4, C5), Component.Output == (W, C0, C1, C2, C3, C4, C5) {
+  ) where RegexOutput == (Substring, C0, C1, C2, C3, C4, C5), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5) {
     self.init(node: .nonCapturingGroup(.atomicNonCapturing, component().regex.root))
   }
 }
 extension Local {
     public init<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexComponent>(
     _ component: Component
-  ) where Output == (Substring, C0, C1, C2, C3, C4, C5, C6), Component.Output == (W, C0, C1, C2, C3, C4, C5, C6) {
+  ) where RegexOutput == (Substring, C0, C1, C2, C3, C4, C5, C6), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6) {
     self.init(node: .nonCapturingGroup(.atomicNonCapturing, component.regex.root))
   }
 }
@@ -1684,14 +1684,14 @@ extension Local {
 extension Local {
     public init<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexComponent>(
     @RegexComponentBuilder _ component: () -> Component
-  ) where Output == (Substring, C0, C1, C2, C3, C4, C5, C6), Component.Output == (W, C0, C1, C2, C3, C4, C5, C6) {
+  ) where RegexOutput == (Substring, C0, C1, C2, C3, C4, C5, C6), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6) {
     self.init(node: .nonCapturingGroup(.atomicNonCapturing, component().regex.root))
   }
 }
 extension Local {
     public init<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexComponent>(
     _ component: Component
-  ) where Output == (Substring, C0, C1, C2, C3, C4, C5, C6, C7), Component.Output == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
+  ) where RegexOutput == (Substring, C0, C1, C2, C3, C4, C5, C6, C7), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
     self.init(node: .nonCapturingGroup(.atomicNonCapturing, component.regex.root))
   }
 }
@@ -1699,14 +1699,14 @@ extension Local {
 extension Local {
     public init<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexComponent>(
     @RegexComponentBuilder _ component: () -> Component
-  ) where Output == (Substring, C0, C1, C2, C3, C4, C5, C6, C7), Component.Output == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
+  ) where RegexOutput == (Substring, C0, C1, C2, C3, C4, C5, C6, C7), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
     self.init(node: .nonCapturingGroup(.atomicNonCapturing, component().regex.root))
   }
 }
 extension Local {
     public init<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexComponent>(
     _ component: Component
-  ) where Output == (Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8), Component.Output == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
+  ) where RegexOutput == (Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
     self.init(node: .nonCapturingGroup(.atomicNonCapturing, component.regex.root))
   }
 }
@@ -1714,14 +1714,14 @@ extension Local {
 extension Local {
     public init<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexComponent>(
     @RegexComponentBuilder _ component: () -> Component
-  ) where Output == (Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8), Component.Output == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
+  ) where RegexOutput == (Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
     self.init(node: .nonCapturingGroup(.atomicNonCapturing, component().regex.root))
   }
 }
 extension Local {
     public init<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9, Component: RegexComponent>(
     _ component: Component
-  ) where Output == (Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9), Component.Output == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
+  ) where RegexOutput == (Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
     self.init(node: .nonCapturingGroup(.atomicNonCapturing, component.regex.root))
   }
 }
@@ -1729,7 +1729,7 @@ extension Local {
 extension Local {
     public init<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9, Component: RegexComponent>(
     @RegexComponentBuilder _ component: () -> Component
-  ) where Output == (Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9), Component.Output == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
+  ) where RegexOutput == (Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
     self.init(node: .nonCapturingGroup(.atomicNonCapturing, component().regex.root))
   }
 }
@@ -1743,498 +1743,498 @@ extension AlternationBuilder {
 extension AlternationBuilder {
   public static func buildPartialBlock<R0, R1, W1, C0>(
     accumulated: R0, next: R1
-  ) -> ChoiceOf<(Substring, C0?)> where R0: RegexComponent, R1: RegexComponent, R1.Output == (W1, C0) {
+  ) -> ChoiceOf<(Substring, C0?)> where R0: RegexComponent, R1: RegexComponent, R1.RegexOutput == (W1, C0) {
     .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 extension AlternationBuilder {
   public static func buildPartialBlock<R0, R1, W1, C0, C1>(
     accumulated: R0, next: R1
-  ) -> ChoiceOf<(Substring, C0?, C1?)> where R0: RegexComponent, R1: RegexComponent, R1.Output == (W1, C0, C1) {
+  ) -> ChoiceOf<(Substring, C0?, C1?)> where R0: RegexComponent, R1: RegexComponent, R1.RegexOutput == (W1, C0, C1) {
     .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 extension AlternationBuilder {
   public static func buildPartialBlock<R0, R1, W1, C0, C1, C2>(
     accumulated: R0, next: R1
-  ) -> ChoiceOf<(Substring, C0?, C1?, C2?)> where R0: RegexComponent, R1: RegexComponent, R1.Output == (W1, C0, C1, C2) {
+  ) -> ChoiceOf<(Substring, C0?, C1?, C2?)> where R0: RegexComponent, R1: RegexComponent, R1.RegexOutput == (W1, C0, C1, C2) {
     .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 extension AlternationBuilder {
   public static func buildPartialBlock<R0, R1, W1, C0, C1, C2, C3>(
     accumulated: R0, next: R1
-  ) -> ChoiceOf<(Substring, C0?, C1?, C2?, C3?)> where R0: RegexComponent, R1: RegexComponent, R1.Output == (W1, C0, C1, C2, C3) {
+  ) -> ChoiceOf<(Substring, C0?, C1?, C2?, C3?)> where R0: RegexComponent, R1: RegexComponent, R1.RegexOutput == (W1, C0, C1, C2, C3) {
     .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 extension AlternationBuilder {
   public static func buildPartialBlock<R0, R1, W1, C0, C1, C2, C3, C4>(
     accumulated: R0, next: R1
-  ) -> ChoiceOf<(Substring, C0?, C1?, C2?, C3?, C4?)> where R0: RegexComponent, R1: RegexComponent, R1.Output == (W1, C0, C1, C2, C3, C4) {
+  ) -> ChoiceOf<(Substring, C0?, C1?, C2?, C3?, C4?)> where R0: RegexComponent, R1: RegexComponent, R1.RegexOutput == (W1, C0, C1, C2, C3, C4) {
     .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 extension AlternationBuilder {
   public static func buildPartialBlock<R0, R1, W1, C0, C1, C2, C3, C4, C5>(
     accumulated: R0, next: R1
-  ) -> ChoiceOf<(Substring, C0?, C1?, C2?, C3?, C4?, C5?)> where R0: RegexComponent, R1: RegexComponent, R1.Output == (W1, C0, C1, C2, C3, C4, C5) {
+  ) -> ChoiceOf<(Substring, C0?, C1?, C2?, C3?, C4?, C5?)> where R0: RegexComponent, R1: RegexComponent, R1.RegexOutput == (W1, C0, C1, C2, C3, C4, C5) {
     .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 extension AlternationBuilder {
   public static func buildPartialBlock<R0, R1, W1, C0, C1, C2, C3, C4, C5, C6>(
     accumulated: R0, next: R1
-  ) -> ChoiceOf<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?)> where R0: RegexComponent, R1: RegexComponent, R1.Output == (W1, C0, C1, C2, C3, C4, C5, C6) {
+  ) -> ChoiceOf<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?)> where R0: RegexComponent, R1: RegexComponent, R1.RegexOutput == (W1, C0, C1, C2, C3, C4, C5, C6) {
     .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 extension AlternationBuilder {
   public static func buildPartialBlock<R0, R1, W1, C0, C1, C2, C3, C4, C5, C6, C7>(
     accumulated: R0, next: R1
-  ) -> ChoiceOf<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?)> where R0: RegexComponent, R1: RegexComponent, R1.Output == (W1, C0, C1, C2, C3, C4, C5, C6, C7) {
+  ) -> ChoiceOf<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?)> where R0: RegexComponent, R1: RegexComponent, R1.RegexOutput == (W1, C0, C1, C2, C3, C4, C5, C6, C7) {
     .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 extension AlternationBuilder {
   public static func buildPartialBlock<R0, R1, W1, C0, C1, C2, C3, C4, C5, C6, C7, C8>(
     accumulated: R0, next: R1
-  ) -> ChoiceOf<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?)> where R0: RegexComponent, R1: RegexComponent, R1.Output == (W1, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
+  ) -> ChoiceOf<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?)> where R0: RegexComponent, R1: RegexComponent, R1.RegexOutput == (W1, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
     .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 extension AlternationBuilder {
   public static func buildPartialBlock<R0, R1, W1, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9>(
     accumulated: R0, next: R1
-  ) -> ChoiceOf<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?)> where R0: RegexComponent, R1: RegexComponent, R1.Output == (W1, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
+  ) -> ChoiceOf<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?)> where R0: RegexComponent, R1: RegexComponent, R1.RegexOutput == (W1, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
     .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 extension AlternationBuilder {
   public static func buildPartialBlock<R0, W0, C0, R1>(
     accumulated: R0, next: R1
-  ) -> ChoiceOf<(Substring, C0)> where R0: RegexComponent, R1: RegexComponent, R0.Output == (W0, C0) {
+  ) -> ChoiceOf<(Substring, C0)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0) {
     .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 extension AlternationBuilder {
   public static func buildPartialBlock<R0, W0, C0, R1, W1, C1>(
     accumulated: R0, next: R1
-  ) -> ChoiceOf<(Substring, C0, C1?)> where R0: RegexComponent, R1: RegexComponent, R0.Output == (W0, C0), R1.Output == (W1, C1) {
+  ) -> ChoiceOf<(Substring, C0, C1?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0), R1.RegexOutput == (W1, C1) {
     .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 extension AlternationBuilder {
   public static func buildPartialBlock<R0, W0, C0, R1, W1, C1, C2>(
     accumulated: R0, next: R1
-  ) -> ChoiceOf<(Substring, C0, C1?, C2?)> where R0: RegexComponent, R1: RegexComponent, R0.Output == (W0, C0), R1.Output == (W1, C1, C2) {
+  ) -> ChoiceOf<(Substring, C0, C1?, C2?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0), R1.RegexOutput == (W1, C1, C2) {
     .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 extension AlternationBuilder {
   public static func buildPartialBlock<R0, W0, C0, R1, W1, C1, C2, C3>(
     accumulated: R0, next: R1
-  ) -> ChoiceOf<(Substring, C0, C1?, C2?, C3?)> where R0: RegexComponent, R1: RegexComponent, R0.Output == (W0, C0), R1.Output == (W1, C1, C2, C3) {
+  ) -> ChoiceOf<(Substring, C0, C1?, C2?, C3?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0), R1.RegexOutput == (W1, C1, C2, C3) {
     .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 extension AlternationBuilder {
   public static func buildPartialBlock<R0, W0, C0, R1, W1, C1, C2, C3, C4>(
     accumulated: R0, next: R1
-  ) -> ChoiceOf<(Substring, C0, C1?, C2?, C3?, C4?)> where R0: RegexComponent, R1: RegexComponent, R0.Output == (W0, C0), R1.Output == (W1, C1, C2, C3, C4) {
+  ) -> ChoiceOf<(Substring, C0, C1?, C2?, C3?, C4?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0), R1.RegexOutput == (W1, C1, C2, C3, C4) {
     .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 extension AlternationBuilder {
   public static func buildPartialBlock<R0, W0, C0, R1, W1, C1, C2, C3, C4, C5>(
     accumulated: R0, next: R1
-  ) -> ChoiceOf<(Substring, C0, C1?, C2?, C3?, C4?, C5?)> where R0: RegexComponent, R1: RegexComponent, R0.Output == (W0, C0), R1.Output == (W1, C1, C2, C3, C4, C5) {
+  ) -> ChoiceOf<(Substring, C0, C1?, C2?, C3?, C4?, C5?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0), R1.RegexOutput == (W1, C1, C2, C3, C4, C5) {
     .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 extension AlternationBuilder {
   public static func buildPartialBlock<R0, W0, C0, R1, W1, C1, C2, C3, C4, C5, C6>(
     accumulated: R0, next: R1
-  ) -> ChoiceOf<(Substring, C0, C1?, C2?, C3?, C4?, C5?, C6?)> where R0: RegexComponent, R1: RegexComponent, R0.Output == (W0, C0), R1.Output == (W1, C1, C2, C3, C4, C5, C6) {
+  ) -> ChoiceOf<(Substring, C0, C1?, C2?, C3?, C4?, C5?, C6?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0), R1.RegexOutput == (W1, C1, C2, C3, C4, C5, C6) {
     .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 extension AlternationBuilder {
   public static func buildPartialBlock<R0, W0, C0, R1, W1, C1, C2, C3, C4, C5, C6, C7>(
     accumulated: R0, next: R1
-  ) -> ChoiceOf<(Substring, C0, C1?, C2?, C3?, C4?, C5?, C6?, C7?)> where R0: RegexComponent, R1: RegexComponent, R0.Output == (W0, C0), R1.Output == (W1, C1, C2, C3, C4, C5, C6, C7) {
+  ) -> ChoiceOf<(Substring, C0, C1?, C2?, C3?, C4?, C5?, C6?, C7?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0), R1.RegexOutput == (W1, C1, C2, C3, C4, C5, C6, C7) {
     .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 extension AlternationBuilder {
   public static func buildPartialBlock<R0, W0, C0, R1, W1, C1, C2, C3, C4, C5, C6, C7, C8>(
     accumulated: R0, next: R1
-  ) -> ChoiceOf<(Substring, C0, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?)> where R0: RegexComponent, R1: RegexComponent, R0.Output == (W0, C0), R1.Output == (W1, C1, C2, C3, C4, C5, C6, C7, C8) {
+  ) -> ChoiceOf<(Substring, C0, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0), R1.RegexOutput == (W1, C1, C2, C3, C4, C5, C6, C7, C8) {
     .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 extension AlternationBuilder {
   public static func buildPartialBlock<R0, W0, C0, R1, W1, C1, C2, C3, C4, C5, C6, C7, C8, C9>(
     accumulated: R0, next: R1
-  ) -> ChoiceOf<(Substring, C0, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?)> where R0: RegexComponent, R1: RegexComponent, R0.Output == (W0, C0), R1.Output == (W1, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
+  ) -> ChoiceOf<(Substring, C0, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0), R1.RegexOutput == (W1, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
     .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 extension AlternationBuilder {
   public static func buildPartialBlock<R0, W0, C0, C1, R1>(
     accumulated: R0, next: R1
-  ) -> ChoiceOf<(Substring, C0, C1)> where R0: RegexComponent, R1: RegexComponent, R0.Output == (W0, C0, C1) {
+  ) -> ChoiceOf<(Substring, C0, C1)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1) {
     .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 extension AlternationBuilder {
   public static func buildPartialBlock<R0, W0, C0, C1, R1, W1, C2>(
     accumulated: R0, next: R1
-  ) -> ChoiceOf<(Substring, C0, C1, C2?)> where R0: RegexComponent, R1: RegexComponent, R0.Output == (W0, C0, C1), R1.Output == (W1, C2) {
+  ) -> ChoiceOf<(Substring, C0, C1, C2?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1), R1.RegexOutput == (W1, C2) {
     .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 extension AlternationBuilder {
   public static func buildPartialBlock<R0, W0, C0, C1, R1, W1, C2, C3>(
     accumulated: R0, next: R1
-  ) -> ChoiceOf<(Substring, C0, C1, C2?, C3?)> where R0: RegexComponent, R1: RegexComponent, R0.Output == (W0, C0, C1), R1.Output == (W1, C2, C3) {
+  ) -> ChoiceOf<(Substring, C0, C1, C2?, C3?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1), R1.RegexOutput == (W1, C2, C3) {
     .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 extension AlternationBuilder {
   public static func buildPartialBlock<R0, W0, C0, C1, R1, W1, C2, C3, C4>(
     accumulated: R0, next: R1
-  ) -> ChoiceOf<(Substring, C0, C1, C2?, C3?, C4?)> where R0: RegexComponent, R1: RegexComponent, R0.Output == (W0, C0, C1), R1.Output == (W1, C2, C3, C4) {
+  ) -> ChoiceOf<(Substring, C0, C1, C2?, C3?, C4?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1), R1.RegexOutput == (W1, C2, C3, C4) {
     .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 extension AlternationBuilder {
   public static func buildPartialBlock<R0, W0, C0, C1, R1, W1, C2, C3, C4, C5>(
     accumulated: R0, next: R1
-  ) -> ChoiceOf<(Substring, C0, C1, C2?, C3?, C4?, C5?)> where R0: RegexComponent, R1: RegexComponent, R0.Output == (W0, C0, C1), R1.Output == (W1, C2, C3, C4, C5) {
+  ) -> ChoiceOf<(Substring, C0, C1, C2?, C3?, C4?, C5?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1), R1.RegexOutput == (W1, C2, C3, C4, C5) {
     .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 extension AlternationBuilder {
   public static func buildPartialBlock<R0, W0, C0, C1, R1, W1, C2, C3, C4, C5, C6>(
     accumulated: R0, next: R1
-  ) -> ChoiceOf<(Substring, C0, C1, C2?, C3?, C4?, C5?, C6?)> where R0: RegexComponent, R1: RegexComponent, R0.Output == (W0, C0, C1), R1.Output == (W1, C2, C3, C4, C5, C6) {
+  ) -> ChoiceOf<(Substring, C0, C1, C2?, C3?, C4?, C5?, C6?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1), R1.RegexOutput == (W1, C2, C3, C4, C5, C6) {
     .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 extension AlternationBuilder {
   public static func buildPartialBlock<R0, W0, C0, C1, R1, W1, C2, C3, C4, C5, C6, C7>(
     accumulated: R0, next: R1
-  ) -> ChoiceOf<(Substring, C0, C1, C2?, C3?, C4?, C5?, C6?, C7?)> where R0: RegexComponent, R1: RegexComponent, R0.Output == (W0, C0, C1), R1.Output == (W1, C2, C3, C4, C5, C6, C7) {
+  ) -> ChoiceOf<(Substring, C0, C1, C2?, C3?, C4?, C5?, C6?, C7?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1), R1.RegexOutput == (W1, C2, C3, C4, C5, C6, C7) {
     .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 extension AlternationBuilder {
   public static func buildPartialBlock<R0, W0, C0, C1, R1, W1, C2, C3, C4, C5, C6, C7, C8>(
     accumulated: R0, next: R1
-  ) -> ChoiceOf<(Substring, C0, C1, C2?, C3?, C4?, C5?, C6?, C7?, C8?)> where R0: RegexComponent, R1: RegexComponent, R0.Output == (W0, C0, C1), R1.Output == (W1, C2, C3, C4, C5, C6, C7, C8) {
+  ) -> ChoiceOf<(Substring, C0, C1, C2?, C3?, C4?, C5?, C6?, C7?, C8?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1), R1.RegexOutput == (W1, C2, C3, C4, C5, C6, C7, C8) {
     .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 extension AlternationBuilder {
   public static func buildPartialBlock<R0, W0, C0, C1, R1, W1, C2, C3, C4, C5, C6, C7, C8, C9>(
     accumulated: R0, next: R1
-  ) -> ChoiceOf<(Substring, C0, C1, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?)> where R0: RegexComponent, R1: RegexComponent, R0.Output == (W0, C0, C1), R1.Output == (W1, C2, C3, C4, C5, C6, C7, C8, C9) {
+  ) -> ChoiceOf<(Substring, C0, C1, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1), R1.RegexOutput == (W1, C2, C3, C4, C5, C6, C7, C8, C9) {
     .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 extension AlternationBuilder {
   public static func buildPartialBlock<R0, W0, C0, C1, C2, R1>(
     accumulated: R0, next: R1
-  ) -> ChoiceOf<(Substring, C0, C1, C2)> where R0: RegexComponent, R1: RegexComponent, R0.Output == (W0, C0, C1, C2) {
+  ) -> ChoiceOf<(Substring, C0, C1, C2)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2) {
     .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 extension AlternationBuilder {
   public static func buildPartialBlock<R0, W0, C0, C1, C2, R1, W1, C3>(
     accumulated: R0, next: R1
-  ) -> ChoiceOf<(Substring, C0, C1, C2, C3?)> where R0: RegexComponent, R1: RegexComponent, R0.Output == (W0, C0, C1, C2), R1.Output == (W1, C3) {
+  ) -> ChoiceOf<(Substring, C0, C1, C2, C3?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2), R1.RegexOutput == (W1, C3) {
     .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 extension AlternationBuilder {
   public static func buildPartialBlock<R0, W0, C0, C1, C2, R1, W1, C3, C4>(
     accumulated: R0, next: R1
-  ) -> ChoiceOf<(Substring, C0, C1, C2, C3?, C4?)> where R0: RegexComponent, R1: RegexComponent, R0.Output == (W0, C0, C1, C2), R1.Output == (W1, C3, C4) {
+  ) -> ChoiceOf<(Substring, C0, C1, C2, C3?, C4?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2), R1.RegexOutput == (W1, C3, C4) {
     .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 extension AlternationBuilder {
   public static func buildPartialBlock<R0, W0, C0, C1, C2, R1, W1, C3, C4, C5>(
     accumulated: R0, next: R1
-  ) -> ChoiceOf<(Substring, C0, C1, C2, C3?, C4?, C5?)> where R0: RegexComponent, R1: RegexComponent, R0.Output == (W0, C0, C1, C2), R1.Output == (W1, C3, C4, C5) {
+  ) -> ChoiceOf<(Substring, C0, C1, C2, C3?, C4?, C5?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2), R1.RegexOutput == (W1, C3, C4, C5) {
     .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 extension AlternationBuilder {
   public static func buildPartialBlock<R0, W0, C0, C1, C2, R1, W1, C3, C4, C5, C6>(
     accumulated: R0, next: R1
-  ) -> ChoiceOf<(Substring, C0, C1, C2, C3?, C4?, C5?, C6?)> where R0: RegexComponent, R1: RegexComponent, R0.Output == (W0, C0, C1, C2), R1.Output == (W1, C3, C4, C5, C6) {
+  ) -> ChoiceOf<(Substring, C0, C1, C2, C3?, C4?, C5?, C6?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2), R1.RegexOutput == (W1, C3, C4, C5, C6) {
     .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 extension AlternationBuilder {
   public static func buildPartialBlock<R0, W0, C0, C1, C2, R1, W1, C3, C4, C5, C6, C7>(
     accumulated: R0, next: R1
-  ) -> ChoiceOf<(Substring, C0, C1, C2, C3?, C4?, C5?, C6?, C7?)> where R0: RegexComponent, R1: RegexComponent, R0.Output == (W0, C0, C1, C2), R1.Output == (W1, C3, C4, C5, C6, C7) {
+  ) -> ChoiceOf<(Substring, C0, C1, C2, C3?, C4?, C5?, C6?, C7?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2), R1.RegexOutput == (W1, C3, C4, C5, C6, C7) {
     .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 extension AlternationBuilder {
   public static func buildPartialBlock<R0, W0, C0, C1, C2, R1, W1, C3, C4, C5, C6, C7, C8>(
     accumulated: R0, next: R1
-  ) -> ChoiceOf<(Substring, C0, C1, C2, C3?, C4?, C5?, C6?, C7?, C8?)> where R0: RegexComponent, R1: RegexComponent, R0.Output == (W0, C0, C1, C2), R1.Output == (W1, C3, C4, C5, C6, C7, C8) {
+  ) -> ChoiceOf<(Substring, C0, C1, C2, C3?, C4?, C5?, C6?, C7?, C8?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2), R1.RegexOutput == (W1, C3, C4, C5, C6, C7, C8) {
     .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 extension AlternationBuilder {
   public static func buildPartialBlock<R0, W0, C0, C1, C2, R1, W1, C3, C4, C5, C6, C7, C8, C9>(
     accumulated: R0, next: R1
-  ) -> ChoiceOf<(Substring, C0, C1, C2, C3?, C4?, C5?, C6?, C7?, C8?, C9?)> where R0: RegexComponent, R1: RegexComponent, R0.Output == (W0, C0, C1, C2), R1.Output == (W1, C3, C4, C5, C6, C7, C8, C9) {
+  ) -> ChoiceOf<(Substring, C0, C1, C2, C3?, C4?, C5?, C6?, C7?, C8?, C9?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2), R1.RegexOutput == (W1, C3, C4, C5, C6, C7, C8, C9) {
     .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 extension AlternationBuilder {
   public static func buildPartialBlock<R0, W0, C0, C1, C2, C3, R1>(
     accumulated: R0, next: R1
-  ) -> ChoiceOf<(Substring, C0, C1, C2, C3)> where R0: RegexComponent, R1: RegexComponent, R0.Output == (W0, C0, C1, C2, C3) {
+  ) -> ChoiceOf<(Substring, C0, C1, C2, C3)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2, C3) {
     .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 extension AlternationBuilder {
   public static func buildPartialBlock<R0, W0, C0, C1, C2, C3, R1, W1, C4>(
     accumulated: R0, next: R1
-  ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4?)> where R0: RegexComponent, R1: RegexComponent, R0.Output == (W0, C0, C1, C2, C3), R1.Output == (W1, C4) {
+  ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2, C3), R1.RegexOutput == (W1, C4) {
     .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 extension AlternationBuilder {
   public static func buildPartialBlock<R0, W0, C0, C1, C2, C3, R1, W1, C4, C5>(
     accumulated: R0, next: R1
-  ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4?, C5?)> where R0: RegexComponent, R1: RegexComponent, R0.Output == (W0, C0, C1, C2, C3), R1.Output == (W1, C4, C5) {
+  ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4?, C5?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2, C3), R1.RegexOutput == (W1, C4, C5) {
     .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 extension AlternationBuilder {
   public static func buildPartialBlock<R0, W0, C0, C1, C2, C3, R1, W1, C4, C5, C6>(
     accumulated: R0, next: R1
-  ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4?, C5?, C6?)> where R0: RegexComponent, R1: RegexComponent, R0.Output == (W0, C0, C1, C2, C3), R1.Output == (W1, C4, C5, C6) {
+  ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4?, C5?, C6?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2, C3), R1.RegexOutput == (W1, C4, C5, C6) {
     .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 extension AlternationBuilder {
   public static func buildPartialBlock<R0, W0, C0, C1, C2, C3, R1, W1, C4, C5, C6, C7>(
     accumulated: R0, next: R1
-  ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4?, C5?, C6?, C7?)> where R0: RegexComponent, R1: RegexComponent, R0.Output == (W0, C0, C1, C2, C3), R1.Output == (W1, C4, C5, C6, C7) {
+  ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4?, C5?, C6?, C7?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2, C3), R1.RegexOutput == (W1, C4, C5, C6, C7) {
     .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 extension AlternationBuilder {
   public static func buildPartialBlock<R0, W0, C0, C1, C2, C3, R1, W1, C4, C5, C6, C7, C8>(
     accumulated: R0, next: R1
-  ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4?, C5?, C6?, C7?, C8?)> where R0: RegexComponent, R1: RegexComponent, R0.Output == (W0, C0, C1, C2, C3), R1.Output == (W1, C4, C5, C6, C7, C8) {
+  ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4?, C5?, C6?, C7?, C8?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2, C3), R1.RegexOutput == (W1, C4, C5, C6, C7, C8) {
     .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 extension AlternationBuilder {
   public static func buildPartialBlock<R0, W0, C0, C1, C2, C3, R1, W1, C4, C5, C6, C7, C8, C9>(
     accumulated: R0, next: R1
-  ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4?, C5?, C6?, C7?, C8?, C9?)> where R0: RegexComponent, R1: RegexComponent, R0.Output == (W0, C0, C1, C2, C3), R1.Output == (W1, C4, C5, C6, C7, C8, C9) {
+  ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4?, C5?, C6?, C7?, C8?, C9?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2, C3), R1.RegexOutput == (W1, C4, C5, C6, C7, C8, C9) {
     .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 extension AlternationBuilder {
   public static func buildPartialBlock<R0, W0, C0, C1, C2, C3, C4, R1>(
     accumulated: R0, next: R1
-  ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4)> where R0: RegexComponent, R1: RegexComponent, R0.Output == (W0, C0, C1, C2, C3, C4) {
+  ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2, C3, C4) {
     .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 extension AlternationBuilder {
   public static func buildPartialBlock<R0, W0, C0, C1, C2, C3, C4, R1, W1, C5>(
     accumulated: R0, next: R1
-  ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4, C5?)> where R0: RegexComponent, R1: RegexComponent, R0.Output == (W0, C0, C1, C2, C3, C4), R1.Output == (W1, C5) {
+  ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4, C5?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2, C3, C4), R1.RegexOutput == (W1, C5) {
     .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 extension AlternationBuilder {
   public static func buildPartialBlock<R0, W0, C0, C1, C2, C3, C4, R1, W1, C5, C6>(
     accumulated: R0, next: R1
-  ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4, C5?, C6?)> where R0: RegexComponent, R1: RegexComponent, R0.Output == (W0, C0, C1, C2, C3, C4), R1.Output == (W1, C5, C6) {
+  ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4, C5?, C6?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2, C3, C4), R1.RegexOutput == (W1, C5, C6) {
     .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 extension AlternationBuilder {
   public static func buildPartialBlock<R0, W0, C0, C1, C2, C3, C4, R1, W1, C5, C6, C7>(
     accumulated: R0, next: R1
-  ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4, C5?, C6?, C7?)> where R0: RegexComponent, R1: RegexComponent, R0.Output == (W0, C0, C1, C2, C3, C4), R1.Output == (W1, C5, C6, C7) {
+  ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4, C5?, C6?, C7?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2, C3, C4), R1.RegexOutput == (W1, C5, C6, C7) {
     .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 extension AlternationBuilder {
   public static func buildPartialBlock<R0, W0, C0, C1, C2, C3, C4, R1, W1, C5, C6, C7, C8>(
     accumulated: R0, next: R1
-  ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4, C5?, C6?, C7?, C8?)> where R0: RegexComponent, R1: RegexComponent, R0.Output == (W0, C0, C1, C2, C3, C4), R1.Output == (W1, C5, C6, C7, C8) {
+  ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4, C5?, C6?, C7?, C8?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2, C3, C4), R1.RegexOutput == (W1, C5, C6, C7, C8) {
     .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 extension AlternationBuilder {
   public static func buildPartialBlock<R0, W0, C0, C1, C2, C3, C4, R1, W1, C5, C6, C7, C8, C9>(
     accumulated: R0, next: R1
-  ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4, C5?, C6?, C7?, C8?, C9?)> where R0: RegexComponent, R1: RegexComponent, R0.Output == (W0, C0, C1, C2, C3, C4), R1.Output == (W1, C5, C6, C7, C8, C9) {
+  ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4, C5?, C6?, C7?, C8?, C9?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2, C3, C4), R1.RegexOutput == (W1, C5, C6, C7, C8, C9) {
     .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 extension AlternationBuilder {
   public static func buildPartialBlock<R0, W0, C0, C1, C2, C3, C4, C5, R1>(
     accumulated: R0, next: R1
-  ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4, C5)> where R0: RegexComponent, R1: RegexComponent, R0.Output == (W0, C0, C1, C2, C3, C4, C5) {
+  ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4, C5)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2, C3, C4, C5) {
     .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 extension AlternationBuilder {
   public static func buildPartialBlock<R0, W0, C0, C1, C2, C3, C4, C5, R1, W1, C6>(
     accumulated: R0, next: R1
-  ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4, C5, C6?)> where R0: RegexComponent, R1: RegexComponent, R0.Output == (W0, C0, C1, C2, C3, C4, C5), R1.Output == (W1, C6) {
+  ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4, C5, C6?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2, C3, C4, C5), R1.RegexOutput == (W1, C6) {
     .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 extension AlternationBuilder {
   public static func buildPartialBlock<R0, W0, C0, C1, C2, C3, C4, C5, R1, W1, C6, C7>(
     accumulated: R0, next: R1
-  ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4, C5, C6?, C7?)> where R0: RegexComponent, R1: RegexComponent, R0.Output == (W0, C0, C1, C2, C3, C4, C5), R1.Output == (W1, C6, C7) {
+  ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4, C5, C6?, C7?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2, C3, C4, C5), R1.RegexOutput == (W1, C6, C7) {
     .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 extension AlternationBuilder {
   public static func buildPartialBlock<R0, W0, C0, C1, C2, C3, C4, C5, R1, W1, C6, C7, C8>(
     accumulated: R0, next: R1
-  ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4, C5, C6?, C7?, C8?)> where R0: RegexComponent, R1: RegexComponent, R0.Output == (W0, C0, C1, C2, C3, C4, C5), R1.Output == (W1, C6, C7, C8) {
+  ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4, C5, C6?, C7?, C8?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2, C3, C4, C5), R1.RegexOutput == (W1, C6, C7, C8) {
     .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 extension AlternationBuilder {
   public static func buildPartialBlock<R0, W0, C0, C1, C2, C3, C4, C5, R1, W1, C6, C7, C8, C9>(
     accumulated: R0, next: R1
-  ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4, C5, C6?, C7?, C8?, C9?)> where R0: RegexComponent, R1: RegexComponent, R0.Output == (W0, C0, C1, C2, C3, C4, C5), R1.Output == (W1, C6, C7, C8, C9) {
+  ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4, C5, C6?, C7?, C8?, C9?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2, C3, C4, C5), R1.RegexOutput == (W1, C6, C7, C8, C9) {
     .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 extension AlternationBuilder {
   public static func buildPartialBlock<R0, W0, C0, C1, C2, C3, C4, C5, C6, R1>(
     accumulated: R0, next: R1
-  ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4, C5, C6)> where R0: RegexComponent, R1: RegexComponent, R0.Output == (W0, C0, C1, C2, C3, C4, C5, C6) {
+  ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4, C5, C6)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2, C3, C4, C5, C6) {
     .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 extension AlternationBuilder {
   public static func buildPartialBlock<R0, W0, C0, C1, C2, C3, C4, C5, C6, R1, W1, C7>(
     accumulated: R0, next: R1
-  ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4, C5, C6, C7?)> where R0: RegexComponent, R1: RegexComponent, R0.Output == (W0, C0, C1, C2, C3, C4, C5, C6), R1.Output == (W1, C7) {
+  ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4, C5, C6, C7?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2, C3, C4, C5, C6), R1.RegexOutput == (W1, C7) {
     .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 extension AlternationBuilder {
   public static func buildPartialBlock<R0, W0, C0, C1, C2, C3, C4, C5, C6, R1, W1, C7, C8>(
     accumulated: R0, next: R1
-  ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4, C5, C6, C7?, C8?)> where R0: RegexComponent, R1: RegexComponent, R0.Output == (W0, C0, C1, C2, C3, C4, C5, C6), R1.Output == (W1, C7, C8) {
+  ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4, C5, C6, C7?, C8?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2, C3, C4, C5, C6), R1.RegexOutput == (W1, C7, C8) {
     .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 extension AlternationBuilder {
   public static func buildPartialBlock<R0, W0, C0, C1, C2, C3, C4, C5, C6, R1, W1, C7, C8, C9>(
     accumulated: R0, next: R1
-  ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4, C5, C6, C7?, C8?, C9?)> where R0: RegexComponent, R1: RegexComponent, R0.Output == (W0, C0, C1, C2, C3, C4, C5, C6), R1.Output == (W1, C7, C8, C9) {
+  ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4, C5, C6, C7?, C8?, C9?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2, C3, C4, C5, C6), R1.RegexOutput == (W1, C7, C8, C9) {
     .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 extension AlternationBuilder {
   public static func buildPartialBlock<R0, W0, C0, C1, C2, C3, C4, C5, C6, C7, R1>(
     accumulated: R0, next: R1
-  ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4, C5, C6, C7)> where R0: RegexComponent, R1: RegexComponent, R0.Output == (W0, C0, C1, C2, C3, C4, C5, C6, C7) {
+  ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4, C5, C6, C7)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2, C3, C4, C5, C6, C7) {
     .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 extension AlternationBuilder {
   public static func buildPartialBlock<R0, W0, C0, C1, C2, C3, C4, C5, C6, C7, R1, W1, C8>(
     accumulated: R0, next: R1
-  ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8?)> where R0: RegexComponent, R1: RegexComponent, R0.Output == (W0, C0, C1, C2, C3, C4, C5, C6, C7), R1.Output == (W1, C8) {
+  ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2, C3, C4, C5, C6, C7), R1.RegexOutput == (W1, C8) {
     .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 extension AlternationBuilder {
   public static func buildPartialBlock<R0, W0, C0, C1, C2, C3, C4, C5, C6, C7, R1, W1, C8, C9>(
     accumulated: R0, next: R1
-  ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8?, C9?)> where R0: RegexComponent, R1: RegexComponent, R0.Output == (W0, C0, C1, C2, C3, C4, C5, C6, C7), R1.Output == (W1, C8, C9) {
+  ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8?, C9?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2, C3, C4, C5, C6, C7), R1.RegexOutput == (W1, C8, C9) {
     .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 extension AlternationBuilder {
   public static func buildPartialBlock<R0, W0, C0, C1, C2, C3, C4, C5, C6, C7, C8, R1>(
     accumulated: R0, next: R1
-  ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8)> where R0: RegexComponent, R1: RegexComponent, R0.Output == (W0, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
+  ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
     .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 extension AlternationBuilder {
   public static func buildPartialBlock<R0, W0, C0, C1, C2, C3, C4, C5, C6, C7, C8, R1, W1, C9>(
     accumulated: R0, next: R1
-  ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9?)> where R0: RegexComponent, R1: RegexComponent, R0.Output == (W0, C0, C1, C2, C3, C4, C5, C6, C7, C8), R1.Output == (W1, C9) {
+  ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2, C3, C4, C5, C6, C7, C8), R1.RegexOutput == (W1, C9) {
     .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
 extension AlternationBuilder {
-  public static func buildPartialBlock<R, W, C0>(first regex: R) -> ChoiceOf<(W, C0?)> where R: RegexComponent, R.Output == (W, C0) {
+  public static func buildPartialBlock<R, W, C0>(first regex: R) -> ChoiceOf<(W, C0?)> where R: RegexComponent, R.RegexOutput == (W, C0) {
     .init(node: .orderedChoice([regex.regex.root]))
   }
 }
 extension AlternationBuilder {
-  public static func buildPartialBlock<R, W, C0, C1>(first regex: R) -> ChoiceOf<(W, C0?, C1?)> where R: RegexComponent, R.Output == (W, C0, C1) {
+  public static func buildPartialBlock<R, W, C0, C1>(first regex: R) -> ChoiceOf<(W, C0?, C1?)> where R: RegexComponent, R.RegexOutput == (W, C0, C1) {
     .init(node: .orderedChoice([regex.regex.root]))
   }
 }
 extension AlternationBuilder {
-  public static func buildPartialBlock<R, W, C0, C1, C2>(first regex: R) -> ChoiceOf<(W, C0?, C1?, C2?)> where R: RegexComponent, R.Output == (W, C0, C1, C2) {
+  public static func buildPartialBlock<R, W, C0, C1, C2>(first regex: R) -> ChoiceOf<(W, C0?, C1?, C2?)> where R: RegexComponent, R.RegexOutput == (W, C0, C1, C2) {
     .init(node: .orderedChoice([regex.regex.root]))
   }
 }
 extension AlternationBuilder {
-  public static func buildPartialBlock<R, W, C0, C1, C2, C3>(first regex: R) -> ChoiceOf<(W, C0?, C1?, C2?, C3?)> where R: RegexComponent, R.Output == (W, C0, C1, C2, C3) {
+  public static func buildPartialBlock<R, W, C0, C1, C2, C3>(first regex: R) -> ChoiceOf<(W, C0?, C1?, C2?, C3?)> where R: RegexComponent, R.RegexOutput == (W, C0, C1, C2, C3) {
     .init(node: .orderedChoice([regex.regex.root]))
   }
 }
 extension AlternationBuilder {
-  public static func buildPartialBlock<R, W, C0, C1, C2, C3, C4>(first regex: R) -> ChoiceOf<(W, C0?, C1?, C2?, C3?, C4?)> where R: RegexComponent, R.Output == (W, C0, C1, C2, C3, C4) {
+  public static func buildPartialBlock<R, W, C0, C1, C2, C3, C4>(first regex: R) -> ChoiceOf<(W, C0?, C1?, C2?, C3?, C4?)> where R: RegexComponent, R.RegexOutput == (W, C0, C1, C2, C3, C4) {
     .init(node: .orderedChoice([regex.regex.root]))
   }
 }
 extension AlternationBuilder {
-  public static func buildPartialBlock<R, W, C0, C1, C2, C3, C4, C5>(first regex: R) -> ChoiceOf<(W, C0?, C1?, C2?, C3?, C4?, C5?)> where R: RegexComponent, R.Output == (W, C0, C1, C2, C3, C4, C5) {
+  public static func buildPartialBlock<R, W, C0, C1, C2, C3, C4, C5>(first regex: R) -> ChoiceOf<(W, C0?, C1?, C2?, C3?, C4?, C5?)> where R: RegexComponent, R.RegexOutput == (W, C0, C1, C2, C3, C4, C5) {
     .init(node: .orderedChoice([regex.regex.root]))
   }
 }
 extension AlternationBuilder {
-  public static func buildPartialBlock<R, W, C0, C1, C2, C3, C4, C5, C6>(first regex: R) -> ChoiceOf<(W, C0?, C1?, C2?, C3?, C4?, C5?, C6?)> where R: RegexComponent, R.Output == (W, C0, C1, C2, C3, C4, C5, C6) {
+  public static func buildPartialBlock<R, W, C0, C1, C2, C3, C4, C5, C6>(first regex: R) -> ChoiceOf<(W, C0?, C1?, C2?, C3?, C4?, C5?, C6?)> where R: RegexComponent, R.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6) {
     .init(node: .orderedChoice([regex.regex.root]))
   }
 }
 extension AlternationBuilder {
-  public static func buildPartialBlock<R, W, C0, C1, C2, C3, C4, C5, C6, C7>(first regex: R) -> ChoiceOf<(W, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?)> where R: RegexComponent, R.Output == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
+  public static func buildPartialBlock<R, W, C0, C1, C2, C3, C4, C5, C6, C7>(first regex: R) -> ChoiceOf<(W, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?)> where R: RegexComponent, R.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
     .init(node: .orderedChoice([regex.regex.root]))
   }
 }
 extension AlternationBuilder {
-  public static func buildPartialBlock<R, W, C0, C1, C2, C3, C4, C5, C6, C7, C8>(first regex: R) -> ChoiceOf<(W, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?)> where R: RegexComponent, R.Output == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
+  public static func buildPartialBlock<R, W, C0, C1, C2, C3, C4, C5, C6, C7, C8>(first regex: R) -> ChoiceOf<(W, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?)> where R: RegexComponent, R.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
     .init(node: .orderedChoice([regex.regex.root]))
   }
 }
 extension AlternationBuilder {
-  public static func buildPartialBlock<R, W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9>(first regex: R) -> ChoiceOf<(W, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?)> where R: RegexComponent, R.Output == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
+  public static func buildPartialBlock<R, W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9>(first regex: R) -> ChoiceOf<(W, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?)> where R: RegexComponent, R.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
     .init(node: .orderedChoice([regex.regex.root]))
   }
 }
@@ -2244,14 +2244,14 @@ extension Capture {
   @_disfavoredOverload
   public init<R: RegexComponent, W>(
     _ component: R
-  ) where Output == (Substring, W), R.Output == W {
+  ) where RegexOutput == (Substring, W), R.RegexOutput == W {
     self.init(node: .capture(component.regex.root))
   }
 
   @_disfavoredOverload
   public init<R: RegexComponent, W>(
     _ component: R, as reference: Reference<W>
-  ) where Output == (Substring, W), R.Output == W {
+  ) where RegexOutput == (Substring, W), R.RegexOutput == W {
     self.init(node: .capture(reference: reference.id, component.regex.root))
   }
 
@@ -2259,7 +2259,7 @@ extension Capture {
   public init<R: RegexComponent, W, NewCapture>(
     _ component: R,
     transform: @escaping (Substring) throws -> NewCapture
-  ) where Output == (Substring, NewCapture), R.Output == W {
+  ) where RegexOutput == (Substring, NewCapture), R.RegexOutput == W {
     self.init(node: .capture(.transform(
       CaptureTransform(resultType: NewCapture.self) {
         try transform($0) as Any
@@ -2272,7 +2272,7 @@ extension Capture {
     _ component: R,
     as reference: Reference<NewCapture>,
     transform: @escaping (Substring) throws -> NewCapture
-  ) where Output == (Substring, NewCapture), R.Output == W {
+  ) where RegexOutput == (Substring, NewCapture), R.RegexOutput == W {
     self.init(node: .capture(
       reference: reference.id,
       .transform(
@@ -2288,7 +2288,7 @@ extension TryCapture {
   public init<R: RegexComponent, W, NewCapture>(
     _ component: R,
     transform: @escaping (Substring) throws -> NewCapture?
-  ) where Output == (Substring, NewCapture), R.Output == W {
+  ) where RegexOutput == (Substring, NewCapture), R.RegexOutput == W {
     self.init(node: .capture(.transform(
       CaptureTransform(resultType: NewCapture.self) {
         try transform($0) as Any?
@@ -2301,7 +2301,7 @@ extension TryCapture {
     _ component: R,
     as reference: Reference<NewCapture>,
     transform: @escaping (Substring) throws -> NewCapture?
-  ) where Output == (Substring, NewCapture), R.Output == W {
+  ) where RegexOutput == (Substring, NewCapture), R.RegexOutput == W {
     self.init(node: .capture(
       reference: reference.id,
       .transform(
@@ -2318,7 +2318,7 @@ extension Capture {
   @_disfavoredOverload
   public init<R: RegexComponent, W>(
     @RegexComponentBuilder _ component: () -> R
-  ) where Output == (Substring, W), R.Output == W {
+  ) where RegexOutput == (Substring, W), R.RegexOutput == W {
     self.init(node: .capture(component().regex.root))
   }
 
@@ -2326,7 +2326,7 @@ extension Capture {
   public init<R: RegexComponent, W>(
     as reference: Reference<W>,
     @RegexComponentBuilder _ component: () -> R
-  ) where Output == (Substring, W), R.Output == W {
+  ) where RegexOutput == (Substring, W), R.RegexOutput == W {
     self.init(node: .capture(
       reference: reference.id,
       component().regex.root))
@@ -2336,7 +2336,7 @@ extension Capture {
   public init<R: RegexComponent, W, NewCapture>(
     @RegexComponentBuilder _ component: () -> R,
     transform: @escaping (Substring) throws -> NewCapture
-  ) where Output == (Substring, NewCapture), R.Output == W {
+  ) where RegexOutput == (Substring, NewCapture), R.RegexOutput == W {
     self.init(node: .capture(.transform(
       CaptureTransform(resultType: NewCapture.self) {
         try transform($0) as Any
@@ -2349,7 +2349,7 @@ extension Capture {
     as reference: Reference<NewCapture>,
     @RegexComponentBuilder _ component: () -> R,
     transform: @escaping (Substring) throws -> NewCapture
-  ) where Output == (Substring, NewCapture), R.Output == W {
+  ) where RegexOutput == (Substring, NewCapture), R.RegexOutput == W {
     self.init(node: .capture(
       reference: reference.id,
       .transform(
@@ -2365,7 +2365,7 @@ extension TryCapture {
   public init<R: RegexComponent, W, NewCapture>(
     @RegexComponentBuilder _ component: () -> R,
     transform: @escaping (Substring) throws -> NewCapture?
-  ) where Output == (Substring, NewCapture), R.Output == W {
+  ) where RegexOutput == (Substring, NewCapture), R.RegexOutput == W {
     self.init(node: .capture(.transform(
       CaptureTransform(resultType: NewCapture.self) {
         try transform($0) as Any?
@@ -2378,7 +2378,7 @@ extension TryCapture {
     as reference: Reference<NewCapture>,
     @RegexComponentBuilder _ component: () -> R,
     transform: @escaping (Substring) throws -> NewCapture?
-  ) where Output == (Substring, NewCapture), R.Output == W {
+  ) where RegexOutput == (Substring, NewCapture), R.RegexOutput == W {
     self.init(node: .capture(
       reference: reference.id,
       .transform(
@@ -2394,20 +2394,20 @@ extension TryCapture {
 extension Capture {
     public init<R: RegexComponent, W, C0>(
     _ component: R
-  ) where Output == (Substring, W, C0), R.Output == (W, C0) {
+  ) where RegexOutput == (Substring, W, C0), R.RegexOutput == (W, C0) {
     self.init(node: .capture(component.regex.root))
   }
 
     public init<R: RegexComponent, W, C0>(
     _ component: R, as reference: Reference<W>
-  ) where Output == (Substring, W, C0), R.Output == (W, C0) {
+  ) where RegexOutput == (Substring, W, C0), R.RegexOutput == (W, C0) {
     self.init(node: .capture(reference: reference.id, component.regex.root))
   }
 
     public init<R: RegexComponent, W, C0, NewCapture>(
     _ component: R,
     transform: @escaping (Substring) throws -> NewCapture
-  ) where Output == (Substring, NewCapture, C0), R.Output == (W, C0) {
+  ) where RegexOutput == (Substring, NewCapture, C0), R.RegexOutput == (W, C0) {
     self.init(node: .capture(.transform(
       CaptureTransform(resultType: NewCapture.self) {
         try transform($0) as Any
@@ -2419,7 +2419,7 @@ extension Capture {
     _ component: R,
     as reference: Reference<NewCapture>,
     transform: @escaping (Substring) throws -> NewCapture
-  ) where Output == (Substring, NewCapture, C0), R.Output == (W, C0) {
+  ) where RegexOutput == (Substring, NewCapture, C0), R.RegexOutput == (W, C0) {
     self.init(node: .capture(
       reference: reference.id,
       .transform(
@@ -2434,7 +2434,7 @@ extension TryCapture {
     public init<R: RegexComponent, W, C0, NewCapture>(
     _ component: R,
     transform: @escaping (Substring) throws -> NewCapture?
-  ) where Output == (Substring, NewCapture, C0), R.Output == (W, C0) {
+  ) where RegexOutput == (Substring, NewCapture, C0), R.RegexOutput == (W, C0) {
     self.init(node: .capture(.transform(
       CaptureTransform(resultType: NewCapture.self) {
         try transform($0) as Any?
@@ -2446,7 +2446,7 @@ extension TryCapture {
     _ component: R,
     as reference: Reference<NewCapture>,
     transform: @escaping (Substring) throws -> NewCapture?
-  ) where Output == (Substring, NewCapture, C0), R.Output == (W, C0) {
+  ) where RegexOutput == (Substring, NewCapture, C0), R.RegexOutput == (W, C0) {
     self.init(node: .capture(
       reference: reference.id,
       .transform(
@@ -2462,14 +2462,14 @@ extension TryCapture {
 extension Capture {
     public init<R: RegexComponent, W, C0>(
     @RegexComponentBuilder _ component: () -> R
-  ) where Output == (Substring, W, C0), R.Output == (W, C0) {
+  ) where RegexOutput == (Substring, W, C0), R.RegexOutput == (W, C0) {
     self.init(node: .capture(component().regex.root))
   }
 
     public init<R: RegexComponent, W, C0>(
     as reference: Reference<W>,
     @RegexComponentBuilder _ component: () -> R
-  ) where Output == (Substring, W, C0), R.Output == (W, C0) {
+  ) where RegexOutput == (Substring, W, C0), R.RegexOutput == (W, C0) {
     self.init(node: .capture(
       reference: reference.id,
       component().regex.root))
@@ -2478,7 +2478,7 @@ extension Capture {
     public init<R: RegexComponent, W, C0, NewCapture>(
     @RegexComponentBuilder _ component: () -> R,
     transform: @escaping (Substring) throws -> NewCapture
-  ) where Output == (Substring, NewCapture, C0), R.Output == (W, C0) {
+  ) where RegexOutput == (Substring, NewCapture, C0), R.RegexOutput == (W, C0) {
     self.init(node: .capture(.transform(
       CaptureTransform(resultType: NewCapture.self) {
         try transform($0) as Any
@@ -2490,7 +2490,7 @@ extension Capture {
     as reference: Reference<NewCapture>,
     @RegexComponentBuilder _ component: () -> R,
     transform: @escaping (Substring) throws -> NewCapture
-  ) where Output == (Substring, NewCapture, C0), R.Output == (W, C0) {
+  ) where RegexOutput == (Substring, NewCapture, C0), R.RegexOutput == (W, C0) {
     self.init(node: .capture(
       reference: reference.id,
       .transform(
@@ -2505,7 +2505,7 @@ extension TryCapture {
     public init<R: RegexComponent, W, C0, NewCapture>(
     @RegexComponentBuilder _ component: () -> R,
     transform: @escaping (Substring) throws -> NewCapture?
-  ) where Output == (Substring, NewCapture, C0), R.Output == (W, C0) {
+  ) where RegexOutput == (Substring, NewCapture, C0), R.RegexOutput == (W, C0) {
     self.init(node: .capture(.transform(
       CaptureTransform(resultType: NewCapture.self) {
         try transform($0) as Any?
@@ -2517,7 +2517,7 @@ extension TryCapture {
     as reference: Reference<NewCapture>,
     @RegexComponentBuilder _ component: () -> R,
     transform: @escaping (Substring) throws -> NewCapture?
-  ) where Output == (Substring, NewCapture, C0), R.Output == (W, C0) {
+  ) where RegexOutput == (Substring, NewCapture, C0), R.RegexOutput == (W, C0) {
     self.init(node: .capture(
       reference: reference.id,
       .transform(
@@ -2533,20 +2533,20 @@ extension TryCapture {
 extension Capture {
     public init<R: RegexComponent, W, C0, C1>(
     _ component: R
-  ) where Output == (Substring, W, C0, C1), R.Output == (W, C0, C1) {
+  ) where RegexOutput == (Substring, W, C0, C1), R.RegexOutput == (W, C0, C1) {
     self.init(node: .capture(component.regex.root))
   }
 
     public init<R: RegexComponent, W, C0, C1>(
     _ component: R, as reference: Reference<W>
-  ) where Output == (Substring, W, C0, C1), R.Output == (W, C0, C1) {
+  ) where RegexOutput == (Substring, W, C0, C1), R.RegexOutput == (W, C0, C1) {
     self.init(node: .capture(reference: reference.id, component.regex.root))
   }
 
     public init<R: RegexComponent, W, C0, C1, NewCapture>(
     _ component: R,
     transform: @escaping (Substring) throws -> NewCapture
-  ) where Output == (Substring, NewCapture, C0, C1), R.Output == (W, C0, C1) {
+  ) where RegexOutput == (Substring, NewCapture, C0, C1), R.RegexOutput == (W, C0, C1) {
     self.init(node: .capture(.transform(
       CaptureTransform(resultType: NewCapture.self) {
         try transform($0) as Any
@@ -2558,7 +2558,7 @@ extension Capture {
     _ component: R,
     as reference: Reference<NewCapture>,
     transform: @escaping (Substring) throws -> NewCapture
-  ) where Output == (Substring, NewCapture, C0, C1), R.Output == (W, C0, C1) {
+  ) where RegexOutput == (Substring, NewCapture, C0, C1), R.RegexOutput == (W, C0, C1) {
     self.init(node: .capture(
       reference: reference.id,
       .transform(
@@ -2573,7 +2573,7 @@ extension TryCapture {
     public init<R: RegexComponent, W, C0, C1, NewCapture>(
     _ component: R,
     transform: @escaping (Substring) throws -> NewCapture?
-  ) where Output == (Substring, NewCapture, C0, C1), R.Output == (W, C0, C1) {
+  ) where RegexOutput == (Substring, NewCapture, C0, C1), R.RegexOutput == (W, C0, C1) {
     self.init(node: .capture(.transform(
       CaptureTransform(resultType: NewCapture.self) {
         try transform($0) as Any?
@@ -2585,7 +2585,7 @@ extension TryCapture {
     _ component: R,
     as reference: Reference<NewCapture>,
     transform: @escaping (Substring) throws -> NewCapture?
-  ) where Output == (Substring, NewCapture, C0, C1), R.Output == (W, C0, C1) {
+  ) where RegexOutput == (Substring, NewCapture, C0, C1), R.RegexOutput == (W, C0, C1) {
     self.init(node: .capture(
       reference: reference.id,
       .transform(
@@ -2601,14 +2601,14 @@ extension TryCapture {
 extension Capture {
     public init<R: RegexComponent, W, C0, C1>(
     @RegexComponentBuilder _ component: () -> R
-  ) where Output == (Substring, W, C0, C1), R.Output == (W, C0, C1) {
+  ) where RegexOutput == (Substring, W, C0, C1), R.RegexOutput == (W, C0, C1) {
     self.init(node: .capture(component().regex.root))
   }
 
     public init<R: RegexComponent, W, C0, C1>(
     as reference: Reference<W>,
     @RegexComponentBuilder _ component: () -> R
-  ) where Output == (Substring, W, C0, C1), R.Output == (W, C0, C1) {
+  ) where RegexOutput == (Substring, W, C0, C1), R.RegexOutput == (W, C0, C1) {
     self.init(node: .capture(
       reference: reference.id,
       component().regex.root))
@@ -2617,7 +2617,7 @@ extension Capture {
     public init<R: RegexComponent, W, C0, C1, NewCapture>(
     @RegexComponentBuilder _ component: () -> R,
     transform: @escaping (Substring) throws -> NewCapture
-  ) where Output == (Substring, NewCapture, C0, C1), R.Output == (W, C0, C1) {
+  ) where RegexOutput == (Substring, NewCapture, C0, C1), R.RegexOutput == (W, C0, C1) {
     self.init(node: .capture(.transform(
       CaptureTransform(resultType: NewCapture.self) {
         try transform($0) as Any
@@ -2629,7 +2629,7 @@ extension Capture {
     as reference: Reference<NewCapture>,
     @RegexComponentBuilder _ component: () -> R,
     transform: @escaping (Substring) throws -> NewCapture
-  ) where Output == (Substring, NewCapture, C0, C1), R.Output == (W, C0, C1) {
+  ) where RegexOutput == (Substring, NewCapture, C0, C1), R.RegexOutput == (W, C0, C1) {
     self.init(node: .capture(
       reference: reference.id,
       .transform(
@@ -2644,7 +2644,7 @@ extension TryCapture {
     public init<R: RegexComponent, W, C0, C1, NewCapture>(
     @RegexComponentBuilder _ component: () -> R,
     transform: @escaping (Substring) throws -> NewCapture?
-  ) where Output == (Substring, NewCapture, C0, C1), R.Output == (W, C0, C1) {
+  ) where RegexOutput == (Substring, NewCapture, C0, C1), R.RegexOutput == (W, C0, C1) {
     self.init(node: .capture(.transform(
       CaptureTransform(resultType: NewCapture.self) {
         try transform($0) as Any?
@@ -2656,7 +2656,7 @@ extension TryCapture {
     as reference: Reference<NewCapture>,
     @RegexComponentBuilder _ component: () -> R,
     transform: @escaping (Substring) throws -> NewCapture?
-  ) where Output == (Substring, NewCapture, C0, C1), R.Output == (W, C0, C1) {
+  ) where RegexOutput == (Substring, NewCapture, C0, C1), R.RegexOutput == (W, C0, C1) {
     self.init(node: .capture(
       reference: reference.id,
       .transform(
@@ -2672,20 +2672,20 @@ extension TryCapture {
 extension Capture {
     public init<R: RegexComponent, W, C0, C1, C2>(
     _ component: R
-  ) where Output == (Substring, W, C0, C1, C2), R.Output == (W, C0, C1, C2) {
+  ) where RegexOutput == (Substring, W, C0, C1, C2), R.RegexOutput == (W, C0, C1, C2) {
     self.init(node: .capture(component.regex.root))
   }
 
     public init<R: RegexComponent, W, C0, C1, C2>(
     _ component: R, as reference: Reference<W>
-  ) where Output == (Substring, W, C0, C1, C2), R.Output == (W, C0, C1, C2) {
+  ) where RegexOutput == (Substring, W, C0, C1, C2), R.RegexOutput == (W, C0, C1, C2) {
     self.init(node: .capture(reference: reference.id, component.regex.root))
   }
 
     public init<R: RegexComponent, W, C0, C1, C2, NewCapture>(
     _ component: R,
     transform: @escaping (Substring) throws -> NewCapture
-  ) where Output == (Substring, NewCapture, C0, C1, C2), R.Output == (W, C0, C1, C2) {
+  ) where RegexOutput == (Substring, NewCapture, C0, C1, C2), R.RegexOutput == (W, C0, C1, C2) {
     self.init(node: .capture(.transform(
       CaptureTransform(resultType: NewCapture.self) {
         try transform($0) as Any
@@ -2697,7 +2697,7 @@ extension Capture {
     _ component: R,
     as reference: Reference<NewCapture>,
     transform: @escaping (Substring) throws -> NewCapture
-  ) where Output == (Substring, NewCapture, C0, C1, C2), R.Output == (W, C0, C1, C2) {
+  ) where RegexOutput == (Substring, NewCapture, C0, C1, C2), R.RegexOutput == (W, C0, C1, C2) {
     self.init(node: .capture(
       reference: reference.id,
       .transform(
@@ -2712,7 +2712,7 @@ extension TryCapture {
     public init<R: RegexComponent, W, C0, C1, C2, NewCapture>(
     _ component: R,
     transform: @escaping (Substring) throws -> NewCapture?
-  ) where Output == (Substring, NewCapture, C0, C1, C2), R.Output == (W, C0, C1, C2) {
+  ) where RegexOutput == (Substring, NewCapture, C0, C1, C2), R.RegexOutput == (W, C0, C1, C2) {
     self.init(node: .capture(.transform(
       CaptureTransform(resultType: NewCapture.self) {
         try transform($0) as Any?
@@ -2724,7 +2724,7 @@ extension TryCapture {
     _ component: R,
     as reference: Reference<NewCapture>,
     transform: @escaping (Substring) throws -> NewCapture?
-  ) where Output == (Substring, NewCapture, C0, C1, C2), R.Output == (W, C0, C1, C2) {
+  ) where RegexOutput == (Substring, NewCapture, C0, C1, C2), R.RegexOutput == (W, C0, C1, C2) {
     self.init(node: .capture(
       reference: reference.id,
       .transform(
@@ -2740,14 +2740,14 @@ extension TryCapture {
 extension Capture {
     public init<R: RegexComponent, W, C0, C1, C2>(
     @RegexComponentBuilder _ component: () -> R
-  ) where Output == (Substring, W, C0, C1, C2), R.Output == (W, C0, C1, C2) {
+  ) where RegexOutput == (Substring, W, C0, C1, C2), R.RegexOutput == (W, C0, C1, C2) {
     self.init(node: .capture(component().regex.root))
   }
 
     public init<R: RegexComponent, W, C0, C1, C2>(
     as reference: Reference<W>,
     @RegexComponentBuilder _ component: () -> R
-  ) where Output == (Substring, W, C0, C1, C2), R.Output == (W, C0, C1, C2) {
+  ) where RegexOutput == (Substring, W, C0, C1, C2), R.RegexOutput == (W, C0, C1, C2) {
     self.init(node: .capture(
       reference: reference.id,
       component().regex.root))
@@ -2756,7 +2756,7 @@ extension Capture {
     public init<R: RegexComponent, W, C0, C1, C2, NewCapture>(
     @RegexComponentBuilder _ component: () -> R,
     transform: @escaping (Substring) throws -> NewCapture
-  ) where Output == (Substring, NewCapture, C0, C1, C2), R.Output == (W, C0, C1, C2) {
+  ) where RegexOutput == (Substring, NewCapture, C0, C1, C2), R.RegexOutput == (W, C0, C1, C2) {
     self.init(node: .capture(.transform(
       CaptureTransform(resultType: NewCapture.self) {
         try transform($0) as Any
@@ -2768,7 +2768,7 @@ extension Capture {
     as reference: Reference<NewCapture>,
     @RegexComponentBuilder _ component: () -> R,
     transform: @escaping (Substring) throws -> NewCapture
-  ) where Output == (Substring, NewCapture, C0, C1, C2), R.Output == (W, C0, C1, C2) {
+  ) where RegexOutput == (Substring, NewCapture, C0, C1, C2), R.RegexOutput == (W, C0, C1, C2) {
     self.init(node: .capture(
       reference: reference.id,
       .transform(
@@ -2783,7 +2783,7 @@ extension TryCapture {
     public init<R: RegexComponent, W, C0, C1, C2, NewCapture>(
     @RegexComponentBuilder _ component: () -> R,
     transform: @escaping (Substring) throws -> NewCapture?
-  ) where Output == (Substring, NewCapture, C0, C1, C2), R.Output == (W, C0, C1, C2) {
+  ) where RegexOutput == (Substring, NewCapture, C0, C1, C2), R.RegexOutput == (W, C0, C1, C2) {
     self.init(node: .capture(.transform(
       CaptureTransform(resultType: NewCapture.self) {
         try transform($0) as Any?
@@ -2795,7 +2795,7 @@ extension TryCapture {
     as reference: Reference<NewCapture>,
     @RegexComponentBuilder _ component: () -> R,
     transform: @escaping (Substring) throws -> NewCapture?
-  ) where Output == (Substring, NewCapture, C0, C1, C2), R.Output == (W, C0, C1, C2) {
+  ) where RegexOutput == (Substring, NewCapture, C0, C1, C2), R.RegexOutput == (W, C0, C1, C2) {
     self.init(node: .capture(
       reference: reference.id,
       .transform(
@@ -2811,20 +2811,20 @@ extension TryCapture {
 extension Capture {
     public init<R: RegexComponent, W, C0, C1, C2, C3>(
     _ component: R
-  ) where Output == (Substring, W, C0, C1, C2, C3), R.Output == (W, C0, C1, C2, C3) {
+  ) where RegexOutput == (Substring, W, C0, C1, C2, C3), R.RegexOutput == (W, C0, C1, C2, C3) {
     self.init(node: .capture(component.regex.root))
   }
 
     public init<R: RegexComponent, W, C0, C1, C2, C3>(
     _ component: R, as reference: Reference<W>
-  ) where Output == (Substring, W, C0, C1, C2, C3), R.Output == (W, C0, C1, C2, C3) {
+  ) where RegexOutput == (Substring, W, C0, C1, C2, C3), R.RegexOutput == (W, C0, C1, C2, C3) {
     self.init(node: .capture(reference: reference.id, component.regex.root))
   }
 
     public init<R: RegexComponent, W, C0, C1, C2, C3, NewCapture>(
     _ component: R,
     transform: @escaping (Substring) throws -> NewCapture
-  ) where Output == (Substring, NewCapture, C0, C1, C2, C3), R.Output == (W, C0, C1, C2, C3) {
+  ) where RegexOutput == (Substring, NewCapture, C0, C1, C2, C3), R.RegexOutput == (W, C0, C1, C2, C3) {
     self.init(node: .capture(.transform(
       CaptureTransform(resultType: NewCapture.self) {
         try transform($0) as Any
@@ -2836,7 +2836,7 @@ extension Capture {
     _ component: R,
     as reference: Reference<NewCapture>,
     transform: @escaping (Substring) throws -> NewCapture
-  ) where Output == (Substring, NewCapture, C0, C1, C2, C3), R.Output == (W, C0, C1, C2, C3) {
+  ) where RegexOutput == (Substring, NewCapture, C0, C1, C2, C3), R.RegexOutput == (W, C0, C1, C2, C3) {
     self.init(node: .capture(
       reference: reference.id,
       .transform(
@@ -2851,7 +2851,7 @@ extension TryCapture {
     public init<R: RegexComponent, W, C0, C1, C2, C3, NewCapture>(
     _ component: R,
     transform: @escaping (Substring) throws -> NewCapture?
-  ) where Output == (Substring, NewCapture, C0, C1, C2, C3), R.Output == (W, C0, C1, C2, C3) {
+  ) where RegexOutput == (Substring, NewCapture, C0, C1, C2, C3), R.RegexOutput == (W, C0, C1, C2, C3) {
     self.init(node: .capture(.transform(
       CaptureTransform(resultType: NewCapture.self) {
         try transform($0) as Any?
@@ -2863,7 +2863,7 @@ extension TryCapture {
     _ component: R,
     as reference: Reference<NewCapture>,
     transform: @escaping (Substring) throws -> NewCapture?
-  ) where Output == (Substring, NewCapture, C0, C1, C2, C3), R.Output == (W, C0, C1, C2, C3) {
+  ) where RegexOutput == (Substring, NewCapture, C0, C1, C2, C3), R.RegexOutput == (W, C0, C1, C2, C3) {
     self.init(node: .capture(
       reference: reference.id,
       .transform(
@@ -2879,14 +2879,14 @@ extension TryCapture {
 extension Capture {
     public init<R: RegexComponent, W, C0, C1, C2, C3>(
     @RegexComponentBuilder _ component: () -> R
-  ) where Output == (Substring, W, C0, C1, C2, C3), R.Output == (W, C0, C1, C2, C3) {
+  ) where RegexOutput == (Substring, W, C0, C1, C2, C3), R.RegexOutput == (W, C0, C1, C2, C3) {
     self.init(node: .capture(component().regex.root))
   }
 
     public init<R: RegexComponent, W, C0, C1, C2, C3>(
     as reference: Reference<W>,
     @RegexComponentBuilder _ component: () -> R
-  ) where Output == (Substring, W, C0, C1, C2, C3), R.Output == (W, C0, C1, C2, C3) {
+  ) where RegexOutput == (Substring, W, C0, C1, C2, C3), R.RegexOutput == (W, C0, C1, C2, C3) {
     self.init(node: .capture(
       reference: reference.id,
       component().regex.root))
@@ -2895,7 +2895,7 @@ extension Capture {
     public init<R: RegexComponent, W, C0, C1, C2, C3, NewCapture>(
     @RegexComponentBuilder _ component: () -> R,
     transform: @escaping (Substring) throws -> NewCapture
-  ) where Output == (Substring, NewCapture, C0, C1, C2, C3), R.Output == (W, C0, C1, C2, C3) {
+  ) where RegexOutput == (Substring, NewCapture, C0, C1, C2, C3), R.RegexOutput == (W, C0, C1, C2, C3) {
     self.init(node: .capture(.transform(
       CaptureTransform(resultType: NewCapture.self) {
         try transform($0) as Any
@@ -2907,7 +2907,7 @@ extension Capture {
     as reference: Reference<NewCapture>,
     @RegexComponentBuilder _ component: () -> R,
     transform: @escaping (Substring) throws -> NewCapture
-  ) where Output == (Substring, NewCapture, C0, C1, C2, C3), R.Output == (W, C0, C1, C2, C3) {
+  ) where RegexOutput == (Substring, NewCapture, C0, C1, C2, C3), R.RegexOutput == (W, C0, C1, C2, C3) {
     self.init(node: .capture(
       reference: reference.id,
       .transform(
@@ -2922,7 +2922,7 @@ extension TryCapture {
     public init<R: RegexComponent, W, C0, C1, C2, C3, NewCapture>(
     @RegexComponentBuilder _ component: () -> R,
     transform: @escaping (Substring) throws -> NewCapture?
-  ) where Output == (Substring, NewCapture, C0, C1, C2, C3), R.Output == (W, C0, C1, C2, C3) {
+  ) where RegexOutput == (Substring, NewCapture, C0, C1, C2, C3), R.RegexOutput == (W, C0, C1, C2, C3) {
     self.init(node: .capture(.transform(
       CaptureTransform(resultType: NewCapture.self) {
         try transform($0) as Any?
@@ -2934,7 +2934,7 @@ extension TryCapture {
     as reference: Reference<NewCapture>,
     @RegexComponentBuilder _ component: () -> R,
     transform: @escaping (Substring) throws -> NewCapture?
-  ) where Output == (Substring, NewCapture, C0, C1, C2, C3), R.Output == (W, C0, C1, C2, C3) {
+  ) where RegexOutput == (Substring, NewCapture, C0, C1, C2, C3), R.RegexOutput == (W, C0, C1, C2, C3) {
     self.init(node: .capture(
       reference: reference.id,
       .transform(
@@ -2950,20 +2950,20 @@ extension TryCapture {
 extension Capture {
     public init<R: RegexComponent, W, C0, C1, C2, C3, C4>(
     _ component: R
-  ) where Output == (Substring, W, C0, C1, C2, C3, C4), R.Output == (W, C0, C1, C2, C3, C4) {
+  ) where RegexOutput == (Substring, W, C0, C1, C2, C3, C4), R.RegexOutput == (W, C0, C1, C2, C3, C4) {
     self.init(node: .capture(component.regex.root))
   }
 
     public init<R: RegexComponent, W, C0, C1, C2, C3, C4>(
     _ component: R, as reference: Reference<W>
-  ) where Output == (Substring, W, C0, C1, C2, C3, C4), R.Output == (W, C0, C1, C2, C3, C4) {
+  ) where RegexOutput == (Substring, W, C0, C1, C2, C3, C4), R.RegexOutput == (W, C0, C1, C2, C3, C4) {
     self.init(node: .capture(reference: reference.id, component.regex.root))
   }
 
     public init<R: RegexComponent, W, C0, C1, C2, C3, C4, NewCapture>(
     _ component: R,
     transform: @escaping (Substring) throws -> NewCapture
-  ) where Output == (Substring, NewCapture, C0, C1, C2, C3, C4), R.Output == (W, C0, C1, C2, C3, C4) {
+  ) where RegexOutput == (Substring, NewCapture, C0, C1, C2, C3, C4), R.RegexOutput == (W, C0, C1, C2, C3, C4) {
     self.init(node: .capture(.transform(
       CaptureTransform(resultType: NewCapture.self) {
         try transform($0) as Any
@@ -2975,7 +2975,7 @@ extension Capture {
     _ component: R,
     as reference: Reference<NewCapture>,
     transform: @escaping (Substring) throws -> NewCapture
-  ) where Output == (Substring, NewCapture, C0, C1, C2, C3, C4), R.Output == (W, C0, C1, C2, C3, C4) {
+  ) where RegexOutput == (Substring, NewCapture, C0, C1, C2, C3, C4), R.RegexOutput == (W, C0, C1, C2, C3, C4) {
     self.init(node: .capture(
       reference: reference.id,
       .transform(
@@ -2990,7 +2990,7 @@ extension TryCapture {
     public init<R: RegexComponent, W, C0, C1, C2, C3, C4, NewCapture>(
     _ component: R,
     transform: @escaping (Substring) throws -> NewCapture?
-  ) where Output == (Substring, NewCapture, C0, C1, C2, C3, C4), R.Output == (W, C0, C1, C2, C3, C4) {
+  ) where RegexOutput == (Substring, NewCapture, C0, C1, C2, C3, C4), R.RegexOutput == (W, C0, C1, C2, C3, C4) {
     self.init(node: .capture(.transform(
       CaptureTransform(resultType: NewCapture.self) {
         try transform($0) as Any?
@@ -3002,7 +3002,7 @@ extension TryCapture {
     _ component: R,
     as reference: Reference<NewCapture>,
     transform: @escaping (Substring) throws -> NewCapture?
-  ) where Output == (Substring, NewCapture, C0, C1, C2, C3, C4), R.Output == (W, C0, C1, C2, C3, C4) {
+  ) where RegexOutput == (Substring, NewCapture, C0, C1, C2, C3, C4), R.RegexOutput == (W, C0, C1, C2, C3, C4) {
     self.init(node: .capture(
       reference: reference.id,
       .transform(
@@ -3018,14 +3018,14 @@ extension TryCapture {
 extension Capture {
     public init<R: RegexComponent, W, C0, C1, C2, C3, C4>(
     @RegexComponentBuilder _ component: () -> R
-  ) where Output == (Substring, W, C0, C1, C2, C3, C4), R.Output == (W, C0, C1, C2, C3, C4) {
+  ) where RegexOutput == (Substring, W, C0, C1, C2, C3, C4), R.RegexOutput == (W, C0, C1, C2, C3, C4) {
     self.init(node: .capture(component().regex.root))
   }
 
     public init<R: RegexComponent, W, C0, C1, C2, C3, C4>(
     as reference: Reference<W>,
     @RegexComponentBuilder _ component: () -> R
-  ) where Output == (Substring, W, C0, C1, C2, C3, C4), R.Output == (W, C0, C1, C2, C3, C4) {
+  ) where RegexOutput == (Substring, W, C0, C1, C2, C3, C4), R.RegexOutput == (W, C0, C1, C2, C3, C4) {
     self.init(node: .capture(
       reference: reference.id,
       component().regex.root))
@@ -3034,7 +3034,7 @@ extension Capture {
     public init<R: RegexComponent, W, C0, C1, C2, C3, C4, NewCapture>(
     @RegexComponentBuilder _ component: () -> R,
     transform: @escaping (Substring) throws -> NewCapture
-  ) where Output == (Substring, NewCapture, C0, C1, C2, C3, C4), R.Output == (W, C0, C1, C2, C3, C4) {
+  ) where RegexOutput == (Substring, NewCapture, C0, C1, C2, C3, C4), R.RegexOutput == (W, C0, C1, C2, C3, C4) {
     self.init(node: .capture(.transform(
       CaptureTransform(resultType: NewCapture.self) {
         try transform($0) as Any
@@ -3046,7 +3046,7 @@ extension Capture {
     as reference: Reference<NewCapture>,
     @RegexComponentBuilder _ component: () -> R,
     transform: @escaping (Substring) throws -> NewCapture
-  ) where Output == (Substring, NewCapture, C0, C1, C2, C3, C4), R.Output == (W, C0, C1, C2, C3, C4) {
+  ) where RegexOutput == (Substring, NewCapture, C0, C1, C2, C3, C4), R.RegexOutput == (W, C0, C1, C2, C3, C4) {
     self.init(node: .capture(
       reference: reference.id,
       .transform(
@@ -3061,7 +3061,7 @@ extension TryCapture {
     public init<R: RegexComponent, W, C0, C1, C2, C3, C4, NewCapture>(
     @RegexComponentBuilder _ component: () -> R,
     transform: @escaping (Substring) throws -> NewCapture?
-  ) where Output == (Substring, NewCapture, C0, C1, C2, C3, C4), R.Output == (W, C0, C1, C2, C3, C4) {
+  ) where RegexOutput == (Substring, NewCapture, C0, C1, C2, C3, C4), R.RegexOutput == (W, C0, C1, C2, C3, C4) {
     self.init(node: .capture(.transform(
       CaptureTransform(resultType: NewCapture.self) {
         try transform($0) as Any?
@@ -3073,7 +3073,7 @@ extension TryCapture {
     as reference: Reference<NewCapture>,
     @RegexComponentBuilder _ component: () -> R,
     transform: @escaping (Substring) throws -> NewCapture?
-  ) where Output == (Substring, NewCapture, C0, C1, C2, C3, C4), R.Output == (W, C0, C1, C2, C3, C4) {
+  ) where RegexOutput == (Substring, NewCapture, C0, C1, C2, C3, C4), R.RegexOutput == (W, C0, C1, C2, C3, C4) {
     self.init(node: .capture(
       reference: reference.id,
       .transform(
@@ -3089,20 +3089,20 @@ extension TryCapture {
 extension Capture {
     public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5>(
     _ component: R
-  ) where Output == (Substring, W, C0, C1, C2, C3, C4, C5), R.Output == (W, C0, C1, C2, C3, C4, C5) {
+  ) where RegexOutput == (Substring, W, C0, C1, C2, C3, C4, C5), R.RegexOutput == (W, C0, C1, C2, C3, C4, C5) {
     self.init(node: .capture(component.regex.root))
   }
 
     public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5>(
     _ component: R, as reference: Reference<W>
-  ) where Output == (Substring, W, C0, C1, C2, C3, C4, C5), R.Output == (W, C0, C1, C2, C3, C4, C5) {
+  ) where RegexOutput == (Substring, W, C0, C1, C2, C3, C4, C5), R.RegexOutput == (W, C0, C1, C2, C3, C4, C5) {
     self.init(node: .capture(reference: reference.id, component.regex.root))
   }
 
     public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, NewCapture>(
     _ component: R,
     transform: @escaping (Substring) throws -> NewCapture
-  ) where Output == (Substring, NewCapture, C0, C1, C2, C3, C4, C5), R.Output == (W, C0, C1, C2, C3, C4, C5) {
+  ) where RegexOutput == (Substring, NewCapture, C0, C1, C2, C3, C4, C5), R.RegexOutput == (W, C0, C1, C2, C3, C4, C5) {
     self.init(node: .capture(.transform(
       CaptureTransform(resultType: NewCapture.self) {
         try transform($0) as Any
@@ -3114,7 +3114,7 @@ extension Capture {
     _ component: R,
     as reference: Reference<NewCapture>,
     transform: @escaping (Substring) throws -> NewCapture
-  ) where Output == (Substring, NewCapture, C0, C1, C2, C3, C4, C5), R.Output == (W, C0, C1, C2, C3, C4, C5) {
+  ) where RegexOutput == (Substring, NewCapture, C0, C1, C2, C3, C4, C5), R.RegexOutput == (W, C0, C1, C2, C3, C4, C5) {
     self.init(node: .capture(
       reference: reference.id,
       .transform(
@@ -3129,7 +3129,7 @@ extension TryCapture {
     public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, NewCapture>(
     _ component: R,
     transform: @escaping (Substring) throws -> NewCapture?
-  ) where Output == (Substring, NewCapture, C0, C1, C2, C3, C4, C5), R.Output == (W, C0, C1, C2, C3, C4, C5) {
+  ) where RegexOutput == (Substring, NewCapture, C0, C1, C2, C3, C4, C5), R.RegexOutput == (W, C0, C1, C2, C3, C4, C5) {
     self.init(node: .capture(.transform(
       CaptureTransform(resultType: NewCapture.self) {
         try transform($0) as Any?
@@ -3141,7 +3141,7 @@ extension TryCapture {
     _ component: R,
     as reference: Reference<NewCapture>,
     transform: @escaping (Substring) throws -> NewCapture?
-  ) where Output == (Substring, NewCapture, C0, C1, C2, C3, C4, C5), R.Output == (W, C0, C1, C2, C3, C4, C5) {
+  ) where RegexOutput == (Substring, NewCapture, C0, C1, C2, C3, C4, C5), R.RegexOutput == (W, C0, C1, C2, C3, C4, C5) {
     self.init(node: .capture(
       reference: reference.id,
       .transform(
@@ -3157,14 +3157,14 @@ extension TryCapture {
 extension Capture {
     public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5>(
     @RegexComponentBuilder _ component: () -> R
-  ) where Output == (Substring, W, C0, C1, C2, C3, C4, C5), R.Output == (W, C0, C1, C2, C3, C4, C5) {
+  ) where RegexOutput == (Substring, W, C0, C1, C2, C3, C4, C5), R.RegexOutput == (W, C0, C1, C2, C3, C4, C5) {
     self.init(node: .capture(component().regex.root))
   }
 
     public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5>(
     as reference: Reference<W>,
     @RegexComponentBuilder _ component: () -> R
-  ) where Output == (Substring, W, C0, C1, C2, C3, C4, C5), R.Output == (W, C0, C1, C2, C3, C4, C5) {
+  ) where RegexOutput == (Substring, W, C0, C1, C2, C3, C4, C5), R.RegexOutput == (W, C0, C1, C2, C3, C4, C5) {
     self.init(node: .capture(
       reference: reference.id,
       component().regex.root))
@@ -3173,7 +3173,7 @@ extension Capture {
     public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, NewCapture>(
     @RegexComponentBuilder _ component: () -> R,
     transform: @escaping (Substring) throws -> NewCapture
-  ) where Output == (Substring, NewCapture, C0, C1, C2, C3, C4, C5), R.Output == (W, C0, C1, C2, C3, C4, C5) {
+  ) where RegexOutput == (Substring, NewCapture, C0, C1, C2, C3, C4, C5), R.RegexOutput == (W, C0, C1, C2, C3, C4, C5) {
     self.init(node: .capture(.transform(
       CaptureTransform(resultType: NewCapture.self) {
         try transform($0) as Any
@@ -3185,7 +3185,7 @@ extension Capture {
     as reference: Reference<NewCapture>,
     @RegexComponentBuilder _ component: () -> R,
     transform: @escaping (Substring) throws -> NewCapture
-  ) where Output == (Substring, NewCapture, C0, C1, C2, C3, C4, C5), R.Output == (W, C0, C1, C2, C3, C4, C5) {
+  ) where RegexOutput == (Substring, NewCapture, C0, C1, C2, C3, C4, C5), R.RegexOutput == (W, C0, C1, C2, C3, C4, C5) {
     self.init(node: .capture(
       reference: reference.id,
       .transform(
@@ -3200,7 +3200,7 @@ extension TryCapture {
     public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, NewCapture>(
     @RegexComponentBuilder _ component: () -> R,
     transform: @escaping (Substring) throws -> NewCapture?
-  ) where Output == (Substring, NewCapture, C0, C1, C2, C3, C4, C5), R.Output == (W, C0, C1, C2, C3, C4, C5) {
+  ) where RegexOutput == (Substring, NewCapture, C0, C1, C2, C3, C4, C5), R.RegexOutput == (W, C0, C1, C2, C3, C4, C5) {
     self.init(node: .capture(.transform(
       CaptureTransform(resultType: NewCapture.self) {
         try transform($0) as Any?
@@ -3212,7 +3212,7 @@ extension TryCapture {
     as reference: Reference<NewCapture>,
     @RegexComponentBuilder _ component: () -> R,
     transform: @escaping (Substring) throws -> NewCapture?
-  ) where Output == (Substring, NewCapture, C0, C1, C2, C3, C4, C5), R.Output == (W, C0, C1, C2, C3, C4, C5) {
+  ) where RegexOutput == (Substring, NewCapture, C0, C1, C2, C3, C4, C5), R.RegexOutput == (W, C0, C1, C2, C3, C4, C5) {
     self.init(node: .capture(
       reference: reference.id,
       .transform(
@@ -3228,20 +3228,20 @@ extension TryCapture {
 extension Capture {
     public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6>(
     _ component: R
-  ) where Output == (Substring, W, C0, C1, C2, C3, C4, C5, C6), R.Output == (W, C0, C1, C2, C3, C4, C5, C6) {
+  ) where RegexOutput == (Substring, W, C0, C1, C2, C3, C4, C5, C6), R.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6) {
     self.init(node: .capture(component.regex.root))
   }
 
     public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6>(
     _ component: R, as reference: Reference<W>
-  ) where Output == (Substring, W, C0, C1, C2, C3, C4, C5, C6), R.Output == (W, C0, C1, C2, C3, C4, C5, C6) {
+  ) where RegexOutput == (Substring, W, C0, C1, C2, C3, C4, C5, C6), R.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6) {
     self.init(node: .capture(reference: reference.id, component.regex.root))
   }
 
     public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, NewCapture>(
     _ component: R,
     transform: @escaping (Substring) throws -> NewCapture
-  ) where Output == (Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6), R.Output == (W, C0, C1, C2, C3, C4, C5, C6) {
+  ) where RegexOutput == (Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6), R.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6) {
     self.init(node: .capture(.transform(
       CaptureTransform(resultType: NewCapture.self) {
         try transform($0) as Any
@@ -3253,7 +3253,7 @@ extension Capture {
     _ component: R,
     as reference: Reference<NewCapture>,
     transform: @escaping (Substring) throws -> NewCapture
-  ) where Output == (Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6), R.Output == (W, C0, C1, C2, C3, C4, C5, C6) {
+  ) where RegexOutput == (Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6), R.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6) {
     self.init(node: .capture(
       reference: reference.id,
       .transform(
@@ -3268,7 +3268,7 @@ extension TryCapture {
     public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, NewCapture>(
     _ component: R,
     transform: @escaping (Substring) throws -> NewCapture?
-  ) where Output == (Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6), R.Output == (W, C0, C1, C2, C3, C4, C5, C6) {
+  ) where RegexOutput == (Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6), R.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6) {
     self.init(node: .capture(.transform(
       CaptureTransform(resultType: NewCapture.self) {
         try transform($0) as Any?
@@ -3280,7 +3280,7 @@ extension TryCapture {
     _ component: R,
     as reference: Reference<NewCapture>,
     transform: @escaping (Substring) throws -> NewCapture?
-  ) where Output == (Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6), R.Output == (W, C0, C1, C2, C3, C4, C5, C6) {
+  ) where RegexOutput == (Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6), R.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6) {
     self.init(node: .capture(
       reference: reference.id,
       .transform(
@@ -3296,14 +3296,14 @@ extension TryCapture {
 extension Capture {
     public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6>(
     @RegexComponentBuilder _ component: () -> R
-  ) where Output == (Substring, W, C0, C1, C2, C3, C4, C5, C6), R.Output == (W, C0, C1, C2, C3, C4, C5, C6) {
+  ) where RegexOutput == (Substring, W, C0, C1, C2, C3, C4, C5, C6), R.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6) {
     self.init(node: .capture(component().regex.root))
   }
 
     public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6>(
     as reference: Reference<W>,
     @RegexComponentBuilder _ component: () -> R
-  ) where Output == (Substring, W, C0, C1, C2, C3, C4, C5, C6), R.Output == (W, C0, C1, C2, C3, C4, C5, C6) {
+  ) where RegexOutput == (Substring, W, C0, C1, C2, C3, C4, C5, C6), R.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6) {
     self.init(node: .capture(
       reference: reference.id,
       component().regex.root))
@@ -3312,7 +3312,7 @@ extension Capture {
     public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, NewCapture>(
     @RegexComponentBuilder _ component: () -> R,
     transform: @escaping (Substring) throws -> NewCapture
-  ) where Output == (Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6), R.Output == (W, C0, C1, C2, C3, C4, C5, C6) {
+  ) where RegexOutput == (Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6), R.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6) {
     self.init(node: .capture(.transform(
       CaptureTransform(resultType: NewCapture.self) {
         try transform($0) as Any
@@ -3324,7 +3324,7 @@ extension Capture {
     as reference: Reference<NewCapture>,
     @RegexComponentBuilder _ component: () -> R,
     transform: @escaping (Substring) throws -> NewCapture
-  ) where Output == (Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6), R.Output == (W, C0, C1, C2, C3, C4, C5, C6) {
+  ) where RegexOutput == (Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6), R.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6) {
     self.init(node: .capture(
       reference: reference.id,
       .transform(
@@ -3339,7 +3339,7 @@ extension TryCapture {
     public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, NewCapture>(
     @RegexComponentBuilder _ component: () -> R,
     transform: @escaping (Substring) throws -> NewCapture?
-  ) where Output == (Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6), R.Output == (W, C0, C1, C2, C3, C4, C5, C6) {
+  ) where RegexOutput == (Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6), R.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6) {
     self.init(node: .capture(.transform(
       CaptureTransform(resultType: NewCapture.self) {
         try transform($0) as Any?
@@ -3351,7 +3351,7 @@ extension TryCapture {
     as reference: Reference<NewCapture>,
     @RegexComponentBuilder _ component: () -> R,
     transform: @escaping (Substring) throws -> NewCapture?
-  ) where Output == (Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6), R.Output == (W, C0, C1, C2, C3, C4, C5, C6) {
+  ) where RegexOutput == (Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6), R.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6) {
     self.init(node: .capture(
       reference: reference.id,
       .transform(
@@ -3367,20 +3367,20 @@ extension TryCapture {
 extension Capture {
     public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7>(
     _ component: R
-  ) where Output == (Substring, W, C0, C1, C2, C3, C4, C5, C6, C7), R.Output == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
+  ) where RegexOutput == (Substring, W, C0, C1, C2, C3, C4, C5, C6, C7), R.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
     self.init(node: .capture(component.regex.root))
   }
 
     public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7>(
     _ component: R, as reference: Reference<W>
-  ) where Output == (Substring, W, C0, C1, C2, C3, C4, C5, C6, C7), R.Output == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
+  ) where RegexOutput == (Substring, W, C0, C1, C2, C3, C4, C5, C6, C7), R.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
     self.init(node: .capture(reference: reference.id, component.regex.root))
   }
 
     public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, NewCapture>(
     _ component: R,
     transform: @escaping (Substring) throws -> NewCapture
-  ) where Output == (Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6, C7), R.Output == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
+  ) where RegexOutput == (Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6, C7), R.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
     self.init(node: .capture(.transform(
       CaptureTransform(resultType: NewCapture.self) {
         try transform($0) as Any
@@ -3392,7 +3392,7 @@ extension Capture {
     _ component: R,
     as reference: Reference<NewCapture>,
     transform: @escaping (Substring) throws -> NewCapture
-  ) where Output == (Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6, C7), R.Output == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
+  ) where RegexOutput == (Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6, C7), R.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
     self.init(node: .capture(
       reference: reference.id,
       .transform(
@@ -3407,7 +3407,7 @@ extension TryCapture {
     public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, NewCapture>(
     _ component: R,
     transform: @escaping (Substring) throws -> NewCapture?
-  ) where Output == (Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6, C7), R.Output == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
+  ) where RegexOutput == (Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6, C7), R.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
     self.init(node: .capture(.transform(
       CaptureTransform(resultType: NewCapture.self) {
         try transform($0) as Any?
@@ -3419,7 +3419,7 @@ extension TryCapture {
     _ component: R,
     as reference: Reference<NewCapture>,
     transform: @escaping (Substring) throws -> NewCapture?
-  ) where Output == (Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6, C7), R.Output == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
+  ) where RegexOutput == (Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6, C7), R.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
     self.init(node: .capture(
       reference: reference.id,
       .transform(
@@ -3435,14 +3435,14 @@ extension TryCapture {
 extension Capture {
     public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7>(
     @RegexComponentBuilder _ component: () -> R
-  ) where Output == (Substring, W, C0, C1, C2, C3, C4, C5, C6, C7), R.Output == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
+  ) where RegexOutput == (Substring, W, C0, C1, C2, C3, C4, C5, C6, C7), R.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
     self.init(node: .capture(component().regex.root))
   }
 
     public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7>(
     as reference: Reference<W>,
     @RegexComponentBuilder _ component: () -> R
-  ) where Output == (Substring, W, C0, C1, C2, C3, C4, C5, C6, C7), R.Output == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
+  ) where RegexOutput == (Substring, W, C0, C1, C2, C3, C4, C5, C6, C7), R.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
     self.init(node: .capture(
       reference: reference.id,
       component().regex.root))
@@ -3451,7 +3451,7 @@ extension Capture {
     public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, NewCapture>(
     @RegexComponentBuilder _ component: () -> R,
     transform: @escaping (Substring) throws -> NewCapture
-  ) where Output == (Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6, C7), R.Output == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
+  ) where RegexOutput == (Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6, C7), R.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
     self.init(node: .capture(.transform(
       CaptureTransform(resultType: NewCapture.self) {
         try transform($0) as Any
@@ -3463,7 +3463,7 @@ extension Capture {
     as reference: Reference<NewCapture>,
     @RegexComponentBuilder _ component: () -> R,
     transform: @escaping (Substring) throws -> NewCapture
-  ) where Output == (Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6, C7), R.Output == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
+  ) where RegexOutput == (Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6, C7), R.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
     self.init(node: .capture(
       reference: reference.id,
       .transform(
@@ -3478,7 +3478,7 @@ extension TryCapture {
     public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, NewCapture>(
     @RegexComponentBuilder _ component: () -> R,
     transform: @escaping (Substring) throws -> NewCapture?
-  ) where Output == (Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6, C7), R.Output == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
+  ) where RegexOutput == (Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6, C7), R.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
     self.init(node: .capture(.transform(
       CaptureTransform(resultType: NewCapture.self) {
         try transform($0) as Any?
@@ -3490,7 +3490,7 @@ extension TryCapture {
     as reference: Reference<NewCapture>,
     @RegexComponentBuilder _ component: () -> R,
     transform: @escaping (Substring) throws -> NewCapture?
-  ) where Output == (Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6, C7), R.Output == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
+  ) where RegexOutput == (Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6, C7), R.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
     self.init(node: .capture(
       reference: reference.id,
       .transform(
@@ -3506,20 +3506,20 @@ extension TryCapture {
 extension Capture {
     public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, C8>(
     _ component: R
-  ) where Output == (Substring, W, C0, C1, C2, C3, C4, C5, C6, C7, C8), R.Output == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
+  ) where RegexOutput == (Substring, W, C0, C1, C2, C3, C4, C5, C6, C7, C8), R.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
     self.init(node: .capture(component.regex.root))
   }
 
     public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, C8>(
     _ component: R, as reference: Reference<W>
-  ) where Output == (Substring, W, C0, C1, C2, C3, C4, C5, C6, C7, C8), R.Output == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
+  ) where RegexOutput == (Substring, W, C0, C1, C2, C3, C4, C5, C6, C7, C8), R.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
     self.init(node: .capture(reference: reference.id, component.regex.root))
   }
 
     public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, C8, NewCapture>(
     _ component: R,
     transform: @escaping (Substring) throws -> NewCapture
-  ) where Output == (Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6, C7, C8), R.Output == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
+  ) where RegexOutput == (Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6, C7, C8), R.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
     self.init(node: .capture(.transform(
       CaptureTransform(resultType: NewCapture.self) {
         try transform($0) as Any
@@ -3531,7 +3531,7 @@ extension Capture {
     _ component: R,
     as reference: Reference<NewCapture>,
     transform: @escaping (Substring) throws -> NewCapture
-  ) where Output == (Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6, C7, C8), R.Output == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
+  ) where RegexOutput == (Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6, C7, C8), R.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
     self.init(node: .capture(
       reference: reference.id,
       .transform(
@@ -3546,7 +3546,7 @@ extension TryCapture {
     public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, C8, NewCapture>(
     _ component: R,
     transform: @escaping (Substring) throws -> NewCapture?
-  ) where Output == (Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6, C7, C8), R.Output == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
+  ) where RegexOutput == (Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6, C7, C8), R.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
     self.init(node: .capture(.transform(
       CaptureTransform(resultType: NewCapture.self) {
         try transform($0) as Any?
@@ -3558,7 +3558,7 @@ extension TryCapture {
     _ component: R,
     as reference: Reference<NewCapture>,
     transform: @escaping (Substring) throws -> NewCapture?
-  ) where Output == (Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6, C7, C8), R.Output == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
+  ) where RegexOutput == (Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6, C7, C8), R.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
     self.init(node: .capture(
       reference: reference.id,
       .transform(
@@ -3574,14 +3574,14 @@ extension TryCapture {
 extension Capture {
     public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, C8>(
     @RegexComponentBuilder _ component: () -> R
-  ) where Output == (Substring, W, C0, C1, C2, C3, C4, C5, C6, C7, C8), R.Output == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
+  ) where RegexOutput == (Substring, W, C0, C1, C2, C3, C4, C5, C6, C7, C8), R.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
     self.init(node: .capture(component().regex.root))
   }
 
     public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, C8>(
     as reference: Reference<W>,
     @RegexComponentBuilder _ component: () -> R
-  ) where Output == (Substring, W, C0, C1, C2, C3, C4, C5, C6, C7, C8), R.Output == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
+  ) where RegexOutput == (Substring, W, C0, C1, C2, C3, C4, C5, C6, C7, C8), R.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
     self.init(node: .capture(
       reference: reference.id,
       component().regex.root))
@@ -3590,7 +3590,7 @@ extension Capture {
     public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, C8, NewCapture>(
     @RegexComponentBuilder _ component: () -> R,
     transform: @escaping (Substring) throws -> NewCapture
-  ) where Output == (Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6, C7, C8), R.Output == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
+  ) where RegexOutput == (Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6, C7, C8), R.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
     self.init(node: .capture(.transform(
       CaptureTransform(resultType: NewCapture.self) {
         try transform($0) as Any
@@ -3602,7 +3602,7 @@ extension Capture {
     as reference: Reference<NewCapture>,
     @RegexComponentBuilder _ component: () -> R,
     transform: @escaping (Substring) throws -> NewCapture
-  ) where Output == (Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6, C7, C8), R.Output == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
+  ) where RegexOutput == (Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6, C7, C8), R.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
     self.init(node: .capture(
       reference: reference.id,
       .transform(
@@ -3617,7 +3617,7 @@ extension TryCapture {
     public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, C8, NewCapture>(
     @RegexComponentBuilder _ component: () -> R,
     transform: @escaping (Substring) throws -> NewCapture?
-  ) where Output == (Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6, C7, C8), R.Output == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
+  ) where RegexOutput == (Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6, C7, C8), R.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
     self.init(node: .capture(.transform(
       CaptureTransform(resultType: NewCapture.self) {
         try transform($0) as Any?
@@ -3629,7 +3629,7 @@ extension TryCapture {
     as reference: Reference<NewCapture>,
     @RegexComponentBuilder _ component: () -> R,
     transform: @escaping (Substring) throws -> NewCapture?
-  ) where Output == (Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6, C7, C8), R.Output == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
+  ) where RegexOutput == (Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6, C7, C8), R.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
     self.init(node: .capture(
       reference: reference.id,
       .transform(
@@ -3645,20 +3645,20 @@ extension TryCapture {
 extension Capture {
     public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9>(
     _ component: R
-  ) where Output == (Substring, W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9), R.Output == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
+  ) where RegexOutput == (Substring, W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9), R.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
     self.init(node: .capture(component.regex.root))
   }
 
     public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9>(
     _ component: R, as reference: Reference<W>
-  ) where Output == (Substring, W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9), R.Output == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
+  ) where RegexOutput == (Substring, W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9), R.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
     self.init(node: .capture(reference: reference.id, component.regex.root))
   }
 
     public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9, NewCapture>(
     _ component: R,
     transform: @escaping (Substring) throws -> NewCapture
-  ) where Output == (Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9), R.Output == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
+  ) where RegexOutput == (Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9), R.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
     self.init(node: .capture(.transform(
       CaptureTransform(resultType: NewCapture.self) {
         try transform($0) as Any
@@ -3670,7 +3670,7 @@ extension Capture {
     _ component: R,
     as reference: Reference<NewCapture>,
     transform: @escaping (Substring) throws -> NewCapture
-  ) where Output == (Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9), R.Output == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
+  ) where RegexOutput == (Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9), R.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
     self.init(node: .capture(
       reference: reference.id,
       .transform(
@@ -3685,7 +3685,7 @@ extension TryCapture {
     public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9, NewCapture>(
     _ component: R,
     transform: @escaping (Substring) throws -> NewCapture?
-  ) where Output == (Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9), R.Output == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
+  ) where RegexOutput == (Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9), R.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
     self.init(node: .capture(.transform(
       CaptureTransform(resultType: NewCapture.self) {
         try transform($0) as Any?
@@ -3697,7 +3697,7 @@ extension TryCapture {
     _ component: R,
     as reference: Reference<NewCapture>,
     transform: @escaping (Substring) throws -> NewCapture?
-  ) where Output == (Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9), R.Output == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
+  ) where RegexOutput == (Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9), R.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
     self.init(node: .capture(
       reference: reference.id,
       .transform(
@@ -3713,14 +3713,14 @@ extension TryCapture {
 extension Capture {
     public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9>(
     @RegexComponentBuilder _ component: () -> R
-  ) where Output == (Substring, W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9), R.Output == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
+  ) where RegexOutput == (Substring, W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9), R.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
     self.init(node: .capture(component().regex.root))
   }
 
     public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9>(
     as reference: Reference<W>,
     @RegexComponentBuilder _ component: () -> R
-  ) where Output == (Substring, W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9), R.Output == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
+  ) where RegexOutput == (Substring, W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9), R.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
     self.init(node: .capture(
       reference: reference.id,
       component().regex.root))
@@ -3729,7 +3729,7 @@ extension Capture {
     public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9, NewCapture>(
     @RegexComponentBuilder _ component: () -> R,
     transform: @escaping (Substring) throws -> NewCapture
-  ) where Output == (Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9), R.Output == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
+  ) where RegexOutput == (Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9), R.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
     self.init(node: .capture(.transform(
       CaptureTransform(resultType: NewCapture.self) {
         try transform($0) as Any
@@ -3741,7 +3741,7 @@ extension Capture {
     as reference: Reference<NewCapture>,
     @RegexComponentBuilder _ component: () -> R,
     transform: @escaping (Substring) throws -> NewCapture
-  ) where Output == (Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9), R.Output == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
+  ) where RegexOutput == (Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9), R.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
     self.init(node: .capture(
       reference: reference.id,
       .transform(
@@ -3756,7 +3756,7 @@ extension TryCapture {
     public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9, NewCapture>(
     @RegexComponentBuilder _ component: () -> R,
     transform: @escaping (Substring) throws -> NewCapture?
-  ) where Output == (Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9), R.Output == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
+  ) where RegexOutput == (Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9), R.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
     self.init(node: .capture(.transform(
       CaptureTransform(resultType: NewCapture.self) {
         try transform($0) as Any?
@@ -3768,7 +3768,7 @@ extension TryCapture {
     as reference: Reference<NewCapture>,
     @RegexComponentBuilder _ component: () -> R,
     transform: @escaping (Substring) throws -> NewCapture?
-  ) where Output == (Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9), R.Output == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
+  ) where RegexOutput == (Substring, NewCapture, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9), R.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
     self.init(node: .capture(
       reference: reference.id,
       .transform(

--- a/Sources/VariadicsGenerator/VariadicsGenerator.swift
+++ b/Sources/VariadicsGenerator/VariadicsGenerator.swift
@@ -90,7 +90,7 @@ var standardError = StandardErrorStream()
 
 typealias Counter = Int64
 let regexComponentProtocolName = "RegexComponent"
-let outputAssociatedTypeName = "Output"
+let outputAssociatedTypeName = "RegexOutput"
 let patternProtocolRequirementName = "regex"
 let regexTypeName = "Regex"
 let baseMatchTypeName = "Substring"

--- a/Sources/_StringProcessing/Algorithms/Consumers/RegexConsumer.swift
+++ b/Sources/_StringProcessing/Algorithms/Consumers/RegexConsumer.swift
@@ -37,7 +37,7 @@ extension RegexConsumer {
 // well, taking advantage of the fact that the captures can be ignored
 
 extension RegexConsumer: MatchingCollectionConsumer {
-  typealias Match = R.Output
+  typealias Match = R.RegexOutput
   
   func matchingConsuming(
     _ consumed: Consumed, in range: Range<Consumed.Index>

--- a/Sources/_StringProcessing/Algorithms/Matching/FirstMatch.swift
+++ b/Sources/_StringProcessing/Algorithms/Matching/FirstMatch.swift
@@ -56,7 +56,7 @@ extension BidirectionalCollection where SubSequence == Substring {
   /// there isn't a match.
   public func firstMatch<R: RegexComponent>(
     of r: R
-  ) -> Regex<R.Output>.Match? {
+  ) -> Regex<R.RegexOutput>.Match? {
     let slice = self[...]
     return try? r.regex.firstMatch(in: slice.base)
   }

--- a/Sources/_StringProcessing/Algorithms/Matching/MatchReplace.swift
+++ b/Sources/_StringProcessing/Algorithms/Matching/MatchReplace.swift
@@ -124,7 +124,7 @@ extension RangeReplaceableCollection where SubSequence == Substring {
   /// matching `regex` are replaced by `replacement`.
   public func replacing<R: RegexComponent, Replacement: Collection>(
     _ regex: R,
-    with replacement: (Regex<R.Output>.Match) throws -> Replacement,
+    with replacement: (Regex<R.RegexOutput>.Match) throws -> Replacement,
     subrange: Range<Index>,
     maxReplacements: Int = .max
   ) rethrows -> Self where Replacement.Element == Element {
@@ -159,7 +159,7 @@ extension RangeReplaceableCollection where SubSequence == Substring {
   /// matching `regex` are replaced by `replacement`.
   public func replacing<R: RegexComponent, Replacement: Collection>(
     _ regex: R,
-    with replacement: (Regex<R.Output>.Match) throws -> Replacement,
+    with replacement: (Regex<R.RegexOutput>.Match) throws -> Replacement,
     maxReplacements: Int = .max
   ) rethrows -> Self where Replacement.Element == Element {
     try replacing(
@@ -179,7 +179,7 @@ extension RangeReplaceableCollection where SubSequence == Substring {
   ///   sequence matching `regex` to replace. Default is `Int.max`.
   public mutating func replace<R: RegexComponent, Replacement: Collection>(
     _ regex: R,
-    with replacement: (Regex<R.Output>.Match) throws -> Replacement,
+    with replacement: (Regex<R.RegexOutput>.Match) throws -> Replacement,
     maxReplacements: Int = .max
   ) rethrows where Replacement.Element == Element {
     self = try replacing(

--- a/Sources/_StringProcessing/Algorithms/Matching/Matches.swift
+++ b/Sources/_StringProcessing/Algorithms/Matching/Matches.swift
@@ -202,13 +202,13 @@ extension BidirectionalCollection where SubSequence == Substring {
 
   // FIXME: Replace the returned value as `some Collection<Regex<R.Output>.Match>
   // when SE-0346 is enabled
-  func _matches<R: RegexComponent>(of r: R) -> [Regex<R.Output>.Match] {
+  func _matches<R: RegexComponent>(of r: R) -> [Regex<R.RegexOutput>.Match] {
     let slice = self[...]
     var start = self.startIndex
     let end = self.endIndex
     let regex = r.regex
 
-    var result = [Regex<R.Output>.Match]()
+    var result = [Regex<R.RegexOutput>.Match]()
     while start < end {
       guard let match = try? regex._firstMatch(
         slice.base, in: start..<end

--- a/Sources/_StringProcessing/Regex/Core.swift
+++ b/Sources/_StringProcessing/Regex/Core.swift
@@ -14,8 +14,8 @@ import _RegexParser
 
 /// A type that represents a regular expression.
 public protocol RegexComponent {
-  associatedtype Output
-  var regex: Regex<Output> { get }
+  associatedtype RegexOutput
+  var regex: Regex<RegexOutput> { get }
 }
 
 /// A regex represents a string processing algorithm.

--- a/Sources/_StringProcessing/Regex/DSLConsumers.swift
+++ b/Sources/_StringProcessing/Regex/DSLConsumers.swift
@@ -14,12 +14,12 @@ public protocol CustomRegexComponent: RegexComponent {
     _ input: String,
     startingAt index: String.Index,
     in bounds: Range<String.Index>
-  ) -> (upperBound: String.Index, output: Output)?
+  ) -> (upperBound: String.Index, output: RegexOutput)?
 }
 
 extension CustomRegexComponent {
-  public var regex: Regex<Output> {
-    Regex(node: .matcher(.init(Output.self), { input, index, bounds in
+  public var regex: Regex<RegexOutput> {
+    Regex(node: .matcher(.init(RegexOutput.self), { input, index, bounds in
       match(input, startingAt: index, in: bounds)
     }))
   }

--- a/Sources/_StringProcessing/Regex/Match.swift
+++ b/Sources/_StringProcessing/Regex/Match.swift
@@ -155,24 +155,24 @@ extension Regex {
 extension String {
   public func wholeMatch<R: RegexComponent>(
     of r: R
-  ) -> Regex<R.Output>.Match? {
+  ) -> Regex<R.RegexOutput>.Match? {
     try? r.regex.wholeMatch(in: self)
   }
   public func prefixMatch<R: RegexComponent>(
     of r: R
-  ) -> Regex<R.Output>.Match? {
+  ) -> Regex<R.RegexOutput>.Match? {
     try? r.regex.prefixMatch(in: self)
   }
 }
 extension Substring {
   public func wholeMatch<R: RegexComponent>(
     of r: R
-  ) -> Regex<R.Output>.Match? {
+  ) -> Regex<R.RegexOutput>.Match? {
     try? r.regex.wholeMatch(in: self)
   }
   public func prefixMatch<R: RegexComponent>(
     of r: R
-  ) -> Regex<R.Output>.Match? {
+  ) -> Regex<R.RegexOutput>.Match? {
     try? r.regex.prefixMatch(in: self)
   }
 }

--- a/Sources/_StringProcessing/Regex/Options.swift
+++ b/Sources/_StringProcessing/Regex/Options.swift
@@ -13,30 +13,30 @@ import _RegexParser
 
 extension RegexComponent {
   /// Returns a regular expression that ignores casing when matching.
-  public func ignoringCase(_ ignoreCase: Bool = true) -> Regex<Output> {
+  public func ignoringCase(_ ignoreCase: Bool = true) -> Regex<RegexOutput> {
     wrapInOption(.caseInsensitive, addingIf: ignoreCase)
   }
 
   /// Returns a regular expression that only matches ASCII characters as "word
   /// characters".
-  public func usingASCIIWordCharacters(_ useASCII: Bool = true) -> Regex<Output> {
+  public func usingASCIIWordCharacters(_ useASCII: Bool = true) -> Regex<RegexOutput> {
     wrapInOption(.asciiOnlyDigit, addingIf: useASCII)
   }
 
   /// Returns a regular expression that only matches ASCII characters as digits.
-  public func usingASCIIDigits(_ useASCII: Bool = true) -> Regex<Output> {
+  public func usingASCIIDigits(_ useASCII: Bool = true) -> Regex<RegexOutput> {
     wrapInOption(.asciiOnlyDigit, addingIf: useASCII)
   }
 
   /// Returns a regular expression that only matches ASCII characters as space
   /// characters.
-  public func usingASCIISpaces(_ useASCII: Bool = true) -> Regex<Output> {
+  public func usingASCIISpaces(_ useASCII: Bool = true) -> Regex<RegexOutput> {
     wrapInOption(.asciiOnlySpace, addingIf: useASCII)
   }
 
   /// Returns a regular expression that only matches ASCII characters when
   /// matching character classes.
-  public func usingASCIICharacterClasses(_ useASCII: Bool = true) -> Regex<Output> {
+  public func usingASCIICharacterClasses(_ useASCII: Bool = true) -> Regex<RegexOutput> {
     wrapInOption(.asciiOnlyPOSIXProps, addingIf: useASCII)
   }
   
@@ -45,7 +45,7 @@ extension RegexComponent {
   ///
   /// This option is enabled by default; pass `false` to disable use of
   /// Unicode's word boundary algorithm.
-  public func usingUnicodeWordBoundaries(_ useUnicodeWordBoundaries: Bool = true) -> Regex<Output> {
+  public func usingUnicodeWordBoundaries(_ useUnicodeWordBoundaries: Bool = true) -> Regex<RegexOutput> {
     wrapInOption(.unicodeWordBoundaries, addingIf: useUnicodeWordBoundaries)
   }
   
@@ -54,7 +54,7 @@ extension RegexComponent {
   ///
   /// - Parameter dotMatchesNewlines: A Boolean value indicating whether `.`
   ///   should match a newline character.
-  public func dotMatchesNewlines(_ dotMatchesNewlines: Bool = true) -> Regex<Output> {
+  public func dotMatchesNewlines(_ dotMatchesNewlines: Bool = true) -> Regex<RegexOutput> {
     wrapInOption(.singleLine, addingIf: dotMatchesNewlines)
   }
   
@@ -95,7 +95,7 @@ extension RegexComponent {
   ///     // Prints "true"
   ///     print(decomposed.contains(queRegexScalar))
   ///     // Prints "false"
-  public func matchingSemantics(_ semanticLevel: RegexSemanticLevel) -> Regex<Output> {
+  public func matchingSemantics(_ semanticLevel: RegexSemanticLevel) -> Regex<RegexOutput> {
     switch semanticLevel.base {
     case .graphemeCluster:
       return wrapInOption(.graphemeClusterSemantics, addingIf: true)
@@ -139,7 +139,7 @@ extension RegexComponent {
   ///
   /// - Parameter matchLineEndings: A Boolean value indicating whether `^` and
   ///   `$` should match the start and end of lines, respectively.
-  public func anchorsMatchLineEndings(_ matchLineEndings: Bool = true) -> Regex<Output> {
+  public func anchorsMatchLineEndings(_ matchLineEndings: Bool = true) -> Regex<RegexOutput> {
     wrapInOption(.multiline, addingIf: matchLineEndings)
   }
   
@@ -153,7 +153,7 @@ extension RegexComponent {
   ///
   /// - Parameter useReluctantCaptures: A Boolean value indicating whether
   ///   quantifiers should be reluctant by default.
-  public func reluctantCaptures(_ useReluctantCaptures: Bool = true) -> Regex<Output> {
+  public func reluctantCaptures(_ useReluctantCaptures: Bool = true) -> Regex<RegexOutput> {
     wrapInOption(.reluctantByDefault, addingIf: useReluctantCaptures)
   }
 }
@@ -162,7 +162,7 @@ extension RegexComponent {
 extension RegexComponent {
   fileprivate func wrapInOption(
     _ option: AST.MatchingOption.Kind,
-    addingIf shouldAdd: Bool) -> Regex<Output>
+    addingIf shouldAdd: Bool) -> Regex<RegexOutput>
   {
     let sequence = shouldAdd
       ? AST.MatchingOptionSequence(adding: [.init(option, location: .fake)])

--- a/Sources/_StringProcessing/_CharacterClassModel.swift
+++ b/Sources/_StringProcessing/_CharacterClassModel.swift
@@ -205,9 +205,9 @@ public struct _CharacterClassModel: Hashable {
 }
 
 extension _CharacterClassModel: RegexComponent {
-  public typealias Output = Substring
+  public typealias RegexOutput = Substring
 
-  public var regex: Regex<Output> {
+  public var regex: Regex<RegexOutput> {
     guard let ast = self.makeAST() else {
       fatalError("FIXME: extended AST?")
     }

--- a/Tests/RegexBuilderTests/AlgorithmsTests.swift
+++ b/Tests/RegexBuilderTests/AlgorithmsTests.swift
@@ -27,7 +27,7 @@ class RegexConsumerTests: XCTestCase {
       _ regex: R,
       input: String,
       result: String,
-      _ replace: (Regex<R.Output>.Match) -> String,
+      _ replace: (Regex<R.RegexOutput>.Match) -> String,
       file: StaticString = #file,
       line: UInt = #line
     ) {

--- a/Tests/RegexBuilderTests/CustomTests.swift
+++ b/Tests/RegexBuilderTests/CustomTests.swift
@@ -15,7 +15,7 @@ import _StringProcessing
 
 // A nibbler processes a single character from a string
 private protocol Nibbler: CustomRegexComponent {
-  func nibble(_: Character) -> Output?
+  func nibble(_: Character) -> RegexOutput?
 }
 
 extension Nibbler {
@@ -24,7 +24,7 @@ extension Nibbler {
     _ input: String,
     startingAt index: String.Index,
     in bounds: Range<String.Index>
-  ) -> (upperBound: String.Index, output: Output)? {
+  ) -> (upperBound: String.Index, output: RegexOutput)? {
     guard index != bounds.upperBound, let res = nibble(input[index]) else {
       return nil
     }
@@ -35,7 +35,7 @@ extension Nibbler {
 
 // A number nibbler
 private struct Numbler: Nibbler {
-  typealias Output = Int
+  typealias RegexOutput = Int
   func nibble(_ c: Character) -> Int? {
     c.wholeNumberValue
   }
@@ -43,7 +43,7 @@ private struct Numbler: Nibbler {
 
 // An ASCII value nibbler
 private struct Asciibbler: Nibbler {
-  typealias Output = UInt8
+  typealias RegexOutput = UInt8
   func nibble(_ c: Character) -> UInt8? {
     c.asciiValue
   }

--- a/Tests/RegexBuilderTests/RegexDSLTests.swift
+++ b/Tests/RegexBuilderTests/RegexDSLTests.swift
@@ -28,10 +28,10 @@ class RegexDSLTests: XCTestCase {
       if let expectedCaptures = maybeExpectedCaptures {
         let match = try XCTUnwrap(maybeMatch, file: file, line: line)
         XCTAssertTrue(
-          type(of: regex).Output.self == MatchType.self,
+          type(of: regex).RegexOutput.self == MatchType.self,
           """
           Expected match type: \(MatchType.self)
-          Actual match type: \(type(of: regex).Output.self)
+          Actual match type: \(type(of: regex).RegexOutput.self)
           """)
         let captures = try XCTUnwrap(match.output as? MatchType, file: file, line: line)
         XCTAssertTrue(
@@ -51,7 +51,7 @@ class RegexDSLTests: XCTestCase {
       TryCapture("1") { Int($0) } // Int
     }
     // Assert the inferred capture type.
-    let _: (Substring, Substring, Int).Type = type(of: regex).Output.self
+    let _: (Substring, Substring, Int).Type = type(of: regex).RegexOutput.self
     let maybeMatch = "ab1".wholeMatch(of: regex)
     let match = try XCTUnwrap(maybeMatch)
     XCTAssertTrue(match.output == ("ab1", "b", 1))
@@ -405,7 +405,7 @@ class RegexDSLTests: XCTestCase {
     // void.
     let regex = ZeroOrMore(.digit)
     // Assert the inferred capture type.
-    let _: Substring.Type = type(of: regex).Output.self
+    let _: Substring.Type = type(of: regex).RegexOutput.self
     let input = "123123"
     let match = try XCTUnwrap(input.wholeMatch(of: regex)?.output)
     XCTAssertTrue(match == input)
@@ -454,7 +454,7 @@ class RegexDSLTests: XCTestCase {
       }
     }
     let _: (Substring, Substring, Substring).Type
-      = type(of: regex1).Output.self
+      = type(of: regex1).RegexOutput.self
     let regex2 = Regex {
       OneOrMore("a")
       Capture {
@@ -465,7 +465,7 @@ class RegexDSLTests: XCTestCase {
       }
     }
     let _: (Substring, Substring, Int?).Type
-      = type(of: regex2).Output.self
+      = type(of: regex2).RegexOutput.self
     let regex3 = Regex {
       OneOrMore("a")
       Capture {
@@ -477,7 +477,7 @@ class RegexDSLTests: XCTestCase {
       }
     }
     let _: (Substring, Substring, Int, Double?).Type
-      = type(of: regex3).Output.self
+      = type(of: regex3).RegexOutput.self
     let regex4 = Regex {
       OneOrMore("a")
       Capture {
@@ -491,7 +491,7 @@ class RegexDSLTests: XCTestCase {
     }
     let _: (
       Substring, Substring, Substring, Substring, Substring?).Type
-      = type(of: regex4).Output.self
+      = type(of: regex4).RegexOutput.self
   }
 
   func testUnicodeScalarPostProcessing() throws {
@@ -530,7 +530,7 @@ class RegexDSLTests: XCTestCase {
     }
 
     // Assert the inferred capture type.
-    let _: (Substring, Substring).Type = type(of: unicodeData).Output.self
+    let _: (Substring, Substring).Type = type(of: unicodeData).RegexOutput.self
 
     let unicodeLine =
       "1BCA0..1BCA3  ; Control # Cf   [4] SHORTHAND FORMAT LETTER OVERLAP..SHORTHAND FORMAT UP STEP"
@@ -565,7 +565,7 @@ class RegexDSLTests: XCTestCase {
       typealias ExpectedMatch = (
         Substring, Unicode.Scalar?, Unicode.Scalar??, Substring
       )
-      let _: ExpectedMatch.Type = type(of: regexWithCapture).Output.self
+      let _: ExpectedMatch.Type = type(of: regexWithCapture).RegexOutput.self
       let maybeMatchResult = line.wholeMatch(of: regexWithCapture)
       let matchResult = try XCTUnwrap(maybeMatchResult)
       let (wholeMatch, lower, upper, propertyString) = matchResult.output
@@ -600,7 +600,7 @@ class RegexDSLTests: XCTestCase {
       typealias ExpectedMatch = (
         Substring, Unicode.Scalar, Unicode.Scalar?, Substring
       )
-      let _: ExpectedMatch.Type = type(of: regexWithTryCapture).Output.self
+      let _: ExpectedMatch.Type = type(of: regexWithTryCapture).RegexOutput.self
       let maybeMatchResult = line.wholeMatch(of: regexWithTryCapture)
       let matchResult = try XCTUnwrap(maybeMatchResult)
       let (wholeMatch, lower, upper, propertyString) = matchResult.output
@@ -744,7 +744,7 @@ class RegexDSLTests: XCTestCase {
       var dev: String?
     }
     struct SemanticVersionParser: CustomRegexComponent {
-      typealias Output = SemanticVersion
+      typealias RegexOutput = SemanticVersion
       func match(
         _ input: String,
         startingAt index: String.Index,


### PR DESCRIPTION
This renames `RegexComponent.Output` to `RegexOutput`, so that it is less likely to collide with other associated type that `String`, etc might conform to.