### PR TITLE
Allow setting any of the three quant behaviors

### DIFF
--- a/Sources/RegexBuilder/DSL.swift
+++ b/Sources/RegexBuilder/DSL.swift
@@ -100,7 +100,7 @@ extension DSLTree.Node {
   @available(SwiftStdlib 5.7, *)
   static func repeating(
     _ range: Range<Int>,
-    _ behavior: RegexQuantificationBehavior?,
+    _ behavior: RegexRepetitionBehavior?,
     _ node: DSLTree.Node
   ) -> DSLTree.Node {
     // TODO: Throw these as errors

--- a/Sources/RegexBuilder/DSL.swift
+++ b/Sources/RegexBuilder/DSL.swift
@@ -94,40 +94,20 @@ extension UnicodeScalar: RegexComponent {
 
 // Note: Quantifiers are currently gyb'd.
 
-/// Specifies how much to attempt to match when using a quantifier.
-@available(SwiftStdlib 5.7, *)
-public struct QuantificationBehavior {
-  internal enum Kind {
-    case eagerly
-    case reluctantly
-    case possessively
-  }
-
-  var kind: Kind
-
-  internal var astKind: DSLTree._AST.QuantificationKind {
-    switch kind {
-    case .eagerly: return .eager
-    case .reluctantly: return .reluctant
-    case .possessively: return .possessive
-    }
-  }
-}
-
 extension DSLTree.Node {
   /// Generates a DSLTree node for a repeated range of the given DSLTree node.
   /// Individual public API functions are in the generated Variadics.swift file.
   @available(SwiftStdlib 5.7, *)
   static func repeating(
     _ range: Range<Int>,
-    _ behavior: QuantificationBehavior?,
+    _ behavior: RegexQuantificationBehavior?,
     _ node: DSLTree.Node
   ) -> DSLTree.Node {
     // TODO: Throw these as errors
     assert(range.lowerBound >= 0, "Cannot specify a negative lower bound")
     assert(!range.isEmpty, "Cannot specify an empty range")
     
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.astKind) } ?? .default
+    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
 
     switch (range.lowerBound, range.upperBound) {
     case (0, Int.max): // 0...
@@ -144,26 +124,6 @@ extension DSLTree.Node {
     default: // any other range
       return .quantification(.range(range.lowerBound, range.upperBound), kind, node)
     }
-  }
-}
-
-@available(SwiftStdlib 5.7, *)
-extension QuantificationBehavior {
-  /// Match as much of the input string as possible, backtracking when
-  /// necessary.
-  public static var eagerly: QuantificationBehavior {
-    .init(kind: .eagerly)
-  }
-
-  /// Match as little of the input string as possible, expanding the matched
-  /// region as necessary to complete a match.
-  public static var reluctantly: QuantificationBehavior {
-    .init(kind: .reluctantly)
-  }
-
-  /// Match as much of the input string as possible, performing no backtracking.
-  public static var possessively: QuantificationBehavior {
-    .init(kind: .possessively)
   }
 }
 

--- a/Sources/RegexBuilder/Variadics.swift
+++ b/Sources/RegexBuilder/Variadics.swift
@@ -615,7 +615,7 @@ extension Optionally {
   @_disfavoredOverload
   public init<Component: RegexComponent>(
     _ component: Component,
-    _ behavior: RegexQuantificationBehavior? = nil
+    _ behavior: RegexRepetitionBehavior? = nil
   ) where RegexOutput == Substring {
     let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.zeroOrOne, kind, component.regex.root))
@@ -627,7 +627,7 @@ extension Optionally {
   @available(SwiftStdlib 5.7, *)
   @_disfavoredOverload
   public init<Component: RegexComponent>(
-    _ behavior: RegexQuantificationBehavior? = nil,
+    _ behavior: RegexRepetitionBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == Substring {
     let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
@@ -650,7 +650,7 @@ extension ZeroOrMore {
   @_disfavoredOverload
   public init<Component: RegexComponent>(
     _ component: Component,
-    _ behavior: RegexQuantificationBehavior? = nil
+    _ behavior: RegexRepetitionBehavior? = nil
   ) where RegexOutput == Substring {
     let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.zeroOrMore, kind, component.regex.root))
@@ -662,7 +662,7 @@ extension ZeroOrMore {
   @available(SwiftStdlib 5.7, *)
   @_disfavoredOverload
   public init<Component: RegexComponent>(
-    _ behavior: RegexQuantificationBehavior? = nil,
+    _ behavior: RegexRepetitionBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == Substring {
     let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
@@ -677,7 +677,7 @@ extension OneOrMore {
   @_disfavoredOverload
   public init<Component: RegexComponent>(
     _ component: Component,
-    _ behavior: RegexQuantificationBehavior? = nil
+    _ behavior: RegexRepetitionBehavior? = nil
   ) where RegexOutput == Substring {
     let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.oneOrMore, kind, component.regex.root))
@@ -689,7 +689,7 @@ extension OneOrMore {
   @available(SwiftStdlib 5.7, *)
   @_disfavoredOverload
   public init<Component: RegexComponent>(
-    _ behavior: RegexQuantificationBehavior? = nil,
+    _ behavior: RegexRepetitionBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == Substring {
     let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
@@ -727,7 +727,7 @@ extension Repeat {
   public init<Component: RegexComponent, R: RangeExpression>(
     _ component: Component,
     _ expression: R,
-    _ behavior: RegexQuantificationBehavior? = nil
+    _ behavior: RegexRepetitionBehavior? = nil
   ) where RegexOutput == Substring, R.Bound == Int {
     self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component.regex.root))
   }
@@ -736,7 +736,7 @@ extension Repeat {
   @_disfavoredOverload
   public init<Component: RegexComponent, R: RangeExpression>(
     _ expression: R,
-    _ behavior: RegexQuantificationBehavior? = nil,
+    _ behavior: RegexRepetitionBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == Substring, R.Bound == Int {
     self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component().regex.root))
@@ -747,7 +747,7 @@ extension Optionally {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, Component: RegexComponent>(
     _ component: Component,
-    _ behavior: RegexQuantificationBehavior? = nil
+    _ behavior: RegexRepetitionBehavior? = nil
   ) where RegexOutput == (Substring, C0?), Component.RegexOutput == (W, C0) {
     let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.zeroOrOne, kind, component.regex.root))
@@ -758,7 +758,7 @@ extension Optionally {
 extension Optionally {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, Component: RegexComponent>(
-    _ behavior: RegexQuantificationBehavior? = nil,
+    _ behavior: RegexRepetitionBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C0?), Component.RegexOutput == (W, C0) {
     let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
@@ -780,7 +780,7 @@ extension ZeroOrMore {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, Component: RegexComponent>(
     _ component: Component,
-    _ behavior: RegexQuantificationBehavior? = nil
+    _ behavior: RegexRepetitionBehavior? = nil
   ) where RegexOutput == (Substring, C0?), Component.RegexOutput == (W, C0) {
     let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.zeroOrMore, kind, component.regex.root))
@@ -791,7 +791,7 @@ extension ZeroOrMore {
 extension ZeroOrMore {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, Component: RegexComponent>(
-    _ behavior: RegexQuantificationBehavior? = nil,
+    _ behavior: RegexRepetitionBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C0?), Component.RegexOutput == (W, C0) {
     let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
@@ -805,7 +805,7 @@ extension OneOrMore {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, Component: RegexComponent>(
     _ component: Component,
-    _ behavior: RegexQuantificationBehavior? = nil
+    _ behavior: RegexRepetitionBehavior? = nil
   ) where RegexOutput == (Substring, C0), Component.RegexOutput == (W, C0) {
     let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.oneOrMore, kind, component.regex.root))
@@ -816,7 +816,7 @@ extension OneOrMore {
 extension OneOrMore {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, Component: RegexComponent>(
-    _ behavior: RegexQuantificationBehavior? = nil,
+    _ behavior: RegexRepetitionBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C0), Component.RegexOutput == (W, C0) {
     let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
@@ -851,7 +851,7 @@ extension Repeat {
     public init<W, C0, Component: RegexComponent, R: RangeExpression>(
     _ component: Component,
     _ expression: R,
-    _ behavior: RegexQuantificationBehavior? = nil
+    _ behavior: RegexRepetitionBehavior? = nil
   ) where RegexOutput == (Substring, C0?), Component.RegexOutput == (W, C0), R.Bound == Int {
     self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component.regex.root))
   }
@@ -859,7 +859,7 @@ extension Repeat {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, Component: RegexComponent, R: RangeExpression>(
     _ expression: R,
-    _ behavior: RegexQuantificationBehavior? = nil,
+    _ behavior: RegexRepetitionBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C0?), Component.RegexOutput == (W, C0), R.Bound == Int {
     self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component().regex.root))
@@ -870,7 +870,7 @@ extension Optionally {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, Component: RegexComponent>(
     _ component: Component,
-    _ behavior: RegexQuantificationBehavior? = nil
+    _ behavior: RegexRepetitionBehavior? = nil
   ) where RegexOutput == (Substring, C0?, C1?), Component.RegexOutput == (W, C0, C1) {
     let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.zeroOrOne, kind, component.regex.root))
@@ -881,7 +881,7 @@ extension Optionally {
 extension Optionally {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, Component: RegexComponent>(
-    _ behavior: RegexQuantificationBehavior? = nil,
+    _ behavior: RegexRepetitionBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C0?, C1?), Component.RegexOutput == (W, C0, C1) {
     let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
@@ -903,7 +903,7 @@ extension ZeroOrMore {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, Component: RegexComponent>(
     _ component: Component,
-    _ behavior: RegexQuantificationBehavior? = nil
+    _ behavior: RegexRepetitionBehavior? = nil
   ) where RegexOutput == (Substring, C0?, C1?), Component.RegexOutput == (W, C0, C1) {
     let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.zeroOrMore, kind, component.regex.root))
@@ -914,7 +914,7 @@ extension ZeroOrMore {
 extension ZeroOrMore {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, Component: RegexComponent>(
-    _ behavior: RegexQuantificationBehavior? = nil,
+    _ behavior: RegexRepetitionBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C0?, C1?), Component.RegexOutput == (W, C0, C1) {
     let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
@@ -928,7 +928,7 @@ extension OneOrMore {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, Component: RegexComponent>(
     _ component: Component,
-    _ behavior: RegexQuantificationBehavior? = nil
+    _ behavior: RegexRepetitionBehavior? = nil
   ) where RegexOutput == (Substring, C0, C1), Component.RegexOutput == (W, C0, C1) {
     let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.oneOrMore, kind, component.regex.root))
@@ -939,7 +939,7 @@ extension OneOrMore {
 extension OneOrMore {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, Component: RegexComponent>(
-    _ behavior: RegexQuantificationBehavior? = nil,
+    _ behavior: RegexRepetitionBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C0, C1), Component.RegexOutput == (W, C0, C1) {
     let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
@@ -974,7 +974,7 @@ extension Repeat {
     public init<W, C0, C1, Component: RegexComponent, R: RangeExpression>(
     _ component: Component,
     _ expression: R,
-    _ behavior: RegexQuantificationBehavior? = nil
+    _ behavior: RegexRepetitionBehavior? = nil
   ) where RegexOutput == (Substring, C0?, C1?), Component.RegexOutput == (W, C0, C1), R.Bound == Int {
     self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component.regex.root))
   }
@@ -982,7 +982,7 @@ extension Repeat {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, Component: RegexComponent, R: RangeExpression>(
     _ expression: R,
-    _ behavior: RegexQuantificationBehavior? = nil,
+    _ behavior: RegexRepetitionBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C0?, C1?), Component.RegexOutput == (W, C0, C1), R.Bound == Int {
     self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component().regex.root))
@@ -993,7 +993,7 @@ extension Optionally {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, Component: RegexComponent>(
     _ component: Component,
-    _ behavior: RegexQuantificationBehavior? = nil
+    _ behavior: RegexRepetitionBehavior? = nil
   ) where RegexOutput == (Substring, C0?, C1?, C2?), Component.RegexOutput == (W, C0, C1, C2) {
     let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.zeroOrOne, kind, component.regex.root))
@@ -1004,7 +1004,7 @@ extension Optionally {
 extension Optionally {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, Component: RegexComponent>(
-    _ behavior: RegexQuantificationBehavior? = nil,
+    _ behavior: RegexRepetitionBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C0?, C1?, C2?), Component.RegexOutput == (W, C0, C1, C2) {
     let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
@@ -1026,7 +1026,7 @@ extension ZeroOrMore {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, Component: RegexComponent>(
     _ component: Component,
-    _ behavior: RegexQuantificationBehavior? = nil
+    _ behavior: RegexRepetitionBehavior? = nil
   ) where RegexOutput == (Substring, C0?, C1?, C2?), Component.RegexOutput == (W, C0, C1, C2) {
     let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.zeroOrMore, kind, component.regex.root))
@@ -1037,7 +1037,7 @@ extension ZeroOrMore {
 extension ZeroOrMore {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, Component: RegexComponent>(
-    _ behavior: RegexQuantificationBehavior? = nil,
+    _ behavior: RegexRepetitionBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C0?, C1?, C2?), Component.RegexOutput == (W, C0, C1, C2) {
     let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
@@ -1051,7 +1051,7 @@ extension OneOrMore {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, Component: RegexComponent>(
     _ component: Component,
-    _ behavior: RegexQuantificationBehavior? = nil
+    _ behavior: RegexRepetitionBehavior? = nil
   ) where RegexOutput == (Substring, C0, C1, C2), Component.RegexOutput == (W, C0, C1, C2) {
     let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.oneOrMore, kind, component.regex.root))
@@ -1062,7 +1062,7 @@ extension OneOrMore {
 extension OneOrMore {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, Component: RegexComponent>(
-    _ behavior: RegexQuantificationBehavior? = nil,
+    _ behavior: RegexRepetitionBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C0, C1, C2), Component.RegexOutput == (W, C0, C1, C2) {
     let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
@@ -1097,7 +1097,7 @@ extension Repeat {
     public init<W, C0, C1, C2, Component: RegexComponent, R: RangeExpression>(
     _ component: Component,
     _ expression: R,
-    _ behavior: RegexQuantificationBehavior? = nil
+    _ behavior: RegexRepetitionBehavior? = nil
   ) where RegexOutput == (Substring, C0?, C1?, C2?), Component.RegexOutput == (W, C0, C1, C2), R.Bound == Int {
     self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component.regex.root))
   }
@@ -1105,7 +1105,7 @@ extension Repeat {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, Component: RegexComponent, R: RangeExpression>(
     _ expression: R,
-    _ behavior: RegexQuantificationBehavior? = nil,
+    _ behavior: RegexRepetitionBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C0?, C1?, C2?), Component.RegexOutput == (W, C0, C1, C2), R.Bound == Int {
     self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component().regex.root))
@@ -1116,7 +1116,7 @@ extension Optionally {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, Component: RegexComponent>(
     _ component: Component,
-    _ behavior: RegexQuantificationBehavior? = nil
+    _ behavior: RegexRepetitionBehavior? = nil
   ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?), Component.RegexOutput == (W, C0, C1, C2, C3) {
     let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.zeroOrOne, kind, component.regex.root))
@@ -1127,7 +1127,7 @@ extension Optionally {
 extension Optionally {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, Component: RegexComponent>(
-    _ behavior: RegexQuantificationBehavior? = nil,
+    _ behavior: RegexRepetitionBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?), Component.RegexOutput == (W, C0, C1, C2, C3) {
     let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
@@ -1149,7 +1149,7 @@ extension ZeroOrMore {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, Component: RegexComponent>(
     _ component: Component,
-    _ behavior: RegexQuantificationBehavior? = nil
+    _ behavior: RegexRepetitionBehavior? = nil
   ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?), Component.RegexOutput == (W, C0, C1, C2, C3) {
     let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.zeroOrMore, kind, component.regex.root))
@@ -1160,7 +1160,7 @@ extension ZeroOrMore {
 extension ZeroOrMore {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, Component: RegexComponent>(
-    _ behavior: RegexQuantificationBehavior? = nil,
+    _ behavior: RegexRepetitionBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?), Component.RegexOutput == (W, C0, C1, C2, C3) {
     let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
@@ -1174,7 +1174,7 @@ extension OneOrMore {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, Component: RegexComponent>(
     _ component: Component,
-    _ behavior: RegexQuantificationBehavior? = nil
+    _ behavior: RegexRepetitionBehavior? = nil
   ) where RegexOutput == (Substring, C0, C1, C2, C3), Component.RegexOutput == (W, C0, C1, C2, C3) {
     let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.oneOrMore, kind, component.regex.root))
@@ -1185,7 +1185,7 @@ extension OneOrMore {
 extension OneOrMore {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, Component: RegexComponent>(
-    _ behavior: RegexQuantificationBehavior? = nil,
+    _ behavior: RegexRepetitionBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C0, C1, C2, C3), Component.RegexOutput == (W, C0, C1, C2, C3) {
     let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
@@ -1220,7 +1220,7 @@ extension Repeat {
     public init<W, C0, C1, C2, C3, Component: RegexComponent, R: RangeExpression>(
     _ component: Component,
     _ expression: R,
-    _ behavior: RegexQuantificationBehavior? = nil
+    _ behavior: RegexRepetitionBehavior? = nil
   ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?), Component.RegexOutput == (W, C0, C1, C2, C3), R.Bound == Int {
     self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component.regex.root))
   }
@@ -1228,7 +1228,7 @@ extension Repeat {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, Component: RegexComponent, R: RangeExpression>(
     _ expression: R,
-    _ behavior: RegexQuantificationBehavior? = nil,
+    _ behavior: RegexRepetitionBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?), Component.RegexOutput == (W, C0, C1, C2, C3), R.Bound == Int {
     self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component().regex.root))
@@ -1239,7 +1239,7 @@ extension Optionally {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, Component: RegexComponent>(
     _ component: Component,
-    _ behavior: RegexQuantificationBehavior? = nil
+    _ behavior: RegexRepetitionBehavior? = nil
   ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?), Component.RegexOutput == (W, C0, C1, C2, C3, C4) {
     let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.zeroOrOne, kind, component.regex.root))
@@ -1250,7 +1250,7 @@ extension Optionally {
 extension Optionally {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, Component: RegexComponent>(
-    _ behavior: RegexQuantificationBehavior? = nil,
+    _ behavior: RegexRepetitionBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?), Component.RegexOutput == (W, C0, C1, C2, C3, C4) {
     let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
@@ -1272,7 +1272,7 @@ extension ZeroOrMore {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, Component: RegexComponent>(
     _ component: Component,
-    _ behavior: RegexQuantificationBehavior? = nil
+    _ behavior: RegexRepetitionBehavior? = nil
   ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?), Component.RegexOutput == (W, C0, C1, C2, C3, C4) {
     let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.zeroOrMore, kind, component.regex.root))
@@ -1283,7 +1283,7 @@ extension ZeroOrMore {
 extension ZeroOrMore {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, Component: RegexComponent>(
-    _ behavior: RegexQuantificationBehavior? = nil,
+    _ behavior: RegexRepetitionBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?), Component.RegexOutput == (W, C0, C1, C2, C3, C4) {
     let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
@@ -1297,7 +1297,7 @@ extension OneOrMore {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, Component: RegexComponent>(
     _ component: Component,
-    _ behavior: RegexQuantificationBehavior? = nil
+    _ behavior: RegexRepetitionBehavior? = nil
   ) where RegexOutput == (Substring, C0, C1, C2, C3, C4), Component.RegexOutput == (W, C0, C1, C2, C3, C4) {
     let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.oneOrMore, kind, component.regex.root))
@@ -1308,7 +1308,7 @@ extension OneOrMore {
 extension OneOrMore {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, Component: RegexComponent>(
-    _ behavior: RegexQuantificationBehavior? = nil,
+    _ behavior: RegexRepetitionBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C0, C1, C2, C3, C4), Component.RegexOutput == (W, C0, C1, C2, C3, C4) {
     let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
@@ -1343,7 +1343,7 @@ extension Repeat {
     public init<W, C0, C1, C2, C3, C4, Component: RegexComponent, R: RangeExpression>(
     _ component: Component,
     _ expression: R,
-    _ behavior: RegexQuantificationBehavior? = nil
+    _ behavior: RegexRepetitionBehavior? = nil
   ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?), Component.RegexOutput == (W, C0, C1, C2, C3, C4), R.Bound == Int {
     self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component.regex.root))
   }
@@ -1351,7 +1351,7 @@ extension Repeat {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, Component: RegexComponent, R: RangeExpression>(
     _ expression: R,
-    _ behavior: RegexQuantificationBehavior? = nil,
+    _ behavior: RegexRepetitionBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?), Component.RegexOutput == (W, C0, C1, C2, C3, C4), R.Bound == Int {
     self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component().regex.root))
@@ -1362,7 +1362,7 @@ extension Optionally {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, Component: RegexComponent>(
     _ component: Component,
-    _ behavior: RegexQuantificationBehavior? = nil
+    _ behavior: RegexRepetitionBehavior? = nil
   ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?, C5?), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5) {
     let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.zeroOrOne, kind, component.regex.root))
@@ -1373,7 +1373,7 @@ extension Optionally {
 extension Optionally {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, Component: RegexComponent>(
-    _ behavior: RegexQuantificationBehavior? = nil,
+    _ behavior: RegexRepetitionBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?, C5?), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5) {
     let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
@@ -1395,7 +1395,7 @@ extension ZeroOrMore {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, Component: RegexComponent>(
     _ component: Component,
-    _ behavior: RegexQuantificationBehavior? = nil
+    _ behavior: RegexRepetitionBehavior? = nil
   ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?, C5?), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5) {
     let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.zeroOrMore, kind, component.regex.root))
@@ -1406,7 +1406,7 @@ extension ZeroOrMore {
 extension ZeroOrMore {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, Component: RegexComponent>(
-    _ behavior: RegexQuantificationBehavior? = nil,
+    _ behavior: RegexRepetitionBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?, C5?), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5) {
     let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
@@ -1420,7 +1420,7 @@ extension OneOrMore {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, Component: RegexComponent>(
     _ component: Component,
-    _ behavior: RegexQuantificationBehavior? = nil
+    _ behavior: RegexRepetitionBehavior? = nil
   ) where RegexOutput == (Substring, C0, C1, C2, C3, C4, C5), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5) {
     let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.oneOrMore, kind, component.regex.root))
@@ -1431,7 +1431,7 @@ extension OneOrMore {
 extension OneOrMore {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, Component: RegexComponent>(
-    _ behavior: RegexQuantificationBehavior? = nil,
+    _ behavior: RegexRepetitionBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C0, C1, C2, C3, C4, C5), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5) {
     let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
@@ -1466,7 +1466,7 @@ extension Repeat {
     public init<W, C0, C1, C2, C3, C4, C5, Component: RegexComponent, R: RangeExpression>(
     _ component: Component,
     _ expression: R,
-    _ behavior: RegexQuantificationBehavior? = nil
+    _ behavior: RegexRepetitionBehavior? = nil
   ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?, C5?), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5), R.Bound == Int {
     self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component.regex.root))
   }
@@ -1474,7 +1474,7 @@ extension Repeat {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, Component: RegexComponent, R: RangeExpression>(
     _ expression: R,
-    _ behavior: RegexQuantificationBehavior? = nil,
+    _ behavior: RegexRepetitionBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?, C5?), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5), R.Bound == Int {
     self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component().regex.root))
@@ -1485,7 +1485,7 @@ extension Optionally {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexComponent>(
     _ component: Component,
-    _ behavior: RegexQuantificationBehavior? = nil
+    _ behavior: RegexRepetitionBehavior? = nil
   ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6) {
     let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.zeroOrOne, kind, component.regex.root))
@@ -1496,7 +1496,7 @@ extension Optionally {
 extension Optionally {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexComponent>(
-    _ behavior: RegexQuantificationBehavior? = nil,
+    _ behavior: RegexRepetitionBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6) {
     let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
@@ -1518,7 +1518,7 @@ extension ZeroOrMore {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexComponent>(
     _ component: Component,
-    _ behavior: RegexQuantificationBehavior? = nil
+    _ behavior: RegexRepetitionBehavior? = nil
   ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6) {
     let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.zeroOrMore, kind, component.regex.root))
@@ -1529,7 +1529,7 @@ extension ZeroOrMore {
 extension ZeroOrMore {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexComponent>(
-    _ behavior: RegexQuantificationBehavior? = nil,
+    _ behavior: RegexRepetitionBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6) {
     let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
@@ -1543,7 +1543,7 @@ extension OneOrMore {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexComponent>(
     _ component: Component,
-    _ behavior: RegexQuantificationBehavior? = nil
+    _ behavior: RegexRepetitionBehavior? = nil
   ) where RegexOutput == (Substring, C0, C1, C2, C3, C4, C5, C6), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6) {
     let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.oneOrMore, kind, component.regex.root))
@@ -1554,7 +1554,7 @@ extension OneOrMore {
 extension OneOrMore {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexComponent>(
-    _ behavior: RegexQuantificationBehavior? = nil,
+    _ behavior: RegexRepetitionBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C0, C1, C2, C3, C4, C5, C6), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6) {
     let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
@@ -1589,7 +1589,7 @@ extension Repeat {
     public init<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexComponent, R: RangeExpression>(
     _ component: Component,
     _ expression: R,
-    _ behavior: RegexQuantificationBehavior? = nil
+    _ behavior: RegexRepetitionBehavior? = nil
   ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6), R.Bound == Int {
     self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component.regex.root))
   }
@@ -1597,7 +1597,7 @@ extension Repeat {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexComponent, R: RangeExpression>(
     _ expression: R,
-    _ behavior: RegexQuantificationBehavior? = nil,
+    _ behavior: RegexRepetitionBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6), R.Bound == Int {
     self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component().regex.root))
@@ -1608,7 +1608,7 @@ extension Optionally {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexComponent>(
     _ component: Component,
-    _ behavior: RegexQuantificationBehavior? = nil
+    _ behavior: RegexRepetitionBehavior? = nil
   ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
     let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.zeroOrOne, kind, component.regex.root))
@@ -1619,7 +1619,7 @@ extension Optionally {
 extension Optionally {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexComponent>(
-    _ behavior: RegexQuantificationBehavior? = nil,
+    _ behavior: RegexRepetitionBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
     let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
@@ -1641,7 +1641,7 @@ extension ZeroOrMore {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexComponent>(
     _ component: Component,
-    _ behavior: RegexQuantificationBehavior? = nil
+    _ behavior: RegexRepetitionBehavior? = nil
   ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
     let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.zeroOrMore, kind, component.regex.root))
@@ -1652,7 +1652,7 @@ extension ZeroOrMore {
 extension ZeroOrMore {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexComponent>(
-    _ behavior: RegexQuantificationBehavior? = nil,
+    _ behavior: RegexRepetitionBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
     let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
@@ -1666,7 +1666,7 @@ extension OneOrMore {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexComponent>(
     _ component: Component,
-    _ behavior: RegexQuantificationBehavior? = nil
+    _ behavior: RegexRepetitionBehavior? = nil
   ) where RegexOutput == (Substring, C0, C1, C2, C3, C4, C5, C6, C7), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
     let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.oneOrMore, kind, component.regex.root))
@@ -1677,7 +1677,7 @@ extension OneOrMore {
 extension OneOrMore {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexComponent>(
-    _ behavior: RegexQuantificationBehavior? = nil,
+    _ behavior: RegexRepetitionBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C0, C1, C2, C3, C4, C5, C6, C7), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
     let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
@@ -1712,7 +1712,7 @@ extension Repeat {
     public init<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexComponent, R: RangeExpression>(
     _ component: Component,
     _ expression: R,
-    _ behavior: RegexQuantificationBehavior? = nil
+    _ behavior: RegexRepetitionBehavior? = nil
   ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7), R.Bound == Int {
     self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component.regex.root))
   }
@@ -1720,7 +1720,7 @@ extension Repeat {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexComponent, R: RangeExpression>(
     _ expression: R,
-    _ behavior: RegexQuantificationBehavior? = nil,
+    _ behavior: RegexRepetitionBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7), R.Bound == Int {
     self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component().regex.root))
@@ -1731,7 +1731,7 @@ extension Optionally {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexComponent>(
     _ component: Component,
-    _ behavior: RegexQuantificationBehavior? = nil
+    _ behavior: RegexRepetitionBehavior? = nil
   ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
     let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.zeroOrOne, kind, component.regex.root))
@@ -1742,7 +1742,7 @@ extension Optionally {
 extension Optionally {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexComponent>(
-    _ behavior: RegexQuantificationBehavior? = nil,
+    _ behavior: RegexRepetitionBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
     let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
@@ -1764,7 +1764,7 @@ extension ZeroOrMore {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexComponent>(
     _ component: Component,
-    _ behavior: RegexQuantificationBehavior? = nil
+    _ behavior: RegexRepetitionBehavior? = nil
   ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
     let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.zeroOrMore, kind, component.regex.root))
@@ -1775,7 +1775,7 @@ extension ZeroOrMore {
 extension ZeroOrMore {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexComponent>(
-    _ behavior: RegexQuantificationBehavior? = nil,
+    _ behavior: RegexRepetitionBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
     let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
@@ -1789,7 +1789,7 @@ extension OneOrMore {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexComponent>(
     _ component: Component,
-    _ behavior: RegexQuantificationBehavior? = nil
+    _ behavior: RegexRepetitionBehavior? = nil
   ) where RegexOutput == (Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
     let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.oneOrMore, kind, component.regex.root))
@@ -1800,7 +1800,7 @@ extension OneOrMore {
 extension OneOrMore {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexComponent>(
-    _ behavior: RegexQuantificationBehavior? = nil,
+    _ behavior: RegexRepetitionBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
     let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
@@ -1835,7 +1835,7 @@ extension Repeat {
     public init<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexComponent, R: RangeExpression>(
     _ component: Component,
     _ expression: R,
-    _ behavior: RegexQuantificationBehavior? = nil
+    _ behavior: RegexRepetitionBehavior? = nil
   ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8), R.Bound == Int {
     self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component.regex.root))
   }
@@ -1843,7 +1843,7 @@ extension Repeat {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexComponent, R: RangeExpression>(
     _ expression: R,
-    _ behavior: RegexQuantificationBehavior? = nil,
+    _ behavior: RegexRepetitionBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8), R.Bound == Int {
     self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component().regex.root))
@@ -1854,7 +1854,7 @@ extension Optionally {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9, Component: RegexComponent>(
     _ component: Component,
-    _ behavior: RegexQuantificationBehavior? = nil
+    _ behavior: RegexRepetitionBehavior? = nil
   ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
     let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.zeroOrOne, kind, component.regex.root))
@@ -1865,7 +1865,7 @@ extension Optionally {
 extension Optionally {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9, Component: RegexComponent>(
-    _ behavior: RegexQuantificationBehavior? = nil,
+    _ behavior: RegexRepetitionBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
     let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
@@ -1887,7 +1887,7 @@ extension ZeroOrMore {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9, Component: RegexComponent>(
     _ component: Component,
-    _ behavior: RegexQuantificationBehavior? = nil
+    _ behavior: RegexRepetitionBehavior? = nil
   ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
     let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.zeroOrMore, kind, component.regex.root))
@@ -1898,7 +1898,7 @@ extension ZeroOrMore {
 extension ZeroOrMore {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9, Component: RegexComponent>(
-    _ behavior: RegexQuantificationBehavior? = nil,
+    _ behavior: RegexRepetitionBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
     let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
@@ -1912,7 +1912,7 @@ extension OneOrMore {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9, Component: RegexComponent>(
     _ component: Component,
-    _ behavior: RegexQuantificationBehavior? = nil
+    _ behavior: RegexRepetitionBehavior? = nil
   ) where RegexOutput == (Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
     let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.oneOrMore, kind, component.regex.root))
@@ -1923,7 +1923,7 @@ extension OneOrMore {
 extension OneOrMore {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9, Component: RegexComponent>(
-    _ behavior: RegexQuantificationBehavior? = nil,
+    _ behavior: RegexRepetitionBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
     let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
@@ -1958,7 +1958,7 @@ extension Repeat {
     public init<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9, Component: RegexComponent, R: RangeExpression>(
     _ component: Component,
     _ expression: R,
-    _ behavior: RegexQuantificationBehavior? = nil
+    _ behavior: RegexRepetitionBehavior? = nil
   ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9), R.Bound == Int {
     self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component.regex.root))
   }
@@ -1966,7 +1966,7 @@ extension Repeat {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9, Component: RegexComponent, R: RangeExpression>(
     _ expression: R,
-    _ behavior: RegexQuantificationBehavior? = nil,
+    _ behavior: RegexRepetitionBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9), R.Bound == Int {
     self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component().regex.root))

--- a/Sources/RegexBuilder/Variadics.swift
+++ b/Sources/RegexBuilder/Variadics.swift
@@ -615,9 +615,9 @@ extension Optionally {
   @_disfavoredOverload
   public init<Component: RegexComponent>(
     _ component: Component,
-    _ behavior: QuantificationBehavior? = nil
+    _ behavior: RegexQuantificationBehavior? = nil
   ) where RegexOutput == Substring {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.astKind) } ?? .default
+    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.zeroOrOne, kind, component.regex.root))
   }
 }
@@ -627,10 +627,10 @@ extension Optionally {
   @available(SwiftStdlib 5.7, *)
   @_disfavoredOverload
   public init<Component: RegexComponent>(
-    _ behavior: QuantificationBehavior? = nil,
+    _ behavior: RegexQuantificationBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == Substring {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.astKind) } ?? .default
+    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.zeroOrOne, kind, component().regex.root))
   }
 }
@@ -650,9 +650,9 @@ extension ZeroOrMore {
   @_disfavoredOverload
   public init<Component: RegexComponent>(
     _ component: Component,
-    _ behavior: QuantificationBehavior? = nil
+    _ behavior: RegexQuantificationBehavior? = nil
   ) where RegexOutput == Substring {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.astKind) } ?? .default
+    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.zeroOrMore, kind, component.regex.root))
   }
 }
@@ -662,10 +662,10 @@ extension ZeroOrMore {
   @available(SwiftStdlib 5.7, *)
   @_disfavoredOverload
   public init<Component: RegexComponent>(
-    _ behavior: QuantificationBehavior? = nil,
+    _ behavior: RegexQuantificationBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == Substring {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.astKind) } ?? .default
+    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.zeroOrMore, kind, component().regex.root))
   }
 }
@@ -677,9 +677,9 @@ extension OneOrMore {
   @_disfavoredOverload
   public init<Component: RegexComponent>(
     _ component: Component,
-    _ behavior: QuantificationBehavior? = nil
+    _ behavior: RegexQuantificationBehavior? = nil
   ) where RegexOutput == Substring {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.astKind) } ?? .default
+    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.oneOrMore, kind, component.regex.root))
   }
 }
@@ -689,10 +689,10 @@ extension OneOrMore {
   @available(SwiftStdlib 5.7, *)
   @_disfavoredOverload
   public init<Component: RegexComponent>(
-    _ behavior: QuantificationBehavior? = nil,
+    _ behavior: RegexQuantificationBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == Substring {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.astKind) } ?? .default
+    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.oneOrMore, kind, component().regex.root))
   }
 }
@@ -727,7 +727,7 @@ extension Repeat {
   public init<Component: RegexComponent, R: RangeExpression>(
     _ component: Component,
     _ expression: R,
-    _ behavior: QuantificationBehavior? = nil
+    _ behavior: RegexQuantificationBehavior? = nil
   ) where RegexOutput == Substring, R.Bound == Int {
     self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component.regex.root))
   }
@@ -736,7 +736,7 @@ extension Repeat {
   @_disfavoredOverload
   public init<Component: RegexComponent, R: RangeExpression>(
     _ expression: R,
-    _ behavior: QuantificationBehavior? = nil,
+    _ behavior: RegexQuantificationBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == Substring, R.Bound == Int {
     self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component().regex.root))
@@ -747,9 +747,9 @@ extension Optionally {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, Component: RegexComponent>(
     _ component: Component,
-    _ behavior: QuantificationBehavior? = nil
+    _ behavior: RegexQuantificationBehavior? = nil
   ) where RegexOutput == (Substring, C0?), Component.RegexOutput == (W, C0) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.astKind) } ?? .default
+    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.zeroOrOne, kind, component.regex.root))
   }
 }
@@ -758,10 +758,10 @@ extension Optionally {
 extension Optionally {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, Component: RegexComponent>(
-    _ behavior: QuantificationBehavior? = nil,
+    _ behavior: RegexQuantificationBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C0?), Component.RegexOutput == (W, C0) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.astKind) } ?? .default
+    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.zeroOrOne, kind, component().regex.root))
   }
 }
@@ -780,9 +780,9 @@ extension ZeroOrMore {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, Component: RegexComponent>(
     _ component: Component,
-    _ behavior: QuantificationBehavior? = nil
+    _ behavior: RegexQuantificationBehavior? = nil
   ) where RegexOutput == (Substring, C0?), Component.RegexOutput == (W, C0) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.astKind) } ?? .default
+    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.zeroOrMore, kind, component.regex.root))
   }
 }
@@ -791,10 +791,10 @@ extension ZeroOrMore {
 extension ZeroOrMore {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, Component: RegexComponent>(
-    _ behavior: QuantificationBehavior? = nil,
+    _ behavior: RegexQuantificationBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C0?), Component.RegexOutput == (W, C0) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.astKind) } ?? .default
+    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.zeroOrMore, kind, component().regex.root))
   }
 }
@@ -805,9 +805,9 @@ extension OneOrMore {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, Component: RegexComponent>(
     _ component: Component,
-    _ behavior: QuantificationBehavior? = nil
+    _ behavior: RegexQuantificationBehavior? = nil
   ) where RegexOutput == (Substring, C0), Component.RegexOutput == (W, C0) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.astKind) } ?? .default
+    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.oneOrMore, kind, component.regex.root))
   }
 }
@@ -816,10 +816,10 @@ extension OneOrMore {
 extension OneOrMore {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, Component: RegexComponent>(
-    _ behavior: QuantificationBehavior? = nil,
+    _ behavior: RegexQuantificationBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C0), Component.RegexOutput == (W, C0) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.astKind) } ?? .default
+    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.oneOrMore, kind, component().regex.root))
   }
 }
@@ -851,7 +851,7 @@ extension Repeat {
     public init<W, C0, Component: RegexComponent, R: RangeExpression>(
     _ component: Component,
     _ expression: R,
-    _ behavior: QuantificationBehavior? = nil
+    _ behavior: RegexQuantificationBehavior? = nil
   ) where RegexOutput == (Substring, C0?), Component.RegexOutput == (W, C0), R.Bound == Int {
     self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component.regex.root))
   }
@@ -859,7 +859,7 @@ extension Repeat {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, Component: RegexComponent, R: RangeExpression>(
     _ expression: R,
-    _ behavior: QuantificationBehavior? = nil,
+    _ behavior: RegexQuantificationBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C0?), Component.RegexOutput == (W, C0), R.Bound == Int {
     self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component().regex.root))
@@ -870,9 +870,9 @@ extension Optionally {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, Component: RegexComponent>(
     _ component: Component,
-    _ behavior: QuantificationBehavior? = nil
+    _ behavior: RegexQuantificationBehavior? = nil
   ) where RegexOutput == (Substring, C0?, C1?), Component.RegexOutput == (W, C0, C1) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.astKind) } ?? .default
+    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.zeroOrOne, kind, component.regex.root))
   }
 }
@@ -881,10 +881,10 @@ extension Optionally {
 extension Optionally {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, Component: RegexComponent>(
-    _ behavior: QuantificationBehavior? = nil,
+    _ behavior: RegexQuantificationBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C0?, C1?), Component.RegexOutput == (W, C0, C1) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.astKind) } ?? .default
+    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.zeroOrOne, kind, component().regex.root))
   }
 }
@@ -903,9 +903,9 @@ extension ZeroOrMore {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, Component: RegexComponent>(
     _ component: Component,
-    _ behavior: QuantificationBehavior? = nil
+    _ behavior: RegexQuantificationBehavior? = nil
   ) where RegexOutput == (Substring, C0?, C1?), Component.RegexOutput == (W, C0, C1) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.astKind) } ?? .default
+    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.zeroOrMore, kind, component.regex.root))
   }
 }
@@ -914,10 +914,10 @@ extension ZeroOrMore {
 extension ZeroOrMore {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, Component: RegexComponent>(
-    _ behavior: QuantificationBehavior? = nil,
+    _ behavior: RegexQuantificationBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C0?, C1?), Component.RegexOutput == (W, C0, C1) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.astKind) } ?? .default
+    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.zeroOrMore, kind, component().regex.root))
   }
 }
@@ -928,9 +928,9 @@ extension OneOrMore {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, Component: RegexComponent>(
     _ component: Component,
-    _ behavior: QuantificationBehavior? = nil
+    _ behavior: RegexQuantificationBehavior? = nil
   ) where RegexOutput == (Substring, C0, C1), Component.RegexOutput == (W, C0, C1) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.astKind) } ?? .default
+    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.oneOrMore, kind, component.regex.root))
   }
 }
@@ -939,10 +939,10 @@ extension OneOrMore {
 extension OneOrMore {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, Component: RegexComponent>(
-    _ behavior: QuantificationBehavior? = nil,
+    _ behavior: RegexQuantificationBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C0, C1), Component.RegexOutput == (W, C0, C1) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.astKind) } ?? .default
+    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.oneOrMore, kind, component().regex.root))
   }
 }
@@ -974,7 +974,7 @@ extension Repeat {
     public init<W, C0, C1, Component: RegexComponent, R: RangeExpression>(
     _ component: Component,
     _ expression: R,
-    _ behavior: QuantificationBehavior? = nil
+    _ behavior: RegexQuantificationBehavior? = nil
   ) where RegexOutput == (Substring, C0?, C1?), Component.RegexOutput == (W, C0, C1), R.Bound == Int {
     self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component.regex.root))
   }
@@ -982,7 +982,7 @@ extension Repeat {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, Component: RegexComponent, R: RangeExpression>(
     _ expression: R,
-    _ behavior: QuantificationBehavior? = nil,
+    _ behavior: RegexQuantificationBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C0?, C1?), Component.RegexOutput == (W, C0, C1), R.Bound == Int {
     self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component().regex.root))
@@ -993,9 +993,9 @@ extension Optionally {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, Component: RegexComponent>(
     _ component: Component,
-    _ behavior: QuantificationBehavior? = nil
+    _ behavior: RegexQuantificationBehavior? = nil
   ) where RegexOutput == (Substring, C0?, C1?, C2?), Component.RegexOutput == (W, C0, C1, C2) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.astKind) } ?? .default
+    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.zeroOrOne, kind, component.regex.root))
   }
 }
