### PR TITLE
Keep track of initial options in compiled program

### DIFF
--- a/Sources/_StringProcessing/ByteCodeGen.swift
+++ b/Sources/_StringProcessing/ByteCodeGen.swift
@@ -35,6 +35,9 @@ extension Compiler.ByteCodeGen {
       builder.buildUnresolvedReference(id: id)
 
     case let .changeMatchingOptions(optionSequence):
+      if !builder.hasReceivedInstructions {
+        builder.initialOptions.apply(optionSequence.ast)
+      }
       options.apply(optionSequence.ast)
 
     case let .unconverted(astAtom):
@@ -379,6 +382,9 @@ extension Compiler.ByteCodeGen {
       throw Unreachable("These should produce a capture node")
 
     case .changeMatchingOptions(let optionSequence):
+      if !builder.hasReceivedInstructions {
+        builder.initialOptions.apply(optionSequence)
+      }
       options.apply(optionSequence)
       try emitNode(child)
 

--- a/Sources/_StringProcessing/Engine/MEBuilder.swift
+++ b/Sources/_StringProcessing/Engine/MEBuilder.swift
@@ -39,6 +39,7 @@ extension MEProgram where Input.Element: Hashable {
     var failAddressToken: AddressToken? = nil
 
     var captureList = CaptureList()
+    var initialOptions = MatchingOptions()
 
     // Symbolic reference resolution
     var unresolvedReferences: [ReferenceID: [InstructionAddress]] = [:]
@@ -76,6 +77,11 @@ extension MEProgram.Builder {
 
   var lastInstructionAddress: InstructionAddress {
     .init(instructions.endIndex - 1)
+  }
+  
+  /// `true` if the builder has received any instructions.
+  var hasReceivedInstructions: Bool {
+    !instructions.isEmpty
   }
 
   mutating func buildNop(_ r: StringRegister? = nil) {
@@ -353,7 +359,8 @@ extension MEProgram.Builder {
       registerInfo: regInfo,
       captureList: captureList,
       referencedCaptureOffsets: referencedCaptureOffsets,
-      namedCaptureOffsets: namedCaptureOffsets)
+      namedCaptureOffsets: namedCaptureOffsets,
+      initialOptions: initialOptions)
   }
 
   mutating func reset() { self = Self() }

--- a/Sources/_StringProcessing/Engine/MEProgram.swift
+++ b/Sources/_StringProcessing/Engine/MEProgram.swift
@@ -37,6 +37,8 @@ struct MEProgram<Input: Collection> where Input.Element: Equatable {
   let captureList: CaptureList
   let referencedCaptureOffsets: [ReferenceID: Int]
   let namedCaptureOffsets: [String: Int]
+  
+  var initialOptions: MatchingOptions
 }
 
 extension MEProgram: CustomStringConvertible {

--- a/Sources/_StringProcessing/MatchingOptions.swift
+++ b/Sources/_StringProcessing/MatchingOptions.swift
@@ -54,6 +54,13 @@ extension MatchingOptions {
     stack[stack.count - 1].apply(sequence)
     _invariantCheck()
   }
+  
+  // @testable
+  /// Returns true if the options at the top of `stack` are equal to those
+  /// for `other`.
+  func _equal(to other: MatchingOptions) -> Bool {
+    stack.last == other.stack.last
+  }
 }
 
 // MARK: Matching behavior API
@@ -127,6 +134,7 @@ extension MatchingOptions {
   }
 }
 
+// MARK: - Implementation
 extension MatchingOptions {
   /// An option that changes the behavior of a regular expression.
   fileprivate enum Option: Int {

--- a/Sources/_StringProcessing/Regex/ASTConversion.swift
+++ b/Sources/_StringProcessing/Regex/ASTConversion.swift
@@ -13,15 +13,7 @@
 
 extension AST {
   var dslTree: DSLTree {
-    return DSLTree(
-      root.dslTreeNode, options: globalOptions?.dslTreeOptions)
-  }
-}
-
-extension AST.GlobalMatchingOptionSequence {
-  var dslTreeOptions: DSLTree.Options {
-    // TODO: map options
-    return .init()
+    return DSLTree(root.dslTreeNode)
   }
 }
 

--- a/Sources/_StringProcessing/Regex/Core.swift
+++ b/Sources/_StringProcessing/Regex/Core.swift
@@ -102,6 +102,6 @@ extension Regex {
 
   @_spi(RegexBuilder)
   public init(node: DSLTree.Node) {
-    self.program = Program(tree: .init(node, options: nil))
+    self.program = Program(tree: .init(node))
   }
 }

--- a/Sources/_StringProcessing/Regex/DSLTree.swift
+++ b/Sources/_StringProcessing/Regex/DSLTree.swift
@@ -14,11 +14,9 @@
 @_spi(RegexBuilder)
 public struct DSLTree {
   var root: Node
-  var options: Options?
 
-  init(_ r: Node, options: Options?) {
+  init(_ r: Node) {
     self.root = r
-    self.options = options
   }
 }
 

--- a/Sources/_StringProcessing/Regex/Match.swift
+++ b/Sources/_StringProcessing/Regex/Match.swift
@@ -158,7 +158,11 @@ extension Regex {
       if let m = try _match(input, in: low..<high, mode: .partialFromFront) {
         return m
       }
-      input.formIndex(after: &low)
+      if regex.program.loweredProgram.initialOptions.semanticLevel == .graphemeCluster {
+        input.formIndex(after: &low)
+      } else {
+        input.unicodeScalars.formIndex(after: &low)
+      }
     }
     return nil
   }

--- a/Tests/RegexTests/CompileTests.swift
+++ b/Tests/RegexTests/CompileTests.swift
@@ -88,4 +88,51 @@ extension RegexTests {
       try testCompilationEquivalence(row)
     }
   }
+  
+  func testCompileInitialOptions() throws {
+    func expectInitialOptions<T>(
+      _ regex: Regex<T>,
+      _ optionSequence: AST.MatchingOptionSequence,
+      file: StaticString = #file,
+      line: UInt = #line
+    ) throws {
+      var options = MatchingOptions()
+      options.apply(optionSequence)
+      
+      XCTAssertTrue(
+        regex.program.loweredProgram.initialOptions._equal(to: options),
+        file: file, line: line)
+    }
+    
+    func expectInitialOptions(
+      _ pattern: String,
+      _ optionSequence: AST.MatchingOptionSequence,
+      file: StaticString = #file,
+      line: UInt = #line
+    ) throws {
+      let regex = try Regex(pattern)
+      try expectInitialOptions(regex, optionSequence, file: file, line: line)
+    }
+
+    try expectInitialOptions(".", matchingOptions())
+    try expectInitialOptions("(?i)(?-i).", matchingOptions())
+
+    try expectInitialOptions("(?i).", matchingOptions(adding: [.caseInsensitive]))
+    try expectInitialOptions("(?i).(?-i)", matchingOptions(adding: [.caseInsensitive]))
+
+    try expectInitialOptions(
+      "(?im)(?s).",
+      matchingOptions(adding: [.caseInsensitive, .multiline, .singleLine]))
+    try expectInitialOptions(".", matchingOptions())
+    try expectInitialOptions(
+      "(?im)(?s).(?u)",
+      matchingOptions(adding: [.caseInsensitive, .multiline, .singleLine]))
+    
+    try expectInitialOptions(
+      "(?i:.)",
+      matchingOptions(adding: [.caseInsensitive]))
+    try expectInitialOptions(
+      "(?i:.)(?m:.)",
+      matchingOptions(adding: [.caseInsensitive]))
+  }
 }

--- a/Tests/RegexTests/MatchTests.swift
+++ b/Tests/RegexTests/MatchTests.swift
@@ -1612,5 +1612,15 @@ extension RegexTests {
   
   // TODO: Add test for grapheme boundaries at start/end of match
 
+  func testCase() {
+    let regex = try! Regex(#".\N{SPARKLING HEART}."#)
+    let input = "🧟‍♀️💖🧠 or 🧠💖☕️"
+    let characterMatches = input.matches(of: regex)
+    XCTAssertEqual(characterMatches.map { $0.0 }, ["🧟‍♀️💖🧠", "🧠💖☕️"])
+
+    let scalarMatches = input.matches(of: regex.matchingSemantics(.unicodeScalar))
+    let scalarExpected: [Substring] = ["\u{FE0F}💖🧠", "🧠💖☕"]
+    XCTAssertEqual(scalarMatches.map { $0.0 }, scalarExpected)
+  }
 }
 


### PR DESCRIPTION
This allows us to fix an issue where searching via `firstMatch` or `matches(of:)` would only _start_ searches at a character index, even when a regex has Unicode scalar semantics.