### PR TITLE
Add `compactingCaptureN` methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 .DS_Store
 
+# The current toolchain is dumping files in the package root, rude
+*.emit-module.*
+
 # Xcode
 #
 # gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore

--- a/Sources/RegexBuilder/Variadics.swift
+++ b/Sources/RegexBuilder/Variadics.swift
@@ -4172,6 +4172,421 @@ extension TryCapture {
   }
 }
 
+@available(SwiftStdlib 5.7, *)
+extension RegexComponent {
+  public func compactingCapture1<C1>()
+    -> Regex<(Substring, C1?)>
+    where RegexOutput == (Substring, C1??)
+  {
+    Regex(castingCaptures: self.regex, to: (Substring, C1?).self)
+  }
+}
+
+@available(SwiftStdlib 5.7, *)
+extension RegexComponent {
+  public func compactingCapture1<C1, C2>()
+    -> Regex<(Substring, C1?, C2)>
+    where RegexOutput == (Substring, C1??, C2)
+  {
+    Regex(castingCaptures: self.regex, to: (Substring, C1?, C2).self)
+  }
+
+  public func compactingCapture2<C1, C2>()
+    -> Regex<(Substring, C1, C2?)>
+    where RegexOutput == (Substring, C1, C2??)
+  {
+    Regex(castingCaptures: self.regex, to: (Substring, C1, C2?).self)
+  }
+}
+
+@available(SwiftStdlib 5.7, *)
+extension RegexComponent {
+  public func compactingCapture1<C1, C2, C3>()
+    -> Regex<(Substring, C1?, C2, C3)>
+    where RegexOutput == (Substring, C1??, C2, C3)
+  {
+    Regex(castingCaptures: self.regex, to: (Substring, C1?, C2, C3).self)
+  }
+
+  public func compactingCapture2<C1, C2, C3>()
+    -> Regex<(Substring, C1, C2?, C3)>
+    where RegexOutput == (Substring, C1, C2??, C3)
+  {
+    Regex(castingCaptures: self.regex, to: (Substring, C1, C2?, C3).self)
+  }
+
+  public func compactingCapture3<C1, C2, C3>()
+    -> Regex<(Substring, C1, C2, C3?)>
+    where RegexOutput == (Substring, C1, C2, C3??)
+  {
+    Regex(castingCaptures: self.regex, to: (Substring, C1, C2, C3?).self)
+  }
+}
+
+@available(SwiftStdlib 5.7, *)
+extension RegexComponent {
+  public func compactingCapture1<C1, C2, C3, C4>()
+    -> Regex<(Substring, C1?, C2, C3, C4)>
+    where RegexOutput == (Substring, C1??, C2, C3, C4)
+  {
+    Regex(castingCaptures: self.regex, to: (Substring, C1?, C2, C3, C4).self)
+  }
+
+  public func compactingCapture2<C1, C2, C3, C4>()
+    -> Regex<(Substring, C1, C2?, C3, C4)>
+    where RegexOutput == (Substring, C1, C2??, C3, C4)
+  {
+    Regex(castingCaptures: self.regex, to: (Substring, C1, C2?, C3, C4).self)
+  }
+
+  public func compactingCapture3<C1, C2, C3, C4>()
+    -> Regex<(Substring, C1, C2, C3?, C4)>
+    where RegexOutput == (Substring, C1, C2, C3??, C4)
+  {
+    Regex(castingCaptures: self.regex, to: (Substring, C1, C2, C3?, C4).self)
+  }
+
+  public func compactingCapture4<C1, C2, C3, C4>()
+    -> Regex<(Substring, C1, C2, C3, C4?)>
+    where RegexOutput == (Substring, C1, C2, C3, C4??)
+  {
+    Regex(castingCaptures: self.regex, to: (Substring, C1, C2, C3, C4?).self)
+  }
+}
+
+@available(SwiftStdlib 5.7, *)
+extension RegexComponent {
+  public func compactingCapture1<C1, C2, C3, C4, C5>()
+    -> Regex<(Substring, C1?, C2, C3, C4, C5)>
+    where RegexOutput == (Substring, C1??, C2, C3, C4, C5)
+  {
+    Regex(castingCaptures: self.regex, to: (Substring, C1?, C2, C3, C4, C5).self)
+  }
+
+  public func compactingCapture2<C1, C2, C3, C4, C5>()
+    -> Regex<(Substring, C1, C2?, C3, C4, C5)>
+    where RegexOutput == (Substring, C1, C2??, C3, C4, C5)
+  {
+    Regex(castingCaptures: self.regex, to: (Substring, C1, C2?, C3, C4, C5).self)
+  }
+
+  public func compactingCapture3<C1, C2, C3, C4, C5>()
+    -> Regex<(Substring, C1, C2, C3?, C4, C5)>
+    where RegexOutput == (Substring, C1, C2, C3??, C4, C5)
+  {
+    Regex(castingCaptures: self.regex, to: (Substring, C1, C2, C3?, C4, C5).self)
+  }
+
+  public func compactingCapture4<C1, C2, C3, C4, C5>()
+    -> Regex<(Substring, C1, C2, C3, C4?, C5)>
+    where RegexOutput == (Substring, C1, C2, C3, C4??, C5)
+  {
+    Regex(castingCaptures: self.regex, to: (Substring, C1, C2, C3, C4?, C5).self)
+  }
+
+  public func compactingCapture5<C1, C2, C3, C4, C5>()
+    -> Regex<(Substring, C1, C2, C3, C4, C5?)>
+    where RegexOutput == (Substring, C1, C2, C3, C4, C5??)
+  {
+    Regex(castingCaptures: self.regex, to: (Substring, C1, C2, C3, C4, C5?).self)
+  }
+}
+
+@available(SwiftStdlib 5.7, *)
+extension RegexComponent {
+  public func compactingCapture1<C1, C2, C3, C4, C5, C6>()
+    -> Regex<(Substring, C1?, C2, C3, C4, C5, C6)>
+    where RegexOutput == (Substring, C1??, C2, C3, C4, C5, C6)
+  {
+    Regex(castingCaptures: self.regex, to: (Substring, C1?, C2, C3, C4, C5, C6).self)
+  }
+
+  public func compactingCapture2<C1, C2, C3, C4, C5, C6>()
+    -> Regex<(Substring, C1, C2?, C3, C4, C5, C6)>
+    where RegexOutput == (Substring, C1, C2??, C3, C4, C5, C6)
+  {
+    Regex(castingCaptures: self.regex, to: (Substring, C1, C2?, C3, C4, C5, C6).self)
+  }
+
+  public func compactingCapture3<C1, C2, C3, C4, C5, C6>()
+    -> Regex<(Substring, C1, C2, C3?, C4, C5, C6)>
+    where RegexOutput == (Substring, C1, C2, C3??, C4, C5, C6)
+  {
+    Regex(castingCaptures: self.regex, to: (Substring, C1, C2, C3?, C4, C5, C6).self)
+  }
+
+  public func compactingCapture4<C1, C2, C3, C4, C5, C6>()
+    -> Regex<(Substring, C1, C2, C3, C4?, C5, C6)>
+    where RegexOutput == (Substring, C1, C2, C3, C4??, C5, C6)
+  {
+    Regex(castingCaptures: self.regex, to: (Substring, C1, C2, C3, C4?, C5, C6).self)
+  }
+
+  public func compactingCapture5<C1, C2, C3, C4, C5, C6>()
+    -> Regex<(Substring, C1, C2, C3, C4, C5?, C6)>
+    where RegexOutput == (Substring, C1, C2, C3, C4, C5??, C6)
+  {
+    Regex(castingCaptures: self.regex, to: (Substring, C1, C2, C3, C4, C5?, C6).self)
+  }
+
+  public func compactingCapture6<C1, C2, C3, C4, C5, C6>()
+    -> Regex<(Substring, C1, C2, C3, C4, C5, C6?)>
+    where RegexOutput == (Substring, C1, C2, C3, C4, C5, C6??)
+  {
+    Regex(castingCaptures: self.regex, to: (Substring, C1, C2, C3, C4, C5, C6?).self)
+  }
+}
+
+@available(SwiftStdlib 5.7, *)
+extension RegexComponent {
+  public func compactingCapture1<C1, C2, C3, C4, C5, C6, C7>()
+    -> Regex<(Substring, C1?, C2, C3, C4, C5, C6, C7)>
+    where RegexOutput == (Substring, C1??, C2, C3, C4, C5, C6, C7)
+  {
+    Regex(castingCaptures: self.regex, to: (Substring, C1?, C2, C3, C4, C5, C6, C7).self)
+  }
+
+  public func compactingCapture2<C1, C2, C3, C4, C5, C6, C7>()
+    -> Regex<(Substring, C1, C2?, C3, C4, C5, C6, C7)>
+    where RegexOutput == (Substring, C1, C2??, C3, C4, C5, C6, C7)
+  {
+    Regex(castingCaptures: self.regex, to: (Substring, C1, C2?, C3, C4, C5, C6, C7).self)
+  }
+
+  public func compactingCapture3<C1, C2, C3, C4, C5, C6, C7>()
+    -> Regex<(Substring, C1, C2, C3?, C4, C5, C6, C7)>
+    where RegexOutput == (Substring, C1, C2, C3??, C4, C5, C6, C7)
+  {
+    Regex(castingCaptures: self.regex, to: (Substring, C1, C2, C3?, C4, C5, C6, C7).self)
+  }
+
+  public func compactingCapture4<C1, C2, C3, C4, C5, C6, C7>()
+    -> Regex<(Substring, C1, C2, C3, C4?, C5, C6, C7)>
+    where RegexOutput == (Substring, C1, C2, C3, C4??, C5, C6, C7)
+  {
+    Regex(castingCaptures: self.regex, to: (Substring, C1, C2, C3, C4?, C5, C6, C7).self)
+  }
+
+  public func compactingCapture5<C1, C2, C3, C4, C5, C6, C7>()
+    -> Regex<(Substring, C1, C2, C3, C4, C5?, C6, C7)>
+    where RegexOutput == (Substring, C1, C2, C3, C4, C5??, C6, C7)
+  {
+    Regex(castingCaptures: self.regex, to: (Substring, C1, C2, C3, C4, C5?, C6, C7).self)
+  }
+
+  public func compactingCapture6<C1, C2, C3, C4, C5, C6, C7>()
+    -> Regex<(Substring, C1, C2, C3, C4, C5, C6?, C7)>
+    where RegexOutput == (Substring, C1, C2, C3, C4, C5, C6??, C7)
+  {
+    Regex(castingCaptures: self.regex, to: (Substring, C1, C2, C3, C4, C5, C6?, C7).self)
+  }
+
+  public func compactingCapture7<C1, C2, C3, C4, C5, C6, C7>()
+    -> Regex<(Substring, C1, C2, C3, C4, C5, C6, C7?)>
+    where RegexOutput == (Substring, C1, C2, C3, C4, C5, C6, C7??)
+  {
+    Regex(castingCaptures: self.regex, to: (Substring, C1, C2, C3, C4, C5, C6, C7?).self)
+  }
+}
+
+@available(SwiftStdlib 5.7, *)
+extension RegexComponent {
+  public func compactingCapture1<C1, C2, C3, C4, C5, C6, C7, C8>()
+    -> Regex<(Substring, C1?, C2, C3, C4, C5, C6, C7, C8)>
+    where RegexOutput == (Substring, C1??, C2, C3, C4, C5, C6, C7, C8)
+  {
+    Regex(castingCaptures: self.regex, to: (Substring, C1?, C2, C3, C4, C5, C6, C7, C8).self)
+  }
+
+  public func compactingCapture2<C1, C2, C3, C4, C5, C6, C7, C8>()
+    -> Regex<(Substring, C1, C2?, C3, C4, C5, C6, C7, C8)>
+    where RegexOutput == (Substring, C1, C2??, C3, C4, C5, C6, C7, C8)
+  {
+    Regex(castingCaptures: self.regex, to: (Substring, C1, C2?, C3, C4, C5, C6, C7, C8).self)
+  }
+
+  public func compactingCapture3<C1, C2, C3, C4, C5, C6, C7, C8>()
+    -> Regex<(Substring, C1, C2, C3?, C4, C5, C6, C7, C8)>
+    where RegexOutput == (Substring, C1, C2, C3??, C4, C5, C6, C7, C8)
+  {
+    Regex(castingCaptures: self.regex, to: (Substring, C1, C2, C3?, C4, C5, C6, C7, C8).self)
+  }
+
+  public func compactingCapture4<C1, C2, C3, C4, C5, C6, C7, C8>()
+    -> Regex<(Substring, C1, C2, C3, C4?, C5, C6, C7, C8)>
+    where RegexOutput == (Substring, C1, C2, C3, C4??, C5, C6, C7, C8)
+  {
+    Regex(castingCaptures: self.regex, to: (Substring, C1, C2, C3, C4?, C5, C6, C7, C8).self)
+  }
+
+  public func compactingCapture5<C1, C2, C3, C4, C5, C6, C7, C8>()
+    -> Regex<(Substring, C1, C2, C3, C4, C5?, C6, C7, C8)>
+    where RegexOutput == (Substring, C1, C2, C3, C4, C5??, C6, C7, C8)
+  {
+    Regex(castingCaptures: self.regex, to: (Substring, C1, C2, C3, C4, C5?, C6, C7, C8).self)
+  }
+
+  public func compactingCapture6<C1, C2, C3, C4, C5, C6, C7, C8>()
+    -> Regex<(Substring, C1, C2, C3, C4, C5, C6?, C7, C8)>
+    where RegexOutput == (Substring, C1, C2, C3, C4, C5, C6??, C7, C8)
+  {
+    Regex(castingCaptures: self.regex, to: (Substring, C1, C2, C3, C4, C5, C6?, C7, C8).self)
+  }
+
+  public func compactingCapture7<C1, C2, C3, C4, C5, C6, C7, C8>()
+    -> Regex<(Substring, C1, C2, C3, C4, C5, C6, C7?, C8)>
+    where RegexOutput == (Substring, C1, C2, C3, C4, C5, C6, C7??, C8)
+  {
+    Regex(castingCaptures: self.regex, to: (Substring, C1, C2, C3, C4, C5, C6, C7?, C8).self)
+  }
+
+  public func compactingCapture8<C1, C2, C3, C4, C5, C6, C7, C8>()
+    -> Regex<(Substring, C1, C2, C3, C4, C5, C6, C7, C8?)>
+    where RegexOutput == (Substring, C1, C2, C3, C4, C5, C6, C7, C8??)
+  {
+    Regex(castingCaptures: self.regex, to: (Substring, C1, C2, C3, C4, C5, C6, C7, C8?).self)
+  }
+}
+
+@available(SwiftStdlib 5.7, *)
+extension RegexComponent {
+  public func compactingCapture1<C1, C2, C3, C4, C5, C6, C7, C8, C9>()
+    -> Regex<(Substring, C1?, C2, C3, C4, C5, C6, C7, C8, C9)>
+    where RegexOutput == (Substring, C1??, C2, C3, C4, C5, C6, C7, C8, C9)
+  {
+    Regex(castingCaptures: self.regex, to: (Substring, C1?, C2, C3, C4, C5, C6, C7, C8, C9).self)
+  }
+
+  public func compactingCapture2<C1, C2, C3, C4, C5, C6, C7, C8, C9>()
+    -> Regex<(Substring, C1, C2?, C3, C4, C5, C6, C7, C8, C9)>
+    where RegexOutput == (Substring, C1, C2??, C3, C4, C5, C6, C7, C8, C9)
+  {
+    Regex(castingCaptures: self.regex, to: (Substring, C1, C2?, C3, C4, C5, C6, C7, C8, C9).self)
+  }
+
+  public func compactingCapture3<C1, C2, C3, C4, C5, C6, C7, C8, C9>()
+    -> Regex<(Substring, C1, C2, C3?, C4, C5, C6, C7, C8, C9)>
+    where RegexOutput == (Substring, C1, C2, C3??, C4, C5, C6, C7, C8, C9)
+  {
+    Regex(castingCaptures: self.regex, to: (Substring, C1, C2, C3?, C4, C5, C6, C7, C8, C9).self)
+  }
+
+  public func compactingCapture4<C1, C2, C3, C4, C5, C6, C7, C8, C9>()
+    -> Regex<(Substring, C1, C2, C3, C4?, C5, C6, C7, C8, C9)>
+    where RegexOutput == (Substring, C1, C2, C3, C4??, C5, C6, C7, C8, C9)
+  {
+    Regex(castingCaptures: self.regex, to: (Substring, C1, C2, C3, C4?, C5, C6, C7, C8, C9).self)
+  }
+
+  public func compactingCapture5<C1, C2, C3, C4, C5, C6, C7, C8, C9>()
+    -> Regex<(Substring, C1, C2, C3, C4, C5?, C6, C7, C8, C9)>
+    where RegexOutput == (Substring, C1, C2, C3, C4, C5??, C6, C7, C8, C9)
+  {
+    Regex(castingCaptures: self.regex, to: (Substring, C1, C2, C3, C4, C5?, C6, C7, C8, C9).self)
+  }
+
+  public func compactingCapture6<C1, C2, C3, C4, C5, C6, C7, C8, C9>()
+    -> Regex<(Substring, C1, C2, C3, C4, C5, C6?, C7, C8, C9)>
+    where RegexOutput == (Substring, C1, C2, C3, C4, C5, C6??, C7, C8, C9)
+  {
+    Regex(castingCaptures: self.regex, to: (Substring, C1, C2, C3, C4, C5, C6?, C7, C8, C9).self)
+  }
+
+  public func compactingCapture7<C1, C2, C3, C4, C5, C6, C7, C8, C9>()
+    -> Regex<(Substring, C1, C2, C3, C4, C5, C6, C7?, C8, C9)>
+    where RegexOutput == (Substring, C1, C2, C3, C4, C5, C6, C7??, C8, C9)
+  {
+    Regex(castingCaptures: self.regex, to: (Substring, C1, C2, C3, C4, C5, C6, C7?, C8, C9).self)
+  }
+
+  public func compactingCapture8<C1, C2, C3, C4, C5, C6, C7, C8, C9>()
+    -> Regex<(Substring, C1, C2, C3, C4, C5, C6, C7, C8?, C9)>
+    where RegexOutput == (Substring, C1, C2, C3, C4, C5, C6, C7, C8??, C9)
+  {
+    Regex(castingCaptures: self.regex, to: (Substring, C1, C2, C3, C4, C5, C6, C7, C8?, C9).self)
+  }
+
+  public func compactingCapture9<C1, C2, C3, C4, C5, C6, C7, C8, C9>()
+    -> Regex<(Substring, C1, C2, C3, C4, C5, C6, C7, C8, C9?)>
+    where RegexOutput == (Substring, C1, C2, C3, C4, C5, C6, C7, C8, C9??)
+  {
+    Regex(castingCaptures: self.regex, to: (Substring, C1, C2, C3, C4, C5, C6, C7, C8, C9?).self)
+  }
+}
+
+@available(SwiftStdlib 5.7, *)
+extension RegexComponent {
+  public func compactingCapture1<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10>()
+    -> Regex<(Substring, C1?, C2, C3, C4, C5, C6, C7, C8, C9, C10)>
+    where RegexOutput == (Substring, C1??, C2, C3, C4, C5, C6, C7, C8, C9, C10)
+  {
+    Regex(castingCaptures: self.regex, to: (Substring, C1?, C2, C3, C4, C5, C6, C7, C8, C9, C10).self)
+  }
+
+  public func compactingCapture2<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10>()
+    -> Regex<(Substring, C1, C2?, C3, C4, C5, C6, C7, C8, C9, C10)>
+    where RegexOutput == (Substring, C1, C2??, C3, C4, C5, C6, C7, C8, C9, C10)
+  {
+    Regex(castingCaptures: self.regex, to: (Substring, C1, C2?, C3, C4, C5, C6, C7, C8, C9, C10).self)
+  }
+
+  public func compactingCapture3<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10>()
+    -> Regex<(Substring, C1, C2, C3?, C4, C5, C6, C7, C8, C9, C10)>
+    where RegexOutput == (Substring, C1, C2, C3??, C4, C5, C6, C7, C8, C9, C10)
+  {
+    Regex(castingCaptures: self.regex, to: (Substring, C1, C2, C3?, C4, C5, C6, C7, C8, C9, C10).self)
+  }
+
+  public func compactingCapture4<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10>()
+    -> Regex<(Substring, C1, C2, C3, C4?, C5, C6, C7, C8, C9, C10)>
+    where RegexOutput == (Substring, C1, C2, C3, C4??, C5, C6, C7, C8, C9, C10)
+  {
+    Regex(castingCaptures: self.regex, to: (Substring, C1, C2, C3, C4?, C5, C6, C7, C8, C9, C10).self)
+  }
+
+  public func compactingCapture5<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10>()
+    -> Regex<(Substring, C1, C2, C3, C4, C5?, C6, C7, C8, C9, C10)>
+    where RegexOutput == (Substring, C1, C2, C3, C4, C5??, C6, C7, C8, C9, C10)
+  {
+    Regex(castingCaptures: self.regex, to: (Substring, C1, C2, C3, C4, C5?, C6, C7, C8, C9, C10).self)
+  }
+
+  public func compactingCapture6<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10>()
+    -> Regex<(Substring, C1, C2, C3, C4, C5, C6?, C7, C8, C9, C10)>
+    where RegexOutput == (Substring, C1, C2, C3, C4, C5, C6??, C7, C8, C9, C10)
+  {
+    Regex(castingCaptures: self.regex, to: (Substring, C1, C2, C3, C4, C5, C6?, C7, C8, C9, C10).self)
+  }
+
+  public func compactingCapture7<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10>()
+    -> Regex<(Substring, C1, C2, C3, C4, C5, C6, C7?, C8, C9, C10)>
+    where RegexOutput == (Substring, C1, C2, C3, C4, C5, C6, C7??, C8, C9, C10)
+  {
+    Regex(castingCaptures: self.regex, to: (Substring, C1, C2, C3, C4, C5, C6, C7?, C8, C9, C10).self)
+  }
+
+  public func compactingCapture8<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10>()
+    -> Regex<(Substring, C1, C2, C3, C4, C5, C6, C7, C8?, C9, C10)>
+    where RegexOutput == (Substring, C1, C2, C3, C4, C5, C6, C7, C8??, C9, C10)
+  {
+    Regex(castingCaptures: self.regex, to: (Substring, C1, C2, C3, C4, C5, C6, C7, C8?, C9, C10).self)
+  }
+
+  public func compactingCapture9<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10>()
+    -> Regex<(Substring, C1, C2, C3, C4, C5, C6, C7, C8, C9?, C10)>
+    where RegexOutput == (Substring, C1, C2, C3, C4, C5, C6, C7, C8, C9??, C10)
+  {
+    Regex(castingCaptures: self.regex, to: (Substring, C1, C2, C3, C4, C5, C6, C7, C8, C9?, C10).self)
+  }
+
+  public func compactingCapture10<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10>()
+    -> Regex<(Substring, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10?)>
+    where RegexOutput == (Substring, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10??)
+  {
+    Regex(castingCaptures: self.regex, to: (Substring, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10?).self)
+  }
+}
+
 
 
 // END AUTO-GENERATED CONTENT