@@ -1004,10 +1004,10 @@ extension Optionally {
 extension Optionally {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, Component: RegexComponent>(
-    _ behavior: QuantificationBehavior? = nil,
+    _ behavior: RegexQuantificationBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C0?, C1?, C2?), Component.RegexOutput == (W, C0, C1, C2) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.astKind) } ?? .default
+    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.zeroOrOne, kind, component().regex.root))
   }
 }
@@ -1026,9 +1026,9 @@ extension ZeroOrMore {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, Component: RegexComponent>(
     _ component: Component,
-    _ behavior: QuantificationBehavior? = nil
+    _ behavior: RegexQuantificationBehavior? = nil
   ) where RegexOutput == (Substring, C0?, C1?, C2?), Component.RegexOutput == (W, C0, C1, C2) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.astKind) } ?? .default
+    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.zeroOrMore, kind, component.regex.root))
   }
 }
@@ -1037,10 +1037,10 @@ extension ZeroOrMore {
 extension ZeroOrMore {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, Component: RegexComponent>(
-    _ behavior: QuantificationBehavior? = nil,
+    _ behavior: RegexQuantificationBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C0?, C1?, C2?), Component.RegexOutput == (W, C0, C1, C2) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.astKind) } ?? .default
+    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.zeroOrMore, kind, component().regex.root))
   }
 }
