### PR TITLE
[5.7] Update API for congruence with Unicode proposal

### DIFF
--- a/Sources/RegexBuilder/CharacterClass.swift
+++ b/Sources/RegexBuilder/CharacterClass.swift
@@ -60,6 +60,10 @@ extension RegexComponent where Self == CharacterClass {
   public static var anyGrapheme: CharacterClass {
     .init(unconverted: .anyGrapheme)
   }
+  
+  public static var anyUnicodeScalar: CharacterClass {
+    .init(unconverted: .anyUnicodeScalar)
+  }
 
   public static var whitespace: CharacterClass {
     .init(unconverted: .whitespace)

--- a/Sources/RegexBuilder/DSL.swift
+++ b/Sources/RegexBuilder/DSL.swift
@@ -94,40 +94,20 @@ extension UnicodeScalar: RegexComponent {
 
 // Note: Quantifiers are currently gyb'd.
 
-/// Specifies how much to attempt to match when using a quantifier.
-@available(SwiftStdlib 5.7, *)
-public struct QuantificationBehavior {
-  internal enum Kind {
-    case eagerly
-    case reluctantly
-    case possessively
-  }
-
-  var kind: Kind
-
-  internal var astKind: AST.Quantification.Kind {
-    switch kind {
-    case .eagerly: return .eager
-    case .reluctantly: return .reluctant
-    case .possessively: return .possessive
-    }
-  }
-}
-
 extension DSLTree.Node {
   /// Generates a DSLTree node for a repeated range of the given DSLTree node.
   /// Individual public API functions are in the generated Variadics.swift file.
   @available(SwiftStdlib 5.7, *)
   static func repeating(
     _ range: Range<Int>,
-    _ behavior: QuantificationBehavior?,
+    _ behavior: RegexRepetitionBehavior?,
     _ node: DSLTree.Node
   ) -> DSLTree.Node {
     // TODO: Throw these as errors
     assert(range.lowerBound >= 0, "Cannot specify a negative lower bound")
     assert(!range.isEmpty, "Cannot specify an empty range")
     
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.astKind) } ?? .default
+    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
 
     switch (range.lowerBound, range.upperBound) {
     case (0, Int.max): // 0...
@@ -144,26 +124,6 @@ extension DSLTree.Node {
     default: // any other range
       return .quantification(.range(.init(faking: range.lowerBound), .init(faking: range.upperBound)), kind, node)
     }
-  }
-}
-
-@available(SwiftStdlib 5.7, *)
-extension QuantificationBehavior {
-  /// Match as much of the input string as possible, backtracking when
-  /// necessary.
-  public static var eagerly: QuantificationBehavior {
-    .init(kind: .eagerly)
-  }
-
-  /// Match as little of the input string as possible, expanding the matched
-  /// region as necessary to complete a match.
-  public static var reluctantly: QuantificationBehavior {
-    .init(kind: .reluctantly)
-  }
-
-  /// Match as much of the input string as possible, performing no backtracking.
-  public static var possessively: QuantificationBehavior {
-    .init(kind: .possessively)
   }
 }
 

--- a/Sources/RegexBuilder/Variadics.swift
+++ b/Sources/RegexBuilder/Variadics.swift
@@ -616,9 +616,9 @@ extension Optionally {
   @_disfavoredOverload
   public init<Component: RegexComponent>(
     _ component: Component,
-    _ behavior: QuantificationBehavior? = nil
+    _ behavior: RegexRepetitionBehavior? = nil
   ) where RegexOutput == Substring {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.astKind) } ?? .default
+    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.zeroOrOne, kind, component.regex.root))
   }
 }
@@ -628,10 +628,10 @@ extension Optionally {
   @available(SwiftStdlib 5.7, *)
   @_disfavoredOverload
   public init<Component: RegexComponent>(
-    _ behavior: QuantificationBehavior? = nil,
+    _ behavior: RegexRepetitionBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == Substring {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.astKind) } ?? .default
+    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.zeroOrOne, kind, component().regex.root))
   }
 }
@@ -651,9 +651,9 @@ extension ZeroOrMore {
   @_disfavoredOverload
   public init<Component: RegexComponent>(
     _ component: Component,
-    _ behavior: QuantificationBehavior? = nil
+    _ behavior: RegexRepetitionBehavior? = nil
   ) where RegexOutput == Substring {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.astKind) } ?? .default
+    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.zeroOrMore, kind, component.regex.root))
   }
 }
@@ -663,10 +663,10 @@ extension ZeroOrMore {
   @available(SwiftStdlib 5.7, *)
   @_disfavoredOverload
   public init<Component: RegexComponent>(
-    _ behavior: QuantificationBehavior? = nil,
+    _ behavior: RegexRepetitionBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == Substring {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.astKind) } ?? .default
+    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.zeroOrMore, kind, component().regex.root))
   }
 }
@@ -678,9 +678,9 @@ extension OneOrMore {
   @_disfavoredOverload
   public init<Component: RegexComponent>(
     _ component: Component,
-    _ behavior: QuantificationBehavior? = nil
+    _ behavior: RegexRepetitionBehavior? = nil
   ) where RegexOutput == Substring {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.astKind) } ?? .default
+    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.oneOrMore, kind, component.regex.root))
   }
 }
@@ -690,10 +690,10 @@ extension OneOrMore {
   @available(SwiftStdlib 5.7, *)
   @_disfavoredOverload
   public init<Component: RegexComponent>(
-    _ behavior: QuantificationBehavior? = nil,
+    _ behavior: RegexRepetitionBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == Substring {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.astKind) } ?? .default
+    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.oneOrMore, kind, component().regex.root))
   }
 }
@@ -728,7 +728,7 @@ extension Repeat {
   public init<Component: RegexComponent, R: RangeExpression>(
     _ component: Component,
     _ expression: R,
-    _ behavior: QuantificationBehavior? = nil
+    _ behavior: RegexRepetitionBehavior? = nil
   ) where RegexOutput == Substring, R.Bound == Int {
     self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component.regex.root))
   }
