### PR TITLE
Implement the `(?n)` option

### DIFF
--- a/Sources/_RegexParser/Regex/AST/MatchingOptions.swift
+++ b/Sources/_RegexParser/Regex/AST/MatchingOptions.swift
@@ -17,7 +17,7 @@ extension AST {
       case caseInsensitive          // i
       case allowDuplicateGroupNames // J
       case multiline                // m
-      case noAutoCapture            // n
+      case namedCapturesOnly        // n
       case singleLine               // s
       case reluctantByDefault       // U
       case extended                 // x

--- a/Sources/_RegexParser/Regex/Parse/LexicalAnalysis.swift
+++ b/Sources/_RegexParser/Regex/Parse/LexicalAnalysis.swift
@@ -616,7 +616,7 @@ extension Source {
       case "i": return advanceAndReturn(.caseInsensitive)
       case "J": return advanceAndReturn(.allowDuplicateGroupNames)
       case "m": return advanceAndReturn(.multiline)
-      case "n": return advanceAndReturn(.noAutoCapture)
+      case "n": return advanceAndReturn(.namedCapturesOnly)
       case "s": return advanceAndReturn(.singleLine)
       case "U": return advanceAndReturn(.reluctantByDefault)
       case "x":

--- a/Sources/_RegexParser/Regex/Parse/LexicalAnalysis.swift
+++ b/Sources/_RegexParser/Regex/Parse/LexicalAnalysis.swift
@@ -914,6 +914,10 @@ extension Source {
         }
         // TODO: (name:)
 
+        // If (?n) is set, a bare (...) group is non-capturing.
+        if context.syntax.contains(.namedCapturesOnly) {
+          return .nonCapture
+        }
         return .capture
       }
     }

--- a/Sources/_RegexParser/Regex/Parse/SyntaxOptions.swift
+++ b/Sources/_RegexParser/Regex/Parse/SyntaxOptions.swift
@@ -63,6 +63,9 @@ public struct SyntaxOptions: OptionSet {
     return [Self(1 << 6), .extendedSyntax]
   }
 
+  /// `(?n)`
+  public static var namedCapturesOnly: Self { Self(1 << 7) }
+
   /*
 
     /// `<digit>*` == `[[:digit:]]*` == `\d*`

--- a/Sources/_StringProcessing/MatchingOptions.swift
+++ b/Sources/_StringProcessing/MatchingOptions.swift
@@ -135,7 +135,7 @@ extension MatchingOptions {
     case caseInsensitive
     case allowDuplicateGroupNames
     case multiline
-    case noAutoCapture
+    case namedCapturesOnly
     case singleLine
     case reluctantByDefault
 
@@ -174,8 +174,8 @@ extension MatchingOptions {
         self = .allowDuplicateGroupNames
       case .multiline:
         self = .multiline
-      case .noAutoCapture:
-        self = .noAutoCapture
+      case .namedCapturesOnly:
+        self = .namedCapturesOnly
       case .singleLine:
         self = .singleLine
       case .reluctantByDefault:

--- a/Tests/RegexTests/ParseTests.swift
+++ b/Tests/RegexTests/ParseTests.swift
@@ -906,7 +906,7 @@ extension RegexTests {
     ))
 
     let allOptions: [AST.MatchingOption.Kind] = [
-      .caseInsensitive, .allowDuplicateGroupNames, .multiline, .noAutoCapture,
+      .caseInsensitive, .allowDuplicateGroupNames, .multiline, .namedCapturesOnly,
       .singleLine, .reluctantByDefault, .extraExtended, .extended,
       .unicodeWordBoundaries, .asciiOnlyDigit, .asciiOnlyPOSIXProps,
       .asciiOnlySpace, .asciiOnlyWord, .textSegmentGraphemeMode,

--- a/Tests/RegexTests/ParseTests.swift
+++ b/Tests/RegexTests/ParseTests.swift
@@ -973,6 +973,13 @@ extension RegexTests {
       "d"
     )), captures: [.cap])
 
+    parseTest("(?n)(?^:())(?<x>)()", concat(
+      changeMatchingOptions(matchingOptions(adding: .namedCapturesOnly)),
+      changeMatchingOptions(unsetMatchingOptions(), capture(empty())),
+      namedCapture("x", empty()),
+      nonCapture(empty())
+    ), captures: [.cap, .named("x")])
+
     // MARK: References
 
     // \1 ... \9 are always backreferences.


### PR DESCRIPTION
This switches `(...)` groups to being non-capturing, with only named groups capturing.