@@ -1051,9 +1051,9 @@ extension OneOrMore {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, Component: RegexComponent>(
     _ component: Component,
-    _ behavior: QuantificationBehavior? = nil
+    _ behavior: RegexQuantificationBehavior? = nil
   ) where RegexOutput == (Substring, C0, C1, C2), Component.RegexOutput == (W, C0, C1, C2) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.astKind) } ?? .default
+    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.oneOrMore, kind, component.regex.root))
   }
 }
@@ -1062,10 +1062,10 @@ extension OneOrMore {
 extension OneOrMore {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, Component: RegexComponent>(
-    _ behavior: QuantificationBehavior? = nil,
+    _ behavior: RegexQuantificationBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C0, C1, C2), Component.RegexOutput == (W, C0, C1, C2) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.astKind) } ?? .default
+    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.oneOrMore, kind, component().regex.root))
   }
 }
@@ -1097,7 +1097,7 @@ extension Repeat {
     public init<W, C0, C1, C2, Component: RegexComponent, R: RangeExpression>(
     _ component: Component,
     _ expression: R,
-    _ behavior: QuantificationBehavior? = nil
+    _ behavior: RegexQuantificationBehavior? = nil
   ) where RegexOutput == (Substring, C0?, C1?, C2?), Component.RegexOutput == (W, C0, C1, C2), R.Bound == Int {
     self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component.regex.root))
   }