@@ -737,7 +737,7 @@ extension Repeat {
   @_disfavoredOverload
   public init<Component: RegexComponent, R: RangeExpression>(
     _ expression: R,
-    _ behavior: QuantificationBehavior? = nil,
+    _ behavior: RegexRepetitionBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == Substring, R.Bound == Int {
     self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component().regex.root))
@@ -748,9 +748,9 @@ extension Optionally {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, Component: RegexComponent>(
     _ component: Component,
-    _ behavior: QuantificationBehavior? = nil
+    _ behavior: RegexRepetitionBehavior? = nil
   ) where RegexOutput == (Substring, C0?), Component.RegexOutput == (W, C0) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.astKind) } ?? .default
+    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.zeroOrOne, kind, component.regex.root))
   }
 }
@@ -759,10 +759,10 @@ extension Optionally {
 extension Optionally {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, Component: RegexComponent>(
-    _ behavior: QuantificationBehavior? = nil,
+    _ behavior: RegexRepetitionBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C0?), Component.RegexOutput == (W, C0) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.astKind) } ?? .default
+    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.zeroOrOne, kind, component().regex.root))
   }
 }
@@ -781,9 +781,9 @@ extension ZeroOrMore {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, Component: RegexComponent>(
     _ component: Component,
-    _ behavior: QuantificationBehavior? = nil
+    _ behavior: RegexRepetitionBehavior? = nil
   ) where RegexOutput == (Substring, C0?), Component.RegexOutput == (W, C0) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.astKind) } ?? .default
+    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.zeroOrMore, kind, component.regex.root))
   }
 }
@@ -792,10 +792,10 @@ extension ZeroOrMore {
 extension ZeroOrMore {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, Component: RegexComponent>(
-    _ behavior: QuantificationBehavior? = nil,
+    _ behavior: RegexRepetitionBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C0?), Component.RegexOutput == (W, C0) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.astKind) } ?? .default
+    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.zeroOrMore, kind, component().regex.root))
   }
 }
@@ -806,9 +806,9 @@ extension OneOrMore {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, Component: RegexComponent>(
     _ component: Component,
-    _ behavior: QuantificationBehavior? = nil
+    _ behavior: RegexRepetitionBehavior? = nil
   ) where RegexOutput == (Substring, C0), Component.RegexOutput == (W, C0) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.astKind) } ?? .default
+    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.oneOrMore, kind, component.regex.root))
   }
 }
@@ -817,10 +817,10 @@ extension OneOrMore {
 extension OneOrMore {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, Component: RegexComponent>(
-    _ behavior: QuantificationBehavior? = nil,
+    _ behavior: RegexRepetitionBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C0), Component.RegexOutput == (W, C0) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.astKind) } ?? .default
+    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.oneOrMore, kind, component().regex.root))
   }
 }
@@ -852,7 +852,7 @@ extension Repeat {
     public init<W, C0, Component: RegexComponent, R: RangeExpression>(
     _ component: Component,
     _ expression: R,
-    _ behavior: QuantificationBehavior? = nil
+    _ behavior: RegexRepetitionBehavior? = nil
   ) where RegexOutput == (Substring, C0?), Component.RegexOutput == (W, C0), R.Bound == Int {
     self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component.regex.root))
   }
@@ -860,7 +860,7 @@ extension Repeat {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, Component: RegexComponent, R: RangeExpression>(
     _ expression: R,
-    _ behavior: QuantificationBehavior? = nil,
+    _ behavior: RegexRepetitionBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C0?), Component.RegexOutput == (W, C0), R.Bound == Int {
     self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component().regex.root))
@@ -871,9 +871,9 @@ extension Optionally {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, Component: RegexComponent>(
     _ component: Component,
-    _ behavior: QuantificationBehavior? = nil
+    _ behavior: RegexRepetitionBehavior? = nil
   ) where RegexOutput == (Substring, C0?, C1?), Component.RegexOutput == (W, C0, C1) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.astKind) } ?? .default
+    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.zeroOrOne, kind, component.regex.root))
   }
 }
@@ -882,10 +882,10 @@ extension Optionally {
 extension Optionally {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, Component: RegexComponent>(
-    _ behavior: QuantificationBehavior? = nil,
+    _ behavior: RegexRepetitionBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C0?, C1?), Component.RegexOutput == (W, C0, C1) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.astKind) } ?? .default
+    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.zeroOrOne, kind, component().regex.root))
   }
 }
@@ -904,9 +904,9 @@ extension ZeroOrMore {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, Component: RegexComponent>(
     _ component: Component,
-    _ behavior: QuantificationBehavior? = nil
+    _ behavior: RegexRepetitionBehavior? = nil
   ) where RegexOutput == (Substring, C0?, C1?), Component.RegexOutput == (W, C0, C1) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.astKind) } ?? .default
+    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.zeroOrMore, kind, component.regex.root))
   }
 }
@@ -915,10 +915,10 @@ extension ZeroOrMore {
 extension ZeroOrMore {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, Component: RegexComponent>(
-    _ behavior: QuantificationBehavior? = nil,
+    _ behavior: RegexRepetitionBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C0?, C1?), Component.RegexOutput == (W, C0, C1) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.astKind) } ?? .default
+    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.zeroOrMore, kind, component().regex.root))
   }
 }
@@ -929,9 +929,9 @@ extension OneOrMore {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, Component: RegexComponent>(
     _ component: Component,
-    _ behavior: QuantificationBehavior? = nil
+    _ behavior: RegexRepetitionBehavior? = nil
   ) where RegexOutput == (Substring, C0, C1), Component.RegexOutput == (W, C0, C1) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.astKind) } ?? .default
+    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.oneOrMore, kind, component.regex.root))
   }
 }
@@ -940,10 +940,10 @@ extension OneOrMore {
 extension OneOrMore {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, Component: RegexComponent>(
-    _ behavior: QuantificationBehavior? = nil,
+    _ behavior: RegexRepetitionBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C0, C1), Component.RegexOutput == (W, C0, C1) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.astKind) } ?? .default
+    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.oneOrMore, kind, component().regex.root))
   }
 }
