### PR TITLE
Add remaining availability annotations.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,7 @@ let availabilityDefinition = PackageDescription.SwiftSetting.unsafeFlags([
     "-Xfrontend",
     "-define-availability",
     "-Xfrontend",
-    #""SwiftStdlib 5.7:macOS 9999, iOS 9999, watchOS 9999, tvOS 9999""#
+    #"SwiftStdlib 5.7:macOS 9999, iOS 9999, watchOS 9999, tvOS 9999"#,
 ])
 
 let package = Package(
@@ -66,44 +66,50 @@ let package = Package(
         .testTarget(
             name: "RegexTests",
             dependencies: ["_StringProcessing"],
-            swiftSettings: [availabilityDefinition]),
+            swiftSettings: [
+                .unsafeFlags(["-Xfrontend", "-disable-availability-checking"])
+            ]),
         .testTarget(
             name: "RegexBuilderTests",
             dependencies: ["_StringProcessing", "RegexBuilder"],
             swiftSettings: [
                 .unsafeFlags(["-Xfrontend", "-enable-experimental-pairwise-build-block"]),
-                availabilityDefinition
+                .unsafeFlags(["-Xfrontend", "-disable-availability-checking"])
             ]),
         .target(
             name: "Prototypes",
             dependencies: ["_RegexParser", "_StringProcessing"],
-            swiftSettings: [availabilityDefinition]),
+            swiftSettings: [
+                .unsafeFlags(["-Xfrontend", "-disable-availability-checking"])
+            ]),
 
         // MARK: Scripts
         .executableTarget(
             name: "VariadicsGenerator",
             dependencies: [
-              .product(name: "ArgumentParser", package: "swift-argument-parser")
+                .product(name: "ArgumentParser", package: "swift-argument-parser")
             ]),
         .executableTarget(
             name: "PatternConverter",
             dependencies: [
-              .product(name: "ArgumentParser", package: "swift-argument-parser"),
-              "_RegexParser",
-              "_StringProcessing"
+                .product(name: "ArgumentParser", package: "swift-argument-parser"),
+                "_RegexParser",
+                "_StringProcessing"
             ]),
 
         // MARK: Exercises
         .target(
-          name: "Exercises",
-          dependencies: ["_RegexParser", "Prototypes", "_StringProcessing", "RegexBuilder"],
-          swiftSettings: [
-              .unsafeFlags(["-Xfrontend", "-enable-experimental-pairwise-build-block"]),
-              availabilityDefinition
-          ]),
+            name: "Exercises",
+            dependencies: ["_RegexParser", "Prototypes", "_StringProcessing", "RegexBuilder"],
+            swiftSettings: [
+                .unsafeFlags(["-Xfrontend", "-enable-experimental-pairwise-build-block"]),
+                .unsafeFlags(["-Xfrontend", "-disable-availability-checking"])
+            ]),
         .testTarget(
-          name: "ExercisesTests",
-          dependencies: ["Exercises"],
-          swiftSettings: [availabilityDefinition]),
+            name: "ExercisesTests",
+            dependencies: ["Exercises"],
+            swiftSettings: [
+                .unsafeFlags(["-Xfrontend", "-disable-availability-checking"])
+            ])
     ]
 )

--- a/Sources/RegexBuilder/Anchor.swift
+++ b/Sources/RegexBuilder/Anchor.swift
@@ -29,6 +29,7 @@ public struct Anchor {
   var isInverted: Bool = false
 }
 