@@ -1105,7 +1105,7 @@ extension Repeat {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, Component: RegexComponent, R: RangeExpression>(
     _ expression: R,
-    _ behavior: QuantificationBehavior? = nil,
+    _ behavior: RegexQuantificationBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C0?, C1?, C2?), Component.RegexOutput == (W, C0, C1, C2), R.Bound == Int {
     self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component().regex.root))
@@ -1116,9 +1116,9 @@ extension Optionally {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, Component: RegexComponent>(
     _ component: Component,
-    _ behavior: QuantificationBehavior? = nil
+    _ behavior: RegexQuantificationBehavior? = nil
   ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?), Component.RegexOutput == (W, C0, C1, C2, C3) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.astKind) } ?? .default
+    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.zeroOrOne, kind, component.regex.root))
   }
 }
@@ -1127,10 +1127,10 @@ extension Optionally {
 extension Optionally {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, Component: RegexComponent>(
-    _ behavior: QuantificationBehavior? = nil,
+    _ behavior: RegexQuantificationBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?), Component.RegexOutput == (W, C0, C1, C2, C3) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.astKind) } ?? .default
+    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.zeroOrOne, kind, component().regex.root))
   }
 }
@@ -1149,9 +1149,9 @@ extension ZeroOrMore {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, Component: RegexComponent>(
     _ component: Component,
-    _ behavior: QuantificationBehavior? = nil
+    _ behavior: RegexQuantificationBehavior? = nil
   ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?), Component.RegexOutput == (W, C0, C1, C2, C3) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.astKind) } ?? .default