--- a/Sources/_StringProcessing/Regex/Core.swift
+++ b/Sources/_StringProcessing/Regex/Core.swift
@@ -55,6 +55,12 @@ public struct Regex<Output>: RegexComponent {
     // in libswiftParseRegexLiteral.
     self.init(ast: try! parseWithDelimiters(pattern))
   }
+  
+  @_spi(RegexBuilder)
+  public init<T>(castingCaptures regex: Regex<T>, to outputType: Output.Type = Output.self) {
+    // TODO: Validate that `Output` and `T` are compatible?
+    self.program = Program(tree: regex.program.tree)
+  }
 
   public var regex: Regex<Output> {
     self


### PR DESCRIPTION
This adds a set of `compactingCaptureN` methods, which let you collapse a double-optional at a specific position in a regex capture list to a single optional. This position-specific approach only requires `arity^2` overloads instead of the `arity!` that a general solution would require.

```swift
let regex = Regex {
    ":"
    ChoiceOf {
        Capture {
            OneOrMore(.word)
        }
        Capture {
            OneOrMore(.digit)
        } transform: { Int($0) }
    }
    ":"
}
// type(of: regex) == Regex<(Substring, Substring?, Int??)>
let flattenedRegex = regex.compactingCapture2()
// type(of: flattenedRegex) == Regex<(Substring, Substring?, Int?)>
```

Note that `compactingCapture2()` could alternatively be added to `ChoiceOf` instead of the outer regex.