@@ -975,7 +975,7 @@ extension Repeat {
     public init<W, C0, C1, Component: RegexComponent, R: RangeExpression>(
     _ component: Component,
     _ expression: R,
-    _ behavior: QuantificationBehavior? = nil
+    _ behavior: RegexRepetitionBehavior? = nil
   ) where RegexOutput == (Substring, C0?, C1?), Component.RegexOutput == (W, C0, C1), R.Bound == Int {
     self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component.regex.root))
   }
@@ -983,7 +983,7 @@ extension Repeat {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, Component: RegexComponent, R: RangeExpression>(
     _ expression: R,
-    _ behavior: QuantificationBehavior? = nil,
+    _ behavior: RegexRepetitionBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C0?, C1?), Component.RegexOutput == (W, C0, C1), R.Bound == Int {
     self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component().regex.root))
@@ -994,9 +994,9 @@ extension Optionally {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, Component: RegexComponent>(
     _ component: Component,
-    _ behavior: QuantificationBehavior? = nil
+    _ behavior: RegexRepetitionBehavior? = nil
   ) where RegexOutput == (Substring, C0?, C1?, C2?), Component.RegexOutput == (W, C0, C1, C2) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.astKind) } ?? .default
+    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.zeroOrOne, kind, component.regex.root))
   }
 }
@@ -1005,10 +1005,10 @@ extension Optionally {
 extension Optionally {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, Component: RegexComponent>(
-    _ behavior: QuantificationBehavior? = nil,
+    _ behavior: RegexRepetitionBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C0?, C1?, C2?), Component.RegexOutput == (W, C0, C1, C2) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.astKind) } ?? .default
+    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.zeroOrOne, kind, component().regex.root))
   }
 }
@@ -1027,9 +1027,9 @@ extension ZeroOrMore {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, Component: RegexComponent>(
     _ component: Component,
-    _ behavior: QuantificationBehavior? = nil
+    _ behavior: RegexRepetitionBehavior? = nil
   ) where RegexOutput == (Substring, C0?, C1?, C2?), Component.RegexOutput == (W, C0, C1, C2) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.astKind) } ?? .default
+    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.zeroOrMore, kind, component.regex.root))
   }
 }
@@ -1038,10 +1038,10 @@ extension ZeroOrMore {
 extension ZeroOrMore {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, Component: RegexComponent>(
-    _ behavior: QuantificationBehavior? = nil,
+    _ behavior: RegexRepetitionBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C0?, C1?, C2?), Component.RegexOutput == (W, C0, C1, C2) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.astKind) } ?? .default
+    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.zeroOrMore, kind, component().regex.root))
   }
 }
@@ -1052,9 +1052,9 @@ extension OneOrMore {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, Component: RegexComponent>(
     _ component: Component,
-    _ behavior: QuantificationBehavior? = nil
+    _ behavior: RegexRepetitionBehavior? = nil
   ) where RegexOutput == (Substring, C0, C1, C2), Component.RegexOutput == (W, C0, C1, C2) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.astKind) } ?? .default
+    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.oneOrMore, kind, component.regex.root))
   }
 }
@@ -1063,10 +1063,10 @@ extension OneOrMore {
 extension OneOrMore {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, Component: RegexComponent>(
-    _ behavior: QuantificationBehavior? = nil,
+    _ behavior: RegexRepetitionBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C0, C1, C2), Component.RegexOutput == (W, C0, C1, C2) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.astKind) } ?? .default
+    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.oneOrMore, kind, component().regex.root))
   }
 }
@@ -1098,7 +1098,7 @@ extension Repeat {
     public init<W, C0, C1, C2, Component: RegexComponent, R: RangeExpression>(
     _ component: Component,
     _ expression: R,
-    _ behavior: QuantificationBehavior? = nil
+    _ behavior: RegexRepetitionBehavior? = nil
   ) where RegexOutput == (Substring, C0?, C1?, C2?), Component.RegexOutput == (W, C0, C1, C2), R.Bound == Int {
     self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component.regex.root))
   }
@@ -1106,7 +1106,7 @@ extension Repeat {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, Component: RegexComponent, R: RangeExpression>(
     _ expression: R,
-    _ behavior: QuantificationBehavior? = nil,
+    _ behavior: RegexRepetitionBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C0?, C1?, C2?), Component.RegexOutput == (W, C0, C1, C2), R.Bound == Int {
     self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component().regex.root))
@@ -1117,9 +1117,9 @@ extension Optionally {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, Component: RegexComponent>(
     _ component: Component,
-    _ behavior: QuantificationBehavior? = nil
+    _ behavior: RegexRepetitionBehavior? = nil
   ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?), Component.RegexOutput == (W, C0, C1, C2, C3) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.astKind) } ?? .default
+    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.zeroOrOne, kind, component.regex.root))
   }
 }
@@ -1128,10 +1128,10 @@ extension Optionally {
 extension Optionally {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, Component: RegexComponent>(
-    _ behavior: QuantificationBehavior? = nil,
+    _ behavior: RegexRepetitionBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?), Component.RegexOutput == (W, C0, C1, C2, C3) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.astKind) } ?? .default
+    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.zeroOrOne, kind, component().regex.root))
   }
 }
@@ -1150,9 +1150,9 @@ extension ZeroOrMore {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, Component: RegexComponent>(
     _ component: Component,
-    _ behavior: QuantificationBehavior? = nil
+    _ behavior: RegexRepetitionBehavior? = nil
   ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?), Component.RegexOutput == (W, C0, C1, C2, C3) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.astKind) } ?? .default
+    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.zeroOrMore, kind, component.regex.root))
   }
 }
@@ -1161,10 +1161,10 @@ extension ZeroOrMore {
 extension ZeroOrMore {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, Component: RegexComponent>(
-    _ behavior: QuantificationBehavior? = nil,
+    _ behavior: RegexRepetitionBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?), Component.RegexOutput == (W, C0, C1, C2, C3) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.astKind) } ?? .default
+    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.zeroOrMore, kind, component().regex.root))
   }
 }