+    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.zeroOrMore, kind, component.regex.root))
   }
 }
@@ -1160,10 +1160,10 @@ extension ZeroOrMore {
 extension ZeroOrMore {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, Component: RegexComponent>(
-    _ behavior: QuantificationBehavior? = nil,
+    _ behavior: RegexQuantificationBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?), Component.RegexOutput == (W, C0, C1, C2, C3) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.astKind) } ?? .default
+    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.zeroOrMore, kind, component().regex.root))
   }
 }
@@ -1174,9 +1174,9 @@ extension OneOrMore {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, Component: RegexComponent>(
     _ component: Component,
-    _ behavior: QuantificationBehavior? = nil
+    _ behavior: RegexQuantificationBehavior? = nil
   ) where RegexOutput == (Substring, C0, C1, C2, C3), Component.RegexOutput == (W, C0, C1, C2, C3) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.astKind) } ?? .default
+    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.oneOrMore, kind, component.regex.root))
   }
 }
@@ -1185,10 +1185,10 @@ extension OneOrMore {
 extension OneOrMore {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, Component: RegexComponent>(
-    _ behavior: QuantificationBehavior? = nil,
+    _ behavior: RegexQuantificationBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C0, C1, C2, C3), Component.RegexOutput == (W, C0, C1, C2, C3) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.astKind) } ?? .default
+    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.oneOrMore, kind, component().regex.root))
   }
 }
@@ -1220,7 +1220,7 @@ extension Repeat {
     public init<W, C0, C1, C2, C3, Component: RegexComponent, R: RangeExpression>(
     _ component: Component,
     _ expression: R,
-    _ behavior: QuantificationBehavior? = nil
+    _ behavior: RegexQuantificationBehavior? = nil
   ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?), Component.RegexOutput == (W, C0, C1, C2, C3), R.Bound == Int {
     self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component.regex.root))
   }
@@ -1228,7 +1228,7 @@ extension Repeat {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, Component: RegexComponent, R: RangeExpression>(
     _ expression: R,
-    _ behavior: QuantificationBehavior? = nil,
+    _ behavior: RegexQuantificationBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?), Component.RegexOutput == (W, C0, C1, C2, C3), R.Bound == Int {
     self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component().regex.root))
@@ -1239,9 +1239,9 @@ extension Optionally {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, Component: RegexComponent>(
     _ component: Component,
-    _ behavior: QuantificationBehavior? = nil
+    _ behavior: RegexQuantificationBehavior? = nil
   ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?), Component.RegexOutput == (W, C0, C1, C2, C3, C4) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.astKind) } ?? .default
+    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.zeroOrOne, kind, component.regex.root))
   }
 }
@@ -1250,10 +1250,10 @@ extension Optionally {
 extension Optionally {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, Component: RegexComponent>(
-    _ behavior: QuantificationBehavior? = nil,
+    _ behavior: RegexQuantificationBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?), Component.RegexOutput == (W, C0, C1, C2, C3, C4) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.astKind) } ?? .default
+    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.zeroOrOne, kind, component().regex.root))
   }
 }
@@ -1272,9 +1272,9 @@ extension ZeroOrMore {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, Component: RegexComponent>(
     _ component: Component,
-    _ behavior: QuantificationBehavior? = nil
+    _ behavior: RegexQuantificationBehavior? = nil
   ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?), Component.RegexOutput == (W, C0, C1, C2, C3, C4) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.astKind) } ?? .default
+    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.zeroOrMore, kind, component.regex.root))
   }
 }
@@ -1283,10 +1283,10 @@ extension ZeroOrMore {
 extension ZeroOrMore {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, Component: RegexComponent>(
-    _ behavior: QuantificationBehavior? = nil,
+    _ behavior: RegexQuantificationBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?), Component.RegexOutput == (W, C0, C1, C2, C3, C4) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.astKind) } ?? .default
+    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.zeroOrMore, kind, component().regex.root))
   }
 }
@@ -1297,9 +1297,9 @@ extension OneOrMore {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, Component: RegexComponent>(
     _ component: Component,
-    _ behavior: QuantificationBehavior? = nil
+    _ behavior: RegexQuantificationBehavior? = nil
   ) where RegexOutput == (Substring, C0, C1, C2, C3, C4), Component.RegexOutput == (W, C0, C1, C2, C3, C4) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.astKind) } ?? .default
+    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.oneOrMore, kind, component.regex.root))
   }
 }
@@ -1308,10 +1308,10 @@ extension OneOrMore {
 extension OneOrMore {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, Component: RegexComponent>(
-    _ behavior: QuantificationBehavior? = nil,
+    _ behavior: RegexQuantificationBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C0, C1, C2, C3, C4), Component.RegexOutput == (W, C0, C1, C2, C3, C4) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.astKind) } ?? .default
+    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.oneOrMore, kind, component().regex.root))
   }
 }
@@ -1343,7 +1343,7 @@ extension Repeat {
     public init<W, C0, C1, C2, C3, C4, Component: RegexComponent, R: RangeExpression>(
     _ component: Component,
     _ expression: R,
-    _ behavior: QuantificationBehavior? = nil
+    _ behavior: RegexQuantificationBehavior? = nil
   ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?), Component.RegexOutput == (W, C0, C1, C2, C3, C4), R.Bound == Int {
     self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component.regex.root))
   }
@@ -1351,7 +1351,7 @@ extension Repeat {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, Component: RegexComponent, R: RangeExpression>(
     _ expression: R,
-    _ behavior: QuantificationBehavior? = nil,
+    _ behavior: RegexQuantificationBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?), Component.RegexOutput == (W, C0, C1, C2, C3, C4), R.Bound == Int {
     self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component().regex.root))
@@ -1362,9 +1362,9 @@ extension Optionally {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, Component: RegexComponent>(
     _ component: Component,
-    _ behavior: QuantificationBehavior? = nil
+    _ behavior: RegexQuantificationBehavior? = nil
   ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?, C5?), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.astKind) } ?? .default
+    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.zeroOrOne, kind, component.regex.root))
   }
 }
@@ -1373,10 +1373,10 @@ extension Optionally {
 extension Optionally {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, Component: RegexComponent>(
-    _ behavior: QuantificationBehavior? = nil,
+    _ behavior: RegexQuantificationBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?, C5?), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.astKind) } ?? .default
+    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.zeroOrOne, kind, component().regex.root))
   }
 }
