### PR TITLE
Don't get stuck on empty matches

### DIFF
--- a/Sources/_StringProcessing/Algorithms/Matching/Matches.swift
+++ b/Sources/_StringProcessing/Algorithms/Matching/Matches.swift
@@ -213,14 +213,22 @@ extension BidirectionalCollection where SubSequence == Substring {
     let regex = r.regex
 
     var result = [Regex<R.RegexOutput>.Match]()
-    while start < end {
+    while start <= end {
       guard let match = try? regex._firstMatch(
         slice.base, in: start..<end
       ) else {
         break
       }
       result.append(match)
-      start = match.range.upperBound
+      if match.range.isEmpty {
+        if match.range.upperBound == end {
+          break
+        }
+        // FIXME: semantic level
+        start = slice.index(after: match.range.upperBound)
+      } else {
+        start = match.range.upperBound
+      }
     }
     return result
   }

--- a/Sources/_StringProcessing/Regex/Match.swift
+++ b/Sources/_StringProcessing/Regex/Match.swift
@@ -154,13 +154,13 @@ extension Regex {
 
     var low = inputRange.lowerBound
     let high = inputRange.upperBound
-    while low < high {
+    while true {
       if let m = try _match(input, in: low..<high, mode: .partialFromFront) {
         return m
       }
+      if low == high { return nil }
       input.formIndex(after: &low)
     }
-    return nil
   }
 }
 

--- a/Tests/RegexTests/AlgorithmsTests.swift
+++ b/Tests/RegexTests/AlgorithmsTests.swift
@@ -67,6 +67,9 @@ class AlgorithmTests: XCTestCase {
       let actualCol: [Range<Int>] = string[...].ranges(of: regex)[...].map(string.offsets(of:))
       XCTAssertEqual(actualCol, expected, file: file, line: line)
       
+      let matchRanges = string.matches(of: regex).map { string.offsets(of: $0.range) }
+      XCTAssertEqual(matchRanges, expected, file: file, line: line)
+
       let firstRange = string.firstRange(of: regex).map(string.offsets(of:))
       XCTAssertEqual(firstRange, expected.first, file: file, line: line)
     }
@@ -332,6 +335,11 @@ class AlgorithmTests: XCTestCase {
     XCTAssertEqual(
       s2.matches(of: regex).map(\.0),
       ["aa"])
+    
+    XCTAssertEqual(
+      s2.matches(of: try Regex("a*?")).map { s2.offsets(of: $0.range) }, [0..<0, 1..<1, 2..<2])
+    XCTAssertEqual(
+      s2.ranges(of: try Regex("a*?")).map(s2.offsets(of:)), [0..<0, 1..<1, 2..<2])
   }
 
   func testSwitches() {


### PR DESCRIPTION
This fixes an issue where calling `matches(of:)` with an pattern that matches an empty substring gets stuck searching the same position over and over.