### PR TITLE
Wrap character classes around One

### DIFF
--- a/Sources/_StringProcessing/PrintAsPattern.swift
+++ b/Sources/_StringProcessing/PrintAsPattern.swift
@@ -437,30 +437,57 @@ extension PrettyPrinter {
       break
       
     case .intersection(let first, let second):
-      printAsPattern(first)
+      if wrap, first.isSimplePrint {
+        indent()
+        output("One(")
+      }
+      
+      printAsPattern(first, wrap: false)
       printIndented { printer in
         printer.indent()
         printer.output(".intersection(")
-        printer.printAsPattern(second, terminateLine: false)
+        printer.printAsPattern(second, wrap: false, terminateLine: false)
         printer.output(")")
+      }
+      
+      if wrap, first.isSimplePrint {
+        output(")")
       }
       
     case .subtraction(let first, let second):
-      printAsPattern(first)
+      if wrap, first.isSimplePrint {
+        indent()
+        output("One(")
+      }
+      
+      printAsPattern(first, wrap: false)
       printIndented { printer in
         printer.indent()
         printer.output(".subtracting(")
-        printer.printAsPattern(second, terminateLine: false)
+        printer.printAsPattern(second, wrap: false, terminateLine: false)
         printer.output(")")
       }
       
+      if wrap, first.isSimplePrint {
+        output(")")
+      }
+      
     case .symmetricDifference(let first, let second):
-      printAsPattern(first)
+      if wrap, first.isSimplePrint {
+        indent()
+        output("One(")
+      }
+      
+      printAsPattern(first, wrap: false)
       printIndented { printer in
         printer.indent()
         printer.output(".symmetricDifference(")
-        printer.printAsPattern(second, terminateLine: false)
+        printer.printAsPattern(second, wrap: false, terminateLine: false)
         printer.output(")")
+      }
+      
+      if wrap, first.isSimplePrint {
+        output(")")
       }
     }
   }


### PR DESCRIPTION
This PR wraps character classes like `.digit` around `One(.digit)` in contexts where it will be treated as a member reference. I also made the change to force syntax like:
```swift
OneOrMore(.digit)
```
to avoid the inevitable:
```swift
OneOrMore {
  One(.digit)
}
```

(DSL printing needs a refactor)