@@ -1395,9 +1395,9 @@ extension ZeroOrMore {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, Component: RegexComponent>(
     _ component: Component,
-    _ behavior: QuantificationBehavior? = nil
+    _ behavior: RegexQuantificationBehavior? = nil
   ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?, C5?), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.astKind) } ?? .default
+    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.zeroOrMore, kind, component.regex.root))
   }
 }
@@ -1406,10 +1406,10 @@ extension ZeroOrMore {
 extension ZeroOrMore {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, Component: RegexComponent>(
-    _ behavior: QuantificationBehavior? = nil,
+    _ behavior: RegexQuantificationBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?, C5?), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.astKind) } ?? .default
+    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.zeroOrMore, kind, component().regex.root))
   }
 }
@@ -1420,9 +1420,9 @@ extension OneOrMore {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, Component: RegexComponent>(
     _ component: Component,
-    _ behavior: QuantificationBehavior? = nil
+    _ behavior: RegexQuantificationBehavior? = nil
   ) where RegexOutput == (Substring, C0, C1, C2, C3, C4, C5), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.astKind) } ?? .default
+    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.oneOrMore, kind, component.regex.root))
   }
 }
@@ -1431,10 +1431,10 @@ extension OneOrMore {
 extension OneOrMore {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, Component: RegexComponent>(
-    _ behavior: QuantificationBehavior? = nil,
+    _ behavior: RegexQuantificationBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C0, C1, C2, C3, C4, C5), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.astKind) } ?? .default
+    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.oneOrMore, kind, component().regex.root))
   }
 }
@@ -1466,7 +1466,7 @@ extension Repeat {
     public init<W, C0, C1, C2, C3, C4, C5, Component: RegexComponent, R: RangeExpression>(
     _ component: Component,
     _ expression: R,
-    _ behavior: QuantificationBehavior? = nil
+    _ behavior: RegexQuantificationBehavior? = nil
   ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?, C5?), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5), R.Bound == Int {
     self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component.regex.root))
   }
@@ -1474,7 +1474,7 @@ extension Repeat {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, Component: RegexComponent, R: RangeExpression>(
     _ expression: R,
-    _ behavior: QuantificationBehavior? = nil,
+    _ behavior: RegexQuantificationBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?, C5?), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5), R.Bound == Int {
     self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component().regex.root))
@@ -1485,9 +1485,9 @@ extension Optionally {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexComponent>(
     _ component: Component,
-    _ behavior: QuantificationBehavior? = nil
+    _ behavior: RegexQuantificationBehavior? = nil
   ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.astKind) } ?? .default
+    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.zeroOrOne, kind, component.regex.root))
   }
 }
@@ -1496,10 +1496,10 @@ extension Optionally {
 extension Optionally {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexComponent>(
-    _ behavior: QuantificationBehavior? = nil,
+    _ behavior: RegexQuantificationBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.astKind) } ?? .default
+    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.zeroOrOne, kind, component().regex.root))
   }
 }
@@ -1518,9 +1518,9 @@ extension ZeroOrMore {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexComponent>(
     _ component: Component,
-    _ behavior: QuantificationBehavior? = nil
+    _ behavior: RegexQuantificationBehavior? = nil
   ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.astKind) } ?? .default
+    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.zeroOrMore, kind, component.regex.root))
   }
 }
@@ -1529,10 +1529,10 @@ extension ZeroOrMore {
 extension ZeroOrMore {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexComponent>(
-    _ behavior: QuantificationBehavior? = nil,
+    _ behavior: RegexQuantificationBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.astKind) } ?? .default
+    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.zeroOrMore, kind, component().regex.root))
   }
 }
@@ -1543,9 +1543,9 @@ extension OneOrMore {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexComponent>(
     _ component: Component,
-    _ behavior: QuantificationBehavior? = nil
+    _ behavior: RegexQuantificationBehavior? = nil
   ) where RegexOutput == (Substring, C0, C1, C2, C3, C4, C5, C6), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.astKind) } ?? .default
+    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.oneOrMore, kind, component.regex.root))
   }
 }
@@ -1554,10 +1554,10 @@ extension OneOrMore {
 extension OneOrMore {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexComponent>(
-    _ behavior: QuantificationBehavior? = nil,
+    _ behavior: RegexQuantificationBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C0, C1, C2, C3, C4, C5, C6), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.astKind) } ?? .default
+    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.oneOrMore, kind, component().regex.root))
   }
 }
@@ -1589,7 +1589,7 @@ extension Repeat {
     public init<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexComponent, R: RangeExpression>(
     _ component: Component,
     _ expression: R,
-    _ behavior: QuantificationBehavior? = nil
+    _ behavior: RegexQuantificationBehavior? = nil
   ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6), R.Bound == Int {
     self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component.regex.root))
   }
@@ -1597,7 +1597,7 @@ extension Repeat {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexComponent, R: RangeExpression>(
     _ expression: R,
-    _ behavior: QuantificationBehavior? = nil,
+    _ behavior: RegexQuantificationBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6), R.Bound == Int {
     self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component().regex.root))
@@ -1608,9 +1608,9 @@ extension Optionally {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexComponent>(
     _ component: Component,
-    _ behavior: QuantificationBehavior? = nil
+    _ behavior: RegexQuantificationBehavior? = nil
   ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.astKind) } ?? .default
+    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.zeroOrOne, kind, component.regex.root))
   }
 }
@@ -1619,10 +1619,10 @@ extension Optionally {
 extension Optionally {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexComponent>(
-    _ behavior: QuantificationBehavior? = nil,
+    _ behavior: RegexQuantificationBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.astKind) } ?? .default
+    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.zeroOrOne, kind, component().regex.root))
   }
 }
@@ -1641,9 +1641,9 @@ extension ZeroOrMore {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexComponent>(
     _ component: Component,
-    _ behavior: QuantificationBehavior? = nil
+    _ behavior: RegexQuantificationBehavior? = nil
   ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.astKind) } ?? .default
+    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.zeroOrMore, kind, component.regex.root))
   }
 }
@@ -1652,10 +1652,10 @@ extension ZeroOrMore {
 extension ZeroOrMore {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexComponent>(
-    _ behavior: QuantificationBehavior? = nil,
+    _ behavior: RegexQuantificationBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.astKind) } ?? .default
+    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.zeroOrMore, kind, component().regex.root))
   }
 }
@@ -1666,9 +1666,9 @@ extension OneOrMore {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexComponent>(
     _ component: Component,
-    _ behavior: QuantificationBehavior? = nil
+    _ behavior: RegexQuantificationBehavior? = nil
   ) where RegexOutput == (Substring, C0, C1, C2, C3, C4, C5, C6, C7), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.astKind) } ?? .default
+    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.oneOrMore, kind, component.regex.root))
   }
 }
@@ -1677,10 +1677,10 @@ extension OneOrMore {
 extension OneOrMore {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexComponent>(
-    _ behavior: QuantificationBehavior? = nil,
+    _ behavior: RegexQuantificationBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C0, C1, C2, C3, C4, C5, C6, C7), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.astKind) } ?? .default
+    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.oneOrMore, kind, component().regex.root))
   }
 }
@@ -1712,7 +1712,7 @@ extension Repeat {
     public init<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexComponent, R: RangeExpression>(
     _ component: Component,
     _ expression: R,
-    _ behavior: QuantificationBehavior? = nil
+    _ behavior: RegexQuantificationBehavior? = nil
   ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7), R.Bound == Int {
     self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component.regex.root))
   }
@@ -1720,7 +1720,7 @@ extension Repeat {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexComponent, R: RangeExpression>(
     _ expression: R,
-    _ behavior: QuantificationBehavior? = nil,
+    _ behavior: RegexQuantificationBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7), R.Bound == Int {
     self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component().regex.root))
@@ -1731,9 +1731,9 @@ extension Optionally {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexComponent>(
     _ component: Component,
-    _ behavior: QuantificationBehavior? = nil
+    _ behavior: RegexQuantificationBehavior? = nil
   ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.astKind) } ?? .default
+    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.zeroOrOne, kind, component.regex.root))
   }
 }
@@ -1742,10 +1742,10 @@ extension Optionally {
 extension Optionally {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexComponent>(
-    _ behavior: QuantificationBehavior? = nil,
+    _ behavior: RegexQuantificationBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.astKind) } ?? .default
+    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.zeroOrOne, kind, component().regex.root))
   }
 }
@@ -1764,9 +1764,9 @@ extension ZeroOrMore {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexComponent>(
     _ component: Component,
-    _ behavior: QuantificationBehavior? = nil
+    _ behavior: RegexQuantificationBehavior? = nil
   ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.astKind) } ?? .default
+    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.zeroOrMore, kind, component.regex.root))
   }
 }
@@ -1775,10 +1775,10 @@ extension ZeroOrMore {
 extension ZeroOrMore {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexComponent>(
-    _ behavior: QuantificationBehavior? = nil,
+    _ behavior: RegexQuantificationBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.astKind) } ?? .default
+    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.zeroOrMore, kind, component().regex.root))
   }
 }
@@ -1789,9 +1789,9 @@ extension OneOrMore {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexComponent>(
     _ component: Component,
-    _ behavior: QuantificationBehavior? = nil
+    _ behavior: RegexQuantificationBehavior? = nil
   ) where RegexOutput == (Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.astKind) } ?? .default
+    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.oneOrMore, kind, component.regex.root))
   }
 }
@@ -1800,10 +1800,10 @@ extension OneOrMore {
 extension OneOrMore {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexComponent>(
-    _ behavior: QuantificationBehavior? = nil,
+    _ behavior: RegexQuantificationBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.astKind) } ?? .default
+    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.oneOrMore, kind, component().regex.root))
   }
 }
@@ -1835,7 +1835,7 @@ extension Repeat {
     public init<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexComponent, R: RangeExpression>(
     _ component: Component,
     _ expression: R,
-    _ behavior: QuantificationBehavior? = nil
+    _ behavior: RegexQuantificationBehavior? = nil
   ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8), R.Bound == Int {
     self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component.regex.root))
   }
@@ -1843,7 +1843,7 @@ extension Repeat {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexComponent, R: RangeExpression>(
     _ expression: R,
-    _ behavior: QuantificationBehavior? = nil,
+    _ behavior: RegexQuantificationBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8), R.Bound == Int {
     self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component().regex.root))
@@ -1854,9 +1854,9 @@ extension Optionally {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9, Component: RegexComponent>(
     _ component: Component,
-    _ behavior: QuantificationBehavior? = nil
+    _ behavior: RegexQuantificationBehavior? = nil
   ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.astKind) } ?? .default
+    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.zeroOrOne, kind, component.regex.root))
   }
 }
@@ -1865,10 +1865,10 @@ extension Optionally {
 extension Optionally {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9, Component: RegexComponent>(
-    _ behavior: QuantificationBehavior? = nil,
+    _ behavior: RegexQuantificationBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.astKind) } ?? .default
+    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.zeroOrOne, kind, component().regex.root))
   }
 }