+@available(SwiftStdlib 5.7, *)
 extension Anchor: RegexComponent {
   var astAssertion: AST.Atom.AssertionKind {
     if !isInverted {
@@ -63,6 +64,7 @@ extension Anchor: RegexComponent {
 
 // MARK: - Public API
 
+@available(SwiftStdlib 5.7, *)
 extension Anchor {
   public static var startOfSubject: Anchor {
     Anchor(kind: .startOfSubject)

--- a/Sources/RegexBuilder/CharacterClass.swift
+++ b/Sources/RegexBuilder/CharacterClass.swift
@@ -37,18 +37,21 @@ public struct CharacterClass {
   }
 }
 
+@available(SwiftStdlib 5.7, *)
 extension CharacterClass: RegexComponent {
   public var regex: Regex<Substring> {
     return Regex(node: DSLTree.Node.customCharacterClass(ccc))
   }
 }
 
+@available(SwiftStdlib 5.7, *)
 extension CharacterClass {
   public var inverted: CharacterClass {
     CharacterClass(ccc.inverted)
   }
 }
 
+@available(SwiftStdlib 5.7, *)
 extension RegexComponent where Self == CharacterClass {
   public static var any: CharacterClass {
     .init(DSLTree.CustomCharacterClass(members: [.atom(.any)]))
@@ -91,6 +94,7 @@ extension RegexComponent where Self == CharacterClass {
   }
 }
 
+@available(SwiftStdlib 5.7, *)
 extension RegexComponent where Self == CharacterClass {
   /// Returns a character class that matches any character in the given string
   /// or sequence.
@@ -112,6 +116,7 @@ extension RegexComponent where Self == CharacterClass {
 }
 
 // Unicode properties
+@available(SwiftStdlib 5.7, *)
 extension CharacterClass {
   public static func generalCategory(_ category: Unicode.GeneralCategory) -> CharacterClass {
     guard let extendedCategory = category.extendedGeneralCategory else {
@@ -179,6 +184,7 @@ extension Unicode.GeneralCategory {
 
 // MARK: - Set algebra methods
 
+@available(SwiftStdlib 5.7, *)
 extension RegexComponent where Self == CharacterClass {
   public init(_ first: CharacterClass, _ rest: CharacterClass...) {
     if rest.isEmpty {
@@ -191,6 +197,7 @@ extension RegexComponent where Self == CharacterClass {
   }
 }
 
+@available(SwiftStdlib 5.7, *)
 extension CharacterClass {
   public func union(_ other: CharacterClass) -> CharacterClass {
     CharacterClass(.init(members: [

--- a/Sources/RegexBuilder/DSL.swift
+++ b/Sources/RegexBuilder/DSL.swift
@@ -12,6 +12,7 @@
 import _RegexParser
 @_spi(RegexBuilder) import _StringProcessing
 
+@available(SwiftStdlib 5.7, *)
 extension Regex {
   public init<Content: RegexComponent>(
     @RegexComponentBuilder _ content: () -> Content
@@ -22,10 +23,12 @@ extension Regex {
 
 // A convenience protocol for builtin regex components that are initialized with
 // a `DSLTree` node.
+@available(SwiftStdlib 5.7, *)
 internal protocol _BuiltinRegexComponent: RegexComponent {
   init(_ regex: Regex<RegexOutput>)
 }
 
+@available(SwiftStdlib 5.7, *)
 extension _BuiltinRegexComponent {
   init(node: DSLTree.Node) {
     self.init(Regex(node: node))
@@ -34,6 +37,7 @@ extension _BuiltinRegexComponent {
 
 // MARK: - Primitive regex components
 
+@available(SwiftStdlib 5.7, *)
 extension String: RegexComponent {
   public typealias Output = Substring
 
@@ -42,6 +46,7 @@ extension String: RegexComponent {
   }
 }
 
+@available(SwiftStdlib 5.7, *)
 extension Substring: RegexComponent {
   public typealias Output = Substring
 
@@ -50,6 +55,7 @@ extension Substring: RegexComponent {
   }
 }
 
+@available(SwiftStdlib 5.7, *)
 extension Character: RegexComponent {
   public typealias Output = Substring
 
@@ -58,6 +64,7 @@ extension Character: RegexComponent {
   }
 }
 
+@available(SwiftStdlib 5.7, *)
 extension UnicodeScalar: RegexComponent {
   public typealias Output = Substring
 
@@ -110,6 +117,7 @@ public struct QuantificationBehavior {
 extension DSLTree.Node {
   /// Generates a DSLTree node for a repeated range of the given DSLTree node.
   /// Individual public API functions are in the generated Variadics.swift file.
+  @available(SwiftStdlib 5.7, *)
   static func repeating(
     _ range: Range<Int>,
     _ behavior: QuantificationBehavior,
@@ -137,6 +145,7 @@ extension DSLTree.Node {
   }
 }
 
+@available(SwiftStdlib 5.7, *)
 extension QuantificationBehavior {
   /// Match as much of the input string as possible, backtracking when
   /// necessary.
@@ -304,6 +313,7 @@ public struct Reference<Capture>: RegexComponent {
   }
 }
 
+@available(SwiftStdlib 5.7, *)
 extension Regex.Match {
   public subscript<Capture>(_ reference: Reference<Capture>) -> Capture {
     self[reference.id]

--- a/Sources/RegexBuilder/Match.swift
+++ b/Sources/RegexBuilder/Match.swift
@@ -11,6 +11,7 @@
 
 import _StringProcessing
 
+@available(SwiftStdlib 5.7, *)
 extension String {
   @available(SwiftStdlib 5.7, *)
   public func wholeMatch<R: RegexComponent>(

--- a/Sources/RegexBuilder/Variadics.swift
+++ b/Sources/RegexBuilder/Variadics.swift
@@ -14,462 +14,594 @@
 import _RegexParser
 @_spi(RegexBuilder) import _StringProcessing
 
+@available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<W0, W1, C0, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C0)>  where R0.RegexOutput == W0, R1.RegexOutput == (W1, C0) {
     .init(node: accumulated.regex.root.appending(next.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<W0, W1, C0, C1, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C0, C1)>  where R0.RegexOutput == W0, R1.RegexOutput == (W1, C0, C1) {
     .init(node: accumulated.regex.root.appending(next.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<W0, W1, C0, C1, C2, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C0, C1, C2)>  where R0.RegexOutput == W0, R1.RegexOutput == (W1, C0, C1, C2) {
     .init(node: accumulated.regex.root.appending(next.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<W0, W1, C0, C1, C2, C3, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C0, C1, C2, C3)>  where R0.RegexOutput == W0, R1.RegexOutput == (W1, C0, C1, C2, C3) {
     .init(node: accumulated.regex.root.appending(next.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<W0, W1, C0, C1, C2, C3, C4, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C0, C1, C2, C3, C4)>  where R0.RegexOutput == W0, R1.RegexOutput == (W1, C0, C1, C2, C3, C4) {
     .init(node: accumulated.regex.root.appending(next.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<W0, W1, C0, C1, C2, C3, C4, C5, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5)>  where R0.RegexOutput == W0, R1.RegexOutput == (W1, C0, C1, C2, C3, C4, C5) {
     .init(node: accumulated.regex.root.appending(next.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<W0, W1, C0, C1, C2, C3, C4, C5, C6, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6)>  where R0.RegexOutput == W0, R1.RegexOutput == (W1, C0, C1, C2, C3, C4, C5, C6) {
     .init(node: accumulated.regex.root.appending(next.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<W0, W1, C0, C1, C2, C3, C4, C5, C6, C7, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7)>  where R0.RegexOutput == W0, R1.RegexOutput == (W1, C0, C1, C2, C3, C4, C5, C6, C7) {
     .init(node: accumulated.regex.root.appending(next.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<W0, W1, C0, C1, C2, C3, C4, C5, C6, C7, C8, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8)>  where R0.RegexOutput == W0, R1.RegexOutput == (W1, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
     .init(node: accumulated.regex.root.appending(next.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<W0, W1, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9)>  where R0.RegexOutput == W0, R1.RegexOutput == (W1, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
     .init(node: accumulated.regex.root.appending(next.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<W0, W1, C0, C1, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C0, C1)>  where R0.RegexOutput == (W0, C0), R1.RegexOutput == (W1, C1) {
     .init(node: accumulated.regex.root.appending(next.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<W0, W1, C0, C1, C2, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C0, C1, C2)>  where R0.RegexOutput == (W0, C0), R1.RegexOutput == (W1, C1, C2) {
     .init(node: accumulated.regex.root.appending(next.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<W0, W1, C0, C1, C2, C3, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C0, C1, C2, C3)>  where R0.RegexOutput == (W0, C0), R1.RegexOutput == (W1, C1, C2, C3) {
     .init(node: accumulated.regex.root.appending(next.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<W0, W1, C0, C1, C2, C3, C4, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C0, C1, C2, C3, C4)>  where R0.RegexOutput == (W0, C0), R1.RegexOutput == (W1, C1, C2, C3, C4) {
     .init(node: accumulated.regex.root.appending(next.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<W0, W1, C0, C1, C2, C3, C4, C5, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5)>  where R0.RegexOutput == (W0, C0), R1.RegexOutput == (W1, C1, C2, C3, C4, C5) {
     .init(node: accumulated.regex.root.appending(next.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<W0, W1, C0, C1, C2, C3, C4, C5, C6, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6)>  where R0.RegexOutput == (W0, C0), R1.RegexOutput == (W1, C1, C2, C3, C4, C5, C6) {
     .init(node: accumulated.regex.root.appending(next.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<W0, W1, C0, C1, C2, C3, C4, C5, C6, C7, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7)>  where R0.RegexOutput == (W0, C0), R1.RegexOutput == (W1, C1, C2, C3, C4, C5, C6, C7) {
     .init(node: accumulated.regex.root.appending(next.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<W0, W1, C0, C1, C2, C3, C4, C5, C6, C7, C8, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8)>  where R0.RegexOutput == (W0, C0), R1.RegexOutput == (W1, C1, C2, C3, C4, C5, C6, C7, C8) {
     .init(node: accumulated.regex.root.appending(next.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<W0, W1, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9)>  where R0.RegexOutput == (W0, C0), R1.RegexOutput == (W1, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
     .init(node: accumulated.regex.root.appending(next.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<W0, W1, C0, C1, C2, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C0, C1, C2)>  where R0.RegexOutput == (W0, C0, C1), R1.RegexOutput == (W1, C2) {
     .init(node: accumulated.regex.root.appending(next.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<W0, W1, C0, C1, C2, C3, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C0, C1, C2, C3)>  where R0.RegexOutput == (W0, C0, C1), R1.RegexOutput == (W1, C2, C3) {
     .init(node: accumulated.regex.root.appending(next.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<W0, W1, C0, C1, C2, C3, C4, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C0, C1, C2, C3, C4)>  where R0.RegexOutput == (W0, C0, C1), R1.RegexOutput == (W1, C2, C3, C4) {
     .init(node: accumulated.regex.root.appending(next.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<W0, W1, C0, C1, C2, C3, C4, C5, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5)>  where R0.RegexOutput == (W0, C0, C1), R1.RegexOutput == (W1, C2, C3, C4, C5) {
     .init(node: accumulated.regex.root.appending(next.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<W0, W1, C0, C1, C2, C3, C4, C5, C6, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6)>  where R0.RegexOutput == (W0, C0, C1), R1.RegexOutput == (W1, C2, C3, C4, C5, C6) {
     .init(node: accumulated.regex.root.appending(next.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<W0, W1, C0, C1, C2, C3, C4, C5, C6, C7, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7)>  where R0.RegexOutput == (W0, C0, C1), R1.RegexOutput == (W1, C2, C3, C4, C5, C6, C7) {
     .init(node: accumulated.regex.root.appending(next.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<W0, W1, C0, C1, C2, C3, C4, C5, C6, C7, C8, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8)>  where R0.RegexOutput == (W0, C0, C1), R1.RegexOutput == (W1, C2, C3, C4, C5, C6, C7, C8) {
     .init(node: accumulated.regex.root.appending(next.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<W0, W1, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9)>  where R0.RegexOutput == (W0, C0, C1), R1.RegexOutput == (W1, C2, C3, C4, C5, C6, C7, C8, C9) {
     .init(node: accumulated.regex.root.appending(next.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<W0, W1, C0, C1, C2, C3, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C0, C1, C2, C3)>  where R0.RegexOutput == (W0, C0, C1, C2), R1.RegexOutput == (W1, C3) {
     .init(node: accumulated.regex.root.appending(next.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<W0, W1, C0, C1, C2, C3, C4, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C0, C1, C2, C3, C4)>  where R0.RegexOutput == (W0, C0, C1, C2), R1.RegexOutput == (W1, C3, C4) {
     .init(node: accumulated.regex.root.appending(next.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<W0, W1, C0, C1, C2, C3, C4, C5, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5)>  where R0.RegexOutput == (W0, C0, C1, C2), R1.RegexOutput == (W1, C3, C4, C5) {
     .init(node: accumulated.regex.root.appending(next.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<W0, W1, C0, C1, C2, C3, C4, C5, C6, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6)>  where R0.RegexOutput == (W0, C0, C1, C2), R1.RegexOutput == (W1, C3, C4, C5, C6) {
     .init(node: accumulated.regex.root.appending(next.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<W0, W1, C0, C1, C2, C3, C4, C5, C6, C7, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7)>  where R0.RegexOutput == (W0, C0, C1, C2), R1.RegexOutput == (W1, C3, C4, C5, C6, C7) {
     .init(node: accumulated.regex.root.appending(next.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<W0, W1, C0, C1, C2, C3, C4, C5, C6, C7, C8, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8)>  where R0.RegexOutput == (W0, C0, C1, C2), R1.RegexOutput == (W1, C3, C4, C5, C6, C7, C8) {
     .init(node: accumulated.regex.root.appending(next.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<W0, W1, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9)>  where R0.RegexOutput == (W0, C0, C1, C2), R1.RegexOutput == (W1, C3, C4, C5, C6, C7, C8, C9) {
     .init(node: accumulated.regex.root.appending(next.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<W0, W1, C0, C1, C2, C3, C4, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C0, C1, C2, C3, C4)>  where R0.RegexOutput == (W0, C0, C1, C2, C3), R1.RegexOutput == (W1, C4) {
     .init(node: accumulated.regex.root.appending(next.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<W0, W1, C0, C1, C2, C3, C4, C5, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5)>  where R0.RegexOutput == (W0, C0, C1, C2, C3), R1.RegexOutput == (W1, C4, C5) {
     .init(node: accumulated.regex.root.appending(next.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<W0, W1, C0, C1, C2, C3, C4, C5, C6, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6)>  where R0.RegexOutput == (W0, C0, C1, C2, C3), R1.RegexOutput == (W1, C4, C5, C6) {
     .init(node: accumulated.regex.root.appending(next.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<W0, W1, C0, C1, C2, C3, C4, C5, C6, C7, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7)>  where R0.RegexOutput == (W0, C0, C1, C2, C3), R1.RegexOutput == (W1, C4, C5, C6, C7) {
     .init(node: accumulated.regex.root.appending(next.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<W0, W1, C0, C1, C2, C3, C4, C5, C6, C7, C8, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8)>  where R0.RegexOutput == (W0, C0, C1, C2, C3), R1.RegexOutput == (W1, C4, C5, C6, C7, C8) {
     .init(node: accumulated.regex.root.appending(next.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<W0, W1, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9)>  where R0.RegexOutput == (W0, C0, C1, C2, C3), R1.RegexOutput == (W1, C4, C5, C6, C7, C8, C9) {
     .init(node: accumulated.regex.root.appending(next.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<W0, W1, C0, C1, C2, C3, C4, C5, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5)>  where R0.RegexOutput == (W0, C0, C1, C2, C3, C4), R1.RegexOutput == (W1, C5) {
     .init(node: accumulated.regex.root.appending(next.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<W0, W1, C0, C1, C2, C3, C4, C5, C6, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6)>  where R0.RegexOutput == (W0, C0, C1, C2, C3, C4), R1.RegexOutput == (W1, C5, C6) {
     .init(node: accumulated.regex.root.appending(next.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<W0, W1, C0, C1, C2, C3, C4, C5, C6, C7, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7)>  where R0.RegexOutput == (W0, C0, C1, C2, C3, C4), R1.RegexOutput == (W1, C5, C6, C7) {
     .init(node: accumulated.regex.root.appending(next.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<W0, W1, C0, C1, C2, C3, C4, C5, C6, C7, C8, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8)>  where R0.RegexOutput == (W0, C0, C1, C2, C3, C4), R1.RegexOutput == (W1, C5, C6, C7, C8) {
     .init(node: accumulated.regex.root.appending(next.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<W0, W1, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9)>  where R0.RegexOutput == (W0, C0, C1, C2, C3, C4), R1.RegexOutput == (W1, C5, C6, C7, C8, C9) {
     .init(node: accumulated.regex.root.appending(next.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<W0, W1, C0, C1, C2, C3, C4, C5, C6, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6)>  where R0.RegexOutput == (W0, C0, C1, C2, C3, C4, C5), R1.RegexOutput == (W1, C6) {
     .init(node: accumulated.regex.root.appending(next.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<W0, W1, C0, C1, C2, C3, C4, C5, C6, C7, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7)>  where R0.RegexOutput == (W0, C0, C1, C2, C3, C4, C5), R1.RegexOutput == (W1, C6, C7) {
     .init(node: accumulated.regex.root.appending(next.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<W0, W1, C0, C1, C2, C3, C4, C5, C6, C7, C8, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8)>  where R0.RegexOutput == (W0, C0, C1, C2, C3, C4, C5), R1.RegexOutput == (W1, C6, C7, C8) {
     .init(node: accumulated.regex.root.appending(next.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<W0, W1, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9)>  where R0.RegexOutput == (W0, C0, C1, C2, C3, C4, C5), R1.RegexOutput == (W1, C6, C7, C8, C9) {
     .init(node: accumulated.regex.root.appending(next.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<W0, W1, C0, C1, C2, C3, C4, C5, C6, C7, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7)>  where R0.RegexOutput == (W0, C0, C1, C2, C3, C4, C5, C6), R1.RegexOutput == (W1, C7) {
     .init(node: accumulated.regex.root.appending(next.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<W0, W1, C0, C1, C2, C3, C4, C5, C6, C7, C8, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8)>  where R0.RegexOutput == (W0, C0, C1, C2, C3, C4, C5, C6), R1.RegexOutput == (W1, C7, C8) {
     .init(node: accumulated.regex.root.appending(next.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<W0, W1, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9)>  where R0.RegexOutput == (W0, C0, C1, C2, C3, C4, C5, C6), R1.RegexOutput == (W1, C7, C8, C9) {
     .init(node: accumulated.regex.root.appending(next.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<W0, W1, C0, C1, C2, C3, C4, C5, C6, C7, C8, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8)>  where R0.RegexOutput == (W0, C0, C1, C2, C3, C4, C5, C6, C7), R1.RegexOutput == (W1, C8) {
     .init(node: accumulated.regex.root.appending(next.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<W0, W1, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9)>  where R0.RegexOutput == (W0, C0, C1, C2, C3, C4, C5, C6, C7), R1.RegexOutput == (W1, C8, C9) {
     .init(node: accumulated.regex.root.appending(next.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<W0, W1, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9)>  where R0.RegexOutput == (W0, C0, C1, C2, C3, C4, C5, C6, C7, C8), R1.RegexOutput == (W1, C9) {
     .init(node: accumulated.regex.root.appending(next.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<W0, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<Substring> where R0.RegexOutput == W0  {
     .init(node: accumulated.regex.root.appending(next.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<W0, C0, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C0)> where R0.RegexOutput == (W0, C0)  {
     .init(node: accumulated.regex.root.appending(next.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<W0, C0, C1, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C0, C1)> where R0.RegexOutput == (W0, C0, C1)  {
     .init(node: accumulated.regex.root.appending(next.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<W0, C0, C1, C2, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C0, C1, C2)> where R0.RegexOutput == (W0, C0, C1, C2)  {
     .init(node: accumulated.regex.root.appending(next.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<W0, C0, C1, C2, C3, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C0, C1, C2, C3)> where R0.RegexOutput == (W0, C0, C1, C2, C3)  {
     .init(node: accumulated.regex.root.appending(next.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<W0, C0, C1, C2, C3, C4, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C0, C1, C2, C3, C4)> where R0.RegexOutput == (W0, C0, C1, C2, C3, C4)  {
     .init(node: accumulated.regex.root.appending(next.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<W0, C0, C1, C2, C3, C4, C5, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5)> where R0.RegexOutput == (W0, C0, C1, C2, C3, C4, C5)  {
     .init(node: accumulated.regex.root.appending(next.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<W0, C0, C1, C2, C3, C4, C5, C6, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6)> where R0.RegexOutput == (W0, C0, C1, C2, C3, C4, C5, C6)  {
     .init(node: accumulated.regex.root.appending(next.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<W0, C0, C1, C2, C3, C4, C5, C6, C7, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7)> where R0.RegexOutput == (W0, C0, C1, C2, C3, C4, C5, C6, C7)  {
     .init(node: accumulated.regex.root.appending(next.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<W0, C0, C1, C2, C3, C4, C5, C6, C7, C8, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8)> where R0.RegexOutput == (W0, C0, C1, C2, C3, C4, C5, C6, C7, C8)  {
     .init(node: accumulated.regex.root.appending(next.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<W0, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9)> where R0.RegexOutput == (W0, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9)  {
@@ -478,7 +610,9 @@ extension RegexComponentBuilder {
 }
 
 
+@available(SwiftStdlib 5.7, *)
 extension Optionally {
+  @available(SwiftStdlib 5.7, *)
   @_disfavoredOverload
   public init<Component: RegexComponent>(
     _ component: Component,
@@ -488,7 +622,9 @@ extension Optionally {
   }
 }
 
+@available(SwiftStdlib 5.7, *)
 extension Optionally {
+  @available(SwiftStdlib 5.7, *)
   @_disfavoredOverload
   public init<Component: RegexComponent>(
     _ behavior: QuantificationBehavior = .eagerly,
@@ -498,14 +634,18 @@ extension Optionally {
   }
 }
 
+@available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildLimitedAvailability<Component: RegexComponent>(
     _ component: Component
   ) -> Regex<Substring>  {
     .init(node: .quantification(.zeroOrOne, .eager, component.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension ZeroOrMore {
+  @available(SwiftStdlib 5.7, *)
   @_disfavoredOverload
   public init<Component: RegexComponent>(
     _ component: Component,
@@ -515,7 +655,9 @@ extension ZeroOrMore {
   }
 }
 
+@available(SwiftStdlib 5.7, *)
 extension ZeroOrMore {
+  @available(SwiftStdlib 5.7, *)
   @_disfavoredOverload
   public init<Component: RegexComponent>(
     _ behavior: QuantificationBehavior = .eagerly,
@@ -526,7 +668,9 @@ extension ZeroOrMore {
 }
 
 
+@available(SwiftStdlib 5.7, *)
 extension OneOrMore {
+  @available(SwiftStdlib 5.7, *)
   @_disfavoredOverload
   public init<Component: RegexComponent>(
     _ component: Component,
@@ -536,7 +680,9 @@ extension OneOrMore {
   }
 }
 
+@available(SwiftStdlib 5.7, *)
 extension OneOrMore {
+  @available(SwiftStdlib 5.7, *)
   @_disfavoredOverload
   public init<Component: RegexComponent>(
     _ behavior: QuantificationBehavior = .eagerly,
@@ -547,7 +693,9 @@ extension OneOrMore {
 }
 
 
+@available(SwiftStdlib 5.7, *)
 extension Repeat {
+  @available(SwiftStdlib 5.7, *)
   @_disfavoredOverload
   public init<Component: RegexComponent>(
     _ component: Component,
@@ -558,6 +706,7 @@ extension Repeat {
     self.init(node: .quantification(.exactly(.init(faking: count)), .eager, component.regex.root))
   }
 
+  @available(SwiftStdlib 5.7, *)
   @_disfavoredOverload
   public init<Component: RegexComponent>(
     count: Int,
@@ -568,6 +717,7 @@ extension Repeat {
     self.init(node: .quantification(.exactly(.init(faking: count)), .eager, component().regex.root))
   }
 
+  @available(SwiftStdlib 5.7, *)
   @_disfavoredOverload
   public init<Component: RegexComponent, R: RangeExpression>(
     _ component: Component,
@@ -577,6 +727,7 @@ extension Repeat {
     self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component.regex.root))
   }
 
+  @available(SwiftStdlib 5.7, *)
   @_disfavoredOverload
   public init<Component: RegexComponent, R: RangeExpression>(
     _ expression: R,
@@ -586,7 +737,9 @@ extension Repeat {
     self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component().regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension Optionally {
+  @available(SwiftStdlib 5.7, *)
     public init<W, C0, Component: RegexComponent>(
     _ component: Component,
     _ behavior: QuantificationBehavior = .eagerly
@@ -595,7 +748,9 @@ extension Optionally {
   }
 }
 
+@available(SwiftStdlib 5.7, *)
 extension Optionally {
+  @available(SwiftStdlib 5.7, *)
     public init<W, C0, Component: RegexComponent>(
     _ behavior: QuantificationBehavior = .eagerly,
     @RegexComponentBuilder _ component: () -> Component
@@ -604,14 +759,18 @@ extension Optionally {
   }
 }
 
+@available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildLimitedAvailability<W, C0, Component: RegexComponent>(
     _ component: Component
   ) -> Regex<(Substring, C0?)> where Component.RegexOutput == (W, C0) {
     .init(node: .quantification(.zeroOrOne, .eager, component.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension ZeroOrMore {
+  @available(SwiftStdlib 5.7, *)
     public init<W, C0, Component: RegexComponent>(
     _ component: Component,
     _ behavior: QuantificationBehavior = .eagerly
@@ -620,7 +779,9 @@ extension ZeroOrMore {
   }
 }
 
+@available(SwiftStdlib 5.7, *)
 extension ZeroOrMore {
+  @available(SwiftStdlib 5.7, *)
     public init<W, C0, Component: RegexComponent>(
     _ behavior: QuantificationBehavior = .eagerly,
     @RegexComponentBuilder _ component: () -> Component
@@ -630,7 +791,9 @@ extension ZeroOrMore {
 }
 
 
+@available(SwiftStdlib 5.7, *)
 extension OneOrMore {
+  @available(SwiftStdlib 5.7, *)
     public init<W, C0, Component: RegexComponent>(
     _ component: Component,
     _ behavior: QuantificationBehavior = .eagerly
@@ -639,7 +802,9 @@ extension OneOrMore {
   }
 }
 
+@available(SwiftStdlib 5.7, *)
 extension OneOrMore {
+  @available(SwiftStdlib 5.7, *)
     public init<W, C0, Component: RegexComponent>(
     _ behavior: QuantificationBehavior = .eagerly,
     @RegexComponentBuilder _ component: () -> Component
@@ -649,7 +814,9 @@ extension OneOrMore {
 }
 
 
+@available(SwiftStdlib 5.7, *)
 extension Repeat {
+  @available(SwiftStdlib 5.7, *)
     public init<W, C0, Component: RegexComponent>(
     _ component: Component,
     count: Int
@@ -659,6 +826,7 @@ extension Repeat {
     self.init(node: .quantification(.exactly(.init(faking: count)), .eager, component.regex.root))
   }
 
+  @available(SwiftStdlib 5.7, *)
     public init<W, C0, Component: RegexComponent>(
     count: Int,
     @RegexComponentBuilder _ component: () -> Component
@@ -668,6 +836,7 @@ extension Repeat {
     self.init(node: .quantification(.exactly(.init(faking: count)), .eager, component().regex.root))
   }
 
+  @available(SwiftStdlib 5.7, *)
     public init<W, C0, Component: RegexComponent, R: RangeExpression>(
     _ component: Component,
     _ expression: R,
@@ -676,6 +845,7 @@ extension Repeat {
     self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component.regex.root))
   }
 
+  @available(SwiftStdlib 5.7, *)
     public init<W, C0, Component: RegexComponent, R: RangeExpression>(
     _ expression: R,
     _ behavior: QuantificationBehavior = .eagerly,
@@ -684,7 +854,9 @@ extension Repeat {
     self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component().regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension Optionally {
+  @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, Component: RegexComponent>(
     _ component: Component,
     _ behavior: QuantificationBehavior = .eagerly
@@ -693,7 +865,9 @@ extension Optionally {
   }
 }
 
+@available(SwiftStdlib 5.7, *)
 extension Optionally {
+  @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, Component: RegexComponent>(
     _ behavior: QuantificationBehavior = .eagerly,
     @RegexComponentBuilder _ component: () -> Component
@@ -702,14 +876,18 @@ extension Optionally {
   }
 }
 
+@available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildLimitedAvailability<W, C0, C1, Component: RegexComponent>(
     _ component: Component
   ) -> Regex<(Substring, C0?, C1?)> where Component.RegexOutput == (W, C0, C1) {
     .init(node: .quantification(.zeroOrOne, .eager, component.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension ZeroOrMore {
+  @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, Component: RegexComponent>(
     _ component: Component,
     _ behavior: QuantificationBehavior = .eagerly
@@ -718,7 +896,9 @@ extension ZeroOrMore {
   }
 }
 
+@available(SwiftStdlib 5.7, *)
 extension ZeroOrMore {
+  @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, Component: RegexComponent>(
     _ behavior: QuantificationBehavior = .eagerly,
     @RegexComponentBuilder _ component: () -> Component
@@ -728,7 +908,9 @@ extension ZeroOrMore {
 }
 
 
+@available(SwiftStdlib 5.7, *)
 extension OneOrMore {
+  @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, Component: RegexComponent>(
     _ component: Component,
     _ behavior: QuantificationBehavior = .eagerly
@@ -737,7 +919,9 @@ extension OneOrMore {
   }
 }
 
+@available(SwiftStdlib 5.7, *)
 extension OneOrMore {
+  @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, Component: RegexComponent>(
     _ behavior: QuantificationBehavior = .eagerly,
     @RegexComponentBuilder _ component: () -> Component
@@ -747,7 +931,9 @@ extension OneOrMore {
 }
 
 
+@available(SwiftStdlib 5.7, *)
 extension Repeat {
+  @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, Component: RegexComponent>(
     _ component: Component,
     count: Int
@@ -757,6 +943,7 @@ extension Repeat {
     self.init(node: .quantification(.exactly(.init(faking: count)), .eager, component.regex.root))
   }
 
+  @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, Component: RegexComponent>(
     count: Int,
     @RegexComponentBuilder _ component: () -> Component
@@ -766,6 +953,7 @@ extension Repeat {
     self.init(node: .quantification(.exactly(.init(faking: count)), .eager, component().regex.root))
   }
 
+  @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, Component: RegexComponent, R: RangeExpression>(
     _ component: Component,
     _ expression: R,
@@ -774,6 +962,7 @@ extension Repeat {
     self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component.regex.root))
   }
 
+  @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, Component: RegexComponent, R: RangeExpression>(
     _ expression: R,
     _ behavior: QuantificationBehavior = .eagerly,
@@ -782,7 +971,9 @@ extension Repeat {
     self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component().regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension Optionally {
+  @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, Component: RegexComponent>(
     _ component: Component,
     _ behavior: QuantificationBehavior = .eagerly
@@ -791,7 +982,9 @@ extension Optionally {
   }
 }
 
+@available(SwiftStdlib 5.7, *)
 extension Optionally {
+  @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, Component: RegexComponent>(
     _ behavior: QuantificationBehavior = .eagerly,
     @RegexComponentBuilder _ component: () -> Component
@@ -800,14 +993,18 @@ extension Optionally {
   }
 }
 
+@available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildLimitedAvailability<W, C0, C1, C2, Component: RegexComponent>(
     _ component: Component
   ) -> Regex<(Substring, C0?, C1?, C2?)> where Component.RegexOutput == (W, C0, C1, C2) {
     .init(node: .quantification(.zeroOrOne, .eager, component.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension ZeroOrMore {
+  @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, Component: RegexComponent>(
     _ component: Component,
     _ behavior: QuantificationBehavior = .eagerly
@@ -816,7 +1013,9 @@ extension ZeroOrMore {
   }
 }
 
+@available(SwiftStdlib 5.7, *)
 extension ZeroOrMore {
+  @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, Component: RegexComponent>(
     _ behavior: QuantificationBehavior = .eagerly,
     @RegexComponentBuilder _ component: () -> Component
@@ -826,7 +1025,9 @@ extension ZeroOrMore {
 }
 
 
+@available(SwiftStdlib 5.7, *)
 extension OneOrMore {
+  @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, Component: RegexComponent>(
     _ component: Component,
     _ behavior: QuantificationBehavior = .eagerly
@@ -835,7 +1036,9 @@ extension OneOrMore {
   }
 }
 
+@available(SwiftStdlib 5.7, *)
 extension OneOrMore {
+  @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, Component: RegexComponent>(
     _ behavior: QuantificationBehavior = .eagerly,
     @RegexComponentBuilder _ component: () -> Component
@@ -845,7 +1048,9 @@ extension OneOrMore {
 }
 
 
+@available(SwiftStdlib 5.7, *)
 extension Repeat {
+  @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, Component: RegexComponent>(
     _ component: Component,
     count: Int
@@ -855,6 +1060,7 @@ extension Repeat {
     self.init(node: .quantification(.exactly(.init(faking: count)), .eager, component.regex.root))
   }
 
+  @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, Component: RegexComponent>(
     count: Int,
     @RegexComponentBuilder _ component: () -> Component
@@ -864,6 +1070,7 @@ extension Repeat {
     self.init(node: .quantification(.exactly(.init(faking: count)), .eager, component().regex.root))
   }
 
+  @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, Component: RegexComponent, R: RangeExpression>(
     _ component: Component,
     _ expression: R,
@@ -872,6 +1079,7 @@ extension Repeat {
     self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component.regex.root))
   }
 
+  @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, Component: RegexComponent, R: RangeExpression>(
     _ expression: R,
     _ behavior: QuantificationBehavior = .eagerly,
@@ -880,7 +1088,9 @@ extension Repeat {
     self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component().regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension Optionally {
+  @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, Component: RegexComponent>(
     _ component: Component,
     _ behavior: QuantificationBehavior = .eagerly
@@ -889,7 +1099,9 @@ extension Optionally {
   }
 }
 
+@available(SwiftStdlib 5.7, *)
 extension Optionally {
+  @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, Component: RegexComponent>(
     _ behavior: QuantificationBehavior = .eagerly,
     @RegexComponentBuilder _ component: () -> Component
@@ -898,14 +1110,18 @@ extension Optionally {
   }
 }
 
+@available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildLimitedAvailability<W, C0, C1, C2, C3, Component: RegexComponent>(
     _ component: Component
   ) -> Regex<(Substring, C0?, C1?, C2?, C3?)> where Component.RegexOutput == (W, C0, C1, C2, C3) {
     .init(node: .quantification(.zeroOrOne, .eager, component.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension ZeroOrMore {
+  @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, Component: RegexComponent>(
     _ component: Component,
     _ behavior: QuantificationBehavior = .eagerly
@@ -914,7 +1130,9 @@ extension ZeroOrMore {
   }
 }
 
+@available(SwiftStdlib 5.7, *)
 extension ZeroOrMore {
+  @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, Component: RegexComponent>(
     _ behavior: QuantificationBehavior = .eagerly,
     @RegexComponentBuilder _ component: () -> Component
@@ -924,7 +1142,9 @@ extension ZeroOrMore {
 }
 
 
+@available(SwiftStdlib 5.7, *)
 extension OneOrMore {
+  @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, Component: RegexComponent>(
     _ component: Component,
     _ behavior: QuantificationBehavior = .eagerly
@@ -933,7 +1153,9 @@ extension OneOrMore {
   }
 }
 
+@available(SwiftStdlib 5.7, *)
 extension OneOrMore {
+  @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, Component: RegexComponent>(
     _ behavior: QuantificationBehavior = .eagerly,
     @RegexComponentBuilder _ component: () -> Component
@@ -943,7 +1165,9 @@ extension OneOrMore {
 }
 
 
+@available(SwiftStdlib 5.7, *)
 extension Repeat {
+  @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, Component: RegexComponent>(
     _ component: Component,
     count: Int
@@ -953,6 +1177,7 @@ extension Repeat {
     self.init(node: .quantification(.exactly(.init(faking: count)), .eager, component.regex.root))
   }
 
+  @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, Component: RegexComponent>(
     count: Int,
     @RegexComponentBuilder _ component: () -> Component
@@ -962,6 +1187,7 @@ extension Repeat {
     self.init(node: .quantification(.exactly(.init(faking: count)), .eager, component().regex.root))
   }
 
+  @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, Component: RegexComponent, R: RangeExpression>(
     _ component: Component,
     _ expression: R,
@@ -970,6 +1196,7 @@ extension Repeat {
     self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component.regex.root))
   }
 
+  @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, Component: RegexComponent, R: RangeExpression>(
     _ expression: R,
     _ behavior: QuantificationBehavior = .eagerly,
@@ -978,7 +1205,9 @@ extension Repeat {
     self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component().regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension Optionally {
+  @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, Component: RegexComponent>(
     _ component: Component,
     _ behavior: QuantificationBehavior = .eagerly
@@ -987,7 +1216,9 @@ extension Optionally {
   }
 }
 
+@available(SwiftStdlib 5.7, *)
 extension Optionally {
+  @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, Component: RegexComponent>(
     _ behavior: QuantificationBehavior = .eagerly,
     @RegexComponentBuilder _ component: () -> Component
@@ -996,14 +1227,18 @@ extension Optionally {
   }
 }
 
+@available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildLimitedAvailability<W, C0, C1, C2, C3, C4, Component: RegexComponent>(
     _ component: Component
   ) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?)> where Component.RegexOutput == (W, C0, C1, C2, C3, C4) {
     .init(node: .quantification(.zeroOrOne, .eager, component.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension ZeroOrMore {
+  @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, Component: RegexComponent>(
     _ component: Component,
     _ behavior: QuantificationBehavior = .eagerly
@@ -1012,7 +1247,9 @@ extension ZeroOrMore {
   }
 }
 
+@available(SwiftStdlib 5.7, *)
 extension ZeroOrMore {
+  @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, Component: RegexComponent>(
     _ behavior: QuantificationBehavior = .eagerly,
     @RegexComponentBuilder _ component: () -> Component
@@ -1022,7 +1259,9 @@ extension ZeroOrMore {
 }
 
 
+@available(SwiftStdlib 5.7, *)
 extension OneOrMore {
+  @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, Component: RegexComponent>(
     _ component: Component,
     _ behavior: QuantificationBehavior = .eagerly
@@ -1031,7 +1270,9 @@ extension OneOrMore {
   }
 }
 
+@available(SwiftStdlib 5.7, *)
 extension OneOrMore {
+  @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, Component: RegexComponent>(
     _ behavior: QuantificationBehavior = .eagerly,
     @RegexComponentBuilder _ component: () -> Component
@@ -1041,7 +1282,9 @@ extension OneOrMore {
 }
 
 
+@available(SwiftStdlib 5.7, *)
 extension Repeat {
+  @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, Component: RegexComponent>(
     _ component: Component,
     count: Int
@@ -1051,6 +1294,7 @@ extension Repeat {
     self.init(node: .quantification(.exactly(.init(faking: count)), .eager, component.regex.root))
   }
 
+  @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, Component: RegexComponent>(
     count: Int,
     @RegexComponentBuilder _ component: () -> Component
@@ -1060,6 +1304,7 @@ extension Repeat {
     self.init(node: .quantification(.exactly(.init(faking: count)), .eager, component().regex.root))
   }
 
+  @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, Component: RegexComponent, R: RangeExpression>(
     _ component: Component,
     _ expression: R,
@@ -1068,6 +1313,7 @@ extension Repeat {
     self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component.regex.root))
   }
 
+  @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, Component: RegexComponent, R: RangeExpression>(
     _ expression: R,
     _ behavior: QuantificationBehavior = .eagerly,
@@ -1076,7 +1322,9 @@ extension Repeat {
     self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component().regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension Optionally {
+  @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, Component: RegexComponent>(
     _ component: Component,
     _ behavior: QuantificationBehavior = .eagerly
@@ -1085,7 +1333,9 @@ extension Optionally {
   }
 }
 
+@available(SwiftStdlib 5.7, *)
 extension Optionally {
+  @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, Component: RegexComponent>(
     _ behavior: QuantificationBehavior = .eagerly,
     @RegexComponentBuilder _ component: () -> Component
@@ -1094,14 +1344,18 @@ extension Optionally {
   }
 }
 
+@available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildLimitedAvailability<W, C0, C1, C2, C3, C4, C5, Component: RegexComponent>(
     _ component: Component
   ) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?)> where Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5) {
     .init(node: .quantification(.zeroOrOne, .eager, component.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension ZeroOrMore {
+  @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, Component: RegexComponent>(
     _ component: Component,
     _ behavior: QuantificationBehavior = .eagerly
@@ -1110,7 +1364,9 @@ extension ZeroOrMore {
   }
 }
 
+@available(SwiftStdlib 5.7, *)
 extension ZeroOrMore {
+  @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, Component: RegexComponent>(
     _ behavior: QuantificationBehavior = .eagerly,
     @RegexComponentBuilder _ component: () -> Component
@@ -1120,7 +1376,9 @@ extension ZeroOrMore {
 }
 
 
+@available(SwiftStdlib 5.7, *)
 extension OneOrMore {
+  @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, Component: RegexComponent>(
     _ component: Component,
     _ behavior: QuantificationBehavior = .eagerly
@@ -1129,7 +1387,9 @@ extension OneOrMore {
   }
 }
 
+@available(SwiftStdlib 5.7, *)
 extension OneOrMore {
+  @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, Component: RegexComponent>(
     _ behavior: QuantificationBehavior = .eagerly,
     @RegexComponentBuilder _ component: () -> Component
@@ -1139,7 +1399,9 @@ extension OneOrMore {
 }
 
 
+@available(SwiftStdlib 5.7, *)
 extension Repeat {
+  @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, Component: RegexComponent>(
     _ component: Component,
     count: Int
@@ -1149,6 +1411,7 @@ extension Repeat {
     self.init(node: .quantification(.exactly(.init(faking: count)), .eager, component.regex.root))
   }
 
+  @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, Component: RegexComponent>(
     count: Int,
     @RegexComponentBuilder _ component: () -> Component
@@ -1158,6 +1421,7 @@ extension Repeat {
     self.init(node: .quantification(.exactly(.init(faking: count)), .eager, component().regex.root))
   }
 
+  @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, Component: RegexComponent, R: RangeExpression>(
     _ component: Component,
     _ expression: R,
@@ -1166,6 +1430,7 @@ extension Repeat {
     self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component.regex.root))
   }
 
+  @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, Component: RegexComponent, R: RangeExpression>(
     _ expression: R,
     _ behavior: QuantificationBehavior = .eagerly,
@@ -1174,7 +1439,9 @@ extension Repeat {
     self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component().regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension Optionally {
+  @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexComponent>(
     _ component: Component,
     _ behavior: QuantificationBehavior = .eagerly
@@ -1183,7 +1450,9 @@ extension Optionally {
   }
 }
 
+@available(SwiftStdlib 5.7, *)
 extension Optionally {
+  @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexComponent>(
     _ behavior: QuantificationBehavior = .eagerly,
     @RegexComponentBuilder _ component: () -> Component
@@ -1192,14 +1461,18 @@ extension Optionally {
   }
 }
 
+@available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildLimitedAvailability<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexComponent>(
     _ component: Component
   ) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?)> where Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6) {
     .init(node: .quantification(.zeroOrOne, .eager, component.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension ZeroOrMore {
+  @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexComponent>(
     _ component: Component,
     _ behavior: QuantificationBehavior = .eagerly
@@ -1208,7 +1481,9 @@ extension ZeroOrMore {
   }
 }
 
+@available(SwiftStdlib 5.7, *)
 extension ZeroOrMore {
+  @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexComponent>(
     _ behavior: QuantificationBehavior = .eagerly,
     @RegexComponentBuilder _ component: () -> Component
@@ -1218,7 +1493,9 @@ extension ZeroOrMore {
 }
 
 
+@available(SwiftStdlib 5.7, *)
 extension OneOrMore {
+  @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexComponent>(
     _ component: Component,
     _ behavior: QuantificationBehavior = .eagerly
@@ -1227,7 +1504,9 @@ extension OneOrMore {
   }
 }
 
+@available(SwiftStdlib 5.7, *)
 extension OneOrMore {
+  @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexComponent>(
     _ behavior: QuantificationBehavior = .eagerly,
     @RegexComponentBuilder _ component: () -> Component
@@ -1237,7 +1516,9 @@ extension OneOrMore {
 }
 
 
+@available(SwiftStdlib 5.7, *)
 extension Repeat {
+  @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexComponent>(
     _ component: Component,
     count: Int
@@ -1247,6 +1528,7 @@ extension Repeat {
     self.init(node: .quantification(.exactly(.init(faking: count)), .eager, component.regex.root))
   }
 
+  @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexComponent>(
     count: Int,
     @RegexComponentBuilder _ component: () -> Component
@@ -1256,6 +1538,7 @@ extension Repeat {
     self.init(node: .quantification(.exactly(.init(faking: count)), .eager, component().regex.root))
   }
 
+  @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexComponent, R: RangeExpression>(
     _ component: Component,
     _ expression: R,
@@ -1264,6 +1547,7 @@ extension Repeat {
     self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component.regex.root))
   }
 
+  @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexComponent, R: RangeExpression>(
     _ expression: R,
     _ behavior: QuantificationBehavior = .eagerly,
@@ -1272,7 +1556,9 @@ extension Repeat {
     self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component().regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension Optionally {
+  @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexComponent>(
     _ component: Component,
     _ behavior: QuantificationBehavior = .eagerly
@@ -1281,7 +1567,9 @@ extension Optionally {
   }
 }
 
+@available(SwiftStdlib 5.7, *)
 extension Optionally {
+  @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexComponent>(
     _ behavior: QuantificationBehavior = .eagerly,
     @RegexComponentBuilder _ component: () -> Component
@@ -1290,14 +1578,18 @@ extension Optionally {
   }
 }
 
+@available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildLimitedAvailability<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexComponent>(
     _ component: Component
   ) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?)> where Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
     .init(node: .quantification(.zeroOrOne, .eager, component.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension ZeroOrMore {
+  @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexComponent>(
     _ component: Component,
     _ behavior: QuantificationBehavior = .eagerly
@@ -1306,7 +1598,9 @@ extension ZeroOrMore {
   }
 }
 
+@available(SwiftStdlib 5.7, *)
 extension ZeroOrMore {
+  @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexComponent>(
     _ behavior: QuantificationBehavior = .eagerly,
     @RegexComponentBuilder _ component: () -> Component
@@ -1316,7 +1610,9 @@ extension ZeroOrMore {
 }
 
 
+@available(SwiftStdlib 5.7, *)
 extension OneOrMore {
+  @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexComponent>(
     _ component: Component,
     _ behavior: QuantificationBehavior = .eagerly
@@ -1325,7 +1621,9 @@ extension OneOrMore {
   }
 }
 
+@available(SwiftStdlib 5.7, *)
 extension OneOrMore {
+  @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexComponent>(
     _ behavior: QuantificationBehavior = .eagerly,
     @RegexComponentBuilder _ component: () -> Component
@@ -1335,7 +1633,9 @@ extension OneOrMore {
 }
 
 
+@available(SwiftStdlib 5.7, *)
 extension Repeat {
+  @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexComponent>(
     _ component: Component,
     count: Int
@@ -1345,6 +1645,7 @@ extension Repeat {
     self.init(node: .quantification(.exactly(.init(faking: count)), .eager, component.regex.root))
   }
 
+  @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexComponent>(
     count: Int,
     @RegexComponentBuilder _ component: () -> Component
@@ -1354,6 +1655,7 @@ extension Repeat {
     self.init(node: .quantification(.exactly(.init(faking: count)), .eager, component().regex.root))
   }
 
+  @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexComponent, R: RangeExpression>(
     _ component: Component,
     _ expression: R,
@@ -1362,6 +1664,7 @@ extension Repeat {
     self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component.regex.root))
   }
 
+  @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexComponent, R: RangeExpression>(
     _ expression: R,
     _ behavior: QuantificationBehavior = .eagerly,
@@ -1370,7 +1673,9 @@ extension Repeat {
     self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component().regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension Optionally {
+  @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexComponent>(
     _ component: Component,
     _ behavior: QuantificationBehavior = .eagerly
@@ -1379,7 +1684,9 @@ extension Optionally {
   }
 }
 
+@available(SwiftStdlib 5.7, *)
 extension Optionally {
+  @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexComponent>(
     _ behavior: QuantificationBehavior = .eagerly,
     @RegexComponentBuilder _ component: () -> Component
@@ -1388,14 +1695,18 @@ extension Optionally {
   }
 }
 
+@available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildLimitedAvailability<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexComponent>(
     _ component: Component
   ) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?)> where Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
     .init(node: .quantification(.zeroOrOne, .eager, component.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension ZeroOrMore {
+  @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexComponent>(
     _ component: Component,
     _ behavior: QuantificationBehavior = .eagerly
@@ -1404,7 +1715,9 @@ extension ZeroOrMore {
   }
 }
 
+@available(SwiftStdlib 5.7, *)
 extension ZeroOrMore {
+  @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexComponent>(
     _ behavior: QuantificationBehavior = .eagerly,
     @RegexComponentBuilder _ component: () -> Component
@@ -1414,7 +1727,9 @@ extension ZeroOrMore {
 }
 
 
+@available(SwiftStdlib 5.7, *)
 extension OneOrMore {
+  @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexComponent>(
     _ component: Component,
     _ behavior: QuantificationBehavior = .eagerly
@@ -1423,7 +1738,9 @@ extension OneOrMore {
   }
 }
 
+@available(SwiftStdlib 5.7, *)
 extension OneOrMore {
+  @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexComponent>(
     _ behavior: QuantificationBehavior = .eagerly,
     @RegexComponentBuilder _ component: () -> Component
@@ -1433,7 +1750,9 @@ extension OneOrMore {
 }
 
 
+@available(SwiftStdlib 5.7, *)
 extension Repeat {
+  @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexComponent>(
     _ component: Component,
     count: Int
@@ -1443,6 +1762,7 @@ extension Repeat {
     self.init(node: .quantification(.exactly(.init(faking: count)), .eager, component.regex.root))
   }
 
+  @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexComponent>(
     count: Int,
     @RegexComponentBuilder _ component: () -> Component
@@ -1452,6 +1772,7 @@ extension Repeat {
     self.init(node: .quantification(.exactly(.init(faking: count)), .eager, component().regex.root))
   }
 
+  @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexComponent, R: RangeExpression>(
     _ component: Component,
     _ expression: R,
@@ -1460,6 +1781,7 @@ extension Repeat {
     self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component.regex.root))
   }
 
+  @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexComponent, R: RangeExpression>(
     _ expression: R,
     _ behavior: QuantificationBehavior = .eagerly,
@@ -1468,7 +1790,9 @@ extension Repeat {
     self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component().regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension Optionally {
+  @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9, Component: RegexComponent>(
     _ component: Component,
     _ behavior: QuantificationBehavior = .eagerly
@@ -1477,7 +1801,9 @@ extension Optionally {
   }
 }
 
+@available(SwiftStdlib 5.7, *)
 extension Optionally {
+  @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9, Component: RegexComponent>(
     _ behavior: QuantificationBehavior = .eagerly,
     @RegexComponentBuilder _ component: () -> Component
@@ -1486,14 +1812,18 @@ extension Optionally {
   }
 }
 
+@available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildLimitedAvailability<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9, Component: RegexComponent>(
     _ component: Component
   ) -> Regex<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?)> where Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
     .init(node: .quantification(.zeroOrOne, .eager, component.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension ZeroOrMore {
+  @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9, Component: RegexComponent>(
     _ component: Component,
     _ behavior: QuantificationBehavior = .eagerly
@@ -1502,7 +1832,9 @@ extension ZeroOrMore {
   }
 }
 
+@available(SwiftStdlib 5.7, *)
 extension ZeroOrMore {
+  @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9, Component: RegexComponent>(
     _ behavior: QuantificationBehavior = .eagerly,
     @RegexComponentBuilder _ component: () -> Component
@@ -1512,7 +1844,9 @@ extension ZeroOrMore {
 }
 
 
+@available(SwiftStdlib 5.7, *)
 extension OneOrMore {
+  @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9, Component: RegexComponent>(
     _ component: Component,
     _ behavior: QuantificationBehavior = .eagerly
@@ -1521,7 +1855,9 @@ extension OneOrMore {
   }
 }
 
+@available(SwiftStdlib 5.7, *)
 extension OneOrMore {
+  @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9, Component: RegexComponent>(
     _ behavior: QuantificationBehavior = .eagerly,
     @RegexComponentBuilder _ component: () -> Component
@@ -1531,7 +1867,9 @@ extension OneOrMore {
 }
 
 
+@available(SwiftStdlib 5.7, *)
 extension Repeat {
+  @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9, Component: RegexComponent>(
     _ component: Component,
     count: Int
@@ -1541,6 +1879,7 @@ extension Repeat {
     self.init(node: .quantification(.exactly(.init(faking: count)), .eager, component.regex.root))
   }
 
+  @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9, Component: RegexComponent>(
     count: Int,
     @RegexComponentBuilder _ component: () -> Component
@@ -1550,6 +1889,7 @@ extension Repeat {
     self.init(node: .quantification(.exactly(.init(faking: count)), .eager, component().regex.root))
   }
 
+  @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9, Component: RegexComponent, R: RangeExpression>(
     _ component: Component,
     _ expression: R,
@@ -1558,6 +1898,7 @@ extension Repeat {
     self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component.regex.root))
   }
 
+  @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9, Component: RegexComponent, R: RangeExpression>(
     _ expression: R,
     _ behavior: QuantificationBehavior = .eagerly,
@@ -1566,7 +1907,9 @@ extension Repeat {
     self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component().regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension Local {
+  @available(SwiftStdlib 5.7, *)
   @_disfavoredOverload
   public init<Component: RegexComponent>(
     _ component: Component
@@ -1575,7 +1918,9 @@ extension Local {
   }
 }
 
+@available(SwiftStdlib 5.7, *)
 extension Local {
+  @available(SwiftStdlib 5.7, *)
   @_disfavoredOverload
   public init<Component: RegexComponent>(
     @RegexComponentBuilder _ component: () -> Component
@@ -1583,7 +1928,9 @@ extension Local {
     self.init(node: .nonCapturingGroup(.atomicNonCapturing, component().regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension Local {
+  @available(SwiftStdlib 5.7, *)
     public init<W, C0, Component: RegexComponent>(
     _ component: Component
   ) where RegexOutput == (Substring, C0), Component.RegexOutput == (W, C0) {
@@ -1591,14 +1938,18 @@ extension Local {
   }
 }
 
+@available(SwiftStdlib 5.7, *)
 extension Local {
+  @available(SwiftStdlib 5.7, *)
     public init<W, C0, Component: RegexComponent>(
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C0), Component.RegexOutput == (W, C0) {
     self.init(node: .nonCapturingGroup(.atomicNonCapturing, component().regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension Local {
+  @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, Component: RegexComponent>(
     _ component: Component
   ) where RegexOutput == (Substring, C0, C1), Component.RegexOutput == (W, C0, C1) {
@@ -1606,14 +1957,18 @@ extension Local {
   }
 }
 
+@available(SwiftStdlib 5.7, *)
 extension Local {
+  @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, Component: RegexComponent>(
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C0, C1), Component.RegexOutput == (W, C0, C1) {
     self.init(node: .nonCapturingGroup(.atomicNonCapturing, component().regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension Local {
+  @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, Component: RegexComponent>(
     _ component: Component
   ) where RegexOutput == (Substring, C0, C1, C2), Component.RegexOutput == (W, C0, C1, C2) {
@@ -1621,14 +1976,18 @@ extension Local {
   }
 }
 
+@available(SwiftStdlib 5.7, *)
 extension Local {
+  @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, Component: RegexComponent>(
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C0, C1, C2), Component.RegexOutput == (W, C0, C1, C2) {
     self.init(node: .nonCapturingGroup(.atomicNonCapturing, component().regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension Local {
+  @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, Component: RegexComponent>(
     _ component: Component
   ) where RegexOutput == (Substring, C0, C1, C2, C3), Component.RegexOutput == (W, C0, C1, C2, C3) {
@@ -1636,14 +1995,18 @@ extension Local {
   }
 }
 
+@available(SwiftStdlib 5.7, *)
 extension Local {
+  @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, Component: RegexComponent>(
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C0, C1, C2, C3), Component.RegexOutput == (W, C0, C1, C2, C3) {
     self.init(node: .nonCapturingGroup(.atomicNonCapturing, component().regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension Local {
+  @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, Component: RegexComponent>(
     _ component: Component
   ) where RegexOutput == (Substring, C0, C1, C2, C3, C4), Component.RegexOutput == (W, C0, C1, C2, C3, C4) {
@@ -1651,14 +2014,18 @@ extension Local {
   }
 }
 
+@available(SwiftStdlib 5.7, *)
 extension Local {
+  @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, Component: RegexComponent>(
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C0, C1, C2, C3, C4), Component.RegexOutput == (W, C0, C1, C2, C3, C4) {
     self.init(node: .nonCapturingGroup(.atomicNonCapturing, component().regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension Local {
+  @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, Component: RegexComponent>(
     _ component: Component
   ) where RegexOutput == (Substring, C0, C1, C2, C3, C4, C5), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5) {
@@ -1666,14 +2033,18 @@ extension Local {
   }
 }
 
+@available(SwiftStdlib 5.7, *)
 extension Local {
+  @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, Component: RegexComponent>(
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C0, C1, C2, C3, C4, C5), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5) {
     self.init(node: .nonCapturingGroup(.atomicNonCapturing, component().regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension Local {
+  @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexComponent>(
     _ component: Component
   ) where RegexOutput == (Substring, C0, C1, C2, C3, C4, C5, C6), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6) {
@@ -1681,14 +2052,18 @@ extension Local {
   }
 }
 
+@available(SwiftStdlib 5.7, *)
 extension Local {
+  @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexComponent>(
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C0, C1, C2, C3, C4, C5, C6), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6) {
     self.init(node: .nonCapturingGroup(.atomicNonCapturing, component().regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension Local {
+  @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexComponent>(
     _ component: Component
   ) where RegexOutput == (Substring, C0, C1, C2, C3, C4, C5, C6, C7), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
@@ -1696,14 +2071,18 @@ extension Local {
   }
 }
 
+@available(SwiftStdlib 5.7, *)
 extension Local {
+  @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexComponent>(
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C0, C1, C2, C3, C4, C5, C6, C7), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
     self.init(node: .nonCapturingGroup(.atomicNonCapturing, component().regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension Local {
+  @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexComponent>(
     _ component: Component
   ) where RegexOutput == (Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
@@ -1711,14 +2090,18 @@ extension Local {
   }
 }
 
+@available(SwiftStdlib 5.7, *)
 extension Local {
+  @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexComponent>(
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
     self.init(node: .nonCapturingGroup(.atomicNonCapturing, component().regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension Local {
+  @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9, Component: RegexComponent>(
     _ component: Component
   ) where RegexOutput == (Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
@@ -1726,521 +2109,675 @@ extension Local {
   }
 }
 
+@available(SwiftStdlib 5.7, *)
 extension Local {
+  @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9, Component: RegexComponent>(
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
     self.init(node: .nonCapturingGroup(.atomicNonCapturing, component().regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<R0, R1>(
     accumulated: R0, next: R1
   ) -> ChoiceOf<Substring> where R0: RegexComponent, R1: RegexComponent {
     .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<R0, R1, W1, C0>(
     accumulated: R0, next: R1
   ) -> ChoiceOf<(Substring, C0?)> where R0: RegexComponent, R1: RegexComponent, R1.RegexOutput == (W1, C0) {
     .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<R0, R1, W1, C0, C1>(
     accumulated: R0, next: R1
   ) -> ChoiceOf<(Substring, C0?, C1?)> where R0: RegexComponent, R1: RegexComponent, R1.RegexOutput == (W1, C0, C1) {
     .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<R0, R1, W1, C0, C1, C2>(
     accumulated: R0, next: R1
   ) -> ChoiceOf<(Substring, C0?, C1?, C2?)> where R0: RegexComponent, R1: RegexComponent, R1.RegexOutput == (W1, C0, C1, C2) {
     .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<R0, R1, W1, C0, C1, C2, C3>(
     accumulated: R0, next: R1
   ) -> ChoiceOf<(Substring, C0?, C1?, C2?, C3?)> where R0: RegexComponent, R1: RegexComponent, R1.RegexOutput == (W1, C0, C1, C2, C3) {
     .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<R0, R1, W1, C0, C1, C2, C3, C4>(
     accumulated: R0, next: R1
   ) -> ChoiceOf<(Substring, C0?, C1?, C2?, C3?, C4?)> where R0: RegexComponent, R1: RegexComponent, R1.RegexOutput == (W1, C0, C1, C2, C3, C4) {
     .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<R0, R1, W1, C0, C1, C2, C3, C4, C5>(
     accumulated: R0, next: R1
   ) -> ChoiceOf<(Substring, C0?, C1?, C2?, C3?, C4?, C5?)> where R0: RegexComponent, R1: RegexComponent, R1.RegexOutput == (W1, C0, C1, C2, C3, C4, C5) {
     .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<R0, R1, W1, C0, C1, C2, C3, C4, C5, C6>(
     accumulated: R0, next: R1
   ) -> ChoiceOf<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?)> where R0: RegexComponent, R1: RegexComponent, R1.RegexOutput == (W1, C0, C1, C2, C3, C4, C5, C6) {
     .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<R0, R1, W1, C0, C1, C2, C3, C4, C5, C6, C7>(
     accumulated: R0, next: R1
   ) -> ChoiceOf<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?)> where R0: RegexComponent, R1: RegexComponent, R1.RegexOutput == (W1, C0, C1, C2, C3, C4, C5, C6, C7) {
     .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<R0, R1, W1, C0, C1, C2, C3, C4, C5, C6, C7, C8>(
     accumulated: R0, next: R1
   ) -> ChoiceOf<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?)> where R0: RegexComponent, R1: RegexComponent, R1.RegexOutput == (W1, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
     .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<R0, R1, W1, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9>(
     accumulated: R0, next: R1
   ) -> ChoiceOf<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?)> where R0: RegexComponent, R1: RegexComponent, R1.RegexOutput == (W1, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
     .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<R0, W0, C0, R1>(
     accumulated: R0, next: R1
   ) -> ChoiceOf<(Substring, C0)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0) {
     .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<R0, W0, C0, R1, W1, C1>(
     accumulated: R0, next: R1
   ) -> ChoiceOf<(Substring, C0, C1?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0), R1.RegexOutput == (W1, C1) {
     .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<R0, W0, C0, R1, W1, C1, C2>(
     accumulated: R0, next: R1
   ) -> ChoiceOf<(Substring, C0, C1?, C2?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0), R1.RegexOutput == (W1, C1, C2) {
     .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<R0, W0, C0, R1, W1, C1, C2, C3>(
     accumulated: R0, next: R1
   ) -> ChoiceOf<(Substring, C0, C1?, C2?, C3?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0), R1.RegexOutput == (W1, C1, C2, C3) {
     .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<R0, W0, C0, R1, W1, C1, C2, C3, C4>(
     accumulated: R0, next: R1
   ) -> ChoiceOf<(Substring, C0, C1?, C2?, C3?, C4?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0), R1.RegexOutput == (W1, C1, C2, C3, C4) {
     .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<R0, W0, C0, R1, W1, C1, C2, C3, C4, C5>(
     accumulated: R0, next: R1
   ) -> ChoiceOf<(Substring, C0, C1?, C2?, C3?, C4?, C5?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0), R1.RegexOutput == (W1, C1, C2, C3, C4, C5) {
     .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<R0, W0, C0, R1, W1, C1, C2, C3, C4, C5, C6>(
     accumulated: R0, next: R1
   ) -> ChoiceOf<(Substring, C0, C1?, C2?, C3?, C4?, C5?, C6?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0), R1.RegexOutput == (W1, C1, C2, C3, C4, C5, C6) {
     .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<R0, W0, C0, R1, W1, C1, C2, C3, C4, C5, C6, C7>(
     accumulated: R0, next: R1
   ) -> ChoiceOf<(Substring, C0, C1?, C2?, C3?, C4?, C5?, C6?, C7?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0), R1.RegexOutput == (W1, C1, C2, C3, C4, C5, C6, C7) {
     .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<R0, W0, C0, R1, W1, C1, C2, C3, C4, C5, C6, C7, C8>(
     accumulated: R0, next: R1
   ) -> ChoiceOf<(Substring, C0, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0), R1.RegexOutput == (W1, C1, C2, C3, C4, C5, C6, C7, C8) {
     .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<R0, W0, C0, R1, W1, C1, C2, C3, C4, C5, C6, C7, C8, C9>(
     accumulated: R0, next: R1
   ) -> ChoiceOf<(Substring, C0, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0), R1.RegexOutput == (W1, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
     .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<R0, W0, C0, C1, R1>(
     accumulated: R0, next: R1
   ) -> ChoiceOf<(Substring, C0, C1)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1) {
     .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<R0, W0, C0, C1, R1, W1, C2>(
     accumulated: R0, next: R1
   ) -> ChoiceOf<(Substring, C0, C1, C2?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1), R1.RegexOutput == (W1, C2) {
     .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<R0, W0, C0, C1, R1, W1, C2, C3>(
     accumulated: R0, next: R1
   ) -> ChoiceOf<(Substring, C0, C1, C2?, C3?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1), R1.RegexOutput == (W1, C2, C3) {
     .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<R0, W0, C0, C1, R1, W1, C2, C3, C4>(
     accumulated: R0, next: R1
   ) -> ChoiceOf<(Substring, C0, C1, C2?, C3?, C4?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1), R1.RegexOutput == (W1, C2, C3, C4) {
     .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<R0, W0, C0, C1, R1, W1, C2, C3, C4, C5>(
     accumulated: R0, next: R1
   ) -> ChoiceOf<(Substring, C0, C1, C2?, C3?, C4?, C5?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1), R1.RegexOutput == (W1, C2, C3, C4, C5) {
     .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<R0, W0, C0, C1, R1, W1, C2, C3, C4, C5, C6>(
     accumulated: R0, next: R1
   ) -> ChoiceOf<(Substring, C0, C1, C2?, C3?, C4?, C5?, C6?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1), R1.RegexOutput == (W1, C2, C3, C4, C5, C6) {
     .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<R0, W0, C0, C1, R1, W1, C2, C3, C4, C5, C6, C7>(
     accumulated: R0, next: R1
   ) -> ChoiceOf<(Substring, C0, C1, C2?, C3?, C4?, C5?, C6?, C7?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1), R1.RegexOutput == (W1, C2, C3, C4, C5, C6, C7) {
     .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<R0, W0, C0, C1, R1, W1, C2, C3, C4, C5, C6, C7, C8>(
     accumulated: R0, next: R1
   ) -> ChoiceOf<(Substring, C0, C1, C2?, C3?, C4?, C5?, C6?, C7?, C8?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1), R1.RegexOutput == (W1, C2, C3, C4, C5, C6, C7, C8) {
     .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<R0, W0, C0, C1, R1, W1, C2, C3, C4, C5, C6, C7, C8, C9>(
     accumulated: R0, next: R1
   ) -> ChoiceOf<(Substring, C0, C1, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1), R1.RegexOutput == (W1, C2, C3, C4, C5, C6, C7, C8, C9) {
     .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<R0, W0, C0, C1, C2, R1>(
     accumulated: R0, next: R1
   ) -> ChoiceOf<(Substring, C0, C1, C2)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2) {
     .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<R0, W0, C0, C1, C2, R1, W1, C3>(
     accumulated: R0, next: R1
   ) -> ChoiceOf<(Substring, C0, C1, C2, C3?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2), R1.RegexOutput == (W1, C3) {
     .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<R0, W0, C0, C1, C2, R1, W1, C3, C4>(
     accumulated: R0, next: R1
   ) -> ChoiceOf<(Substring, C0, C1, C2, C3?, C4?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2), R1.RegexOutput == (W1, C3, C4) {
     .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<R0, W0, C0, C1, C2, R1, W1, C3, C4, C5>(
     accumulated: R0, next: R1
   ) -> ChoiceOf<(Substring, C0, C1, C2, C3?, C4?, C5?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2), R1.RegexOutput == (W1, C3, C4, C5) {
     .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<R0, W0, C0, C1, C2, R1, W1, C3, C4, C5, C6>(
     accumulated: R0, next: R1
   ) -> ChoiceOf<(Substring, C0, C1, C2, C3?, C4?, C5?, C6?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2), R1.RegexOutput == (W1, C3, C4, C5, C6) {
     .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<R0, W0, C0, C1, C2, R1, W1, C3, C4, C5, C6, C7>(
     accumulated: R0, next: R1
   ) -> ChoiceOf<(Substring, C0, C1, C2, C3?, C4?, C5?, C6?, C7?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2), R1.RegexOutput == (W1, C3, C4, C5, C6, C7) {
     .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<R0, W0, C0, C1, C2, R1, W1, C3, C4, C5, C6, C7, C8>(
     accumulated: R0, next: R1
   ) -> ChoiceOf<(Substring, C0, C1, C2, C3?, C4?, C5?, C6?, C7?, C8?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2), R1.RegexOutput == (W1, C3, C4, C5, C6, C7, C8) {
     .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<R0, W0, C0, C1, C2, R1, W1, C3, C4, C5, C6, C7, C8, C9>(
     accumulated: R0, next: R1
   ) -> ChoiceOf<(Substring, C0, C1, C2, C3?, C4?, C5?, C6?, C7?, C8?, C9?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2), R1.RegexOutput == (W1, C3, C4, C5, C6, C7, C8, C9) {
     .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<R0, W0, C0, C1, C2, C3, R1>(
     accumulated: R0, next: R1
   ) -> ChoiceOf<(Substring, C0, C1, C2, C3)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2, C3) {
     .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<R0, W0, C0, C1, C2, C3, R1, W1, C4>(
     accumulated: R0, next: R1
   ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2, C3), R1.RegexOutput == (W1, C4) {
     .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<R0, W0, C0, C1, C2, C3, R1, W1, C4, C5>(
     accumulated: R0, next: R1
   ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4?, C5?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2, C3), R1.RegexOutput == (W1, C4, C5) {
     .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<R0, W0, C0, C1, C2, C3, R1, W1, C4, C5, C6>(
     accumulated: R0, next: R1
   ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4?, C5?, C6?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2, C3), R1.RegexOutput == (W1, C4, C5, C6) {
     .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<R0, W0, C0, C1, C2, C3, R1, W1, C4, C5, C6, C7>(
     accumulated: R0, next: R1
   ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4?, C5?, C6?, C7?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2, C3), R1.RegexOutput == (W1, C4, C5, C6, C7) {
     .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<R0, W0, C0, C1, C2, C3, R1, W1, C4, C5, C6, C7, C8>(
     accumulated: R0, next: R1
   ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4?, C5?, C6?, C7?, C8?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2, C3), R1.RegexOutput == (W1, C4, C5, C6, C7, C8) {
     .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<R0, W0, C0, C1, C2, C3, R1, W1, C4, C5, C6, C7, C8, C9>(
     accumulated: R0, next: R1
   ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4?, C5?, C6?, C7?, C8?, C9?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2, C3), R1.RegexOutput == (W1, C4, C5, C6, C7, C8, C9) {
     .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<R0, W0, C0, C1, C2, C3, C4, R1>(
     accumulated: R0, next: R1
   ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2, C3, C4) {
     .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<R0, W0, C0, C1, C2, C3, C4, R1, W1, C5>(
     accumulated: R0, next: R1
   ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4, C5?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2, C3, C4), R1.RegexOutput == (W1, C5) {
     .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<R0, W0, C0, C1, C2, C3, C4, R1, W1, C5, C6>(
     accumulated: R0, next: R1
   ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4, C5?, C6?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2, C3, C4), R1.RegexOutput == (W1, C5, C6) {
     .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<R0, W0, C0, C1, C2, C3, C4, R1, W1, C5, C6, C7>(
     accumulated: R0, next: R1
   ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4, C5?, C6?, C7?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2, C3, C4), R1.RegexOutput == (W1, C5, C6, C7) {
     .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<R0, W0, C0, C1, C2, C3, C4, R1, W1, C5, C6, C7, C8>(
     accumulated: R0, next: R1
   ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4, C5?, C6?, C7?, C8?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2, C3, C4), R1.RegexOutput == (W1, C5, C6, C7, C8) {
     .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<R0, W0, C0, C1, C2, C3, C4, R1, W1, C5, C6, C7, C8, C9>(
     accumulated: R0, next: R1
   ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4, C5?, C6?, C7?, C8?, C9?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2, C3, C4), R1.RegexOutput == (W1, C5, C6, C7, C8, C9) {
     .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<R0, W0, C0, C1, C2, C3, C4, C5, R1>(
     accumulated: R0, next: R1
   ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4, C5)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2, C3, C4, C5) {
     .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<R0, W0, C0, C1, C2, C3, C4, C5, R1, W1, C6>(
     accumulated: R0, next: R1
   ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4, C5, C6?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2, C3, C4, C5), R1.RegexOutput == (W1, C6) {
     .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<R0, W0, C0, C1, C2, C3, C4, C5, R1, W1, C6, C7>(
     accumulated: R0, next: R1
   ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4, C5, C6?, C7?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2, C3, C4, C5), R1.RegexOutput == (W1, C6, C7) {
     .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<R0, W0, C0, C1, C2, C3, C4, C5, R1, W1, C6, C7, C8>(
     accumulated: R0, next: R1
   ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4, C5, C6?, C7?, C8?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2, C3, C4, C5), R1.RegexOutput == (W1, C6, C7, C8) {
     .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<R0, W0, C0, C1, C2, C3, C4, C5, R1, W1, C6, C7, C8, C9>(
     accumulated: R0, next: R1
   ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4, C5, C6?, C7?, C8?, C9?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2, C3, C4, C5), R1.RegexOutput == (W1, C6, C7, C8, C9) {
     .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<R0, W0, C0, C1, C2, C3, C4, C5, C6, R1>(
     accumulated: R0, next: R1
   ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4, C5, C6)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2, C3, C4, C5, C6) {
     .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<R0, W0, C0, C1, C2, C3, C4, C5, C6, R1, W1, C7>(
     accumulated: R0, next: R1
   ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4, C5, C6, C7?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2, C3, C4, C5, C6), R1.RegexOutput == (W1, C7) {
     .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<R0, W0, C0, C1, C2, C3, C4, C5, C6, R1, W1, C7, C8>(
     accumulated: R0, next: R1
   ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4, C5, C6, C7?, C8?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2, C3, C4, C5, C6), R1.RegexOutput == (W1, C7, C8) {
     .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<R0, W0, C0, C1, C2, C3, C4, C5, C6, R1, W1, C7, C8, C9>(
     accumulated: R0, next: R1
   ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4, C5, C6, C7?, C8?, C9?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2, C3, C4, C5, C6), R1.RegexOutput == (W1, C7, C8, C9) {
     .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<R0, W0, C0, C1, C2, C3, C4, C5, C6, C7, R1>(
     accumulated: R0, next: R1
   ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4, C5, C6, C7)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2, C3, C4, C5, C6, C7) {
     .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<R0, W0, C0, C1, C2, C3, C4, C5, C6, C7, R1, W1, C8>(
     accumulated: R0, next: R1
   ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2, C3, C4, C5, C6, C7), R1.RegexOutput == (W1, C8) {
     .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<R0, W0, C0, C1, C2, C3, C4, C5, C6, C7, R1, W1, C8, C9>(
     accumulated: R0, next: R1
   ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8?, C9?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2, C3, C4, C5, C6, C7), R1.RegexOutput == (W1, C8, C9) {
     .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<R0, W0, C0, C1, C2, C3, C4, C5, C6, C7, C8, R1>(
     accumulated: R0, next: R1
   ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
     .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<R0, W0, C0, C1, C2, C3, C4, C5, C6, C7, C8, R1, W1, C9>(
     accumulated: R0, next: R1
   ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2, C3, C4, C5, C6, C7, C8), R1.RegexOutput == (W1, C9) {
     .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<R, W, C0>(first regex: R) -> ChoiceOf<(W, C0?)> where R: RegexComponent, R.RegexOutput == (W, C0) {
     .init(node: .orderedChoice([regex.regex.root]))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<R, W, C0, C1>(first regex: R) -> ChoiceOf<(W, C0?, C1?)> where R: RegexComponent, R.RegexOutput == (W, C0, C1) {
     .init(node: .orderedChoice([regex.regex.root]))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<R, W, C0, C1, C2>(first regex: R) -> ChoiceOf<(W, C0?, C1?, C2?)> where R: RegexComponent, R.RegexOutput == (W, C0, C1, C2) {
     .init(node: .orderedChoice([regex.regex.root]))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<R, W, C0, C1, C2, C3>(first regex: R) -> ChoiceOf<(W, C0?, C1?, C2?, C3?)> where R: RegexComponent, R.RegexOutput == (W, C0, C1, C2, C3) {
     .init(node: .orderedChoice([regex.regex.root]))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<R, W, C0, C1, C2, C3, C4>(first regex: R) -> ChoiceOf<(W, C0?, C1?, C2?, C3?, C4?)> where R: RegexComponent, R.RegexOutput == (W, C0, C1, C2, C3, C4) {
     .init(node: .orderedChoice([regex.regex.root]))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<R, W, C0, C1, C2, C3, C4, C5>(first regex: R) -> ChoiceOf<(W, C0?, C1?, C2?, C3?, C4?, C5?)> where R: RegexComponent, R.RegexOutput == (W, C0, C1, C2, C3, C4, C5) {
     .init(node: .orderedChoice([regex.regex.root]))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<R, W, C0, C1, C2, C3, C4, C5, C6>(first regex: R) -> ChoiceOf<(W, C0?, C1?, C2?, C3?, C4?, C5?, C6?)> where R: RegexComponent, R.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6) {
     .init(node: .orderedChoice([regex.regex.root]))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<R, W, C0, C1, C2, C3, C4, C5, C6, C7>(first regex: R) -> ChoiceOf<(W, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?)> where R: RegexComponent, R.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
     .init(node: .orderedChoice([regex.regex.root]))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<R, W, C0, C1, C2, C3, C4, C5, C6, C7, C8>(first regex: R) -> ChoiceOf<(W, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?)> where R: RegexComponent, R.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
     .init(node: .orderedChoice([regex.regex.root]))
   }
 }
+@available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @available(SwiftStdlib 5.7, *)
   public static func buildPartialBlock<R, W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9>(first regex: R) -> ChoiceOf<(W, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?)> where R: RegexComponent, R.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
     .init(node: .orderedChoice([regex.regex.root]))
   }
 }
 // MARK: - Non-builder capture arity 0
 
+@available(SwiftStdlib 5.7, *)
 extension Capture {
+  @available(SwiftStdlib 5.7, *)
   @_disfavoredOverload
   public init<R: RegexComponent, W>(
     _ component: R
@@ -2248,6 +2785,7 @@ extension Capture {
     self.init(node: .capture(component.regex.root))
   }
 
+  @available(SwiftStdlib 5.7, *)
   @_disfavoredOverload
   public init<R: RegexComponent, W>(
     _ component: R, as reference: Reference<W>
@@ -2255,6 +2793,7 @@ extension Capture {
     self.init(node: .capture(reference: reference.id, component.regex.root))
   }
 
+  @available(SwiftStdlib 5.7, *)
   @_disfavoredOverload
   public init<R: RegexComponent, W, NewCapture>(
     _ component: R,
@@ -2267,6 +2806,7 @@ extension Capture {
       component.regex.root)))
   }
 
+  @available(SwiftStdlib 5.7, *)
   @_disfavoredOverload
   public init<R: RegexComponent, W, NewCapture>(
     _ component: R,
@@ -2283,7 +2823,9 @@ extension Capture {
   }
 }
 
+@available(SwiftStdlib 5.7, *)
 extension TryCapture {
+  @available(SwiftStdlib 5.7, *)
   @_disfavoredOverload
   public init<R: RegexComponent, W, NewCapture>(
     _ component: R,
@@ -2296,6 +2838,7 @@ extension TryCapture {
       component.regex.root)))
   }
 
+  @available(SwiftStdlib 5.7, *)
   @_disfavoredOverload
   public init<R: RegexComponent, W, NewCapture>(
     _ component: R,
@@ -2314,7 +2857,9 @@ extension TryCapture {
 
 // MARK: - Builder capture arity 0
 
+@available(SwiftStdlib 5.7, *)
 extension Capture {
+  @available(SwiftStdlib 5.7, *)
   @_disfavoredOverload
   public init<R: RegexComponent, W>(
     @RegexComponentBuilder _ component: () -> R
@@ -2322,6 +2867,7 @@ extension Capture {
     self.init(node: .capture(component().regex.root))
   }
 
+  @available(SwiftStdlib 5.7, *)
   @_disfavoredOverload
   public init<R: RegexComponent, W>(
     as reference: Reference<W>,
@@ -2332,6 +2878,7 @@ extension Capture {
       component().regex.root))
   }
 
+  @available(SwiftStdlib 5.7, *)
   @_disfavoredOverload
   public init<R: RegexComponent, W, NewCapture>(
     @RegexComponentBuilder _ component: () -> R,
@@ -2344,6 +2891,7 @@ extension Capture {
       component().regex.root)))
   }
 
+  @available(SwiftStdlib 5.7, *)
   @_disfavoredOverload
   public init<R: RegexComponent, W, NewCapture>(
     as reference: Reference<NewCapture>,
@@ -2360,7 +2908,9 @@ extension Capture {
   }
 }
 
+@available(SwiftStdlib 5.7, *)
 extension TryCapture {
+  @available(SwiftStdlib 5.7, *)
   @_disfavoredOverload
   public init<R: RegexComponent, W, NewCapture>(
     @RegexComponentBuilder _ component: () -> R,
@@ -2373,6 +2923,7 @@ extension TryCapture {
       component().regex.root)))
   }
 
+  @available(SwiftStdlib 5.7, *)
   @_disfavoredOverload
   public init<R: RegexComponent, W, NewCapture>(
     as reference: Reference<NewCapture>,
@@ -2391,19 +2942,23 @@ extension TryCapture {
 
 // MARK: - Non-builder capture arity 1
 
+@available(SwiftStdlib 5.7, *)
 extension Capture {
+  @available(SwiftStdlib 5.7, *)
     public init<R: RegexComponent, W, C0>(
     _ component: R
   ) where RegexOutput == (Substring, W, C0), R.RegexOutput == (W, C0) {
     self.init(node: .capture(component.regex.root))
   }
 
+  @available(SwiftStdlib 5.7, *)
     public init<R: RegexComponent, W, C0>(
     _ component: R, as reference: Reference<W>
   ) where RegexOutput == (Substring, W, C0), R.RegexOutput == (W, C0) {
     self.init(node: .capture(reference: reference.id, component.regex.root))
   }
 
+  @available(SwiftStdlib 5.7, *)
     public init<R: RegexComponent, W, C0, NewCapture>(
     _ component: R,
     transform: @escaping (Substring) throws -> NewCapture
@@ -2415,6 +2970,7 @@ extension Capture {
       component.regex.root)))
   }
 
+  @available(SwiftStdlib 5.7, *)
     public init<R: RegexComponent, W, C0, NewCapture>(
     _ component: R,
     as reference: Reference<NewCapture>,
@@ -2430,7 +2986,9 @@ extension Capture {
   }
 }
 
+@available(SwiftStdlib 5.7, *)
 extension TryCapture {
+  @available(SwiftStdlib 5.7, *)
     public init<R: RegexComponent, W, C0, NewCapture>(
     _ component: R,
     transform: @escaping (Substring) throws -> NewCapture?
@@ -2442,6 +3000,7 @@ extension TryCapture {
       component.regex.root)))
   }
 
+  @available(SwiftStdlib 5.7, *)
     public init<R: RegexComponent, W, C0, NewCapture>(
     _ component: R,
     as reference: Reference<NewCapture>,
@@ -2459,13 +3018,16 @@ extension TryCapture {
 
 // MARK: - Builder capture arity 1
 
+@available(SwiftStdlib 5.7, *)
 extension Capture {
+  @available(SwiftStdlib 5.7, *)
     public init<R: RegexComponent, W, C0>(
     @RegexComponentBuilder _ component: () -> R
   ) where RegexOutput == (Substring, W, C0), R.RegexOutput == (W, C0) {
     self.init(node: .capture(component().regex.root))
   }
 
+  @available(SwiftStdlib 5.7, *)
     public init<R: RegexComponent, W, C0>(
     as reference: Reference<W>,
     @RegexComponentBuilder _ component: () -> R
@@ -2475,6 +3037,7 @@ extension Capture {
       component().regex.root))
   }
 
+  @available(SwiftStdlib 5.7, *)
     public init<R: RegexComponent, W, C0, NewCapture>(
     @RegexComponentBuilder _ component: () -> R,
     transform: @escaping (Substring) throws -> NewCapture
@@ -2486,6 +3049,7 @@ extension Capture {
       component().regex.root)))
   }
 
+  @available(SwiftStdlib 5.7, *)
     public init<R: RegexComponent, W, C0, NewCapture>(
     as reference: Reference<NewCapture>,
     @RegexComponentBuilder _ component: () -> R,
@@ -2501,7 +3065,9 @@ extension Capture {
   }
 }
 
+@available(SwiftStdlib 5.7, *)
 extension TryCapture {
+  @available(SwiftStdlib 5.7, *)
     public init<R: RegexComponent, W, C0, NewCapture>(
     @RegexComponentBuilder _ component: () -> R,
     transform: @escaping (Substring) throws -> NewCapture?
@@ -2513,6 +3079,7 @@ extension TryCapture {
       component().regex.root)))
   }
 
+  @available(SwiftStdlib 5.7, *)
     public init<R: RegexComponent, W, C0, NewCapture>(
     as reference: Reference<NewCapture>,
     @RegexComponentBuilder _ component: () -> R,
@@ -2530,19 +3097,23 @@ extension TryCapture {
 
 // MARK: - Non-builder capture arity 2
 
+@available(SwiftStdlib 5.7, *)
 extension Capture {
+  @available(SwiftStdlib 5.7, *)
     public init<R: RegexComponent, W, C0, C1>(
     _ component: R
   ) where RegexOutput == (Substring, W, C0, C1), R.RegexOutput == (W, C0, C1) {
     self.init(node: .capture(component.regex.root))
   }
 
+  @available(SwiftStdlib 5.7, *)
     public init<R: RegexComponent, W, C0, C1>(
     _ component: R, as reference: Reference<W>
   ) where RegexOutput == (Substring, W, C0, C1), R.RegexOutput == (W, C0, C1) {
     self.init(node: .capture(reference: reference.id, component.regex.root))
   }
 
+  @available(SwiftStdlib 5.7, *)
     public init<R: RegexComponent, W, C0, C1, NewCapture>(
     _ component: R,
     transform: @escaping (Substring) throws -> NewCapture
@@ -2554,6 +3125,7 @@ extension Capture {
       component.regex.root)))
   }
 
+  @available(SwiftStdlib 5.7, *)
     public init<R: RegexComponent, W, C0, C1, NewCapture>(
     _ component: R,
     as reference: Reference<NewCapture>,
@@ -2569,7 +3141,9 @@ extension Capture {
   }
 }
 
+@available(SwiftStdlib 5.7, *)
 extension TryCapture {
+  @available(SwiftStdlib 5.7, *)
     public init<R: RegexComponent, W, C0, C1, NewCapture>(
     _ component: R,
     transform: @escaping (Substring) throws -> NewCapture?
@@ -2581,6 +3155,7 @@ extension TryCapture {
       component.regex.root)))
   }
 
+  @available(SwiftStdlib 5.7, *)
     public init<R: RegexComponent, W, C0, C1, NewCapture>(
     _ component: R,
     as reference: Reference<NewCapture>,
@@ -2598,13 +3173,16 @@ extension TryCapture {
 
 // MARK: - Builder capture arity 2
 
+@available(SwiftStdlib 5.7, *)
 extension Capture {
+  @available(SwiftStdlib 5.7, *)
     public init<R: RegexComponent, W, C0, C1>(
     @RegexComponentBuilder _ component: () -> R
   ) where RegexOutput == (Substring, W, C0, C1), R.RegexOutput == (W, C0, C1) {
     self.init(node: .capture(component().regex.root))
   }
 
+  @available(SwiftStdlib 5.7, *)
     public init<R: RegexComponent, W, C0, C1>(
     as reference: Reference<W>,
     @RegexComponentBuilder _ component: () -> R
@@ -2614,6 +3192,7 @@ extension Capture {
       component().regex.root))
   }
 
+  @available(SwiftStdlib 5.7, *)
     public init<R: RegexComponent, W, C0, C1, NewCapture>(
     @RegexComponentBuilder _ component: () -> R,
     transform: @escaping (Substring) throws -> NewCapture
@@ -2625,6 +3204,7 @@ extension Capture {
       component().regex.root)))
   }
 
+  @available(SwiftStdlib 5.7, *)
     public init<R: RegexComponent, W, C0, C1, NewCapture>(
     as reference: Reference<NewCapture>,
     @RegexComponentBuilder _ component: () -> R,
@@ -2640,7 +3220,9 @@ extension Capture {
   }
 }
 
+@available(SwiftStdlib 5.7, *)
 extension TryCapture {
+  @available(SwiftStdlib 5.7, *)
     public init<R: RegexComponent, W, C0, C1, NewCapture>(
     @RegexComponentBuilder _ component: () -> R,
     transform: @escaping (Substring) throws -> NewCapture?
@@ -2652,6 +3234,7 @@ extension TryCapture {
       component().regex.root)))
   }
 
+  @available(SwiftStdlib 5.7, *)
     public init<R: RegexComponent, W, C0, C1, NewCapture>(
     as reference: Reference<NewCapture>,
     @RegexComponentBuilder _ component: () -> R,
@@ -2669,19 +3252,23 @@ extension TryCapture {
 
 // MARK: - Non-builder capture arity 3
 
+@available(SwiftStdlib 5.7, *)
 extension Capture {
+  @available(SwiftStdlib 5.7, *)
     public init<R: RegexComponent, W, C0, C1, C2>(
     _ component: R
   ) where RegexOutput == (Substring, W, C0, C1, C2), R.RegexOutput == (W, C0, C1, C2) {
     self.init(node: .capture(component.regex.root))
   }
 
+  @available(SwiftStdlib 5.7, *)
     public init<R: RegexComponent, W, C0, C1, C2>(
     _ component: R, as reference: Reference<W>
   ) where RegexOutput == (Substring, W, C0, C1, C2), R.RegexOutput == (W, C0, C1, C2) {
     self.init(node: .capture(reference: reference.id, component.regex.root))
   }
 
+  @available(SwiftStdlib 5.7, *)
     public init<R: RegexComponent, W, C0, C1, C2, NewCapture>(
     _ component: R,
     transform: @escaping (Substring) throws -> NewCapture
@@ -2693,6 +3280,7 @@ extension Capture {
       component.regex.root)))
   }
 
+  @available(SwiftStdlib 5.7, *)
     public init<R: RegexComponent, W, C0, C1, C2, NewCapture>(
     _ component: R,
     as reference: Reference<NewCapture>,
@@ -2708,7 +3296,9 @@ extension Capture {
   }
 }
 
+@available(SwiftStdlib 5.7, *)
 extension TryCapture {
+  @available(SwiftStdlib 5.7, *)
     public init<R: RegexComponent, W, C0, C1, C2, NewCapture>(
     _ component: R,
     transform: @escaping (Substring) throws -> NewCapture?
@@ -2720,6 +3310,7 @@ extension TryCapture {
       component.regex.root)))
   }
 
+  @available(SwiftStdlib 5.7, *)
     public init<R: RegexComponent, W, C0, C1, C2, NewCapture>(
     _ component: R,
     as reference: Reference<NewCapture>,
@@ -2737,13 +3328,16 @@ extension TryCapture {
 
 // MARK: - Builder capture arity 3
 
+@available(SwiftStdlib 5.7, *)
 extension Capture {
+  @available(SwiftStdlib 5.7, *)
     public init<R: RegexComponent, W, C0, C1, C2>(
     @RegexComponentBuilder _ component: () -> R
   ) where RegexOutput == (Substring, W, C0, C1, C2), R.RegexOutput == (W, C0, C1, C2) {
     self.init(node: .capture(component().regex.root))
   }
 
+  @available(SwiftStdlib 5.7, *)
     public init<R: RegexComponent, W, C0, C1, C2>(
     as reference: Reference<W>,
     @RegexComponentBuilder _ component: () -> R
@@ -2753,6 +3347,7 @@ extension Capture {
       component().regex.root))
   }
 
+  @available(SwiftStdlib 5.7, *)
     public init<R: RegexComponent, W, C0, C1, C2, NewCapture>(
     @RegexComponentBuilder _ component: () -> R,
     transform: @escaping (Substring) throws -> NewCapture
@@ -2764,6 +3359,7 @@ extension Capture {
       component().regex.root)))
   }
 
+  @available(SwiftStdlib 5.7, *)
     public init<R: RegexComponent, W, C0, C1, C2, NewCapture>(
     as reference: Reference<NewCapture>,
     @RegexComponentBuilder _ component: () -> R,
@@ -2779,7 +3375,9 @@ extension Capture {
   }
 }
 
+@available(SwiftStdlib 5.7, *)
 extension TryCapture {
+  @available(SwiftStdlib 5.7, *)
     public init<R: RegexComponent, W, C0, C1, C2, NewCapture>(
     @RegexComponentBuilder _ component: () -> R,
     transform: @escaping (Substring) throws -> NewCapture?
@@ -2791,6 +3389,7 @@ extension TryCapture {
       component().regex.root)))
   }
 
+  @available(SwiftStdlib 5.7, *)
     public init<R: RegexComponent, W, C0, C1, C2, NewCapture>(
     as reference: Reference<NewCapture>,
     @RegexComponentBuilder _ component: () -> R,
@@ -2808,19 +3407,23 @@ extension TryCapture {
 
 // MARK: - Non-builder capture arity 4
 
+@available(SwiftStdlib 5.7, *)
 extension Capture {
+  @available(SwiftStdlib 5.7, *)
     public init<R: RegexComponent, W, C0, C1, C2, C3>(
     _ component: R
   ) where RegexOutput == (Substring, W, C0, C1, C2, C3), R.RegexOutput == (W, C0, C1, C2, C3) {
     self.init(node: .capture(component.regex.root))
   }
 
+  @available(SwiftStdlib 5.7, *)
     public init<R: RegexComponent, W, C0, C1, C2, C3>(
     _ component: R, as reference: Reference<W>
   ) where RegexOutput == (Substring, W, C0, C1, C2, C3), R.RegexOutput == (W, C0, C1, C2, C3) {
     self.init(node: .capture(reference: reference.id, component.regex.root))
   }
 
+  @available(SwiftStdlib 5.7, *)
     public init<R: RegexComponent, W, C0, C1, C2, C3, NewCapture>(
     _ component: R,
     transform: @escaping (Substring) throws -> NewCapture
@@ -2832,6 +3435,7 @@ extension Capture {
       component.regex.root)))
   }
 
+  @available(SwiftStdlib 5.7, *)
     public init<R: RegexComponent, W, C0, C1, C2, C3, NewCapture>(
     _ component: R,
     as reference: Reference<NewCapture>,
@@ -2847,7 +3451,9 @@ extension Capture {
   }
 }
 
+@available(SwiftStdlib 5.7, *)
 extension TryCapture {
+  @available(SwiftStdlib 5.7, *)
     public init<R: RegexComponent, W, C0, C1, C2, C3, NewCapture>(
     _ component: R,
     transform: @escaping (Substring) throws -> NewCapture?
@@ -2859,6 +3465,7 @@ extension TryCapture {
       component.regex.root)))
   }
 
+  @available(SwiftStdlib 5.7, *)
     public init<R: RegexComponent, W, C0, C1, C2, C3, NewCapture>(
     _ component: R,
     as reference: Reference<NewCapture>,
@@ -2876,13 +3483,16 @@ extension TryCapture {
 
 // MARK: - Builder capture arity 4
 
+@available(SwiftStdlib 5.7, *)
 extension Capture {
+  @available(SwiftStdlib 5.7, *)
     public init<R: RegexComponent, W, C0, C1, C2, C3>(
     @RegexComponentBuilder _ component: () -> R
   ) where RegexOutput == (Substring, W, C0, C1, C2, C3), R.RegexOutput == (W, C0, C1, C2, C3) {
     self.init(node: .capture(component().regex.root))
   }
 
+  @available(SwiftStdlib 5.7, *)
     public init<R: RegexComponent, W, C0, C1, C2, C3>(
     as reference: Reference<W>,
     @RegexComponentBuilder _ component: () -> R
@@ -2892,6 +3502,7 @@ extension Capture {
       component().regex.root))
   }
 
+  @available(SwiftStdlib 5.7, *)
     public init<R: RegexComponent, W, C0, C1, C2, C3, NewCapture>(
     @RegexComponentBuilder _ component: () -> R,
     transform: @escaping (Substring) throws -> NewCapture
@@ -2903,6 +3514,7 @@ extension Capture {
       component().regex.root)))
   }
 
+  @available(SwiftStdlib 5.7, *)
     public init<R: RegexComponent, W, C0, C1, C2, C3, NewCapture>(
     as reference: Reference<NewCapture>,
     @RegexComponentBuilder _ component: () -> R,
@@ -2918,7 +3530,9 @@ extension Capture {
   }
 }
 
+@available(SwiftStdlib 5.7, *)
 extension TryCapture {
+  @available(SwiftStdlib 5.7, *)
     public init<R: RegexComponent, W, C0, C1, C2, C3, NewCapture>(
     @RegexComponentBuilder _ component: () -> R,
     transform: @escaping (Substring) throws -> NewCapture?
@@ -2930,6 +3544,7 @@ extension TryCapture {
       component().regex.root)))
   }
 
+  @available(SwiftStdlib 5.7, *)
     public init<R: RegexComponent, W, C0, C1, C2, C3, NewCapture>(
     as reference: Reference<NewCapture>,
     @RegexComponentBuilder _ component: () -> R,
@@ -2947,19 +3562,23 @@ extension TryCapture {
 
 // MARK: - Non-builder capture arity 5
 
+@available(SwiftStdlib 5.7, *)
 extension Capture {
+  @available(SwiftStdlib 5.7, *)
     public init<R: RegexComponent, W, C0, C1, C2, C3, C4>(
     _ component: R
   ) where RegexOutput == (Substring, W, C0, C1, C2, C3, C4), R.RegexOutput == (W, C0, C1, C2, C3, C4) {
     self.init(node: .capture(component.regex.root))
   }
 
+  @available(SwiftStdlib 5.7, *)
     public init<R: RegexComponent, W, C0, C1, C2, C3, C4>(
     _ component: R, as reference: Reference<W>
   ) where RegexOutput == (Substring, W, C0, C1, C2, C3, C4), R.RegexOutput == (W, C0, C1, C2, C3, C4) {
     self.init(node: .capture(reference: reference.id, component.regex.root))
   }
 
+  @available(SwiftStdlib 5.7, *)
     public init<R: RegexComponent, W, C0, C1, C2, C3, C4, NewCapture>(
     _ component: R,
     transform: @escaping (Substring) throws -> NewCapture
@@ -2971,6 +3590,7 @@ extension Capture {
       component.regex.root)))
   }
 
+  @available(SwiftStdlib 5.7, *)
     public init<R: RegexComponent, W, C0, C1, C2, C3, C4, NewCapture>(
     _ component: R,
     as reference: Reference<NewCapture>,
@@ -2986,7 +3606,9 @@ extension Capture {
   }
 }
 
+@available(SwiftStdlib 5.7, *)
 extension TryCapture {
+  @available(SwiftStdlib 5.7, *)
     public init<R: RegexComponent, W, C0, C1, C2, C3, C4, NewCapture>(
     _ component: R,
     transform: @escaping (Substring) throws -> NewCapture?
@@ -2998,6 +3620,7 @@ extension TryCapture {
       component.regex.root)))
   }
 
+  @available(SwiftStdlib 5.7, *)
     public init<R: RegexComponent, W, C0, C1, C2, C3, C4, NewCapture>(
     _ component: R,
     as reference: Reference<NewCapture>,
@@ -3015,13 +3638,16 @@ extension TryCapture {
 
 // MARK: - Builder capture arity 5
 
+@available(SwiftStdlib 5.7, *)
 extension Capture {
+  @available(SwiftStdlib 5.7, *)
     public init<R: RegexComponent, W, C0, C1, C2, C3, C4>(
     @RegexComponentBuilder _ component: () -> R
   ) where RegexOutput == (Substring, W, C0, C1, C2, C3, C4), R.RegexOutput == (W, C0, C1, C2, C3, C4) {
     self.init(node: .capture(component().regex.root))
   }
 
+  @available(SwiftStdlib 5.7, *)
     public init<R: RegexComponent, W, C0, C1, C2, C3, C4>(
     as reference: Reference<W>,
     @RegexComponentBuilder _ component: () -> R
@@ -3031,6 +3657,7 @@ extension Capture {
       component().regex.root))
   }
 
+  @available(SwiftStdlib 5.7, *)
     public init<R: RegexComponent, W, C0, C1, C2, C3, C4, NewCapture>(
     @RegexComponentBuilder _ component: () -> R,
     transform: @escaping (Substring) throws -> NewCapture
@@ -3042,6 +3669,7 @@ extension Capture {
       component().regex.root)))
   }
 
+  @available(SwiftStdlib 5.7, *)
     public init<R: RegexComponent, W, C0, C1, C2, C3, C4, NewCapture>(
     as reference: Reference<NewCapture>,
     @RegexComponentBuilder _ component: () -> R,
@@ -3057,7 +3685,9 @@ extension Capture {
   }
 }
 
+@available(SwiftStdlib 5.7, *)
 extension TryCapture {
+  @available(SwiftStdlib 5.7, *)
     public init<R: RegexComponent, W, C0, C1, C2, C3, C4, NewCapture>(
     @RegexComponentBuilder _ component: () -> R,
     transform: @escaping (Substring) throws -> NewCapture?
@@ -3069,6 +3699,7 @@ extension TryCapture {
       component().regex.root)))
   }
 
+  @available(SwiftStdlib 5.7, *)
     public init<R: RegexComponent, W, C0, C1, C2, C3, C4, NewCapture>(
     as reference: Reference<NewCapture>,
     @RegexComponentBuilder _ component: () -> R,
@@ -3086,19 +3717,23 @@ extension TryCapture {
 
 // MARK: - Non-builder capture arity 6
 
+@available(SwiftStdlib 5.7, *)
 extension Capture {
+  @available(SwiftStdlib 5.7, *)
     public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5>(
     _ component: R
   ) where RegexOutput == (Substring, W, C0, C1, C2, C3, C4, C5), R.RegexOutput == (W, C0, C1, C2, C3, C4, C5) {
     self.init(node: .capture(component.regex.root))
   }
 
+  @available(SwiftStdlib 5.7, *)
     public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5>(
     _ component: R, as reference: Reference<W>
   ) where RegexOutput == (Substring, W, C0, C1, C2, C3, C4, C5), R.RegexOutput == (W, C0, C1, C2, C3, C4, C5) {
     self.init(node: .capture(reference: reference.id, component.regex.root))
   }
 
+  @available(SwiftStdlib 5.7, *)
     public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, NewCapture>(
     _ component: R,
     transform: @escaping (Substring) throws -> NewCapture
@@ -3110,6 +3745,7 @@ extension Capture {
       component.regex.root)))
   }
 
+  @available(SwiftStdlib 5.7, *)
     public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, NewCapture>(
     _ component: R,
     as reference: Reference<NewCapture>,
@@ -3125,7 +3761,9 @@ extension Capture {
   }
 }
 
+@available(SwiftStdlib 5.7, *)
 extension TryCapture {
+  @available(SwiftStdlib 5.7, *)
     public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, NewCapture>(
     _ component: R,
     transform: @escaping (Substring) throws -> NewCapture?
@@ -3137,6 +3775,7 @@ extension TryCapture {
       component.regex.root)))
   }
 
+  @available(SwiftStdlib 5.7, *)
     public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, NewCapture>(
     _ component: R,
     as reference: Reference<NewCapture>,
@@ -3154,13 +3793,16 @@ extension TryCapture {
 
 // MARK: - Builder capture arity 6
 
+@available(SwiftStdlib 5.7, *)
 extension Capture {
+  @available(SwiftStdlib 5.7, *)
     public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5>(
     @RegexComponentBuilder _ component: () -> R
   ) where RegexOutput == (Substring, W, C0, C1, C2, C3, C4, C5), R.RegexOutput == (W, C0, C1, C2, C3, C4, C5) {
     self.init(node: .capture(component().regex.root))
   }
 
+  @available(SwiftStdlib 5.7, *)
     public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5>(
     as reference: Reference<W>,
     @RegexComponentBuilder _ component: () -> R
@@ -3170,6 +3812,7 @@ extension Capture {
       component().regex.root))
   }
 
+  @available(SwiftStdlib 5.7, *)
     public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, NewCapture>(
     @RegexComponentBuilder _ component: () -> R,
     transform: @escaping (Substring) throws -> NewCapture
@@ -3181,6 +3824,7 @@ extension Capture {
       component().regex.root)))
   }
 
+  @available(SwiftStdlib 5.7, *)
     public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, NewCapture>(
     as reference: Reference<NewCapture>,
     @RegexComponentBuilder _ component: () -> R,
@@ -3196,7 +3840,9 @@ extension Capture {
   }
 }
 
+@available(SwiftStdlib 5.7, *)
 extension TryCapture {
+  @available(SwiftStdlib 5.7, *)
     public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, NewCapture>(
     @RegexComponentBuilder _ component: () -> R,
     transform: @escaping (Substring) throws -> NewCapture?
@@ -3208,6 +3854,7 @@ extension TryCapture {
       component().regex.root)))
   }
 
+  @available(SwiftStdlib 5.7, *)
     public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, NewCapture>(
     as reference: Reference<NewCapture>,
     @RegexComponentBuilder _ component: () -> R,
@@ -3225,19 +3872,23 @@ extension TryCapture {
 
 // MARK: - Non-builder capture arity 7
 
+@available(SwiftStdlib 5.7, *)
 extension Capture {
+  @available(SwiftStdlib 5.7, *)
     public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6>(
     _ component: R
   ) where RegexOutput == (Substring, W, C0, C1, C2, C3, C4, C5, C6), R.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6) {
     self.init(node: .capture(component.regex.root))
   }
 
+  @available(SwiftStdlib 5.7, *)
     public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6>(
     _ component: R, as reference: Reference<W>
   ) where RegexOutput == (Substring, W, C0, C1, C2, C3, C4, C5, C6), R.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6) {
     self.init(node: .capture(reference: reference.id, component.regex.root))
   }
 
+  @available(SwiftStdlib 5.7, *)
     public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, NewCapture>(
     _ component: R,
     transform: @escaping (Substring) throws -> NewCapture
@@ -3249,6 +3900,7 @@ extension Capture {
       component.regex.root)))
   }
 
+  @available(SwiftStdlib 5.7, *)
     public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, NewCapture>(
     _ component: R,
     as reference: Reference<NewCapture>,
@@ -3264,7 +3916,9 @@ extension Capture {
   }
 }
 
+@available(SwiftStdlib 5.7, *)
 extension TryCapture {
+  @available(SwiftStdlib 5.7, *)
     public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, NewCapture>(
     _ component: R,
     transform: @escaping (Substring) throws -> NewCapture?
@@ -3276,6 +3930,7 @@ extension TryCapture {
       component.regex.root)))
   }
 
+  @available(SwiftStdlib 5.7, *)
     public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, NewCapture>(
     _ component: R,
     as reference: Reference<NewCapture>,
@@ -3293,13 +3948,16 @@ extension TryCapture {
 
 // MARK: - Builder capture arity 7
 
+@available(SwiftStdlib 5.7, *)
 extension Capture {
+  @available(SwiftStdlib 5.7, *)
     public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6>(
     @RegexComponentBuilder _ component: () -> R
   ) where RegexOutput == (Substring, W, C0, C1, C2, C3, C4, C5, C6), R.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6) {
     self.init(node: .capture(component().regex.root))
   }
 
+  @available(SwiftStdlib 5.7, *)
     public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6>(
     as reference: Reference<W>,
     @RegexComponentBuilder _ component: () -> R
@@ -3309,6 +3967,7 @@ extension Capture {
       component().regex.root))
   }
 
+  @available(SwiftStdlib 5.7, *)
     public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, NewCapture>(
     @RegexComponentBuilder _ component: () -> R,
     transform: @escaping (Substring) throws -> NewCapture
@@ -3320,6 +3979,7 @@ extension Capture {
       component().regex.root)))
   }
 
+  @available(SwiftStdlib 5.7, *)
     public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, NewCapture>(
     as reference: Reference<NewCapture>,
     @RegexComponentBuilder _ component: () -> R,
@@ -3335,7 +3995,9 @@ extension Capture {
   }
 }
 
+@available(SwiftStdlib 5.7, *)
 extension TryCapture {
+  @available(SwiftStdlib 5.7, *)
     public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, NewCapture>(
     @RegexComponentBuilder _ component: () -> R,
     transform: @escaping (Substring) throws -> NewCapture?
@@ -3347,6 +4009,7 @@ extension TryCapture {
       component().regex.root)))
   }
 
+  @available(SwiftStdlib 5.7, *)
     public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, NewCapture>(
     as reference: Reference<NewCapture>,
     @RegexComponentBuilder _ component: () -> R,
@@ -3364,19 +4027,23 @@ extension TryCapture {
 
 // MARK: - Non-builder capture arity 8
 
+@available(SwiftStdlib 5.7, *)
 extension Capture {
+  @available(SwiftStdlib 5.7, *)
     public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7>(
     _ component: R
   ) where RegexOutput == (Substring, W, C0, C1, C2, C3, C4, C5, C6, C7), R.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
     self.init(node: .capture(component.regex.root))
   }
 
+  @available(SwiftStdlib 5.7, *)
     public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7>(
     _ component: R, as reference: Reference<W>
   ) where RegexOutput == (Substring, W, C0, C1, C2, C3, C4, C5, C6, C7), R.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
     self.init(node: .capture(reference: reference.id, component.regex.root))
   }
 
+  @available(SwiftStdlib 5.7, *)
     public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, NewCapture>(
     _ component: R,
     transform: @escaping (Substring) throws -> NewCapture
@@ -3388,6 +4055,7 @@ extension Capture {
       component.regex.root)))
   }
 
+  @available(SwiftStdlib 5.7, *)
     public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, NewCapture>(
     _ component: R,
     as reference: Reference<NewCapture>,
@@ -3403,7 +4071,9 @@ extension Capture {
   }
 }
 
+@available(SwiftStdlib 5.7, *)
 extension TryCapture {
+  @available(SwiftStdlib 5.7, *)
     public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, NewCapture>(
     _ component: R,
     transform: @escaping (Substring) throws -> NewCapture?
@@ -3415,6 +4085,7 @@ extension TryCapture {
       component.regex.root)))
   }
 
+  @available(SwiftStdlib 5.7, *)
     public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, NewCapture>(
     _ component: R,
     as reference: Reference<NewCapture>,
@@ -3432,13 +4103,16 @@ extension TryCapture {
 
 // MARK: - Builder capture arity 8
 
+@available(SwiftStdlib 5.7, *)
 extension Capture {
+  @available(SwiftStdlib 5.7, *)
     public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7>(
     @RegexComponentBuilder _ component: () -> R
   ) where RegexOutput == (Substring, W, C0, C1, C2, C3, C4, C5, C6, C7), R.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
     self.init(node: .capture(component().regex.root))
   }
 
+  @available(SwiftStdlib 5.7, *)
     public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7>(
     as reference: Reference<W>,
     @RegexComponentBuilder _ component: () -> R
@@ -3448,6 +4122,7 @@ extension Capture {
       component().regex.root))
   }
 
+  @available(SwiftStdlib 5.7, *)
     public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, NewCapture>(
     @RegexComponentBuilder _ component: () -> R,
     transform: @escaping (Substring) throws -> NewCapture
@@ -3459,6 +4134,7 @@ extension Capture {
       component().regex.root)))
   }
 
+  @available(SwiftStdlib 5.7, *)
     public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, NewCapture>(
     as reference: Reference<NewCapture>,
     @RegexComponentBuilder _ component: () -> R,
@@ -3474,7 +4150,9 @@ extension Capture {
   }
 }
 
+@available(SwiftStdlib 5.7, *)
 extension TryCapture {
+  @available(SwiftStdlib 5.7, *)
     public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, NewCapture>(
     @RegexComponentBuilder _ component: () -> R,
     transform: @escaping (Substring) throws -> NewCapture?
@@ -3486,6 +4164,7 @@ extension TryCapture {
       component().regex.root)))
   }
 
+  @available(SwiftStdlib 5.7, *)
     public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, NewCapture>(
     as reference: Reference<NewCapture>,
     @RegexComponentBuilder _ component: () -> R,
@@ -3503,19 +4182,23 @@ extension TryCapture {
 
 // MARK: - Non-builder capture arity 9
 
+@available(SwiftStdlib 5.7, *)
 extension Capture {
+  @available(SwiftStdlib 5.7, *)
     public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, C8>(
     _ component: R
   ) where RegexOutput == (Substring, W, C0, C1, C2, C3, C4, C5, C6, C7, C8), R.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
     self.init(node: .capture(component.regex.root))
   }
 
+  @available(SwiftStdlib 5.7, *)
     public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, C8>(
     _ component: R, as reference: Reference<W>
   ) where RegexOutput == (Substring, W, C0, C1, C2, C3, C4, C5, C6, C7, C8), R.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
     self.init(node: .capture(reference: reference.id, component.regex.root))
   }
 
+  @available(SwiftStdlib 5.7, *)
     public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, C8, NewCapture>(
     _ component: R,
     transform: @escaping (Substring) throws -> NewCapture
@@ -3527,6 +4210,7 @@ extension Capture {
       component.regex.root)))
   }
 
+  @available(SwiftStdlib 5.7, *)
     public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, C8, NewCapture>(
     _ component: R,
     as reference: Reference<NewCapture>,
@@ -3542,7 +4226,9 @@ extension Capture {
   }
 }
 
+@available(SwiftStdlib 5.7, *)
 extension TryCapture {
+  @available(SwiftStdlib 5.7, *)
     public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, C8, NewCapture>(
     _ component: R,
     transform: @escaping (Substring) throws -> NewCapture?
@@ -3554,6 +4240,7 @@ extension TryCapture {
       component.regex.root)))
   }
 
+  @available(SwiftStdlib 5.7, *)
     public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, C8, NewCapture>(
     _ component: R,
     as reference: Reference<NewCapture>,
@@ -3571,13 +4258,16 @@ extension TryCapture {
 
 // MARK: - Builder capture arity 9
 
+@available(SwiftStdlib 5.7, *)
 extension Capture {
+  @available(SwiftStdlib 5.7, *)
     public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, C8>(
     @RegexComponentBuilder _ component: () -> R
   ) where RegexOutput == (Substring, W, C0, C1, C2, C3, C4, C5, C6, C7, C8), R.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
     self.init(node: .capture(component().regex.root))
   }
 
+  @available(SwiftStdlib 5.7, *)
     public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, C8>(
     as reference: Reference<W>,
     @RegexComponentBuilder _ component: () -> R
@@ -3587,6 +4277,7 @@ extension Capture {
       component().regex.root))
   }
 
+  @available(SwiftStdlib 5.7, *)
     public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, C8, NewCapture>(
     @RegexComponentBuilder _ component: () -> R,
     transform: @escaping (Substring) throws -> NewCapture
@@ -3598,6 +4289,7 @@ extension Capture {
       component().regex.root)))
   }
 
+  @available(SwiftStdlib 5.7, *)
     public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, C8, NewCapture>(
     as reference: Reference<NewCapture>,
     @RegexComponentBuilder _ component: () -> R,
@@ -3613,7 +4305,9 @@ extension Capture {
   }
 }
 
+@available(SwiftStdlib 5.7, *)
 extension TryCapture {
+  @available(SwiftStdlib 5.7, *)
     public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, C8, NewCapture>(
     @RegexComponentBuilder _ component: () -> R,
     transform: @escaping (Substring) throws -> NewCapture?
@@ -3625,6 +4319,7 @@ extension TryCapture {
       component().regex.root)))
   }
 
+  @available(SwiftStdlib 5.7, *)
     public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, C8, NewCapture>(
     as reference: Reference<NewCapture>,
     @RegexComponentBuilder _ component: () -> R,
@@ -3642,19 +4337,23 @@ extension TryCapture {
 
 // MARK: - Non-builder capture arity 10
 
+@available(SwiftStdlib 5.7, *)
 extension Capture {
+  @available(SwiftStdlib 5.7, *)
     public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9>(
     _ component: R
   ) where RegexOutput == (Substring, W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9), R.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
     self.init(node: .capture(component.regex.root))
   }
 
+  @available(SwiftStdlib 5.7, *)
     public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9>(
     _ component: R, as reference: Reference<W>
   ) where RegexOutput == (Substring, W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9), R.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
     self.init(node: .capture(reference: reference.id, component.regex.root))
   }
 
+  @available(SwiftStdlib 5.7, *)
     public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9, NewCapture>(
     _ component: R,
     transform: @escaping (Substring) throws -> NewCapture
@@ -3666,6 +4365,7 @@ extension Capture {
       component.regex.root)))
   }
 
+  @available(SwiftStdlib 5.7, *)
     public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9, NewCapture>(
     _ component: R,
     as reference: Reference<NewCapture>,
@@ -3681,7 +4381,9 @@ extension Capture {
   }
 }
 
+@available(SwiftStdlib 5.7, *)
 extension TryCapture {
+  @available(SwiftStdlib 5.7, *)
     public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9, NewCapture>(
     _ component: R,
     transform: @escaping (Substring) throws -> NewCapture?
@@ -3693,6 +4395,7 @@ extension TryCapture {
       component.regex.root)))
   }
 
+  @available(SwiftStdlib 5.7, *)
     public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9, NewCapture>(
     _ component: R,
     as reference: Reference<NewCapture>,
@@ -3710,13 +4413,16 @@ extension TryCapture {
 
 // MARK: - Builder capture arity 10
 
+@available(SwiftStdlib 5.7, *)
 extension Capture {
+  @available(SwiftStdlib 5.7, *)
     public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9>(
     @RegexComponentBuilder _ component: () -> R
   ) where RegexOutput == (Substring, W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9), R.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
     self.init(node: .capture(component().regex.root))
   }
 
+  @available(SwiftStdlib 5.7, *)
     public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9>(
     as reference: Reference<W>,
     @RegexComponentBuilder _ component: () -> R
@@ -3726,6 +4432,7 @@ extension Capture {
       component().regex.root))
   }
 
+  @available(SwiftStdlib 5.7, *)
     public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9, NewCapture>(
     @RegexComponentBuilder _ component: () -> R,
     transform: @escaping (Substring) throws -> NewCapture
@@ -3737,6 +4444,7 @@ extension Capture {
       component().regex.root)))
   }
 
+  @available(SwiftStdlib 5.7, *)
     public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9, NewCapture>(
     as reference: Reference<NewCapture>,
     @RegexComponentBuilder _ component: () -> R,
@@ -3752,7 +4460,9 @@ extension Capture {
   }
 }
 
+@available(SwiftStdlib 5.7, *)
 extension TryCapture {
+  @available(SwiftStdlib 5.7, *)
     public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9, NewCapture>(
     @RegexComponentBuilder _ component: () -> R,
     transform: @escaping (Substring) throws -> NewCapture?
@@ -3764,6 +4474,7 @@ extension TryCapture {
       component().regex.root)))
   }
 
+  @available(SwiftStdlib 5.7, *)
     public init<R: RegexComponent, W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9, NewCapture>(
     as reference: Reference<NewCapture>,
     @RegexComponentBuilder _ component: () -> R,

--- a/Sources/VariadicsGenerator/VariadicsGenerator.swift
+++ b/Sources/VariadicsGenerator/VariadicsGenerator.swift
@@ -96,6 +96,7 @@ let regexTypeName = "Regex"
 let baseMatchTypeName = "Substring"
 let concatBuilderName = "RegexComponentBuilder"
 let altBuilderName = "AlternationBuilder"
+let defaultAvailableAttr = "@available(SwiftStdlib 5.7, *)"
 
 @main
 struct VariadicsGenerator: ParsableCommand {
@@ -240,8 +241,10 @@ struct VariadicsGenerator: ParsableCommand {
     }()
 
     // Emit concatenation builder.
-    output("extension \(concatBuilderName) {\n")
     output("""
+      \(defaultAvailableAttr)
+      extension \(concatBuilderName) {
+        \(defaultAvailableAttr)
         public static func buildPartialBlock<\(genericParams)>(
           accumulated: R0, next: R1
         ) -> \(regexTypeName)<\(matchType)> \(whereClause) {
@@ -255,9 +258,11 @@ struct VariadicsGenerator: ParsableCommand {
   func emitConcatenationWithEmpty(leftArity: Int) {
     // T + () = T
     output("""
-       extension \(concatBuilderName) {
-         public static func buildPartialBlock<W0
-       """)
+      \(defaultAvailableAttr)
+      extension \(concatBuilderName) {
+        \(defaultAvailableAttr)
+        public static func buildPartialBlock<W0
+      """)
     outputForEach(0..<leftArity) {
       ", C\($0)"
     }
@@ -367,7 +372,9 @@ struct VariadicsGenerator: ParsableCommand {
     assert(arity >= 0)
     let params = QuantifierParameters(kind: kind, arity: arity)
     output("""
+      \(defaultAvailableAttr)
       extension \(kind.rawValue) {
+        \(defaultAvailableAttr)
         \(params.disfavored)\
         public init<\(params.genericParams)>(
           _ component: Component,
@@ -377,7 +384,9 @@ struct VariadicsGenerator: ParsableCommand {
         }
       }
 
+      \(defaultAvailableAttr)
       extension \(kind.rawValue) {
+        \(defaultAvailableAttr)
         \(params.disfavored)\
         public init<\(params.genericParams)>(
           _ behavior: QuantificationBehavior = .eagerly,
@@ -389,7 +398,9 @@ struct VariadicsGenerator: ParsableCommand {
 
       \(kind == .zeroOrOne ?
         """
+        \(defaultAvailableAttr)
         extension \(concatBuilderName) {
+          \(defaultAvailableAttr)
           public static func buildLimitedAvailability<\(params.genericParams)>(
             _ component: Component
           ) -> \(regexTypeName)<\(params.matchType)> \(params.whereClause) {
@@ -433,7 +444,9 @@ struct VariadicsGenerator: ParsableCommand {
       (arity == 0 ? "" : ", Component.\(outputAssociatedTypeName) == (W, \(capturesJoined))")
 
     output("""
+      \(defaultAvailableAttr)
       extension \(groupName) {
+        \(defaultAvailableAttr)
         \(disfavored)\
         public init<\(genericParams)>(
           _ component: Component
@@ -442,7 +455,9 @@ struct VariadicsGenerator: ParsableCommand {
         }
       }
 
+      \(defaultAvailableAttr)
       extension \(groupName) {
+        \(defaultAvailableAttr)
         \(disfavored)\
         public init<\(genericParams)>(
           @\(concatBuilderName) _ component: () -> Component
@@ -463,7 +478,9 @@ struct VariadicsGenerator: ParsableCommand {
     // We would need to prohibit `repeat(count: 0)`; can only happen at runtime
     
     output("""
+      \(defaultAvailableAttr)
       extension Repeat {
+        \(defaultAvailableAttr)
         \(params.disfavored)\
         public init<\(params.genericParams)>(
           _ component: Component,
@@ -474,6 +491,7 @@ struct VariadicsGenerator: ParsableCommand {
           self.init(node: .quantification(.exactly(.init(faking: count)), .eager, component.regex.root))
         }
 
+        \(defaultAvailableAttr)
         \(params.disfavored)\
         public init<\(params.genericParams)>(
           count: Int,
@@ -484,6 +502,7 @@ struct VariadicsGenerator: ParsableCommand {
           self.init(node: .quantification(.exactly(.init(faking: count)), .eager, component().regex.root))
         }
 
+        \(defaultAvailableAttr)
         \(params.disfavored)\
         public init<\(params.genericParams), R: RangeExpression>(
           _ component: Component,
@@ -493,6 +512,7 @@ struct VariadicsGenerator: ParsableCommand {
           self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component.regex.root))
         }
 
+        \(defaultAvailableAttr)
         \(params.disfavored)\
         public init<\(params.genericParams), R: RangeExpression>(
           _ expression: R,
@@ -545,7 +565,9 @@ struct VariadicsGenerator: ParsableCommand {
       return "(\(baseMatchTypeName), \(resultCaptures))"
     }()
     output("""
+      \(defaultAvailableAttr)
       extension \(altBuilderName) {
+        \(defaultAvailableAttr)
         public static func buildPartialBlock<\(genericParams)>(
           accumulated: R0, next: R1
         ) -> ChoiceOf<\(matchType)> \(whereClause) {
@@ -571,7 +593,9 @@ struct VariadicsGenerator: ParsableCommand {
       """
     let resultCaptures = (0..<arity).map { "C\($0)?" }.joined(separator: ", ")
     output("""
+      \(defaultAvailableAttr)
       extension \(altBuilderName) {
+        \(defaultAvailableAttr)
         public static func buildPartialBlock<\(genericParams)>(first regex: R) -> ChoiceOf<(W, \(resultCaptures))> \(whereClause) {
           .init(node: .orderedChoice([regex.regex.root]))
         }
@@ -600,7 +624,9 @@ struct VariadicsGenerator: ParsableCommand {
     output("""
       // MARK: - Non-builder capture arity \(arity)
 
+      \(defaultAvailableAttr)
       extension Capture {
+        \(defaultAvailableAttr)
         \(disfavored)\
         public init<\(genericParams)>(
           _ component: R
@@ -608,6 +634,7 @@ struct VariadicsGenerator: ParsableCommand {
           self.init(node: .capture(component.regex.root))
         }
 
+        \(defaultAvailableAttr)
         \(disfavored)\
         public init<\(genericParams)>(
           _ component: R, as reference: Reference<W>
@@ -615,6 +642,7 @@ struct VariadicsGenerator: ParsableCommand {
           self.init(node: .capture(reference: reference.id, component.regex.root))
         }
 
+        \(defaultAvailableAttr)
         \(disfavored)\
         public init<\(genericParams), NewCapture>(
           _ component: R,
@@ -627,6 +655,7 @@ struct VariadicsGenerator: ParsableCommand {
             component.regex.root)))
         }
 
+        \(defaultAvailableAttr)
         \(disfavored)\
         public init<\(genericParams), NewCapture>(
           _ component: R,
@@ -643,7 +672,9 @@ struct VariadicsGenerator: ParsableCommand {
         }
       }
 
+      \(defaultAvailableAttr)
       extension TryCapture {
+        \(defaultAvailableAttr)
         \(disfavored)\
         public init<\(genericParams), NewCapture>(
           _ component: R,
@@ -656,6 +687,7 @@ struct VariadicsGenerator: ParsableCommand {
             component.regex.root)))
         }
 
+        \(defaultAvailableAttr)
         \(disfavored)\
         public init<\(genericParams), NewCapture>(
           _ component: R,
@@ -674,7 +706,9 @@ struct VariadicsGenerator: ParsableCommand {
 
       // MARK: - Builder capture arity \(arity)
 
+      \(defaultAvailableAttr)
       extension Capture {
+        \(defaultAvailableAttr)
         \(disfavored)\
         public init<\(genericParams)>(
           @\(concatBuilderName) _ component: () -> R
@@ -682,6 +716,7 @@ struct VariadicsGenerator: ParsableCommand {
           self.init(node: .capture(component().regex.root))
         }
 
+        \(defaultAvailableAttr)
         \(disfavored)\
         public init<\(genericParams)>(
           as reference: Reference<W>,
@@ -692,6 +727,7 @@ struct VariadicsGenerator: ParsableCommand {
             component().regex.root))
         }
 
+        \(defaultAvailableAttr)
         \(disfavored)\
         public init<\(genericParams), NewCapture>(
           @\(concatBuilderName) _ component: () -> R,
@@ -704,6 +740,7 @@ struct VariadicsGenerator: ParsableCommand {
             component().regex.root)))
         }
 
+        \(defaultAvailableAttr)
         \(disfavored)\
         public init<\(genericParams), NewCapture>(
           as reference: Reference<NewCapture>,
@@ -720,7 +757,9 @@ struct VariadicsGenerator: ParsableCommand {
         }
       }
 
+      \(defaultAvailableAttr)
       extension TryCapture {
+        \(defaultAvailableAttr)
         \(disfavored)\
         public init<\(genericParams), NewCapture>(
           @\(concatBuilderName) _ component: () -> R,
@@ -733,6 +772,7 @@ struct VariadicsGenerator: ParsableCommand {
             component().regex.root)))
         }
 
+        \(defaultAvailableAttr)
         \(disfavored)\
         public init<\(genericParams), NewCapture>(
           as reference: Reference<NewCapture>,

--- a/Sources/_StringProcessing/Algorithms/Algorithms/Contains.swift
+++ b/Sources/_StringProcessing/Algorithms/Algorithms/Contains.swift
@@ -39,7 +39,10 @@ extension BidirectionalCollection where Element: Comparable {
   func contains<S: Sequence>(_ other: S) -> Bool
     where S.Element == Element
   {
-    firstRange(of: other) != nil
+    if #available(SwiftStdlib 5.7, *) {
+      return firstRange(of: other) != nil
+    }
+    fatalError()
   }
 }
 

--- a/Sources/_StringProcessing/Algorithms/Algorithms/FirstRange.swift
+++ b/Sources/_StringProcessing/Algorithms/Algorithms/FirstRange.swift
@@ -77,7 +77,8 @@ extension BidirectionalCollection where SubSequence == Substring {
   public func firstRange<R: RegexComponent>(of regex: R) -> Range<Index>? {
     firstRange(of: RegexConsumer(regex))
   }
-  
+
+  @available(SwiftStdlib 5.7, *)
   func lastRange<R: RegexComponent>(of regex: R) -> Range<Index>? {
     lastRange(of: RegexConsumer(regex))
   }

--- a/Sources/_StringProcessing/Algorithms/Algorithms/Ranges.swift
+++ b/Sources/_StringProcessing/Algorithms/Algorithms/Ranges.swift
@@ -218,12 +218,14 @@ extension BidirectionalCollection where Element: Comparable {
 
 extension BidirectionalCollection where SubSequence == Substring {
   // FIXME: Replace `RangesCollection` when SE-0346 is enabled
+  @available(SwiftStdlib 5.7, *)
   func ranges<R: RegexComponent>(
     of regex: R
   ) -> RangesCollection<RegexConsumer<R, Self>> {
     ranges(of: RegexConsumer(regex))
   }
-  
+
+  @available(SwiftStdlib 5.7, *)
   func rangesFromBack<R: RegexComponent>(
     of regex: R
   ) -> ReversedRangesCollection<RegexConsumer<R, Self>> {

--- a/Sources/_StringProcessing/Algorithms/Algorithms/Split.swift
+++ b/Sources/_StringProcessing/Algorithms/Algorithms/Split.swift
@@ -280,6 +280,7 @@ extension BidirectionalCollection where Element: Comparable {
 
 // MARK: Regex algorithms
 
+@available(SwiftStdlib 5.7, *)
 extension BidirectionalCollection where SubSequence == Substring {
   // FIXME: Replace `SplitCollection` when SE-0346 is enabled
   /// Returns the longest possible subsequences of the collection, in order,

--- a/Sources/_StringProcessing/Algorithms/Algorithms/StartsWith.swift
+++ b/Sources/_StringProcessing/Algorithms/Algorithms/StartsWith.swift
@@ -47,13 +47,13 @@ extension BidirectionalCollection where Element: Equatable {
 
 // MARK: Regex algorithms
 
+@available(SwiftStdlib 5.7, *)
 extension BidirectionalCollection where SubSequence == Substring {
   /// Returns a Boolean value indicating whether the initial elements of the
   /// sequence are the same as the elements in the specified regex.
   /// - Parameter regex: A regex to compare to this sequence.
   /// - Returns: `true` if the initial elements of the sequence matches the
   /// beginning of `regex`; otherwise, `false`.
-  @available(SwiftStdlib 5.7, *)
   public func starts<R: RegexComponent>(with regex: R) -> Bool {
     starts(with: RegexConsumer(regex))
   }

--- a/Sources/_StringProcessing/Algorithms/Algorithms/Trim.swift
+++ b/Sources/_StringProcessing/Algorithms/Algorithms/Trim.swift
@@ -288,11 +288,13 @@ extension BidirectionalCollection where SubSequence == Substring {
   public func trimmingPrefix<R: RegexComponent>(_ regex: R) -> SubSequence {
     trimmingPrefix(RegexConsumer(regex))
   }
-  
+
+  @available(SwiftStdlib 5.7, *)
   func trimmingSuffix<R: RegexComponent>(_ regex: R) -> SubSequence {
     trimmingSuffix(RegexConsumer(regex))
   }
-  
+
+  @available(SwiftStdlib 5.7, *)
   func trimming<R: RegexComponent>(_ regex: R) -> SubSequence {
     trimming(RegexConsumer(regex))
   }
@@ -307,11 +309,13 @@ extension RangeReplaceableCollection
   public mutating func trimPrefix<R: RegexComponent>(_ regex: R) {
     trimPrefix(RegexConsumer(regex))
   }
-  
+
+  @available(SwiftStdlib 5.7, *)
   mutating func trimSuffix<R: RegexComponent>(_ regex: R) {
     trimSuffix(RegexConsumer(regex))
   }
-  
+
+  @available(SwiftStdlib 5.7, *)
   mutating func trim<R: RegexComponent>(_ regex: R) {
     let consumer = RegexConsumer<R, Self>(regex)
     trimPrefix(consumer)
@@ -320,14 +324,17 @@ extension RangeReplaceableCollection
 }
 
 extension Substring {
+  @available(SwiftStdlib 5.7, *)
   mutating func trimPrefix<R: RegexComponent>(_ regex: R) {
     trimPrefix(RegexConsumer(regex))
   }
-  
+
+  @available(SwiftStdlib 5.7, *)
   mutating func trimSuffix<R: RegexComponent>(_ regex: R) {
     trimSuffix(RegexConsumer(regex))
   }
-  
+
+  @available(SwiftStdlib 5.7, *)
   mutating func trim<R: RegexComponent>(_ regex: R) {
     let consumer = RegexConsumer<R, Self>(regex)
     trimPrefix(consumer)

--- a/Sources/_StringProcessing/Algorithms/Consumers/RegexConsumer.swift
+++ b/Sources/_StringProcessing/Algorithms/Consumers/RegexConsumer.swift
@@ -10,6 +10,7 @@
 //===----------------------------------------------------------------------===//
 
 // FIXME: What even is this? Can we delete this whole thing?
+@available(SwiftStdlib 5.7, *)
 struct RegexConsumer<
   R: RegexComponent, Consumed: BidirectionalCollection
 > where Consumed.SubSequence == Substring {
@@ -21,6 +22,7 @@ struct RegexConsumer<
   }
 }
 
+@available(SwiftStdlib 5.7, *)
 extension RegexConsumer {
   func _matchingConsuming(
     _ consumed: Substring, in range: Range<String.Index>
@@ -36,6 +38,7 @@ extension RegexConsumer {
 // TODO: Explicitly implement the non-matching consumer/searcher protocols as
 // well, taking advantage of the fact that the captures can be ignored
 
+@available(SwiftStdlib 5.7, *)
 extension RegexConsumer: MatchingCollectionConsumer {
   typealias Match = R.RegexOutput
   
@@ -47,6 +50,7 @@ extension RegexConsumer: MatchingCollectionConsumer {
 }
 
 // TODO: We'll want to bake backwards into the engine
+@available(SwiftStdlib 5.7, *)
 extension RegexConsumer: BidirectionalMatchingCollectionConsumer {
   func matchingConsumingBack(
     _ consumed: Consumed, in range: Range<Consumed.Index>
@@ -67,6 +71,7 @@ extension RegexConsumer: BidirectionalMatchingCollectionConsumer {
   }
 }
 
+@available(SwiftStdlib 5.7, *)
 extension RegexConsumer: MatchingStatelessCollectionSearcher {
   typealias Searched = Consumed
 
@@ -81,6 +86,7 @@ extension RegexConsumer: MatchingStatelessCollectionSearcher {
 }
 
 // TODO: Bake in search-back to engine too
+@available(SwiftStdlib 5.7, *)
 extension RegexConsumer: BackwardMatchingStatelessCollectionSearcher {
   typealias BackwardSearched = Consumed
   

--- a/Sources/_StringProcessing/Algorithms/Matching/FirstMatch.swift
+++ b/Sources/_StringProcessing/Algorithms/Matching/FirstMatch.swift
@@ -38,12 +38,14 @@ extension BidirectionalCollection {
 // MARK: Regex algorithms
 
 extension BidirectionalCollection where SubSequence == Substring {
+  @available(SwiftStdlib 5.7, *)
   func firstMatch<R: RegexComponent>(
     of regex: R
   ) -> _MatchResult<RegexConsumer<R, Self>>? {
     firstMatch(of: RegexConsumer(regex))
   }
-  
+
+  @available(SwiftStdlib 5.7, *)
   func lastMatch<R: RegexComponent>(
     of regex: R
   ) -> _BackwardMatchResult<RegexConsumer<R, Self>>? {
@@ -54,6 +56,7 @@ extension BidirectionalCollection where SubSequence == Substring {
   /// - Parameter regex: The regex to search for.
   /// - Returns: The first match of `regex` in the collection, or `nil` if
   /// there isn't a match.
+  @available(SwiftStdlib 5.7, *)
   public func firstMatch<R: RegexComponent>(
     of r: R
   ) -> Regex<R.RegexOutput>.Match? {

--- a/Sources/_StringProcessing/Algorithms/Matching/MatchReplace.swift
+++ b/Sources/_StringProcessing/Algorithms/Matching/MatchReplace.swift
@@ -75,6 +75,7 @@ extension RangeReplaceableCollection {
 // MARK: Regex algorithms
 
 extension RangeReplaceableCollection where SubSequence == Substring {
+  @available(SwiftStdlib 5.7, *)
   func replacing<R: RegexComponent, Replacement: Collection>(
     _ regex: R,
     with replacement: (_MatchResult<RegexConsumer<R, Substring>>) throws -> Replacement,
@@ -87,7 +88,8 @@ extension RangeReplaceableCollection where SubSequence == Substring {
       subrange: subrange,
       maxReplacements: maxReplacements)
   }
-  
+
+  @available(SwiftStdlib 5.7, *)
   func replacing<R: RegexComponent, Replacement: Collection>(
     _ regex: R,
     with replacement: (_MatchResult<RegexConsumer<R, Substring>>) throws -> Replacement,
@@ -99,7 +101,8 @@ extension RangeReplaceableCollection where SubSequence == Substring {
       subrange: startIndex..<endIndex,
       maxReplacements: maxReplacements)
   }
-  
+
+  @available(SwiftStdlib 5.7, *)
   mutating func replace<R: RegexComponent, Replacement: Collection>(
     _ regex: R,
     with replacement: (_MatchResult<RegexConsumer<R, Substring>>) throws -> Replacement,

--- a/Sources/_StringProcessing/Algorithms/Matching/Matches.swift
+++ b/Sources/_StringProcessing/Algorithms/Matching/Matches.swift
@@ -188,12 +188,14 @@ extension BidirectionalCollection where SubSequence == Substring {
   /// Returns a collection containing all matches of the specified regex.
   /// - Parameter regex: The regex to search for.
   /// - Returns: A collection of matches of `regex`.
+  @available(SwiftStdlib 5.7, *)
   func matches<R: RegexComponent>(
     of regex: R
   ) -> MatchesCollection<RegexConsumer<R, Self>> {
     matches(of: RegexConsumer(regex))
   }
 
+  @available(SwiftStdlib 5.7, *)
   func matchesFromBack<R: RegexComponent>(
     of regex: R
   ) -> ReversedMatchesCollection<RegexConsumer<R, Self>> {
@@ -202,6 +204,7 @@ extension BidirectionalCollection where SubSequence == Substring {
 
   // FIXME: Replace the returned value as `some Collection<Regex<R.Output>.Match>
   // when SE-0346 is enabled
+  @available(SwiftStdlib 5.7, *)
   func _matches<R: RegexComponent>(of r: R) -> [Regex<R.RegexOutput>.Match] {
     let slice = self[...]
     var start = self.startIndex

--- a/Sources/_StringProcessing/Executor.swift
+++ b/Sources/_StringProcessing/Executor.swift
@@ -19,6 +19,7 @@ struct Executor {
     self.engine = Engine(program, enableTracing: enablesTracing)
   }
 
+  @available(SwiftStdlib 5.7, *)
   func match<Output>(
     _ input: String,
     in inputRange: Range<String.Index>,
@@ -64,6 +65,7 @@ struct Executor {
       value: value)
   }
 
+  @available(SwiftStdlib 5.7, *)
   func dynamicMatch(
     _ input: String,
     in inputRange: Range<String.Index>,

--- a/Sources/_StringProcessing/Regex/AnyRegexOutput.swift
+++ b/Sources/_StringProcessing/Regex/AnyRegexOutput.swift
@@ -11,6 +11,7 @@
 
 import _RegexParser
 
+@available(SwiftStdlib 5.7, *)
 extension Regex where Output == AnyRegexOutput {
   /// Parse and compile `pattern`, resulting in an existentially-typed capture list.
   public init(compiling pattern: String) throws {
@@ -18,6 +19,7 @@ extension Regex where Output == AnyRegexOutput {
   }
 }
 
+@available(SwiftStdlib 5.7, *)
 extension Regex {
   /// Parse and compile `pattern`, resulting in a strongly-typed capture list.
   public init(
@@ -28,6 +30,7 @@ extension Regex {
   }
 }
 
+@available(SwiftStdlib 5.7, *)
 extension Regex.Match where Output == AnyRegexOutput {
   // Ensures `.0` always refers to the whole match.
   public subscript(
@@ -54,6 +57,7 @@ public struct AnyRegexOutput {
   }
 }
 
+@available(SwiftStdlib 5.7, *)
 extension AnyRegexOutput {
   /// Creates a type-erased regex output from an existing output.
   ///
@@ -87,6 +91,7 @@ extension AnyRegexOutput {
   }
 }
 
+@available(SwiftStdlib 5.7, *)
 extension AnyRegexOutput {
   internal init<C: Collection>(
     input: String, elements: C
@@ -95,6 +100,7 @@ extension AnyRegexOutput {
   }
 }
 
+@available(SwiftStdlib 5.7, *)
 extension AnyRegexOutput.ElementRepresentation {
   init(_ element: StructuredCapture) {
     self.init(
@@ -117,6 +123,7 @@ extension AnyRegexOutput.ElementRepresentation {
   }
 }
 
+@available(SwiftStdlib 5.7, *)
 extension AnyRegexOutput: RandomAccessCollection {
   public struct Element {
     fileprivate let representation: ElementRepresentation
@@ -163,6 +170,7 @@ extension AnyRegexOutput: RandomAccessCollection {
   }
 }
 
+@available(SwiftStdlib 5.7, *)
 extension Regex.Match where Output == AnyRegexOutput {
   /// Creates a type-erased regex match from an existing match.
   ///

--- a/Sources/_StringProcessing/Regex/Core.swift
+++ b/Sources/_StringProcessing/Regex/Core.swift
@@ -61,6 +61,7 @@ public struct Regex<Output>: RegexComponent {
   }
 }
 
+@available(SwiftStdlib 5.7, *)
 extension Regex {
   /// A program representation that caches any lowered representation for
   /// execution.
@@ -85,6 +86,7 @@ extension Regex {
   }
 }
 
+@available(SwiftStdlib 5.7, *)
 extension Regex {
   @_spi(RegexBuilder)
   public var root: DSLTree.Node {
@@ -95,5 +97,4 @@ extension Regex {
   public init(node: DSLTree.Node) {
     self.program = Program(tree: .init(node, options: nil))
   }
-
 }

--- a/Sources/_StringProcessing/Regex/DSLConsumers.swift
+++ b/Sources/_StringProcessing/Regex/DSLConsumers.swift
@@ -18,6 +18,7 @@ public protocol CustomRegexComponent: RegexComponent {
   ) -> (upperBound: String.Index, output: RegexOutput)?
 }
 
+@available(SwiftStdlib 5.7, *)
 extension CustomRegexComponent {
   public var regex: Regex<RegexOutput> {
     Regex(node: .matcher(.init(RegexOutput.self), { input, index, bounds in

--- a/Sources/_StringProcessing/Regex/DSLTree.swift
+++ b/Sources/_StringProcessing/Regex/DSLTree.swift
@@ -12,7 +12,6 @@
 import _RegexParser
 
 @_spi(RegexBuilder)
-@available(SwiftStdlib 5.7, *)
 public struct DSLTree {
   var root: Node
   var options: Options?
@@ -165,7 +164,6 @@ extension DSLTree {
 
 // CollectionConsumer
 @_spi(RegexBuilder)
-@available(SwiftStdlib 5.7, *)
 public typealias _ConsumerInterface = (
   String, Range<String.Index>
 ) throws -> String.Index?
@@ -173,14 +171,12 @@ public typealias _ConsumerInterface = (
 // Type producing consume
 // TODO: better name
 @_spi(RegexBuilder)
-@available(SwiftStdlib 5.7, *)
 public typealias _MatcherInterface = (
   String, String.Index, Range<String.Index>
 ) throws -> (String.Index, Any)?
 
 // Character-set (post grapheme segmentation)
 @_spi(RegexBuilder)
-@available(SwiftStdlib 5.7, *)
 public typealias _CharacterPredicateInterface = (
   (Character) -> Bool
 )
@@ -381,7 +377,6 @@ extension DSLTree.Node {
 }
 
 @_spi(RegexBuilder)
-@available(SwiftStdlib 5.7, *)
 public struct ReferenceID: Hashable, Equatable {
   private static var counter: Int = 0
   var base: Int
@@ -393,7 +388,6 @@ public struct ReferenceID: Hashable, Equatable {
 }
 
 @_spi(RegexBuilder)
-@available(SwiftStdlib 5.7, *)
 public struct CaptureTransform: Hashable, CustomStringConvertible {
   public enum Closure {
     case failable((Substring) throws -> Any?)

--- a/Sources/_StringProcessing/Regex/Match.swift
+++ b/Sources/_StringProcessing/Regex/Match.swift
@@ -9,6 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+@available(SwiftStdlib 5.7, *)
 extension Regex {
   /// The result of matching a regex against a string.
   ///
@@ -29,6 +30,7 @@ extension Regex {
   }
 }
 
+@available(SwiftStdlib 5.7, *)
 extension Regex.Match {
   /// The produced output from the match operation
   public var output: Output {
@@ -81,6 +83,7 @@ extension Regex.Match {
   }
 }
 
+@available(SwiftStdlib 5.7, *)
 extension Regex {
   /// Match a string in its entirety.
   ///
@@ -152,24 +155,29 @@ extension Regex {
   }
 }
 
+@available(SwiftStdlib 5.7, *)
 extension String {
   public func wholeMatch<R: RegexComponent>(
     of r: R
   ) -> Regex<R.RegexOutput>.Match? {
     try? r.regex.wholeMatch(in: self)
   }
+
   public func prefixMatch<R: RegexComponent>(
     of r: R
   ) -> Regex<R.RegexOutput>.Match? {
     try? r.regex.prefixMatch(in: self)
   }
 }
+
+@available(SwiftStdlib 5.7, *)
 extension Substring {
   public func wholeMatch<R: RegexComponent>(
     of r: R
   ) -> Regex<R.RegexOutput>.Match? {
     try? r.regex.wholeMatch(in: self)
   }
+
   public func prefixMatch<R: RegexComponent>(
     of r: R
   ) -> Regex<R.RegexOutput>.Match? {

--- a/Sources/_StringProcessing/Regex/Options.swift
+++ b/Sources/_StringProcessing/Regex/Options.swift
@@ -11,6 +11,7 @@
 
 import _RegexParser
 
+@available(SwiftStdlib 5.7, *)
 extension RegexComponent {
   /// Returns a regular expression that ignores casing when matching.
   public func ignoringCase(_ ignoreCase: Bool = true) -> Regex<RegexOutput> {
@@ -105,6 +106,7 @@ extension RegexComponent {
   }
 }
 
+@available(SwiftStdlib 5.7, *)
 public struct RegexSemanticLevel: Hashable {
   internal enum Representation {
     case graphemeCluster
@@ -127,6 +129,7 @@ public struct RegexSemanticLevel: Hashable {
 }
 
 // Options that only affect literals
+@available(SwiftStdlib 5.7, *)
 extension RegexComponent {
   /// Returns a regular expression where the start and end of input
   /// anchors (`^` and `$`) also match against the start and end of a line.
@@ -159,6 +162,8 @@ extension RegexComponent {
 }
 
 // MARK: - Helper method
+
+@available(SwiftStdlib 5.7, *)
 extension RegexComponent {
   fileprivate func wrapInOption(
     _ option: AST.MatchingOption.Kind,

--- a/Sources/_StringProcessing/_CharacterClassModel.swift
+++ b/Sources/_StringProcessing/_CharacterClassModel.swift
@@ -16,7 +16,6 @@ import _RegexParser
 // of parsing or to store in an AST
 
 @_spi(RegexBuilder)
-@available(SwiftStdlib 5.7, *)
 public struct _CharacterClassModel: Hashable {
   /// The actual character class to match.
   var cc: Representation
@@ -29,7 +28,7 @@ public struct _CharacterClassModel: Hashable {
   var isInverted: Bool = false
 
   // TODO: Split out builtin character classes into their own type?
-  public enum Representation: Hashable {
+    public enum Representation: Hashable {
     /// Any character
     case any
     /// Any grapheme cluster
@@ -56,8 +55,7 @@ public struct _CharacterClassModel: Hashable {
   public typealias SetOperator = AST.CustomCharacterClass.SetOp
 
   /// A binary set operation that forms a character class component.
-  @_spi(RegexBuilder)
-  public struct SetOperation: Hashable {
+    public struct SetOperation: Hashable {
     var lhs: CharacterSetComponent
     var op: SetOperator
     var rhs: CharacterSetComponent
@@ -74,8 +72,7 @@ public struct _CharacterClassModel: Hashable {
     }
   }
 
-  @_spi(RegexBuilder)
-  public enum CharacterSetComponent: Hashable {
+    public enum CharacterSetComponent: Hashable {
     case character(Character)
     case range(ClosedRange<Character>)
 
@@ -205,6 +202,7 @@ public struct _CharacterClassModel: Hashable {
   }
 }
 
+@available(SwiftStdlib 5.7, *)
 extension _CharacterClassModel: RegexComponent {
   public typealias RegexOutput = Substring
 
@@ -374,7 +372,7 @@ extension _CharacterClassModel {
 }
 
 extension DSLTree.Atom {
-  var characterClass: _CharacterClassModel? {
+    var characterClass: _CharacterClassModel? {
     switch self {
     case let .unconverted(a):
       return a.characterClass
@@ -385,7 +383,7 @@ extension DSLTree.Atom {
 }
 
 extension AST.Atom {
-  var characterClass: _CharacterClassModel? {
+    var characterClass: _CharacterClassModel? {
     switch kind {
     case let .escaped(b): return b.characterClass
 
@@ -411,7 +409,7 @@ extension AST.Atom {
 }
 
 extension AST.Atom.EscapedBuiltin {
-  var characterClass: _CharacterClassModel? {
+    var characterClass: _CharacterClassModel? {
     switch self {
     case .decimalDigit:    return .digit
     case .notDecimalDigit: return .digit.inverted


### PR DESCRIPTION
Tests now have flag `-disable-availability-checking` because XCTests always test the just-built modules, rather than the modules in the OS.