@@ -1175,9 +1175,9 @@ extension OneOrMore {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, Component: RegexComponent>(
     _ component: Component,
-    _ behavior: QuantificationBehavior? = nil
+    _ behavior: RegexRepetitionBehavior? = nil
   ) where RegexOutput == (Substring, C0, C1, C2, C3), Component.RegexOutput == (W, C0, C1, C2, C3) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.astKind) } ?? .default
+    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.oneOrMore, kind, component.regex.root))
   }
 }
@@ -1186,10 +1186,10 @@ extension OneOrMore {
 extension OneOrMore {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, Component: RegexComponent>(
-    _ behavior: QuantificationBehavior? = nil,
+    _ behavior: RegexRepetitionBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C0, C1, C2, C3), Component.RegexOutput == (W, C0, C1, C2, C3) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.astKind) } ?? .default
+    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.oneOrMore, kind, component().regex.root))
   }
 }
@@ -1221,7 +1221,7 @@ extension Repeat {
     public init<W, C0, C1, C2, C3, Component: RegexComponent, R: RangeExpression>(
     _ component: Component,
     _ expression: R,
-    _ behavior: QuantificationBehavior? = nil
+    _ behavior: RegexRepetitionBehavior? = nil
   ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?), Component.RegexOutput == (W, C0, C1, C2, C3), R.Bound == Int {
     self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component.regex.root))
   }
@@ -1229,7 +1229,7 @@ extension Repeat {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, Component: RegexComponent, R: RangeExpression>(
     _ expression: R,
-    _ behavior: QuantificationBehavior? = nil,
+    _ behavior: RegexRepetitionBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?), Component.RegexOutput == (W, C0, C1, C2, C3), R.Bound == Int {
     self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component().regex.root))
@@ -1240,9 +1240,9 @@ extension Optionally {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, Component: RegexComponent>(
     _ component: Component,
-    _ behavior: QuantificationBehavior? = nil
+    _ behavior: RegexRepetitionBehavior? = nil
   ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?), Component.RegexOutput == (W, C0, C1, C2, C3, C4) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.astKind) } ?? .default
+    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.zeroOrOne, kind, component.regex.root))
   }
 }
@@ -1251,10 +1251,10 @@ extension Optionally {
 extension Optionally {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, Component: RegexComponent>(
-    _ behavior: QuantificationBehavior? = nil,
+    _ behavior: RegexRepetitionBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?), Component.RegexOutput == (W, C0, C1, C2, C3, C4) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.astKind) } ?? .default
+    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.zeroOrOne, kind, component().regex.root))
   }
 }
@@ -1273,9 +1273,9 @@ extension ZeroOrMore {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, Component: RegexComponent>(
     _ component: Component,
-    _ behavior: QuantificationBehavior? = nil
+    _ behavior: RegexRepetitionBehavior? = nil
   ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?), Component.RegexOutput == (W, C0, C1, C2, C3, C4) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.astKind) } ?? .default
+    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.zeroOrMore, kind, component.regex.root))
   }
 }
@@ -1284,10 +1284,10 @@ extension ZeroOrMore {
 extension ZeroOrMore {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, Component: RegexComponent>(
-    _ behavior: QuantificationBehavior? = nil,
+    _ behavior: RegexRepetitionBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?), Component.RegexOutput == (W, C0, C1, C2, C3, C4) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.astKind) } ?? .default
+    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.zeroOrMore, kind, component().regex.root))
   }
 }
@@ -1298,9 +1298,9 @@ extension OneOrMore {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, Component: RegexComponent>(
     _ component: Component,
-    _ behavior: QuantificationBehavior? = nil
+    _ behavior: RegexRepetitionBehavior? = nil
   ) where RegexOutput == (Substring, C0, C1, C2, C3, C4), Component.RegexOutput == (W, C0, C1, C2, C3, C4) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.astKind) } ?? .default
+    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.oneOrMore, kind, component.regex.root))
   }
 }
@@ -1309,10 +1309,10 @@ extension OneOrMore {
 extension OneOrMore {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, Component: RegexComponent>(
-    _ behavior: QuantificationBehavior? = nil,
+    _ behavior: RegexRepetitionBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C0, C1, C2, C3, C4), Component.RegexOutput == (W, C0, C1, C2, C3, C4) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.astKind) } ?? .default
+    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.oneOrMore, kind, component().regex.root))
   }
 }
@@ -1344,7 +1344,7 @@ extension Repeat {
     public init<W, C0, C1, C2, C3, C4, Component: RegexComponent, R: RangeExpression>(
     _ component: Component,
     _ expression: R,
-    _ behavior: QuantificationBehavior? = nil
+    _ behavior: RegexRepetitionBehavior? = nil
   ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?), Component.RegexOutput == (W, C0, C1, C2, C3, C4), R.Bound == Int {
     self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component.regex.root))
   }
@@ -1352,7 +1352,7 @@ extension Repeat {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, Component: RegexComponent, R: RangeExpression>(
     _ expression: R,
-    _ behavior: QuantificationBehavior? = nil,
+    _ behavior: RegexRepetitionBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?), Component.RegexOutput == (W, C0, C1, C2, C3, C4), R.Bound == Int {
     self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component().regex.root))
@@ -1363,9 +1363,9 @@ extension Optionally {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, Component: RegexComponent>(
     _ component: Component,
-    _ behavior: QuantificationBehavior? = nil
+    _ behavior: RegexRepetitionBehavior? = nil
   ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?, C5?), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.astKind) } ?? .default
+    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.zeroOrOne, kind, component.regex.root))
   }
 }
@@ -1374,10 +1374,10 @@ extension Optionally {
 extension Optionally {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, Component: RegexComponent>(
-    _ behavior: QuantificationBehavior? = nil,
+    _ behavior: RegexRepetitionBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?, C5?), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.astKind) } ?? .default
+    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.zeroOrOne, kind, component().regex.root))
   }
 }
@@ -1396,9 +1396,9 @@ extension ZeroOrMore {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, Component: RegexComponent>(
     _ component: Component,
-    _ behavior: QuantificationBehavior? = nil
+    _ behavior: RegexRepetitionBehavior? = nil
   ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?, C5?), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.astKind) } ?? .default
