### PR TITLE
Generic `~=` operator

### DIFF
--- a/Sources/_StringProcessing/Regex/Core.swift
+++ b/Sources/_StringProcessing/Regex/Core.swift
@@ -63,6 +63,13 @@ public struct Regex<Output>: RegexComponent {
 
 @available(SwiftStdlib 5.7, *)
 extension Regex {
+  public init(quoting string: String) {
+    self.init(node: .quotedLiteral(string))
+  }
+}
+
+@available(SwiftStdlib 5.7, *)
+extension Regex {
   /// A program representation that caches any lowered representation for
   /// execution.
   internal class Program {

--- a/Sources/_StringProcessing/Regex/Match.swift
+++ b/Sources/_StringProcessing/Regex/Match.swift
@@ -180,20 +180,12 @@ extension BidirectionalCollection where SubSequence == Substring {
 }
 
 @available(SwiftStdlib 5.7, *)
-extension Regex {
-  public init(quoting string: String) {
-    self.init(node: .quotedLiteral(string))
+extension RegexComponent {
+  public static func ~=(regex: Self, input: String) -> Bool {
+    input.wholeMatch(of: regex) != nil
   }
-}
 
-@available(SwiftStdlib 5.7, *)
-public func ~=<Output>(regex: Regex<Output>, input: String) -> Bool {
-  guard let _ = try? regex.wholeMatch(in: input) else { return false }
-  return true
-}
-
-@available(SwiftStdlib 5.7, *)
-public func ~=<Output>(regex: Regex<Output>, input: Substring) -> Bool {
-  guard let _ = try? regex.wholeMatch(in: input) else { return false }
-  return true
+  public static func ~=(regex: Self, input: Substring) -> Bool {
+    input.wholeMatch(of: regex) != nil
+  }
 }

--- a/Tests/RegexBuilderTests/AlgorithmsTests.swift
+++ b/Tests/RegexBuilderTests/AlgorithmsTests.swift
@@ -104,4 +104,61 @@ class RegexConsumerTests: XCTestCase {
        result: "9+16, 3, 10, 99+1")
     )
   }
+
+  func testSwitches() {
+    // Failure cases
+    do {
+      switch "abcde" {
+      case Regex {
+        "a"
+        ZeroOrMore(.any)
+        "f"
+      }:
+        XCTFail()
+
+      case "abc":
+        XCTFail()
+
+      case Regex {
+        "a"
+        "b"
+        "c"
+      }:
+        XCTFail()
+
+      default:
+        break
+      }
+    }
+    // Success cases
+    do {
+      let input = "abcde"
+
+      switch input {
+      case Regex {
+        "a"
+        ZeroOrMore(.any)
+        "e"
+      }:
+        break
+
+      default:
+        XCTFail()
+      }
+
+      guard case Regex({
+        "a"
+        ZeroOrMore(.any)
+        "e"
+      }) = input else {
+        XCTFail()
+        return
+      }
+
+      guard case OneOrMore(.word) = input else {
+        XCTFail()
+        return
+      }
+    }
+  }
 }


### PR DESCRIPTION
Make `~=` generic over `RegexComponent` so that one can use builder components, e.g. `OneOrMore(...)`, or custom-consuming regex components as patterns.