### PR TITLE
De-deprecate MatchingOptions.matchLevel

### DIFF
--- a/Sources/_StringProcessing/MatchingOptions.swift
+++ b/Sources/_StringProcessing/MatchingOptions.swift
@@ -117,7 +117,6 @@ extension MatchingOptions {
 
 // Deprecated CharacterClass.MatchLevel API
 extension MatchingOptions {
-  @available(*, deprecated)
   var matchLevel: _CharacterClassModel.MatchLevel {
     switch semanticLevel {
     case .graphemeCluster:


### PR DESCRIPTION
I had marked this as deprecated in an ill-advised effort to encourage refactoring `_CharacterClassModel.MatchLevel` out of existence, but so far it's only had the effect of generating annoying build warnings.

Resolves #284.