+    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.zeroOrMore, kind, component.regex.root))
   }
 }
@@ -1407,10 +1407,10 @@ extension ZeroOrMore {
 extension ZeroOrMore {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, Component: RegexComponent>(
-    _ behavior: QuantificationBehavior? = nil,
+    _ behavior: RegexRepetitionBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?, C5?), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.astKind) } ?? .default
+    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.zeroOrMore, kind, component().regex.root))
   }
 }
@@ -1421,9 +1421,9 @@ extension OneOrMore {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, Component: RegexComponent>(
     _ component: Component,
-    _ behavior: QuantificationBehavior? = nil
+    _ behavior: RegexRepetitionBehavior? = nil
   ) where RegexOutput == (Substring, C0, C1, C2, C3, C4, C5), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.astKind) } ?? .default
+    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.oneOrMore, kind, component.regex.root))
   }
 }
@@ -1432,10 +1432,10 @@ extension OneOrMore {
 extension OneOrMore {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, Component: RegexComponent>(
-    _ behavior: QuantificationBehavior? = nil,
+    _ behavior: RegexRepetitionBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C0, C1, C2, C3, C4, C5), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.astKind) } ?? .default
+    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.oneOrMore, kind, component().regex.root))
   }
 }
@@ -1467,7 +1467,7 @@ extension Repeat {
     public init<W, C0, C1, C2, C3, C4, C5, Component: RegexComponent, R: RangeExpression>(
     _ component: Component,
     _ expression: R,
-    _ behavior: QuantificationBehavior? = nil
+    _ behavior: RegexRepetitionBehavior? = nil
   ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?, C5?), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5), R.Bound == Int {
     self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component.regex.root))
   }
@@ -1475,7 +1475,7 @@ extension Repeat {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, Component: RegexComponent, R: RangeExpression>(
     _ expression: R,
-    _ behavior: QuantificationBehavior? = nil,
+    _ behavior: RegexRepetitionBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?, C5?), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5), R.Bound == Int {
     self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component().regex.root))
@@ -1486,9 +1486,9 @@ extension Optionally {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexComponent>(
     _ component: Component,
-    _ behavior: QuantificationBehavior? = nil
+    _ behavior: RegexRepetitionBehavior? = nil
   ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.astKind) } ?? .default
+    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.zeroOrOne, kind, component.regex.root))
   }
 }
@@ -1497,10 +1497,10 @@ extension Optionally {
 extension Optionally {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexComponent>(
-    _ behavior: QuantificationBehavior? = nil,
+    _ behavior: RegexRepetitionBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.astKind) } ?? .default
+    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.zeroOrOne, kind, component().regex.root))
   }
 }
@@ -1519,9 +1519,9 @@ extension ZeroOrMore {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexComponent>(
     _ component: Component,
-    _ behavior: QuantificationBehavior? = nil
+    _ behavior: RegexRepetitionBehavior? = nil
   ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.astKind) } ?? .default
+    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.zeroOrMore, kind, component.regex.root))
   }
 }
@@ -1530,10 +1530,10 @@ extension ZeroOrMore {
 extension ZeroOrMore {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexComponent>(
-    _ behavior: QuantificationBehavior? = nil,
+    _ behavior: RegexRepetitionBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.astKind) } ?? .default
+    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.zeroOrMore, kind, component().regex.root))
   }
 }
@@ -1544,9 +1544,9 @@ extension OneOrMore {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexComponent>(
     _ component: Component,
-    _ behavior: QuantificationBehavior? = nil
+    _ behavior: RegexRepetitionBehavior? = nil
   ) where RegexOutput == (Substring, C0, C1, C2, C3, C4, C5, C6), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.astKind) } ?? .default
+    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.oneOrMore, kind, component.regex.root))
   }
 }
@@ -1555,10 +1555,10 @@ extension OneOrMore {
 extension OneOrMore {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexComponent>(
-    _ behavior: QuantificationBehavior? = nil,
+    _ behavior: RegexRepetitionBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C0, C1, C2, C3, C4, C5, C6), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.astKind) } ?? .default
+    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.oneOrMore, kind, component().regex.root))
   }
 }
@@ -1590,7 +1590,7 @@ extension Repeat {
     public init<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexComponent, R: RangeExpression>(
     _ component: Component,
     _ expression: R,
-    _ behavior: QuantificationBehavior? = nil
+    _ behavior: RegexRepetitionBehavior? = nil
   ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6), R.Bound == Int {
     self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component.regex.root))
   }
@@ -1598,7 +1598,7 @@ extension Repeat {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, C6, Component: RegexComponent, R: RangeExpression>(
     _ expression: R,
-    _ behavior: QuantificationBehavior? = nil,
+    _ behavior: RegexRepetitionBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6), R.Bound == Int {
     self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component().regex.root))
@@ -1609,9 +1609,9 @@ extension Optionally {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexComponent>(
     _ component: Component,
-    _ behavior: QuantificationBehavior? = nil
+    _ behavior: RegexRepetitionBehavior? = nil
   ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.astKind) } ?? .default
+    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.zeroOrOne, kind, component.regex.root))
   }
 }
@@ -1620,10 +1620,10 @@ extension Optionally {
 extension Optionally {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexComponent>(
-    _ behavior: QuantificationBehavior? = nil,
+    _ behavior: RegexRepetitionBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.astKind) } ?? .default
+    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.zeroOrOne, kind, component().regex.root))
   }
 }
@@ -1642,9 +1642,9 @@ extension ZeroOrMore {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexComponent>(
     _ component: Component,
-    _ behavior: QuantificationBehavior? = nil
+    _ behavior: RegexRepetitionBehavior? = nil
   ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.astKind) } ?? .default
+    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.zeroOrMore, kind, component.regex.root))
   }
 }
@@ -1653,10 +1653,10 @@ extension ZeroOrMore {
 extension ZeroOrMore {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexComponent>(
-    _ behavior: QuantificationBehavior? = nil,
+    _ behavior: RegexRepetitionBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.astKind) } ?? .default
+    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.zeroOrMore, kind, component().regex.root))
   }
 }
