### PR TITLE
[5.7-04182022] Tidy up build flags and fix implicit import circular dependency (#392)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -10,6 +10,13 @@ let availabilityDefinition = PackageDescription.SwiftSetting.unsafeFlags([
     #"SwiftStdlib 5.7:macOS 9999, iOS 9999, watchOS 9999, tvOS 9999"#,
 ])
 
+let stdlibSettings: [PackageDescription.SwiftSetting] = [
+    .unsafeFlags(["-enable-library-evolution"]),
+    .unsafeFlags(["-Xfrontend", "-disable-implicit-concurrency-module-import"]),
+    .unsafeFlags(["-Xfrontend", "-disable-implicit-string-processing-module-import"]),
+    availabilityDefinition
+]
+
 let package = Package(
     name: "swift-experimental-string-processing",
     products: [
@@ -36,10 +43,7 @@ let package = Package(
         .target(
             name: "_RegexParser",
             dependencies: [],
-            swiftSettings: [
-                .unsafeFlags(["-enable-library-evolution"]),
-                availabilityDefinition
-            ]),
+            swiftSettings: stdlibSettings),
         .testTarget(
             name: "MatchingEngineTests",
             dependencies: [
@@ -51,18 +55,11 @@ let package = Package(
         .target(
             name: "_StringProcessing",
             dependencies: ["_RegexParser", "_CUnicode"],
-            swiftSettings: [
-                .unsafeFlags(["-enable-library-evolution"]),
-                availabilityDefinition
-            ]),
+            swiftSettings: stdlibSettings),
         .target(
             name: "RegexBuilder",
             dependencies: ["_StringProcessing", "_RegexParser"],
-            swiftSettings: [
-                .unsafeFlags(["-enable-library-evolution"]),
-                .unsafeFlags(["-Xfrontend", "-enable-experimental-pairwise-build-block"]),
-                availabilityDefinition
-            ]),
+            swiftSettings: stdlibSettings),
         .testTarget(
             name: "RegexTests",
             dependencies: ["_StringProcessing"],
@@ -73,7 +70,6 @@ let package = Package(
             name: "RegexBuilderTests",
             dependencies: ["_StringProcessing", "RegexBuilder"],
             swiftSettings: [
-                .unsafeFlags(["-Xfrontend", "-enable-experimental-pairwise-build-block"]),
                 .unsafeFlags(["-Xfrontend", "-disable-availability-checking"])
             ]),
         .target(
@@ -100,9 +96,8 @@ let package = Package(
         // MARK: Exercises
         .target(
             name: "Exercises",
-            dependencies: ["_RegexParser", "Prototypes", "_StringProcessing", "RegexBuilder"],
+            dependencies: ["_RegexParser", "_StringProcessing", "RegexBuilder"],
             swiftSettings: [
-                .unsafeFlags(["-Xfrontend", "-enable-experimental-pairwise-build-block"]),
                 .unsafeFlags(["-Xfrontend", "-disable-availability-checking"])
             ]),
         .testTarget(

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ See [Declarative String Processing Overview][decl-string]
 
 ## Requirements
 
-- [Swift Trunk Development Snapshot](https://www.swift.org/download/#snapshots) DEVELOPMENT-SNAPSHOT-2022-03-09 or later.
+- [Swift Trunk Development Snapshot](https://www.swift.org/download/#snapshots) DEVELOPMENT-SNAPSHOT-2022-04-20 or later.
 
 ## Integration with Swift
 


### PR DESCRIPTION
Cherry-pick of #392
Reason: Without this, the package will fail to build when the compiler enables string processing by default.

-----

- Explicitly ask the compiler not to implicitly import _StringProessing. This is to avoid a circular dependency when `-enable-experimental-string-processing` is enabled by default.
- Unify the build flags for modules that are built in the compiler repo into a `stdlibSettings` value.
- Disable implicit _Concurrency import as well since it is how it's built in the compiler repo. This helps us catch errors before we integrate with the compiler repo.
- Remove `-enable-experimental-pairwise-build-block` since SE-0348 has been implemented and enabled.
- Update the minimum toolchain requirement to 2022-04-20.