@@ -1887,9 +1887,9 @@ extension ZeroOrMore {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9, Component: RegexComponent>(
     _ component: Component,
-    _ behavior: QuantificationBehavior? = nil
+    _ behavior: RegexQuantificationBehavior? = nil
   ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.astKind) } ?? .default
+    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.zeroOrMore, kind, component.regex.root))
   }
 }
@@ -1898,10 +1898,10 @@ extension ZeroOrMore {
 extension ZeroOrMore {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9, Component: RegexComponent>(
-    _ behavior: QuantificationBehavior? = nil,
+    _ behavior: RegexQuantificationBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.astKind) } ?? .default
+    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.zeroOrMore, kind, component().regex.root))
   }
 }
@@ -1912,9 +1912,9 @@ extension OneOrMore {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9, Component: RegexComponent>(
     _ component: Component,
-    _ behavior: QuantificationBehavior? = nil
+    _ behavior: RegexQuantificationBehavior? = nil
   ) where RegexOutput == (Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.astKind) } ?? .default
+    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.oneOrMore, kind, component.regex.root))
   }
 }
@@ -1923,10 +1923,10 @@ extension OneOrMore {
 extension OneOrMore {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9, Component: RegexComponent>(
-    _ behavior: QuantificationBehavior? = nil,
+    _ behavior: RegexQuantificationBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.astKind) } ?? .default
+    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.oneOrMore, kind, component().regex.root))
   }
 }
@@ -1958,7 +1958,7 @@ extension Repeat {
     public init<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9, Component: RegexComponent, R: RangeExpression>(
     _ component: Component,
     _ expression: R,
-    _ behavior: QuantificationBehavior? = nil
+    _ behavior: RegexQuantificationBehavior? = nil
   ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9), R.Bound == Int {
     self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component.regex.root))
   }
@@ -1966,7 +1966,7 @@ extension Repeat {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9, Component: RegexComponent, R: RangeExpression>(
     _ expression: R,
-    _ behavior: QuantificationBehavior? = nil,
+    _ behavior: RegexQuantificationBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9), R.Bound == Int {
     self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component().regex.root))

--- a/Sources/VariadicsGenerator/VariadicsGenerator.swift
+++ b/Sources/VariadicsGenerator/VariadicsGenerator.swift
@@ -377,7 +377,7 @@ struct VariadicsGenerator: ParsableCommand {
         \(params.disfavored)\
         public init<\(params.genericParams)>(
           _ component: Component,
-          _ behavior: RegexQuantificationBehavior? = nil
+          _ behavior: RegexRepetitionBehavior? = nil
         ) \(params.whereClauseForInit) {
           let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
           self.init(node: .quantification(.\(kind.astQuantifierAmount), kind, component.regex.root))
@@ -389,7 +389,7 @@ struct VariadicsGenerator: ParsableCommand {
         \(defaultAvailableAttr)
         \(params.disfavored)\
         public init<\(params.genericParams)>(
-          _ behavior: RegexQuantificationBehavior? = nil,
+          _ behavior: RegexRepetitionBehavior? = nil,
           @\(concatBuilderName) _ component: () -> Component
         ) \(params.whereClauseForInit) {
           let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
@@ -508,7 +508,7 @@ struct VariadicsGenerator: ParsableCommand {
         public init<\(params.genericParams), R: RangeExpression>(
           _ component: Component,
           _ expression: R,
-          _ behavior: RegexQuantificationBehavior? = nil
+          _ behavior: RegexRepetitionBehavior? = nil
         ) \(params.repeatingWhereClause) {
           self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component.regex.root))
         }

--- a/Sources/VariadicsGenerator/VariadicsGenerator.swift
+++ b/Sources/VariadicsGenerator/VariadicsGenerator.swift
@@ -377,9 +377,9 @@ struct VariadicsGenerator: ParsableCommand {
         \(params.disfavored)\
         public init<\(params.genericParams)>(
           _ component: Component,
-          _ behavior: QuantificationBehavior? = nil
+          _ behavior: RegexQuantificationBehavior? = nil
         ) \(params.whereClauseForInit) {
-          let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.astKind) } ?? .default
+          let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
           self.init(node: .quantification(.\(kind.astQuantifierAmount), kind, component.regex.root))
         }
       }
@@ -389,10 +389,10 @@ struct VariadicsGenerator: ParsableCommand {
         \(defaultAvailableAttr)
         \(params.disfavored)\
         public init<\(params.genericParams)>(
-          _ behavior: QuantificationBehavior? = nil,
+          _ behavior: RegexQuantificationBehavior? = nil,
           @\(concatBuilderName) _ component: () -> Component
         ) \(params.whereClauseForInit) {
-          let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.astKind) } ?? .default
+          let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
           self.init(node: .quantification(.\(kind.astQuantifierAmount), kind, component().regex.root))
         }
       }
@@ -508,7 +508,7 @@ struct VariadicsGenerator: ParsableCommand {
         public init<\(params.genericParams), R: RangeExpression>(
           _ component: Component,
           _ expression: R,
-          _ behavior: QuantificationBehavior? = nil
+          _ behavior: RegexQuantificationBehavior? = nil
         ) \(params.repeatingWhereClause) {
           self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component.regex.root))
         }

--- a/Sources/_RegexParser/Regex/AST/MatchingOptions.swift
+++ b/Sources/_RegexParser/Regex/AST/MatchingOptions.swift
@@ -41,7 +41,11 @@ extension AST {
       case graphemeClusterSemantics // X
       case unicodeScalarSemantics   // u
       case byteSemantics            // b
+      
+      // Swift-only default possessive quantifier
+      case possessiveByDefault      // t.b.d.
     }
+    
     public var kind: Kind
     public var location: SourceLocation
 

--- a/Sources/_StringProcessing/ByteCodeGen.swift
+++ b/Sources/_StringProcessing/ByteCodeGen.swift
@@ -374,9 +374,7 @@ extension Compiler.ByteCodeGen {
     case .syntax(let kind):
       updatedKind = kind.ast.applying(options)
     case .default:
-      updatedKind = options.isReluctantByDefault
-        ? .reluctant
-        : .eager
+      updatedKind = options.defaultQuantificationKind
     }
 
     let (low, high) = amount.bounds

--- a/Sources/_StringProcessing/MatchingOptions.swift
+++ b/Sources/_StringProcessing/MatchingOptions.swift
@@ -63,6 +63,16 @@ extension MatchingOptions {
     stack.last!.contains(.reluctantByDefault)
   }
   
+  var defaultQuantificationKind: AST.Quantification.Kind {
+    if stack.last!.contains(.possessiveByDefault) {
+      return .possessive
+    } else if stack.last!.contains(.reluctantByDefault) {
+      return .reluctant
+    } else {
+      return .eager
+    }
+  }
+  
   var dotMatchesNewline: Bool {
     stack.last!.contains(.singleLine)
   }
