### PR TITLE
Preparation for location aware diagnostics in the compiler

### DIFF
--- a/Sources/_RegexParser/Regex/Parse/DelimiterLexing.swift
+++ b/Sources/_RegexParser/Regex/Parse/DelimiterLexing.swift
@@ -9,7 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-struct Delimiter: Hashable {
+public struct Delimiter: Hashable {
   let kind: Kind
   let poundCount: Int
 
@@ -74,8 +74,8 @@ extension Delimiter {
   }
 }
 
-struct DelimiterLexError: Error, CustomStringConvertible {
-  enum Kind: Hashable {
+public struct DelimiterLexError: Error, CustomStringConvertible {
+  public enum Kind: Hashable {
     case unterminated
     case invalidUTF8 // TODO: better range reporting
     case unknownDelimiter
@@ -83,17 +83,17 @@ struct DelimiterLexError: Error, CustomStringConvertible {
     case multilineClosingNotOnNewline
   }
 
-  var kind: Kind
+  public var kind: Kind
 
   /// The pointer at which to resume lexing.
-  var resumePtr: UnsafeRawPointer
+  public var resumePtr: UnsafeRawPointer
 
   init(_ kind: Kind, resumeAt resumePtr: UnsafeRawPointer) {
     self.kind = kind
     self.resumePtr = resumePtr
   }
 
-  var description: String {
+  public var description: String {
     switch kind {
     case .unterminated: return "unterminated regex literal"
     case .invalidUTF8: return "invalid UTF-8 found in source file"
@@ -461,4 +461,10 @@ func lexRegex(
 ) throws -> (contents: String, Delimiter, end: UnsafeRawPointer) {
   var lexer = DelimiterLexer(start: start, end: end, delimiters: delimiters)
   return try lexer.lex()
+}
+
+public func lexRegex(
+  start: UnsafeRawPointer, end: UnsafeRawPointer
+) throws -> (contents: String, Delimiter, end: UnsafeRawPointer)  {
+  return try lexRegex(start: start, end: end, delimiters: Delimiter.enabledDelimiters)
 }

--- a/Sources/_RegexParser/Regex/Parse/LexicalAnalysis.swift
+++ b/Sources/_RegexParser/Regex/Parse/LexicalAnalysis.swift
@@ -24,7 +24,7 @@ API convention:
 extension Error {
   func addingLocation(_ loc: Range<Source.Position>) -> Error {
     // If we're already a LocatedError, don't change the location.
-    if self is _LocatedErrorProtocol {
+    if self is LocatedErrorProtocol {
       return self
     }
     return Source.LocatedError<Self>(self, loc)

--- a/Sources/_RegexParser/Regex/Parse/Mocking.swift
+++ b/Sources/_RegexParser/Regex/Parse/Mocking.swift
@@ -9,6 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+@available(*, deprecated, message: "moving to SwiftCompilerModules")
 private func copyCString(_ str: String) -> UnsafePointer<CChar> {
   let count = str.utf8.count + 1
   return str.withCString {
@@ -36,6 +37,7 @@ private func copyCString(_ str: String) -> UnsafePointer<CChar> {
 /// - Returns: A bool indicating whether lexing was completely erroneous, and
 ///            cannot be recovered from, or false if there either was no error,
 ///            or there was a recoverable error.
+@available(*, deprecated, message: "moving to SwiftCompilerModules")
 func libswiftLexRegexLiteral(
   _ curPtrPtr: UnsafeMutablePointer<UnsafePointer<CChar>?>?,
   _ bufferEndPtr: UnsafePointer<CChar>?,
@@ -93,6 +95,7 @@ public let currentRegexLiteralFormatVersion: CUnsignedInt = 1
 ///     capture structure.
 ///   - captureStructureSize: The size of the capture structure buffer. Must be
 ///     greater than or equal to `strlen(inputPtr)`.
+@available(*, deprecated, message: "moving to SwiftCompilerModules")
 func libswiftParseRegexLiteral(
   _ inputPtr: UnsafePointer<CChar>?,
   _ errOut: UnsafeMutablePointer<UnsafePointer<CChar>?>?,

--- a/Sources/_RegexParser/Regex/Parse/SourceLocation.swift
+++ b/Sources/_RegexParser/Regex/Parse/SourceLocation.swift
@@ -56,11 +56,14 @@ extension Source {
   var currentPosition: Position { bounds.lowerBound }
 }
 
-protocol _LocatedErrorProtocol: Error {}
+public protocol LocatedErrorProtocol: Error {
+  var location: SourceLocation { get }
+  var _typeErasedError: Error { get }
+}
 
 extension Source {
   /// An error with source location info
-  public struct LocatedError<E: Error>: Error, _LocatedErrorProtocol {
+  public struct LocatedError<E: Error>: Error, LocatedErrorProtocol {
     public let error: E
     public let location: SourceLocation
 
@@ -117,5 +120,9 @@ extension Source.LocatedError: CustomStringConvertible {
     // Just return the underlying error's description, which is currently how
     // we present the message to the compiler.
     "\(error)"
+  }
+
+  public var _typeErasedError: Error {
+    return error
   }
 }


### PR DESCRIPTION
Changes for https://github.com/apple/swift/pull/42583

Moving `libswiftLexRegexLiteral()` and `libswiftParseRegexLiteral()` to the compiler repository because these functions are basically just bridging the compiler to the actual lexing/parsing function.

 * Make some Lexing error APIs public.
 * Make LocatedErrorProtocol public and expose the `location` property
 * Shift the location of `LocatedError` in `parseWithDelimiters` so the client can get the valid string indices of the passed-in literal string.