### PR TITLE
[5.7] Introduce `One`

### DIFF
--- a/Sources/RegexBuilder/DSL.swift
+++ b/Sources/RegexBuilder/DSL.swift
@@ -127,6 +127,19 @@ extension DSLTree.Node {
   }
 }
 
+/// A regex component that matches exactly one occurrence of its underlying
+/// component.
+@available(SwiftStdlib 5.7, *)
+public struct One<Output>: RegexComponent {
+  public var regex: Regex<Output>
+
+  public init<Component: RegexComponent>(
+    _ component: Component
+  ) where Component.RegexOutput == Output {
+    self.regex = component.regex
+  }
+}
+
 @available(SwiftStdlib 5.7, *)
 public struct OneOrMore<Output>: _BuiltinRegexComponent {
   public var regex: Regex<Output>

--- a/Tests/RegexBuilderTests/RegexDSLTests.swift
+++ b/Tests/RegexBuilderTests/RegexDSLTests.swift
@@ -66,7 +66,7 @@ class RegexDSLTests: XCTestCase {
       ("a c", ("a c", " ", "c")),
       matchType: (Substring, Substring, Substring).self, ==)
     {
-      .any
+      One(.any)
       Capture(.whitespace) // Substring
       Capture("c") // Substring
     }
@@ -344,7 +344,7 @@ class RegexDSLTests: XCTestCase {
       matchType: (Substring, Substring).self, ==)
     {
       OneOrMore(.reluctant) {
-        .word
+        One(.word)
       }.repetitionBehavior(.possessive)
       Capture(.digit)
       ZeroOrMore(.any)
@@ -615,13 +615,13 @@ class RegexDSLTests: XCTestCase {
   func testUnicodeScalarPostProcessing() throws {
     let spaces = Regex {
       ZeroOrMore {
-        .whitespace
+        One(.whitespace)
       }
     }
 
     let unicodeScalar = Regex {
       OneOrMore {
-        .hexDigit
+        One(.hexDigit)
       }
       spaces
     }
@@ -637,14 +637,10 @@ class RegexDSLTests: XCTestCase {
       spaces
 
       Capture {
-        OneOrMore {
-          .word
-        }
+        OneOrMore(.word)
       }
 
-      ZeroOrMore {
-        .any
-      }
+      ZeroOrMore(.any)
     }
 
     // Assert the inferred capture type.
@@ -841,7 +837,7 @@ class RegexDSLTests: XCTestCase {
         let a = Reference(Substring.self)
         ChoiceOf<(Substring, Substring?)> {
           Regex {
-            .word
+            One(.word)
             a
           }
           Regex {


### PR DESCRIPTION
Cherry-pick of #403 

-----

One is a lightweight component that allows the use of the leading dot syntax to reference `RegexComponent` static members such as character classes as a non-first expression in a regex builder block.

---

Before:

```swift
Regex {
    .digit // works today but brittle; inserting anything above this line will break this

    OneOrMore(.whitespace)

    .word // ❌ error: 'OneOrMore' has no member named 'word' (because this is parsed as a member reference on the preceeding expression)
}
```

After:

```swift
Regex {
    One(.digit)              // recommended even though `.digit` works today
    OneOrMore(.whitespace)
    One(.word)
} // ✅
```

In a follow-up patch, we will propose adding an additional protocol inheriting from `RegexComponent` that will ban the use of the leading dot syntax even on the first line of `Regex { ... }`, as this will enforce the recommended style (use of `One`), and prevent surprises when the user inserts a pattern above the leading dot line.