@@ -150,6 +160,9 @@ extension MatchingOptions {
     case unicodeScalarSemantics
     case byteSemantics
     
+    // Swift-only default possessive quantifier
+    case possessiveByDefault
+
     init?(_ astKind: AST.MatchingOption.Kind) {
       switch astKind {
       case .caseInsensitive:
@@ -184,6 +197,8 @@ extension MatchingOptions {
         self = .unicodeScalarSemantics
       case .byteSemantics:
         self = .byteSemantics
+      case .possessiveByDefault:
+        self = .possessiveByDefault
         
       // Whitespace options are only relevant during parsing, not compilation.
       case .extended, .extraExtended:
@@ -218,6 +233,9 @@ extension MatchingOptions {
       }
       if Self.textSegmentOptions.contains(opt.representation) {
         remove(.textSegmentOptions)
+      }
+      if Self.quantificationBehaviors.contains(opt.representation) {
+        remove(.quantificationBehaviors)
       }
 
       insert(opt.representation)
@@ -274,7 +292,15 @@ extension MatchingOptions.Representation {
   static var semanticMatchingLevels: Self {
     [.graphemeClusterSemantics, .unicodeScalarSemantics, .byteSemantics]
   }
-    
+  
+  // Quantification behavior options
+  static var reluctantByDefault: Self { .init(.reluctantByDefault) }
+  static var possessiveByDefault: Self { .init(.possessiveByDefault) }
+
+  static var quantificationBehaviors: Self {
+    [.reluctantByDefault, .possessiveByDefault]
+  }
+  
   /// The default set of options.
   static var `default`: Self {
     [.graphemeClusterSemantics, .textSegmentGraphemeMode]

--- a/Sources/_StringProcessing/MatchingOptions.swift
+++ b/Sources/_StringProcessing/MatchingOptions.swift
@@ -24,7 +24,7 @@ struct MatchingOptions {
     assert(stack.last!.intersection(.semanticMatchingLevels).rawValue.nonzeroBitCount == 1)
     
     // Must contain at most one quantifier behavior
-    assert(stack.last!.intersection(.quantificationBehaviors).rawValue.nonzeroBitCount <= 1)
+    assert(stack.last!.intersection(.repetitionBehaviors).rawValue.nonzeroBitCount <= 1)
   }
 }
 
@@ -237,8 +237,8 @@ extension MatchingOptions {
       if Self.textSegmentOptions.contains(opt.representation) {
         remove(.textSegmentOptions)
       }
-      if Self.quantificationBehaviors.contains(opt.representation) {
-        remove(.quantificationBehaviors)
+      if Self.repetitionBehaviors.contains(opt.representation) {
+        remove(.repetitionBehaviors)
       }
 
       insert(opt.representation)
@@ -262,8 +262,8 @@ extension MatchingOptions {
         guard let opt = Option(opt.kind) else {
           continue
         }
-        if Self.quantificationBehaviors.contains(opt.representation) {
-          remove(.quantificationBehaviors)
+        if Self.repetitionBehaviors.contains(opt.representation) {
+          remove(.repetitionBehaviors)
         }
         remove(opt.representation)
       }
@@ -303,7 +303,7 @@ extension MatchingOptions.Representation {
   static var reluctantByDefault: Self { .init(.reluctantByDefault) }
   static var possessiveByDefault: Self { .init(.possessiveByDefault) }
 
-  static var quantificationBehaviors: Self {
+  static var repetitionBehaviors: Self {
     [.reluctantByDefault, .possessiveByDefault]
   }
   

--- a/Sources/_StringProcessing/MatchingOptions.swift
+++ b/Sources/_StringProcessing/MatchingOptions.swift
@@ -22,6 +22,9 @@ struct MatchingOptions {
     // Must contain exactly one of each mutually exclusive group
     assert(stack.last!.intersection(.textSegmentOptions).rawValue.nonzeroBitCount == 1)
     assert(stack.last!.intersection(.semanticMatchingLevels).rawValue.nonzeroBitCount == 1)
+    
+    // Must contain at most one quantifier behavior
+    assert(stack.last!.intersection(.quantificationBehaviors).rawValue.nonzeroBitCount <= 1)
   }
 }
 
@@ -258,6 +261,9 @@ extension MatchingOptions {
       for opt in sequence.removing {
         guard let opt = Option(opt.kind) else {
           continue
+        }
+        if Self.quantificationBehaviors.contains(opt.representation) {
+          remove(.quantificationBehaviors)
         }
         remove(opt.representation)
       }

--- a/Sources/_StringProcessing/Regex/Options.swift
+++ b/Sources/_StringProcessing/Regex/Options.swift
@@ -79,7 +79,7 @@ extension RegexComponent {
   /// the `(?-U)` or `(?U)` option in regex syntax, respectively.
   ///
   /// - Parameter behavior: The default behavior to use for quantifiers.
-  public func quantificationBehavior(_ behavior: RegexQuantificationBehavior) -> Regex<RegexOutput> {
+  public func repetitionBehavior(_ behavior: RegexRepetitionBehavior) -> Regex<RegexOutput> {
     if behavior == .possessive {
       return wrapInOption(.possessiveByDefault, addingIf: true)
     } else {
@@ -191,7 +191,7 @@ public struct RegexWordBoundaryKind: Hashable {
 
 /// Specifies how much to attempt to match when using a quantifier.
 @available(SwiftStdlib 5.7, *)
-public struct RegexQuantificationBehavior: Hashable {
+public struct RegexRepetitionBehavior: Hashable {
   internal enum Kind {
     case eager
     case reluctant
@@ -210,7 +210,7 @@ public struct RegexQuantificationBehavior: Hashable {
 }
 
 @available(SwiftStdlib 5.7, *)
-extension RegexQuantificationBehavior {
+extension RegexRepetitionBehavior {
   /// Match as much of the input string as possible, backtracking when
   /// necessary.
   public static var eager: Self {

--- a/Sources/_StringProcessing/Regex/Options.swift
+++ b/Sources/_StringProcessing/Regex/Options.swift
@@ -58,8 +58,8 @@ extension RegexComponent {
   /// Returns a regular expression where the start and end of input
   /// anchors (`^` and `$`) also match against the start and end of a line.
   ///
-  /// This method corresponds to applying the `m` option in a regular
-  /// expression literal. For this behavior in the `RegexBuilder` syntax, see
+  /// This method corresponds to applying the `m` option in regex syntax. For
+  /// this behavior in the `RegexBuilder` syntax, see
   /// ``Anchor.startOfLine``, ``Anchor.endOfLine``, ``Anchor.startOfInput``,
   /// and ``Anchor.endOfInput``.
   ///
@@ -69,14 +69,16 @@ extension RegexComponent {
     wrapInOption(.multiline, addingIf: matchLineEndings)
   }
   
-  /// Returns a regular expression where quantifiers are reluctant by default
-  /// instead of eager.
+  /// Returns a regular expression where quantifiers use the specified behavior
+  /// by default.
   ///
-  /// This method corresponds to applying the `U` option in a regular
-  /// expression literal.
+  /// This setting does not affect calls to quantifier methods, such as
+  /// `OneOrMore`, that include an explicit `behavior` parameter.
   ///
-  /// - Parameter useReluctantQuantifiers: A Boolean value indicating whether
-  ///   quantifiers should be reluctant by default.
+  /// Passing `.eager` or `.reluctant` to this method corresponds to applying
+  /// the `(?-U)` or `(?U)` option in regex syntax, respectively.
+  ///
+  /// - Parameter behavior: The default behavior to use for quantifiers.
   public func quantificationBehavior(_ behavior: RegexQuantificationBehavior) -> Regex<RegexOutput> {
     if behavior == .possessive {
       return wrapInOption(.possessiveByDefault, addingIf: true)

--- a/Tests/RegexBuilderTests/RegexDSLTests.swift
+++ b/Tests/RegexBuilderTests/RegexDSLTests.swift
@@ -293,14 +293,14 @@ class RegexDSLTests: XCTestCase {
         Capture {
           // Reluctant behavior due to option
           OneOrMore(.anyOf("abcd"))
-            .quantificationBehavior(.reluctant)
+            .repetitionBehavior(.reluctant)
         }
         ZeroOrMore("a"..."z")
         
         Capture {
           // Eager behavior due to explicit parameter, despite option
           OneOrMore(.digit, .eager)
-            .quantificationBehavior(.reluctant)
+            .repetitionBehavior(.reluctant)
         }
         ZeroOrMore(.digit)
       }
@@ -345,7 +345,7 @@ class RegexDSLTests: XCTestCase {
     {
       OneOrMore(.reluctant) {
         .word
-      }.quantificationBehavior(.possessive)
+      }.repetitionBehavior(.possessive)
       Capture(.digit)
       ZeroOrMore(.any)
     }
@@ -358,7 +358,7 @@ class RegexDSLTests: XCTestCase {
         OneOrMore(.word)
         Capture(.digit)
         ZeroOrMore(.any)
-      }.quantificationBehavior(.reluctant)
+      }.repetitionBehavior(.reluctant)
     }
     // Default set to reluctant applies to regex syntax
     try _testDSLCaptures(
@@ -366,7 +366,7 @@ class RegexDSLTests: XCTestCase {
       matchType: (Substring, Substring).self, ==)
     {
       try! Regex(#"\w+(\d).*"#, as: (Substring, Substring).self)
-        .quantificationBehavior(.reluctant)
+        .repetitionBehavior(.reluctant)
     }
     
     // Explicitly possessive
@@ -387,7 +387,7 @@ class RegexDSLTests: XCTestCase {
       Regex {
         OneOrMore("a")
         "a"
-      }.quantificationBehavior(.possessive)
+      }.repetitionBehavior(.possessive)
     }
     // More specific default set to eager
     try _testDSLCaptures(
@@ -397,10 +397,10 @@ class RegexDSLTests: XCTestCase {
       Regex {
         Capture {
           OneOrMore("a")
-            .quantificationBehavior(.eager)
+            .repetitionBehavior(.eager)
         }
         OneOrMore("a")
-      }.quantificationBehavior(.possessive)
+      }.repetitionBehavior(.possessive)
     }
     // More specific default set to reluctant
     try _testDSLCaptures(
@@ -410,10 +410,10 @@ class RegexDSLTests: XCTestCase {
       Regex {
         Capture {
           OneOrMore("a")
-            .quantificationBehavior(.reluctant)
+            .repetitionBehavior(.reluctant)
         }
         OneOrMore("a")
-      }.quantificationBehavior(.possessive)
+      }.repetitionBehavior(.possessive)
     }
 
     try _testDSLCaptures(

--- a/Tests/RegexBuilderTests/RegexDSLTests.swift
+++ b/Tests/RegexBuilderTests/RegexDSLTests.swift
@@ -360,7 +360,7 @@ class RegexDSLTests: XCTestCase {
       ("abc1def2", ("abc1def2", "1")),
       matchType: (Substring, Substring).self, ==)
     {
-      try! Regex(compiling: #"\w+(\d).*"#, as: (Substring, Substring).self)
+      try! Regex(#"\w+(\d).*"#, as: (Substring, Substring).self)
         .quantificationBehavior(.reluctant)
     }
     try _testDSLCaptures(

--- a/Tests/RegexBuilderTests/RegexDSLTests.swift
+++ b/Tests/RegexBuilderTests/RegexDSLTests.swift
@@ -319,6 +319,7 @@ class RegexDSLTests: XCTestCase {
   }
   
   func testQuantificationBehavior() throws {
+    // Eager by default
     try _testDSLCaptures(
       ("abc1def2", ("abc1def2", "2")),
       matchType: (Substring, Substring).self, ==)
@@ -328,6 +329,7 @@ class RegexDSLTests: XCTestCase {
       ZeroOrMore(.any)
     }
 
+    // Explicitly reluctant
     try _testDSLCaptures(
       ("abc1def2", ("abc1def2", "1")),
       matchType: (Substring, Substring).self, ==)
@@ -336,6 +338,7 @@ class RegexDSLTests: XCTestCase {
       Capture(.digit)
       ZeroOrMore(.any)
     }
+    // Explicitly reluctant overrides default option
     try _testDSLCaptures(
       ("abc1def2", ("abc1def2", "1")),
       matchType: (Substring, Substring).self, ==)
@@ -346,6 +349,7 @@ class RegexDSLTests: XCTestCase {
       Capture(.digit)
       ZeroOrMore(.any)
     }
+    // Default set to reluctant
     try _testDSLCaptures(
       ("abc1def2", ("abc1def2", "1")),
       matchType: (Substring, Substring).self, ==)
@@ -356,6 +360,7 @@ class RegexDSLTests: XCTestCase {
         ZeroOrMore(.any)
       }.quantificationBehavior(.reluctant)
     }
+    // Default set to reluctant applies to regex syntax
     try _testDSLCaptures(
       ("abc1def2", ("abc1def2", "1")),
       matchType: (Substring, Substring).self, ==)
@@ -363,22 +368,51 @@ class RegexDSLTests: XCTestCase {
       try! Regex(#"\w+(\d).*"#, as: (Substring, Substring).self)
         .quantificationBehavior(.reluctant)
     }
+    
+    // Explicitly possessive
     try _testDSLCaptures(
       ("aaaa", nil),
-      matchType: (Substring, Substring).self, ==)
+      matchType: Substring.self, ==)
     {
       Regex {
         OneOrMore("a", .possessive)
         "a"
       }
     }
+    // Default set to possessive
     try _testDSLCaptures(
       ("aaaa", nil),
-      matchType: (Substring, Substring).self, ==)
+      matchType: Substring.self, ==)
     {
       Regex {
         OneOrMore("a")
         "a"
+      }.quantificationBehavior(.possessive)
+    }
+    // More specific default set to eager
+    try _testDSLCaptures(
+      ("aaaa", ("aaaa", "aaa")),
+      matchType: (Substring, Substring).self, ==)
+    {
+      Regex {
+        Capture {
+          OneOrMore("a")
+            .quantificationBehavior(.eager)
+        }
+        OneOrMore("a")
+      }.quantificationBehavior(.possessive)
+    }
+    // More specific default set to reluctant
+    try _testDSLCaptures(
+      ("aaaa", ("aaaa", "a")),
+      matchType: (Substring, Substring).self, ==)
+    {
+      Regex {
+        Capture {
+          OneOrMore("a")
+            .quantificationBehavior(.reluctant)
+        }
+        OneOrMore("a")
       }.quantificationBehavior(.possessive)
     }
 


### PR DESCRIPTION
This also moves `QuantificationBehavior` from the `RegexBuilder` module down to `_StringProcessing,` and renames it `RegexQuantificationBehavior`.