@@ -1667,9 +1667,9 @@ extension OneOrMore {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexComponent>(
     _ component: Component,
-    _ behavior: QuantificationBehavior? = nil
+    _ behavior: RegexRepetitionBehavior? = nil
   ) where RegexOutput == (Substring, C0, C1, C2, C3, C4, C5, C6, C7), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.astKind) } ?? .default
+    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.oneOrMore, kind, component.regex.root))
   }
 }
@@ -1678,10 +1678,10 @@ extension OneOrMore {
 extension OneOrMore {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexComponent>(
-    _ behavior: QuantificationBehavior? = nil,
+    _ behavior: RegexRepetitionBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C0, C1, C2, C3, C4, C5, C6, C7), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.astKind) } ?? .default
+    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.oneOrMore, kind, component().regex.root))
   }
 }
@@ -1713,7 +1713,7 @@ extension Repeat {
     public init<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexComponent, R: RangeExpression>(
     _ component: Component,
     _ expression: R,
-    _ behavior: QuantificationBehavior? = nil
+    _ behavior: RegexRepetitionBehavior? = nil
   ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7), R.Bound == Int {
     self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component.regex.root))
   }
@@ -1721,7 +1721,7 @@ extension Repeat {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, C6, C7, Component: RegexComponent, R: RangeExpression>(
     _ expression: R,
-    _ behavior: QuantificationBehavior? = nil,
+    _ behavior: RegexRepetitionBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7), R.Bound == Int {
     self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component().regex.root))
@@ -1732,9 +1732,9 @@ extension Optionally {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexComponent>(
     _ component: Component,
-    _ behavior: QuantificationBehavior? = nil
+    _ behavior: RegexRepetitionBehavior? = nil
   ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.astKind) } ?? .default
+    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.zeroOrOne, kind, component.regex.root))
   }
 }
@@ -1743,10 +1743,10 @@ extension Optionally {
 extension Optionally {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexComponent>(
-    _ behavior: QuantificationBehavior? = nil,
+    _ behavior: RegexRepetitionBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.astKind) } ?? .default
+    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.zeroOrOne, kind, component().regex.root))
   }
 }
@@ -1765,9 +1765,9 @@ extension ZeroOrMore {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexComponent>(
     _ component: Component,
-    _ behavior: QuantificationBehavior? = nil
+    _ behavior: RegexRepetitionBehavior? = nil
   ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.astKind) } ?? .default
+    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.zeroOrMore, kind, component.regex.root))
   }
 }
@@ -1776,10 +1776,10 @@ extension ZeroOrMore {
 extension ZeroOrMore {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexComponent>(
-    _ behavior: QuantificationBehavior? = nil,
+    _ behavior: RegexRepetitionBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.astKind) } ?? .default
+    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.zeroOrMore, kind, component().regex.root))
   }
 }
@@ -1790,9 +1790,9 @@ extension OneOrMore {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexComponent>(
     _ component: Component,
-    _ behavior: QuantificationBehavior? = nil
+    _ behavior: RegexRepetitionBehavior? = nil
   ) where RegexOutput == (Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.astKind) } ?? .default
+    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.oneOrMore, kind, component.regex.root))
   }
 }
@@ -1801,10 +1801,10 @@ extension OneOrMore {
 extension OneOrMore {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexComponent>(
-    _ behavior: QuantificationBehavior? = nil,
+    _ behavior: RegexRepetitionBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.astKind) } ?? .default
+    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.oneOrMore, kind, component().regex.root))
   }
 }
@@ -1836,7 +1836,7 @@ extension Repeat {
     public init<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexComponent, R: RangeExpression>(
     _ component: Component,
     _ expression: R,
-    _ behavior: QuantificationBehavior? = nil
+    _ behavior: RegexRepetitionBehavior? = nil
   ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8), R.Bound == Int {
     self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component.regex.root))
   }
@@ -1844,7 +1844,7 @@ extension Repeat {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexComponent, R: RangeExpression>(
     _ expression: R,
-    _ behavior: QuantificationBehavior? = nil,
+    _ behavior: RegexRepetitionBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8), R.Bound == Int {
     self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component().regex.root))
@@ -1855,9 +1855,9 @@ extension Optionally {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9, Component: RegexComponent>(
     _ component: Component,
-    _ behavior: QuantificationBehavior? = nil
+    _ behavior: RegexRepetitionBehavior? = nil
   ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.astKind) } ?? .default
+    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.zeroOrOne, kind, component.regex.root))
   }
 }
@@ -1866,10 +1866,10 @@ extension Optionally {
 extension Optionally {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9, Component: RegexComponent>(
-    _ behavior: QuantificationBehavior? = nil,
+    _ behavior: RegexRepetitionBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.astKind) } ?? .default
+    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.zeroOrOne, kind, component().regex.root))
   }
 }
@@ -1888,9 +1888,9 @@ extension ZeroOrMore {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9, Component: RegexComponent>(
     _ component: Component,
-    _ behavior: QuantificationBehavior? = nil
+    _ behavior: RegexRepetitionBehavior? = nil
   ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.astKind) } ?? .default
+    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.zeroOrMore, kind, component.regex.root))
   }
 }
@@ -1899,10 +1899,10 @@ extension ZeroOrMore {
 extension ZeroOrMore {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9, Component: RegexComponent>(
-    _ behavior: QuantificationBehavior? = nil,
+    _ behavior: RegexRepetitionBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.astKind) } ?? .default
+    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.zeroOrMore, kind, component().regex.root))
   }
 }
@@ -1913,9 +1913,9 @@ extension OneOrMore {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9, Component: RegexComponent>(
     _ component: Component,
-    _ behavior: QuantificationBehavior? = nil
+    _ behavior: RegexRepetitionBehavior? = nil
   ) where RegexOutput == (Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.astKind) } ?? .default
+    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.oneOrMore, kind, component.regex.root))
   }
 }
