### PR TITLE
Disable resilience on _RegexParser

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -7,10 +7,18 @@ let availabilityDefinition = PackageDescription.SwiftSetting.unsafeFlags([
     "-Xfrontend",
     "-define-availability",
     "-Xfrontend",
-    #"SwiftStdlib 5.7:macOS 9999, iOS 9999, watchOS 9999, tvOS 9999"#,
+    "SwiftStdlib 5.7:macOS 9999, iOS 9999, watchOS 9999, tvOS 9999",
 ])
 
-let stdlibSettings: [PackageDescription.SwiftSetting] = [
+/// Swift settings for building a private stdlib-like module that is to be used
+/// by other stdlib-like modules only.
+let privateStdlibSettings: [PackageDescription.SwiftSetting] = [
+    .unsafeFlags(["-Xfrontend", "-disable-implicit-concurrency-module-import"]),
+    .unsafeFlags(["-Xfrontend", "-disable-implicit-string-processing-module-import"]),
+]
+
+/// Swift settings for building a user-facing stdlib-like module.
+let publicStdlibSettings: [PackageDescription.SwiftSetting] = [
     .unsafeFlags(["-enable-library-evolution"]),
     .unsafeFlags(["-Xfrontend", "-disable-implicit-concurrency-module-import"]),
     .unsafeFlags(["-Xfrontend", "-disable-implicit-string-processing-module-import"]),
@@ -43,7 +51,7 @@ let package = Package(
         .target(
             name: "_RegexParser",
             dependencies: [],
-            swiftSettings: stdlibSettings),
+            swiftSettings: privateStdlibSettings),
         .testTarget(
             name: "MatchingEngineTests",
             dependencies: [
@@ -55,11 +63,11 @@ let package = Package(
         .target(
             name: "_StringProcessing",
             dependencies: ["_RegexParser", "_CUnicode"],
-            swiftSettings: stdlibSettings),
+            swiftSettings: publicStdlibSettings),
         .target(
             name: "RegexBuilder",
             dependencies: ["_StringProcessing", "_RegexParser"],
-            swiftSettings: stdlibSettings),
+            swiftSettings: publicStdlibSettings),
         .testTarget(
             name: "RegexTests",
             dependencies: ["_StringProcessing"],

--- a/Sources/_RegexParser/Regex/AST/AST.swift
+++ b/Sources/_RegexParser/Regex/AST/AST.swift
@@ -29,7 +29,6 @@ extension AST {
 
 extension AST {
   /// A node in the regex AST.
-  @frozen
   public indirect enum Node:
     Hashable, _TreeNode //, _ASTPrintable ASTValue, ASTAction
   {
@@ -249,7 +248,6 @@ extension AST {
   }
 
   public struct Reference: Hashable {
-    @frozen
     public enum Kind: Hashable {
       // \n \gn \g{n} \g<n> \g'n' (?n) (?(n)...
       // Oniguruma: \k<n>, \k'n'

--- a/Sources/_RegexParser/Regex/AST/Atom.swift
+++ b/Sources/_RegexParser/Regex/AST/Atom.swift
@@ -19,7 +19,6 @@ extension AST {
       self.location = loc
     }
 
-    @frozen
     public enum Kind: Hashable {
       /// Just a character
       ///
@@ -146,7 +145,6 @@ extension AST.Atom {
 
   // Characters, character types, literals, etc., derived from
   // an escape sequence.
-  @frozen
   public enum EscapedBuiltin: Hashable {
     // TODO: better doc comments
 
@@ -399,7 +397,6 @@ extension AST.Atom {
 }
 
 extension AST.Atom.CharacterProperty {
-  @frozen
   public enum Kind: Hashable {
     /// Matches any character, equivalent to Oniguruma's '\O'.
     case any
@@ -438,7 +435,6 @@ extension AST.Atom.CharacterProperty {
   }
 
   // TODO: erm, separate out or fold into something? splat it in?
-  @frozen
   public enum PCRESpecialCategory: String, Hashable {
     case alphanumeric     = "Xan"
     case posixSpace       = "Xps"
@@ -450,7 +446,6 @@ extension AST.Atom.CharacterProperty {
 
 extension AST.Atom {
   /// Anchors and other built-in zero-width assertions.
-  @frozen
   public enum AssertionKind: String {
     /// \A
     case startOfSubject = #"\A"#

--- a/Sources/_RegexParser/Regex/AST/CustomCharClass.swift
+++ b/Sources/_RegexParser/Regex/AST/CustomCharClass.swift
@@ -27,7 +27,6 @@ extension AST {
       self.location = sr
     }
 
-    @frozen
     public enum Member: Hashable {
       /// A nested custom character class `[[ab][cd]]`
       case custom(CustomCharacterClass)
@@ -59,13 +58,11 @@ extension AST {
         self.rhs = rhs
       }
     }
-    @frozen
     public enum SetOp: String, Hashable {
       case subtraction = "--"
       case intersection = "&&"
       case symmetricDifference = "~~"
     }
-    @frozen
     public enum Start: String {
       case normal = "["
       case inverted = "[^"

--- a/Sources/_RegexParser/Regex/AST/Quantification.swift
+++ b/Sources/_RegexParser/Regex/AST/Quantification.swift
@@ -36,7 +36,6 @@ extension AST {
       self.trivia = trivia
     }
 
-    @frozen
     public enum Amount: Hashable {
       case zeroOrMore              // *
       case oneOrMore               // +
@@ -47,7 +46,6 @@ extension AST {
       case range(Located<Int>, Located<Int>) // {n,m}
     }
 
-    @frozen
     public enum Kind: String, Hashable {
       case eager      = ""
       case reluctant  = "?"

--- a/Sources/_RegexParser/Utility/MissingUnicode.swift
+++ b/Sources/_RegexParser/Utility/MissingUnicode.swift
@@ -19,7 +19,6 @@ extension Unicode {
   // other script types.
 
   /// Character script types.
-  @frozen
   public enum Script: String, Hashable {
     case adlam = "Adlam"
     case ahom = "Ahom"
@@ -188,7 +187,6 @@ extension Unicode {
 
   /// POSIX character properties not already covered by general categories or
   /// binary properties.
-  @frozen
   public enum POSIXProperty: String, Hashable {
     case alnum = "alnum"
     case blank = "blank"
@@ -206,7 +204,6 @@ extension Unicode {
 
   /// Unicode.GeneralCategory + cases for "meta categories" such as "L", which
   /// encompasses Lu | Ll | Lt | Lm | Lo.
-  @frozen
   public enum ExtendedGeneralCategory: String, Hashable {
     case other = "C"
     case control = "Cc"
@@ -257,7 +254,6 @@ extension Unicode {
   /// A list of Unicode properties that can either be true or false.
   ///
   /// https://www.unicode.org/Public/UCD/latest/ucd/PropertyAliases.txt
-  @frozen
   public enum BinaryProperty: String, Hashable {
     case asciiHexDigit = "ASCII_Hex_Digit"
     case alphabetic = "Alphabetic"
@@ -333,7 +329,6 @@ extension Unicode {
 // property.
 
 /// Oniguruma properties that are not covered by Unicode spellings.
-@frozen
 public enum OnigurumaSpecialProperty: String, Hashable {
   case inBasicLatin = "In_Basic_Latin"
   case inLatin1Supplement = "In_Latin_1_Supplement"

--- a/Sources/_StringProcessing/MatchingOptions.swift
+++ b/Sources/_StringProcessing/MatchingOptions.swift
@@ -205,9 +205,6 @@ extension MatchingOptions {
       // Whitespace options are only relevant during parsing, not compilation.
       case .extended, .extraExtended:
         return nil
-      @unknown default:
-        // Ignore unknown 
-        return nil
       }
     }
     

--- a/Sources/_StringProcessing/Regex/DSLTree.swift
+++ b/Sources/_StringProcessing/Regex/DSLTree.swift
@@ -507,8 +507,6 @@ extension DSLTree.Node {
         child._addCaptures(to: &list, optionalNesting: nesting)
       case .clearer, .repeater, .stopper:
         break
-      @unknown default:
-        fatalError()
       }
 
     case let .convertedRegexLiteral(n, _):

--- a/Tests/RegexBuilderTests/AlgorithmsTests.swift
+++ b/Tests/RegexBuilderTests/AlgorithmsTests.swift
@@ -13,7 +13,6 @@ import XCTest
 import _StringProcessing
 import RegexBuilder
 
-@available(SwiftStdlib 5.7, *)
 class RegexConsumerTests: XCTestCase {
   func testMatches() {
     let regex = Capture(OneOrMore(.digit)) { 2 * Int($0)! }


### PR DESCRIPTION
_RegexParser does not need resilience as it's only ever going to be used by _StringProcessing and RegexBuilder.