### PR TITLE
Adds RegexBuilder.CharacterClass.anyUnicodeScalar

### DIFF
--- a/Sources/RegexBuilder/CharacterClass.swift
+++ b/Sources/RegexBuilder/CharacterClass.swift
@@ -51,6 +51,10 @@ extension RegexComponent where Self == CharacterClass {
   public static var anyGrapheme: CharacterClass {
     .init(unconverted: .anyGrapheme)
   }
+  
+  public static var anyUnicodeScalar: CharacterClass {
+    .init(unconverted: .anyUnicodeScalar)
+  }
 
   public static var whitespace: CharacterClass {
     .init(unconverted: .whitespace)

--- a/Tests/RegexTests/MatchTests.swift
+++ b/Tests/RegexTests/MatchTests.swift
@@ -1512,13 +1512,11 @@ extension RegexTests {
       (eDecomposed, false))
     
     // FIXME: \O is unsupported
-    firstMatchTest(#"\O\u{301}"#, input: eDecomposed, match: eDecomposed,
-              xfail: true)
-    firstMatchTest(#"e\O"#, input: eDecomposed, match: eDecomposed,
-              xfail: true)
-    firstMatchTest(#"\O\u{301}"#, input: eComposed, match: nil,
-              xfail: true)
-    firstMatchTest(#"e\O"#, input: eComposed, match: nil,
+    firstMatchTest(#"(?u)\O\u{301}"#, input: eDecomposed, match: eDecomposed)
+    firstMatchTest(#"(?u)e\O"#, input: eDecomposed, match: eDecomposed,
+      xfail: true)
+    firstMatchTest(#"\O"#, input: eComposed, match: eComposed)
+    firstMatchTest(#"\O"#, input: eDecomposed, match: nil,
               xfail: true)
 
     matchTest(


### PR DESCRIPTION
This provides a RegexBuilder API that represents the same as `\O` in regex syntax.