@@ -1924,10 +1924,10 @@ extension OneOrMore {
 extension OneOrMore {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9, Component: RegexComponent>(
-    _ behavior: QuantificationBehavior? = nil,
+    _ behavior: RegexRepetitionBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.astKind) } ?? .default
+    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
     self.init(node: .quantification(.oneOrMore, kind, component().regex.root))
   }
 }
@@ -1959,7 +1959,7 @@ extension Repeat {
     public init<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9, Component: RegexComponent, R: RangeExpression>(
     _ component: Component,
     _ expression: R,
-    _ behavior: QuantificationBehavior? = nil
+    _ behavior: RegexRepetitionBehavior? = nil
   ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9), R.Bound == Int {
     self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component.regex.root))
   }
@@ -1967,7 +1967,7 @@ extension Repeat {
   @available(SwiftStdlib 5.7, *)
     public init<W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9, Component: RegexComponent, R: RangeExpression>(
     _ expression: R,
-    _ behavior: QuantificationBehavior? = nil,
+    _ behavior: RegexRepetitionBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?), Component.RegexOutput == (W, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9), R.Bound == Int {
     self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component().regex.root))

--- a/Sources/VariadicsGenerator/VariadicsGenerator.swift
+++ b/Sources/VariadicsGenerator/VariadicsGenerator.swift
@@ -378,9 +378,9 @@ struct VariadicsGenerator: ParsableCommand {
         \(params.disfavored)\
         public init<\(params.genericParams)>(
           _ component: Component,
-          _ behavior: QuantificationBehavior? = nil
+          _ behavior: RegexRepetitionBehavior? = nil
         ) \(params.whereClauseForInit) {
-          let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.astKind) } ?? .default
+          let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
           self.init(node: .quantification(.\(kind.astQuantifierAmount), kind, component.regex.root))
         }
       }
@@ -390,10 +390,10 @@ struct VariadicsGenerator: ParsableCommand {
         \(defaultAvailableAttr)
         \(params.disfavored)\
         public init<\(params.genericParams)>(
-          _ behavior: QuantificationBehavior? = nil,
+          _ behavior: RegexRepetitionBehavior? = nil,
           @\(concatBuilderName) _ component: () -> Component
         ) \(params.whereClauseForInit) {
-          let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.astKind) } ?? .default
+          let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
           self.init(node: .quantification(.\(kind.astQuantifierAmount), kind, component().regex.root))
         }
       }
@@ -509,7 +509,7 @@ struct VariadicsGenerator: ParsableCommand {
         public init<\(params.genericParams), R: RangeExpression>(
           _ component: Component,
           _ expression: R,
-          _ behavior: QuantificationBehavior? = nil
+          _ behavior: RegexRepetitionBehavior? = nil
         ) \(params.repeatingWhereClause) {
           self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component.regex.root))
         }

--- a/Sources/_RegexParser/Regex/AST/MatchingOptions.swift
+++ b/Sources/_RegexParser/Regex/AST/MatchingOptions.swift
@@ -41,7 +41,11 @@ extension AST {
       case graphemeClusterSemantics // X
       case unicodeScalarSemantics   // u
       case byteSemantics            // b
+      
+      // Swift-only default possessive quantifier
+      case possessiveByDefault      // t.b.d.
     }
+    
     public var kind: Kind
     public var location: SourceLocation
 

--- a/Sources/_StringProcessing/ByteCodeGen.swift
+++ b/Sources/_StringProcessing/ByteCodeGen.swift
@@ -371,9 +371,7 @@ extension Compiler.ByteCodeGen {
     case .syntax(let kind):
       updatedKind = kind.applying(options)
     case .default:
-      updatedKind = options.isReluctantByDefault
-        ? .reluctant
-        : .eager
+      updatedKind = options.defaultQuantificationKind
     }
 
     let (low, high) = amount.bounds

