### PR TITLE
Move the closure argument to the end of the arg list

### DIFF
--- a/Documentation/Evolution/StringProcessingAlgorithms.md
+++ b/Documentation/Evolution/StringProcessingAlgorithms.md
@@ -511,48 +511,48 @@ extension RangeReplaceableCollection where SubSequence == Substring {
     /// the given regex are replaced by another regex match.
     /// - Parameters:
     ///   - regex: A regex describing the sequence to replace.
-    ///   - replacement: A closure that receives the full match information,
-    ///   including captures, and returns a replacement collection.
     ///   - subrange: The range in the collection in which to search for `regex`.
     ///   - maxReplacements: A number specifying how many occurrences of the
     ///   sequence matching `regex` to replace. Default is `Int.max`.
+    ///   - replacement: A closure that receives the full match information,
+    ///   including captures, and returns a replacement collection.
     /// - Returns: A new collection in which all occurrences of subsequence
     /// matching `regex` are replaced by `replacement`.
     public func replacing<R: RegexComponent, Replacement: Collection>(
         _ regex: R,
-        with replacement: (RegexMatch<R.Match>) throws -> Replacement,
         subrange: Range<Index>,
-        maxReplacements: Int = .max
+        maxReplacements: Int = .max,
+        with replacement: (RegexMatch<R.Match>) throws -> Replacement
     ) rethrows -> Self where Replacement.Element == Element
   
     /// Returns a new collection in which all occurrences of a sequence matching
     /// the given regex are replaced by another collection.
     /// - Parameters:
     ///   - regex: A regex describing the sequence to replace.
-    ///   - replacement: A closure that receives the full match information,
-    ///   including captures, and returns a replacement collection.
     ///   - maxReplacements: A number specifying how many occurrences of the
     ///   sequence matching `regex` to replace. Default is `Int.max`.
+    ///   - replacement: A closure that receives the full match information,
+    ///   including captures, and returns a replacement collection.
     /// - Returns: A new collection in which all occurrences of subsequence
     /// matching `regex` are replaced by `replacement`.
     public func replacing<R: RegexComponent, Replacement: Collection>(
         _ regex: R,
-        with replacement: (RegexMatch<R.Match>) throws -> Replacement,
-        maxReplacements: Int = .max
+        maxReplacements: Int = .max,
+        with replacement: (RegexMatch<R.Match>) throws -> Replacement
     ) rethrows -> Self where Replacement.Element == Element
   
     /// Replaces all occurrences of the sequence matching the given regex with
     /// a given collection.
     /// - Parameters:
     ///   - regex: A regex describing the sequence to replace.
-    ///   - replacement: A closure that receives the full match information,
-    ///   including captures, and returns a replacement collection.
     ///   - maxReplacements: A number specifying how many occurrences of the
     ///   sequence matching `regex` to replace. Default is `Int.max`.
+    ///   - replacement: A closure that receives the full match information,
+    ///   including captures, and returns a replacement collection.
     public mutating func replace<R: RegexComponent, Replacement: Collection>(
         _ regex: R,
-        with replacement: (RegexMatch<R.Match>) throws -> Replacement,
-        maxReplacements: Int = .max
+        maxReplacements: Int = .max,
+        with replacement: (RegexMatch<R.Match>) throws -> Replacement
     ) rethrows where Replacement.Element == Element
 }
 ```

--- a/Sources/_StringProcessing/Algorithms/Matching/MatchReplace.swift
+++ b/Sources/_StringProcessing/Algorithms/Matching/MatchReplace.swift
@@ -118,19 +118,19 @@ extension RangeReplaceableCollection where SubSequence == Substring {
   /// the given regex are replaced by another regex match.
   /// - Parameters:
   ///   - regex: A regex describing the sequence to replace.
-  ///   - replacement: A closure that receives the full match information,
-  ///   including captures, and returns a replacement collection.
   ///   - subrange: The range in the collection in which to search for `regex`.
   ///   - maxReplacements: A number specifying how many occurrences of the
   ///   sequence matching `regex` to replace. Default is `Int.max`.
+  ///   - replacement: A closure that receives the full match information,
+  ///   including captures, and returns a replacement collection.
   /// - Returns: A new collection in which all occurrences of subsequence
   /// matching `regex` are replaced by `replacement`.
   @available(SwiftStdlib 5.7, *)
   public func replacing<R: RegexComponent, Replacement: Collection>(
     _ regex: R,
-    with replacement: (Regex<R.RegexOutput>.Match) throws -> Replacement,
     subrange: Range<Index>,
-    maxReplacements: Int = .max
+    maxReplacements: Int = .max,
+    with replacement: (Regex<R.RegexOutput>.Match) throws -> Replacement
   ) rethrows -> Self where Replacement.Element == Element {
 
     precondition(maxReplacements >= 0)
@@ -155,43 +155,43 @@ extension RangeReplaceableCollection where SubSequence == Substring {
   /// the given regex are replaced by another collection.
   /// - Parameters:
   ///   - regex: A regex describing the sequence to replace.
-  ///   - replacement: A closure that receives the full match information,
-  ///   including captures, and returns a replacement collection.
   ///   - maxReplacements: A number specifying how many occurrences of the
   ///   sequence matching `regex` to replace. Default is `Int.max`.
+  ///   - replacement: A closure that receives the full match information,
+  ///   including captures, and returns a replacement collection.
   /// - Returns: A new collection in which all occurrences of subsequence
   /// matching `regex` are replaced by `replacement`.
   @available(SwiftStdlib 5.7, *)
   public func replacing<R: RegexComponent, Replacement: Collection>(
     _ regex: R,
-    with replacement: (Regex<R.RegexOutput>.Match) throws -> Replacement,
-    maxReplacements: Int = .max
+    maxReplacements: Int = .max,
+    with replacement: (Regex<R.RegexOutput>.Match) throws -> Replacement
   ) rethrows -> Self where Replacement.Element == Element {
     try replacing(
       regex,
-      with: replacement,
       subrange: startIndex..<endIndex,
-      maxReplacements: maxReplacements)
+      maxReplacements: maxReplacements,
+      with: replacement)
   }
 
   /// Replaces all occurrences of the sequence matching the given regex with
   /// a given collection.
   /// - Parameters:
   ///   - regex: A regex describing the sequence to replace.
-  ///   - replacement: A closure that receives the full match information,
-  ///   including captures, and returns a replacement collection.
   ///   - maxReplacements: A number specifying how many occurrences of the
   ///   sequence matching `regex` to replace. Default is `Int.max`.
+  ///   - replacement: A closure that receives the full match information,
+  ///   including captures, and returns a replacement collection.
   @available(SwiftStdlib 5.7, *)
   public mutating func replace<R: RegexComponent, Replacement: Collection>(
     _ regex: R,
-    with replacement: (Regex<R.RegexOutput>.Match) throws -> Replacement,
-    maxReplacements: Int = .max
+    maxReplacements: Int = .max,
+    with replacement: (Regex<R.RegexOutput>.Match) throws -> Replacement
   ) rethrows where Replacement.Element == Element {
     self = try replacing(
       regex,
-      with: replacement,
       subrange: startIndex..<endIndex,
-      maxReplacements: maxReplacements)
+      maxReplacements: maxReplacements,
+      with: replacement)
   }
 }

--- a/Tests/RegexBuilderTests/AlgorithmsTests.swift
+++ b/Tests/RegexBuilderTests/AlgorithmsTests.swift
@@ -60,4 +60,48 @@ class RegexConsumerTests: XCTestCase {
       result: "6 60 0 6x4",
       { match in "\(match.output.1 * match.output.2 * (match.output.3 ?? 1))" })
   }
+
+  func testMatchReplaceSubrange() {
+    func replaceTest<R: RegexComponent>(
+      _ regex: R,
+      input: String,
+      _ replace: (Regex<R.RegexOutput>.Match) -> String,
+      _ tests: (subrange: Range<String.Index>, maxReplacement: Int, result: String)...,
+      file: StaticString = #file,
+      line: UInt = #line
+    ) {
+      for (subrange, maxReplacement, result) in tests {
+        XCTAssertEqual(input.replacing(regex, subrange: subrange, maxReplacements: maxReplacement, with: replace), result, file: file, line: line)
+      }
+    }
+
+    let int = Capture(OneOrMore(.digit)) { Int($0)! }
+
+    let addition = "9+16, 0+3, 5+5, 99+1"
+
+    replaceTest(
+      Regex { int; "+"; int },
+      input: "9+16, 0+3, 5+5, 99+1",
+      { match in "\(match.output.1 + match.output.2)" },
+
+      (subrange: addition.startIndex..<addition.endIndex,
+       maxReplacement: 0,
+       result: "9+16, 0+3, 5+5, 99+1"),
+      (subrange: addition.startIndex..<addition.endIndex,
+       maxReplacement: .max,
+       result: "25, 3, 10, 100"),
+      (subrange: addition.startIndex..<addition.endIndex,
+       maxReplacement: 2,
+       result: "25, 3, 5+5, 99+1"),
+      (subrange: addition.index(addition.startIndex, offsetBy: 5) ..< addition.endIndex,
+       maxReplacement: .max,
+       result: "9+16, 3, 10, 100"),
+      (subrange: addition.startIndex ..< addition.index(addition.startIndex, offsetBy: 5),
+       maxReplacement: .max,
+       result: "25, 0+3, 5+5, 99+1"),
+      (subrange: addition.index(addition.startIndex, offsetBy: 5) ..< addition.endIndex,
+       maxReplacement: 2,
+       result: "9+16, 3, 10, 99+1")
+    )
+  }
 }


### PR DESCRIPTION
Move the closure argument in `replace` and `replacing` to the end of the argument list for trailing closure syntax. Add a test for replacing within a range.