### PR TITLE
Implement \R, \v, \h for character/scalar modes

### DIFF
--- a/Sources/_RegexParser/Regex/Parse/Sema.swift
+++ b/Sources/_RegexParser/Regex/Parse/Sema.swift
@@ -182,7 +182,7 @@ extension RegexValidator {
     _ esc: AST.Atom.EscapedBuiltin, at loc: SourceLocation
   ) throws {
     switch esc {
-    case .resetStartOfMatch, .singleDataUnit, .verticalTab, .notVerticalTab,
+    case .resetStartOfMatch, .singleDataUnit,
         // '\N' needs to be emitted using 'emitAny'.
         .notNewline:
       throw error(.unsupported("'\\\(esc.character)'"), at: loc)
@@ -190,7 +190,8 @@ extension RegexValidator {
     // Character classes.
     case .decimalDigit, .notDecimalDigit, .whitespace, .notWhitespace,
         .wordCharacter, .notWordCharacter, .graphemeCluster, .trueAnychar,
-        .horizontalWhitespace, .notHorizontalWhitespace:
+        .horizontalWhitespace, .notHorizontalWhitespace,
+        .verticalTab, .notVerticalTab:
       break
 
     case .newlineSequence:

--- a/Sources/_StringProcessing/Unicode/ScalarProps.swift
+++ b/Sources/_StringProcessing/Unicode/ScalarProps.swift
@@ -52,7 +52,7 @@ extension UnicodeScalar {
     value == 0x09 || properties.generalCategory == .spaceSeparator
   }
   
-  var isVerticalWhitespace: Bool {
+  var isNewline: Bool {
     switch value {
       case 0x000A...0x000D /* LF ... CR */: return true
       case 0x0085 /* NEXT LINE (NEL) */: return true

--- a/Sources/_StringProcessing/Unicode/ScalarProps.swift
+++ b/Sources/_StringProcessing/Unicode/ScalarProps.swift
@@ -46,3 +46,19 @@ extension Unicode.Script {
     return result
   }
 }
+
+extension UnicodeScalar {
+  var isHorizontalWhitespace: Bool {
+    value == 0x09 || properties.generalCategory == .spaceSeparator
+  }
+  
+  var isVerticalWhitespace: Bool {
+    switch value {
+      case 0x000A...0x000D /* LF ... CR */: return true
+      case 0x0085 /* NEXT LINE (NEL) */: return true
+      case 0x2028 /* LINE SEPARATOR */: return true
+      case 0x2029 /* PARAGRAPH SEPARATOR */: return true
+      default: return false
+    }
+  }
+}

--- a/Sources/_StringProcessing/_CharacterClassModel.swift
+++ b/Sources/_StringProcessing/_CharacterClassModel.swift
@@ -178,15 +178,18 @@ public struct _CharacterClassModel: Hashable {
         matched = c.isNumber && (c.isASCII || !options.usesASCIIDigits)
       case .hexDigit:
         matched = c.isHexDigit && (c.isASCII || !options.usesASCIIDigits)
-      case .horizontalWhitespace: fatalError("Not implemented")
-      case .newlineSequence:
-        matched = c.isNewline && (c.isASCII || !options.usesASCIISpaces)
-      case .verticalWhitespace: fatalError("Not implemented")
+      case .horizontalWhitespace:
+        matched = c.unicodeScalars.first?.isHorizontalWhitespace == true
+          && (c.isASCII || !options.usesASCIISpaces)
+      case .newlineSequence, .verticalWhitespace:
+        matched = c.unicodeScalars.first?.isVerticalWhitespace == true
+          && (c.isASCII || !options.usesASCIISpaces)
       case .whitespace:
         matched = c.isWhitespace && (c.isASCII || !options.usesASCIISpaces)
       case .word:
         matched = c.isWordCharacter && (c.isASCII || !options.usesASCIIWord)
-      case .custom(let set): matched = set.any { $0.matches(c, with: options) }
+      case .custom(let set):
+        matched = set.any { $0.matches(c, with: options) }
       }
       if isInverted {
         matched.toggle()
@@ -206,14 +209,21 @@ public struct _CharacterClassModel: Hashable {
         matched = c.properties.numericType != nil && (c.isASCII || !options.usesASCIIDigits)
       case .hexDigit:
         matched = Character(c).isHexDigit && (c.isASCII || !options.usesASCIIDigits)
-      case .horizontalWhitespace: fatalError("Not implemented")
-      case .newlineSequence: fatalError("Not implemented")
-      case .verticalWhitespace: fatalError("Not implemented")
+      case .horizontalWhitespace:
+        matched = c.isHorizontalWhitespace && (c.isASCII || !options.usesASCIISpaces)
+      case .verticalWhitespace:
+        matched = c.isVerticalWhitespace && (c.isASCII || !options.usesASCIISpaces)
+      case .newlineSequence:
+        matched = c.isVerticalWhitespace && (c.isASCII || !options.usesASCIISpaces)
+        if c == "\r" && nextIndex != str.endIndex && str.unicodeScalars[nextIndex] == "\n" {
+          str.unicodeScalars.formIndex(after: &nextIndex)
+        }
       case .whitespace:
         matched = c.properties.isWhitespace && (c.isASCII || !options.usesASCIISpaces)
       case .word:
         matched = (c.properties.isAlphabetic || c == "_") && (c.isASCII || !options.usesASCIIWord)
-      case .custom: fatalError("Not supported")
+      case .custom(let set):
+        matched = set.any { $0.matches(Character(c), with: options) }
       }
       if isInverted {
         matched.toggle()

--- a/Sources/_StringProcessing/_CharacterClassModel.swift
+++ b/Sources/_StringProcessing/_CharacterClassModel.swift
@@ -182,7 +182,7 @@ public struct _CharacterClassModel: Hashable {
         matched = c.unicodeScalars.first?.isHorizontalWhitespace == true
           && (c.isASCII || !options.usesASCIISpaces)
       case .newlineSequence, .verticalWhitespace:
-        matched = c.unicodeScalars.first?.isVerticalWhitespace == true
+        matched = c.unicodeScalars.first?.isNewline == true
           && (c.isASCII || !options.usesASCIISpaces)
       case .whitespace:
         matched = c.isWhitespace && (c.isASCII || !options.usesASCIISpaces)
@@ -212,9 +212,9 @@ public struct _CharacterClassModel: Hashable {
       case .horizontalWhitespace:
         matched = c.isHorizontalWhitespace && (c.isASCII || !options.usesASCIISpaces)
       case .verticalWhitespace:
-        matched = c.isVerticalWhitespace && (c.isASCII || !options.usesASCIISpaces)
+        matched = c.isNewline && (c.isASCII || !options.usesASCIISpaces)
       case .newlineSequence:
-        matched = c.isVerticalWhitespace && (c.isASCII || !options.usesASCIISpaces)
+        matched = c.isNewline && (c.isASCII || !options.usesASCIISpaces)
         if c == "\r" && nextIndex != str.endIndex && str.unicodeScalars[nextIndex] == "\n" {
           str.unicodeScalars.formIndex(after: &nextIndex)
         }

--- a/Tests/RegexTests/UTS18Tests.swift
+++ b/Tests/RegexTests/UTS18Tests.swift
@@ -284,10 +284,14 @@ extension UTS18Tests {
     lines = lineInput.matches(
       of: regex(#"\d{2}\R^"#).matchingSemantics(.unicodeScalar).anchorsMatchLineEndings())
     XCTAssertEqual(lines.count, 11)
+    XCTAssertNotNil(lineInput.firstMatch(
+      of: regex(#"08\R^"#).matchingSemantics(.unicodeScalar).anchorsMatchLineEndings()))
     // Unicode scalar semantics - \v matches all except for \r\n sequence
     lines = lineInput.matches(
       of: regex(#"\d{2}\v^"#).matchingSemantics(.unicodeScalar).anchorsMatchLineEndings())
     XCTAssertEqual(lines.count, 10)
+    XCTAssertNil(lineInput.firstMatch(
+      of: regex(#"08\v^"#).matchingSemantics(.unicodeScalar).anchorsMatchLineEndings()))
 
     // Does not contain an empty line
     XCTAssertFalse(lineInput.contains(regex(#"^$"#)))

--- a/Tests/RegexTests/UTS18Tests.swift
+++ b/Tests/RegexTests/UTS18Tests.swift
@@ -22,6 +22,14 @@ import XCTest
 @testable // for internal `matches(of:)`
 import _StringProcessing
 
+extension UnicodeScalar {
+  var value4Digits: String {
+    let valueString = String(value, radix: 16, uppercase: true)
+    if valueString.count >= 4 { return valueString }
+    return String(repeating: "0", count: 4 - valueString.count) + valueString
+  }
+}
+
 class UTS18Tests: XCTestCase {
   var input: String {
     "ABCdefghîøu\u{308}\u{FFF0} -–—[]123"
@@ -292,6 +300,16 @@ extension UTS18Tests {
     XCTAssertEqual(lines.count, 10)
     XCTAssertNil(lineInput.firstMatch(
       of: regex(#"08\v^"#).matchingSemantics(.unicodeScalar).anchorsMatchLineEndings()))
+
+    XCTAssertNotNil(lineInput.firstMatch(of: regex(#"08\u{d}\u{a}"#).matchingSemantics(.unicodeScalar)))
+    XCTAssertNotNil(lineInput.firstMatch(
+      of: regex(#"08..09"#).matchingSemantics(.unicodeScalar).dotMatchesNewlines()))
+
+    for _ in 0..<10 { print("---") }
+    for (i, s) in lineInput.unicodeScalars.enumerated() {
+      print("\(i): scalar U+\(s.value4Digits)")
+    }
+    for _ in 0..<10 { print("---") }
 
     // Does not contain an empty line
     XCTAssertFalse(lineInput.contains(regex(#"^$"#)))

--- a/Tests/RegexTests/UTS18Tests.swift
+++ b/Tests/RegexTests/UTS18Tests.swift
@@ -290,45 +290,12 @@ extension UTS18Tests {
     
     // Unicode scalar semantics - \R still matches all, including \r\n sequence
     lines = lineInput.matches(
-      of: regex(#"\d{2}\R^"#).matchingSemantics(.unicodeScalar).anchorsMatchLineEndings())
-    XCTAssertEqual(lines.count, 11)
-    lines = lineInput.matches(
       of: regex(#"\d{2}\R(?=\d)"#).matchingSemantics(.unicodeScalar).anchorsMatchLineEndings())
     XCTAssertEqual(lines.count, 11)
-    XCTAssertNotNil(lineInput.firstMatch(
-      of: regex(#"08\R^"#).matchingSemantics(.unicodeScalar).anchorsMatchLineEndings()))
     // Unicode scalar semantics - \v matches all except for \r\n sequence
-    print("\n\n\n-------", #line, "\n\n\n")
-    lines = lineInput.matches(
-      of: regex(#"\d{2}\v^"#).matchingSemantics(.unicodeScalar).anchorsMatchLineEndings())
-    
-    print(lines.map {
-      "\n\n```\($0.0)```\n\n"
-      +
-      "```\($0.0.unicodeScalars.map { $0.value4Digits })```"
-    }.joined())
-    
-    XCTAssertEqual(lines.count, 10)
-    print("\n\n\n-------", #line, "\n\n\n")
     lines = lineInput.matches(
       of: regex(#"\d{2}\v(?=\d)"#).matchingSemantics(.unicodeScalar).anchorsMatchLineEndings())
     XCTAssertEqual(lines.count, 10)
-    XCTAssertNil(lineInput.firstMatch(
-      of: regex(#"08\v^"#).matchingSemantics(.unicodeScalar).anchorsMatchLineEndings()))
-
-    XCTAssertNotNil(lineInput.firstMatch(of: regex(#"08\u{d}\u{a}"#).matchingSemantics(.unicodeScalar)))
-    XCTAssertNotNil(lineInput.firstMatch(
-      of: regex(#"08..09"#).matchingSemantics(.unicodeScalar).dotMatchesNewlines()))
-
-    for _ in 0..<5 { print("---") }
-    for (i, s) in lineInput.unicodeScalars.enumerated() {
-      print("\(i): scalar U+\(s.value4Digits)")
-    }
-    for _ in 0..<5 { print("---") }
-    for match in lineInput.matches(of: regex(#"\v"#).matchingSemantics(.unicodeScalar)) {
-      print(lineInput.unicodeScalars.offsets(of: match.0.startIndex..<match.0.endIndex))
-    }
-    for _ in 0..<5 { print("---") }
 
     // Does not contain an empty line
     XCTAssertFalse(lineInput.contains(regex(#"^$"#)))

--- a/Tests/RegexTests/UTS18Tests.swift
+++ b/Tests/RegexTests/UTS18Tests.swift
@@ -270,11 +270,11 @@ extension UTS18Tests {
       09\u{85}\
       10\u{2028}\
       11\u{2029}\
-      
+      12
       """
     // Check the input counts
     var lines = lineInput.matches(of: regex(#"\d{2}"#))
-    XCTAssertEqual(lines.count, 11)
+    XCTAssertEqual(lines.count, 12)
     // Test \R - newline sequence
     lines = lineInput.matches(of: regex(#"\d{2}\R^"#).anchorsMatchLineEndings())
     XCTAssertEqual(lines.count, 11)
@@ -283,20 +283,35 @@ extension UTS18Tests {
     XCTAssertEqual(lines.count, 11)
     // Test anchors as line boundaries
     lines = lineInput.matches(of: regex(#"^\d{2}$"#).anchorsMatchLineEndings())
-    XCTAssertEqual(lines.count, 11)
+    XCTAssertEqual(lines.count, 12)
     // Test that dot does not match line endings
     lines = lineInput.matches(of: regex(#".+"#))
-    XCTAssertEqual(lines.count, 11)
+    XCTAssertEqual(lines.count, 12)
     
     // Unicode scalar semantics - \R still matches all, including \r\n sequence
     lines = lineInput.matches(
       of: regex(#"\d{2}\R^"#).matchingSemantics(.unicodeScalar).anchorsMatchLineEndings())
     XCTAssertEqual(lines.count, 11)
+    lines = lineInput.matches(
+      of: regex(#"\d{2}\R(?=\d)"#).matchingSemantics(.unicodeScalar).anchorsMatchLineEndings())
+    XCTAssertEqual(lines.count, 11)
     XCTAssertNotNil(lineInput.firstMatch(
       of: regex(#"08\R^"#).matchingSemantics(.unicodeScalar).anchorsMatchLineEndings()))
     // Unicode scalar semantics - \v matches all except for \r\n sequence
+    print("\n\n\n-------", #line, "\n\n\n")
     lines = lineInput.matches(
       of: regex(#"\d{2}\v^"#).matchingSemantics(.unicodeScalar).anchorsMatchLineEndings())
+    
+    print(lines.map {
+      "\n\n```\($0.0)```\n\n"
+      +
+      "```\($0.0.unicodeScalars.map { $0.value4Digits })```"
+    }.joined())
+    
+    XCTAssertEqual(lines.count, 10)
+    print("\n\n\n-------", #line, "\n\n\n")
+    lines = lineInput.matches(
+      of: regex(#"\d{2}\v(?=\d)"#).matchingSemantics(.unicodeScalar).anchorsMatchLineEndings())
     XCTAssertEqual(lines.count, 10)
     XCTAssertNil(lineInput.firstMatch(
       of: regex(#"08\v^"#).matchingSemantics(.unicodeScalar).anchorsMatchLineEndings()))

--- a/Tests/RegexTests/UTS18Tests.swift
+++ b/Tests/RegexTests/UTS18Tests.swift
@@ -268,7 +268,10 @@ extension UTS18Tests {
     var lines = lineInput.matches(of: regex(#"\d{2}"#))
     XCTAssertEqual(lines.count, 11)
     // Test \R - newline sequence
-    lines = lineInput.matches(of: regex(#"\d{2}\R"#))
+    lines = lineInput.matches(of: regex(#"\d{2}\R^"#).anchorsMatchLineEndings())
+    XCTAssertEqual(lines.count, 11)
+    // Test \v - vertical space
+    lines = lineInput.matches(of: regex(#"\d{2}\v^"#).anchorsMatchLineEndings())
     XCTAssertEqual(lines.count, 11)
     // Test anchors as line boundaries
     lines = lineInput.matches(of: regex(#"^\d{2}$"#).anchorsMatchLineEndings())
@@ -277,6 +280,15 @@ extension UTS18Tests {
     lines = lineInput.matches(of: regex(#".+"#))
     XCTAssertEqual(lines.count, 11)
     
+    // Unicode scalar semantics - \R still matches all, including \r\n sequence
+    lines = lineInput.matches(
+      of: regex(#"\d{2}\R^"#).matchingSemantics(.unicodeScalar).anchorsMatchLineEndings())
+    XCTAssertEqual(lines.count, 11)
+    // Unicode scalar semantics - \v matches all except for \r\n sequence
+    lines = lineInput.matches(
+      of: regex(#"\d{2}\v^"#).matchingSemantics(.unicodeScalar).anchorsMatchLineEndings())
+    XCTAssertEqual(lines.count, 10)
+
     // Does not contain an empty line
     XCTAssertFalse(lineInput.contains(regex(#"^$"#)))
     // Does contain an empty line (between \n and \r, which are reversed here)

--- a/Tests/RegexTests/UTS18Tests.swift
+++ b/Tests/RegexTests/UTS18Tests.swift
@@ -305,11 +305,15 @@ extension UTS18Tests {
     XCTAssertNotNil(lineInput.firstMatch(
       of: regex(#"08..09"#).matchingSemantics(.unicodeScalar).dotMatchesNewlines()))
 
-    for _ in 0..<10 { print("---") }
+    for _ in 0..<5 { print("---") }
     for (i, s) in lineInput.unicodeScalars.enumerated() {
       print("\(i): scalar U+\(s.value4Digits)")
     }
-    for _ in 0..<10 { print("---") }
+    for _ in 0..<5 { print("---") }
+    for match in lineInput.matches(of: regex(#"\v"#).matchingSemantics(.unicodeScalar)) {
+      print(lineInput.unicodeScalars.offsets(of: match.0.startIndex..<match.0.endIndex))
+    }
+    for _ in 0..<5 { print("---") }
 
     // Does not contain an empty line
     XCTAssertFalse(lineInput.contains(regex(#"^$"#)))


### PR DESCRIPTION
This implements these meta characters as per the Unicode proposal. We still need to expand how we treat `\n`. It should have mostly the same behavior as `\v`, but I also want to make sure that `/\r\n/` will match an `"\r\n"` character.