--- a/Sources/_StringProcessing/Regex/Options.swift
+++ b/Sources/_StringProcessing/Regex/Options.swift
@@ -58,8 +58,8 @@ extension RegexComponent {
   /// Returns a regular expression where the start and end of input
   /// anchors (`^` and `$`) also match against the start and end of a line.
   ///
-  /// This method corresponds to applying the `m` option in a regular
-  /// expression literal. For this behavior in the `RegexBuilder` syntax, see
+  /// This method corresponds to applying the `m` option in regex syntax. For
+  /// this behavior in the `RegexBuilder` syntax, see
   /// ``Anchor.startOfLine``, ``Anchor.endOfLine``, ``Anchor.startOfInput``,
   /// and ``Anchor.endOfInput``.
   ///
@@ -69,16 +69,22 @@ extension RegexComponent {
     wrapInOption(.multiline, addingIf: matchLineEndings)
   }
   
-  /// Returns a regular expression where quantifiers are reluctant by default
-  /// instead of eager.
+  /// Returns a regular expression where quantifiers use the specified behavior
+  /// by default.
   ///
-  /// This method corresponds to applying the `U` option in a regular
-  /// expression literal.
+  /// This setting does not affect calls to quantifier methods, such as
+  /// `OneOrMore`, that include an explicit `behavior` parameter.
   ///
-  /// - Parameter useReluctantQuantifiers: A Boolean value indicating whether
-  ///   quantifiers should be reluctant by default.
-  public func reluctantQuantifiers(_ useReluctantQuantifiers: Bool = true) -> Regex<RegexOutput> {
-    wrapInOption(.reluctantByDefault, addingIf: useReluctantQuantifiers)
+  /// Passing `.eager` or `.reluctant` to this method corresponds to applying
+  /// the `(?-U)` or `(?U)` option in regex syntax, respectively.
+  ///
+  /// - Parameter behavior: The default behavior to use for quantifiers.
+  public func repetitionBehavior(_ behavior: RegexRepetitionBehavior) -> Regex<RegexOutput> {
+    if behavior == .possessive {
+      return wrapInOption(.possessiveByDefault, addingIf: true)
+    } else {
+      return wrapInOption(.reluctantByDefault, addingIf: behavior == .reluctant)
+    }
   }
 
   /// Returns a regular expression that matches with the specified semantic
@@ -180,6 +186,46 @@ public struct RegexWordBoundaryKind: Hashable {
   /// punctuation, changes in script, and Emoji.
   public static var unicodeLevel2: Self {
     .init(base: .unicodeLevel2)
+  }
+}
+
+/// Specifies how much to attempt to match when using a quantifier.
+@available(SwiftStdlib 5.7, *)
+public struct RegexRepetitionBehavior: Hashable {
+  internal enum Kind {
+    case eager
+    case reluctant
+    case possessive
+  }
+
+  var kind: Kind
+
+  @_spi(RegexBuilder) public var dslTreeKind: DSLTree._AST.QuantificationKind {
+    switch kind {
+    case .eager: return .eager
+    case .reluctant: return .reluctant
+    case .possessive: return .possessive
+    }
+  }
+}
+
+@available(SwiftStdlib 5.7, *)
+extension RegexRepetitionBehavior {
+  /// Match as much of the input string as possible, backtracking when
+  /// necessary.
+  public static var eager: Self {
+    .init(kind: .eager)
+  }
+
+  /// Match as little of the input string as possible, expanding the matched
+  /// region as necessary to complete a match.
+  public static var reluctant: Self {
+    .init(kind: .reluctant)
+  }
+
+  /// Match as much of the input string as possible, performing no backtracking.
+  public static var possessive: Self {
+    .init(kind: .possessive)
   }
 }
 

--- a/Sources/_StringProcessing/Regex/Options.swift
+++ b/Sources/_StringProcessing/Regex/Options.swift
@@ -200,7 +200,7 @@ public struct RegexRepetitionBehavior: Hashable {
 
   var kind: Kind
 
-  @_spi(RegexBuilder) public var dslTreeKind: DSLTree._AST.QuantificationKind {
+  @_spi(RegexBuilder) public var dslTreeKind: AST.Quantification.Kind {
     switch kind {
     case .eager: return .eager
     case .reluctant: return .reluctant

--- a/Sources/_StringProcessing/_CharacterClassModel.swift
+++ b/Sources/_StringProcessing/_CharacterClassModel.swift
@@ -33,6 +33,8 @@ public struct _CharacterClassModel: Hashable {
     case any
     /// Any grapheme cluster
     case anyGrapheme
+    /// Any Unicode scalar
+    case anyScalar
     /// Character.isDigit
     case digit
     /// Character.isHexDigit
@@ -155,8 +157,12 @@ public struct _CharacterClassModel: Hashable {
     case .graphemeCluster:
       let c = str[i]
       var matched: Bool
+      var next = str.index(after: i)
       switch cc {
       case .any, .anyGrapheme: matched = true
+      case .anyScalar:
+        matched = true
+        next = str.unicodeScalars.index(after: i)
       case .digit:
         matched = c.isNumber && (c.isASCII || !options.usesASCIIDigits)
       case .hexDigit:
@@ -174,12 +180,13 @@ public struct _CharacterClassModel: Hashable {
       if isInverted {
         matched.toggle()
       }
-      return matched ? str.index(after: i) : nil
+      return matched ? next : nil
     case .unicodeScalar:
       let c = str.unicodeScalars[i]
       var matched: Bool
       switch cc {
       case .any: matched = true
+      case .anyScalar: matched = true
       case .anyGrapheme: fatalError("Not matched in this mode")
       case .digit:
         matched = c.properties.numericType != nil && (c.isASCII || !options.usesASCIIDigits)
@@ -222,6 +229,10 @@ extension _CharacterClassModel {
 
   public static var anyGrapheme: _CharacterClassModel {
     .init(cc: .anyGrapheme, matchLevel: .graphemeCluster)
+  }
+
+  public static var anyUnicodeScalar: _CharacterClassModel {
+    .init(cc: .any, matchLevel: .unicodeScalar)
   }
 
   public static var whitespace: _CharacterClassModel {
@@ -275,6 +286,7 @@ extension _CharacterClassModel.Representation: CustomStringConvertible {
     switch self {
     case .any: return "<any>"
     case .anyGrapheme: return "<any grapheme>"
+    case .anyScalar: return "<any scalar>"
     case .digit: return "<digit>"
     case .hexDigit: return "<hex digit>"
     case .horizontalWhitespace: return "<horizontal whitespace>"
@@ -431,6 +443,7 @@ extension AST.Atom.EscapedBuiltin {
     case .notWordCharacter: return .word.inverted
 
     case .graphemeCluster: return .anyGrapheme
+    case .trueAnychar: return .anyUnicodeScalar
 
     default:
       return nil

--- a/Tests/RegexTests/MatchTests.swift
+++ b/Tests/RegexTests/MatchTests.swift
@@ -1483,13 +1483,11 @@ extension RegexTests {
       (eDecomposed, false))
     
     // FIXME: \O is unsupported
-    firstMatchTest(#"\O\u{301}"#, input: eDecomposed, match: eDecomposed,
-              xfail: true)
-    firstMatchTest(#"e\O"#, input: eDecomposed, match: eDecomposed,
-              xfail: true)
-    firstMatchTest(#"\O\u{301}"#, input: eComposed, match: nil,
-              xfail: true)
-    firstMatchTest(#"e\O"#, input: eComposed, match: nil,
+    firstMatchTest(#"(?u)\O\u{301}"#, input: eDecomposed, match: eDecomposed)
+    firstMatchTest(#"(?u)e\O"#, input: eDecomposed, match: eDecomposed,
+      xfail: true)
+    firstMatchTest(#"\O"#, input: eComposed, match: eComposed)
+    firstMatchTest(#"\O"#, input: eDecomposed, match: nil,
               xfail: true)
 
     matchTest(


### PR DESCRIPTION
This updates two API points to align with the Unicode for String Processing proposal:

- Adds a `anyUnicodeScalar` static property to `RegexBuilder.CharacterClass` — this functionality is already available via regex syntax as `\O`.
- Changes `reluctantQuantifiers()` to a `repetitionBehavior(_:)` method that takes the preferred behavior for the modified regex. This includes a move of the `QuantificationBehavior` type from the `RegexBuilder` module to the `_StringProcessing` module, and a rename to `RegexRepetitionBehavior`.