### PR TITLE
Add Substring algorithms tests

### DIFF
--- a/Sources/_StringProcessing/Algorithms/Matching/FirstMatch.swift
+++ b/Sources/_StringProcessing/Algorithms/Matching/FirstMatch.swift
@@ -61,6 +61,6 @@ extension BidirectionalCollection where SubSequence == Substring {
     of r: R
   ) -> Regex<R.RegexOutput>.Match? {
     let slice = self[...]
-    return try? r.regex.firstMatch(in: slice.base)
+    return try? r.regex.firstMatch(in: slice)
   }
 }

--- a/Sources/_StringProcessing/Regex/Match.swift
+++ b/Sources/_StringProcessing/Regex/Match.swift
@@ -123,7 +123,7 @@ extension Regex {
   /// Find the first match in a substring
   ///
   /// Returns `nil` if no match is found and throws on abort
-  public func firstMatch(_ s: Substring) throws -> Regex<Output>.Match? {
+  public func firstMatch(in s: Substring) throws -> Regex<Output>.Match? {
     try _firstMatch(s.base, in: s.startIndex..<s.endIndex)
   }
 

--- a/Tests/RegexTests/AlgorithmsTests.swift
+++ b/Tests/RegexTests/AlgorithmsTests.swift
@@ -34,19 +34,11 @@ class RegexConsumerTests: XCTestCase {
     ) {
       let regex = try! Regex(compiling: regex)
       
-      let actualSeq: [Range<Int>] = string[...].ranges(of: regex).map {
-        let start = string.offset(ofIndex: $0.lowerBound)
-        let end = string.offset(ofIndex: $0.upperBound)
-        return start..<end
-      }
+      let actualSeq: [Range<Int>] = string[...].ranges(of: regex).map(string.offsets(of:))
       XCTAssertEqual(actualSeq, expected, file: file, line: line)
 
       // `IndexingIterator` tests the collection conformance
-      let actualCol: [Range<Int>] = string[...].ranges(of: regex)[...].map {
-        let start = string.offset(ofIndex: $0.lowerBound)
-        let end = string.offset(ofIndex: $0.upperBound)
-        return start..<end
-      }
+      let actualCol: [Range<Int>] = string[...].ranges(of: regex)[...].map(string.offsets(of:))
       XCTAssertEqual(actualCol, expected, file: file, line: line)
     }
 
@@ -144,5 +136,40 @@ class RegexConsumerTests: XCTestCase {
     XCTAssertEqual(str.dropFirst(), str.trimmingPrefix(r))
     XCTAssertEqual("x", "axb".trimming(r))
     XCTAssertEqual("x", "axbb".trimming(r))
+  }
+  
+  func testSubstring() throws {
+    let s = "aaa | aaaaaa | aaaaaaaaaa"
+    let s1 = s.dropFirst(6)  // "aaaaaa | aaaaaaaaaa"
+    let s2 = s1.dropLast(17) // "aa"
+    let regex = try! Regex(compiling: "a+")
+
+    XCTAssertEqual(s.firstMatch(of: regex)?.0, "aaa")
+    XCTAssertEqual(s1.firstMatch(of: regex)?.0, "aaaaaa")
+    XCTAssertEqual(s2.firstMatch(of: regex)?.0, "aa")
+
+    XCTAssertEqual(
+      s.ranges(of: regex).map(s.offsets(of:)),
+      [0..<3, 6..<12, 15..<25])
+    XCTAssertEqual(
+      s1.ranges(of: regex).map(s.offsets(of:)),
+      [6..<12, 15..<25])
+    XCTAssertEqual(
+      s2.ranges(of: regex).map(s.offsets(of:)),
+      [6..<8])
+
+    XCTAssertEqual(s.replacing(regex, with: ""), " |  | ")
+    XCTAssertEqual(s1.replacing(regex, with: ""), " | ")
+    XCTAssertEqual(s2.replacing(regex, with: ""), "")
+
+    XCTAssertEqual(
+      s._matches(of: regex).map(\.0),
+      ["aaa", "aaaaaa", "aaaaaaaaaa"])
+    XCTAssertEqual(
+      s1._matches(of: regex).map(\.0),
+      ["aaaaaa", "aaaaaaaaaa"])
+    XCTAssertEqual(
+      s2._matches(of: regex).map(\.0),
+      ["aa"])
   }
 }


### PR DESCRIPTION
`firstMatch(of:)` was ignoring the start/endIndex when searching in substrings; this change fixes that issue. Also adds the 'in' label to `Regex.firstMatch(in:Substring)` to match the rest of the related APIs.