### PR TITLE
[5.7] Algorithm correctness cherry-picks

### DIFF
--- a/Sources/_StringProcessing/Algorithms/Algorithms/Contains.swift
+++ b/Sources/_StringProcessing/Algorithms/Algorithms/Contains.swift
@@ -12,10 +12,10 @@
 // MARK: `CollectionSearcher` algorithms
 
 extension Collection {
-  func contains<Searcher: CollectionSearcher>(
+  func _contains<Searcher: CollectionSearcher>(
     _ searcher: Searcher
   ) -> Bool where Searcher.Searched == Self {
-    firstRange(of: searcher) != nil
+    _firstRange(of: searcher) != nil
   }
 }
 
@@ -36,7 +36,7 @@ extension Collection where Element: Equatable {
 }
 
 extension BidirectionalCollection where Element: Comparable {
-  func contains<C: Collection>(_ other: C) -> Bool
+  func _contains<C: Collection>(_ other: C) -> Bool
     where C.Element == Element
   {
     if #available(SwiftStdlib 5.7, *) {
@@ -70,6 +70,6 @@ extension BidirectionalCollection where SubSequence == Substring {
   /// `false`.
   @available(SwiftStdlib 5.7, *)
   public func contains<R: RegexComponent>(_ regex: R) -> Bool {
-    contains(RegexConsumer(regex))
+    _contains(RegexConsumer(regex))
   }
 }

--- a/Sources/_StringProcessing/Algorithms/Algorithms/FirstRange.swift
+++ b/Sources/_StringProcessing/Algorithms/Algorithms/FirstRange.swift
@@ -12,7 +12,7 @@
 // MARK: `CollectionSearcher` algorithms
 
 extension Collection {
-  func firstRange<S: CollectionSearcher>(
+  func _firstRange<S: CollectionSearcher>(
     of searcher: S
   ) -> Range<Index>? where S.Searched == Self {
     var state = searcher.state(for: self, in: startIndex..<endIndex)
@@ -21,7 +21,7 @@ extension Collection {
 }
 
 extension BidirectionalCollection {
-  func lastRange<S: BackwardCollectionSearcher>(
+  func _lastRange<S: BackwardCollectionSearcher>(
     of searcher: S
   ) -> Range<Index>? where S.BackwardSearched == Self {
     var state = searcher.backwardState(for: self, in: startIndex..<endIndex)
@@ -77,11 +77,11 @@ extension BidirectionalCollection where SubSequence == Substring {
   /// Returns `nil` if `regex` is not found.
   @available(SwiftStdlib 5.7, *)
   public func firstRange<R: RegexComponent>(of regex: R) -> Range<Index>? {
-    firstRange(of: RegexConsumer(regex))
+    _firstRange(of: RegexConsumer(regex))
   }
 
   @available(SwiftStdlib 5.7, *)
-  func lastRange<R: RegexComponent>(of regex: R) -> Range<Index>? {
-    lastRange(of: RegexConsumer(regex))
+  func _lastRange<R: RegexComponent>(of regex: R) -> Range<Index>? {
+    _lastRange(of: RegexConsumer(regex))
   }
 }

--- a/Sources/_StringProcessing/Algorithms/Algorithms/Ranges.swift
+++ b/Sources/_StringProcessing/Algorithms/Algorithms/Ranges.swift
@@ -157,7 +157,7 @@ extension ReversedRangesCollection: Sequence {
 // MARK: `CollectionSearcher` algorithms
 
 extension Collection {
-  func ranges<S: CollectionSearcher>(
+  func _ranges<S: CollectionSearcher>(
     of searcher: S
   ) -> RangesCollection<S> where S.Searched == Self {
     RangesCollection(base: self, searcher: searcher)
@@ -165,7 +165,7 @@ extension Collection {
 }
 
 extension BidirectionalCollection {
-  func rangesFromBack<S: BackwardCollectionSearcher>(
+  func _rangesFromBack<S: BackwardCollectionSearcher>(
     of searcher: S
   ) -> ReversedRangesCollection<S> where S.BackwardSearched == Self {
     ReversedRangesCollection(base: self, searcher: searcher)
@@ -175,10 +175,10 @@ extension BidirectionalCollection {
 // MARK: Fixed pattern algorithms
 
 extension Collection where Element: Equatable {
-  func ranges<C: Collection>(
+  func _ranges<C: Collection>(
     of other: C
   ) -> RangesCollection<ZSearcher<Self>> where C.Element == Element {
-    ranges(of: ZSearcher(pattern: Array(other), by: ==))
+    _ranges(of: ZSearcher(pattern: Array(other), by: ==))
   }
 
   // FIXME: Return `some Collection<Range<Index>>` for SE-0346
@@ -191,7 +191,7 @@ extension Collection where Element: Equatable {
   public func ranges<C: Collection>(
     of other: C
   ) -> [Range<Index>] where C.Element == Element {
-    ranges(of: ZSearcher(pattern: Array(other), by: ==)).map { $0 }
+    Array(_ranges(of: other))
   }
 }
 
@@ -207,12 +207,12 @@ extension BidirectionalCollection where Element: Equatable {
 }
 
 extension BidirectionalCollection where Element: Comparable {
-  func ranges<C: Collection>(
+  func _ranges<C: Collection>(
     of other: C
   ) -> RangesCollection<PatternOrEmpty<TwoWaySearcher<Self>>>
     where C.Element == Element
   {
-    ranges(of: PatternOrEmpty(searcher: TwoWaySearcher(pattern: Array(other))))
+    _ranges(of: PatternOrEmpty(searcher: TwoWaySearcher(pattern: Array(other))))
   }
   
   // FIXME
@@ -231,17 +231,17 @@ extension BidirectionalCollection where Element: Comparable {
 extension BidirectionalCollection where SubSequence == Substring {
   @available(SwiftStdlib 5.7, *)
   @_disfavoredOverload
-  func ranges<R: RegexComponent>(
+  func _ranges<R: RegexComponent>(
     of regex: R
   ) -> RangesCollection<RegexConsumer<R, Self>> {
-    ranges(of: RegexConsumer(regex))
+    _ranges(of: RegexConsumer(regex))
   }
 
   @available(SwiftStdlib 5.7, *)
-  func rangesFromBack<R: RegexComponent>(
+  func _rangesFromBack<R: RegexComponent>(
     of regex: R
   ) -> ReversedRangesCollection<RegexConsumer<R, Self>> {
-    rangesFromBack(of: RegexConsumer(regex))
+    _rangesFromBack(of: RegexConsumer(regex))
   }
 
   // FIXME: Return `some Collection<Range<Index>>` for SE-0346
@@ -255,6 +255,6 @@ extension BidirectionalCollection where SubSequence == Substring {
   public func ranges<R: RegexComponent>(
     of regex: R
   ) -> [Range<Index>] {
-    Array(ranges(of: RegexConsumer(regex)))
+    Array(_ranges(of: regex))
   }
 }

--- a/Sources/_StringProcessing/Algorithms/Algorithms/Replace.swift
+++ b/Sources/_StringProcessing/Algorithms/Algorithms/Replace.swift
@@ -12,7 +12,7 @@
 // MARK: `CollectionSearcher` algorithms
 
 extension RangeReplaceableCollection {
-  func replacing<Searcher: CollectionSearcher, Replacement: Collection>(
+  func _replacing<Searcher: CollectionSearcher, Replacement: Collection>(
     _ searcher: Searcher,
     with replacement: Replacement,
     subrange: Range<Index>,
@@ -26,7 +26,7 @@ extension RangeReplaceableCollection {
     var result = Self()
     result.append(contentsOf: self[..<index])
     
-    for range in self[subrange].ranges(of: searcher).prefix(maxReplacements) {
+    for range in self[subrange]._ranges(of: searcher).prefix(maxReplacements) {
       result.append(contentsOf: self[index..<range.lowerBound])
       result.append(contentsOf: replacement)
       index = range.upperBound
@@ -36,28 +36,28 @@ extension RangeReplaceableCollection {
     return result
   }
   
-  func replacing<Searcher: CollectionSearcher, Replacement: Collection>(
+  func _replacing<Searcher: CollectionSearcher, Replacement: Collection>(
     _ searcher: Searcher,
     with replacement: Replacement,
     maxReplacements: Int = .max
   ) -> Self where Searcher.Searched == SubSequence,
                   Replacement.Element == Element
   {
-    replacing(
+    _replacing(
       searcher,
       with: replacement,
       subrange: startIndex..<endIndex,
       maxReplacements: maxReplacements)
   }
   
-  mutating func replace<
+  mutating func _replace<
     Searcher: CollectionSearcher, Replacement: Collection
   >(
     _ searcher: Searcher,
     with replacement: Replacement,
     maxReplacements: Int = .max
   ) where Searcher.Searched == SubSequence, Replacement.Element == Element {
-    self = replacing(
+    self = _replacing(
       searcher,
       with: replacement,
       maxReplacements: maxReplacements)
@@ -84,7 +84,7 @@ extension RangeReplaceableCollection where Element: Equatable {
     subrange: Range<Index>,
     maxReplacements: Int = .max
   ) -> Self where C.Element == Element, Replacement.Element == Element {
-    replacing(
+    _replacing(
       ZSearcher(pattern: Array(other), by: ==),
       with: replacement,
       subrange: subrange,
@@ -136,37 +136,37 @@ extension RangeReplaceableCollection where Element: Equatable {
 extension RangeReplaceableCollection
   where Self: BidirectionalCollection, Element: Comparable
 {
-  func replacing<C: Collection, Replacement: Collection>(
+  func _replacing<C: Collection, Replacement: Collection>(
     _ other: C,
     with replacement: Replacement,
     subrange: Range<Index>,
     maxReplacements: Int = .max
   ) -> Self where C.Element == Element, Replacement.Element == Element {
-    replacing(
+    _replacing(
       PatternOrEmpty(searcher: TwoWaySearcher(pattern: Array(other))),
       with: replacement,
       subrange: subrange,
       maxReplacements: maxReplacements)
   }
       
-  func replacing<C: Collection, Replacement: Collection>(
+  func _replacing<C: Collection, Replacement: Collection>(
     _ other: C,
     with replacement: Replacement,
     maxReplacements: Int = .max
   ) -> Self where C.Element == Element, Replacement.Element == Element {
-    replacing(
+    _replacing(
       other,
       with: replacement,
       subrange: startIndex..<endIndex,
       maxReplacements: maxReplacements)
   }
   
-  mutating func replace<C: Collection, Replacement: Collection>(
+  mutating func _replace<C: Collection, Replacement: Collection>(
     _ other: C,
     with replacement: Replacement,
     maxReplacements: Int = .max
   ) where C.Element == Element, Replacement.Element == Element {
-    self = replacing(
+    self = _replacing(
       other,
       with: replacement,
       subrange: startIndex..<endIndex,
@@ -194,7 +194,7 @@ extension RangeReplaceableCollection where SubSequence == Substring {
     subrange: Range<Index>,
     maxReplacements: Int = .max
   ) -> Self where Replacement.Element == Element {
-    replacing(
+    _replacing(
       RegexConsumer(regex),
       with: replacement,
       subrange: subrange,

--- a/Sources/_StringProcessing/Algorithms/Algorithms/Split.swift
+++ b/Sources/_StringProcessing/Algorithms/Algorithms/Split.swift
@@ -34,7 +34,7 @@ struct SplitCollection<Searcher: CollectionSearcher> {
     maxSplits: Int,
     omittingEmptySubsequences: Bool)
   {
-    self.ranges = base.ranges(of: searcher)
+    self.ranges = base._ranges(of: searcher)
     self.maxSplits = maxSplits
     self.omittingEmptySubsequences = omittingEmptySubsequences
   }
@@ -183,7 +183,7 @@ struct ReversedSplitCollection<Searcher: BackwardCollectionSearcher> {
   }
 
   init(base: Base, searcher: Searcher) {
-    self.ranges = base.rangesFromBack(of: searcher)
+    self.ranges = base._rangesFromBack(of: searcher)
   }
 }
 

--- a/Sources/_StringProcessing/Algorithms/Algorithms/StartsWith.swift
+++ b/Sources/_StringProcessing/Algorithms/Algorithms/StartsWith.swift
@@ -12,7 +12,7 @@
 // MARK: `CollectionConsumer` algorithms
 
 extension Collection {
-  func starts<C: CollectionConsumer>(with consumer: C) -> Bool
+  func _starts<C: CollectionConsumer>(with consumer: C) -> Bool
     where C.Consumed == SubSequence
   {
     consumer.consuming(self[...]) != nil
@@ -20,7 +20,7 @@ extension Collection {
 }
 
 extension BidirectionalCollection {
-  func ends<C: BidirectionalCollectionConsumer>(with consumer: C) -> Bool
+  func _ends<C: BidirectionalCollectionConsumer>(with consumer: C) -> Bool
     where C.Consumed == SubSequence
   {
     consumer.consumingBack(self[...]) != nil
@@ -30,18 +30,18 @@ extension BidirectionalCollection {
 // MARK: Fixed pattern algorithms
 
 extension Collection where Element: Equatable {
-  func starts<C: Collection>(with prefix: C) -> Bool
+  func _starts<C: Collection>(with prefix: C) -> Bool
     where C.Element == Element
   {
-    starts(with: FixedPatternConsumer(pattern: prefix))
+    _starts(with: FixedPatternConsumer(pattern: prefix))
   }
 }
 
 extension BidirectionalCollection where Element: Equatable {
-  func ends<C: BidirectionalCollection>(with suffix: C) -> Bool
+  func _ends<C: BidirectionalCollection>(with suffix: C) -> Bool
     where C.Element == Element
   {
-    ends(with: FixedPatternConsumer(pattern: suffix))
+    _ends(with: FixedPatternConsumer(pattern: suffix))
   }
 }
 
@@ -56,10 +56,10 @@ extension BidirectionalCollection where SubSequence == Substring {
   /// - Returns: `true` if the initial elements of the sequence matches the
   ///   beginning of `regex`; otherwise, `false`.
   public func starts<R: RegexComponent>(with regex: R) -> Bool {
-    starts(with: RegexConsumer(regex))
+    _starts(with: RegexConsumer(regex))
   }
   
-  func ends<R: RegexComponent>(with regex: R) -> Bool {
-    ends(with: RegexConsumer(regex))
+  func _ends<R: RegexComponent>(with regex: R) -> Bool {
+    _ends(with: RegexConsumer(regex))
   }
 }

--- a/Sources/_StringProcessing/Algorithms/Algorithms/Trim.swift
+++ b/Sources/_StringProcessing/Algorithms/Algorithms/Trim.swift
@@ -12,7 +12,7 @@
 // MARK: `CollectionConsumer` algorithms
 
 extension Collection {
-  func trimmingPrefix<Consumer: CollectionConsumer>(
+  func _trimmingPrefix<Consumer: CollectionConsumer>(
     _ consumer: Consumer
   ) -> SubSequence where Consumer.Consumed == Self {
     let start = consumer.consuming(self) ?? startIndex
@@ -21,7 +21,7 @@ extension Collection {
 }
 
 extension Collection where SubSequence == Self {
-  mutating func trimPrefix<Consumer: CollectionConsumer>(
+  mutating func _trimPrefix<Consumer: CollectionConsumer>(
     _ consumer: Consumer
   ) where Consumer.Consumed == Self {
     _ = consumer.consume(&self)
@@ -32,7 +32,7 @@ extension RangeReplaceableCollection {
   // NOTE: Disfavored because the `Collection with SubSequence == Self` overload
   // should be preferred whenever both are available
   @_disfavoredOverload
-  mutating func trimPrefix<Consumer: CollectionConsumer>(
+  mutating func _trimPrefix<Consumer: CollectionConsumer>(
     _ consumer: Consumer
   ) where Consumer.Consumed == Self {
     if let start = consumer.consuming(self) {
@@ -42,7 +42,7 @@ extension RangeReplaceableCollection {
 }
 
 extension BidirectionalCollection {
-  func trimmingSuffix<Consumer: BidirectionalCollectionConsumer>(
+  func _trimmingSuffix<Consumer: BidirectionalCollectionConsumer>(
     _ consumer: Consumer
   ) -> SubSequence
     where Consumer.Consumed == Self
@@ -51,7 +51,7 @@ extension BidirectionalCollection {
     return self[..<end]
   }
   
-  func trimming<Consumer: BidirectionalCollectionConsumer>(
+  func _trimming<Consumer: BidirectionalCollectionConsumer>(
     _ consumer: Consumer
   ) -> SubSequence where Consumer.Consumed == Self {
     // NOTE: Might give different results than trimming the suffix before
@@ -64,24 +64,24 @@ extension BidirectionalCollection {
 }
 
 extension BidirectionalCollection where SubSequence == Self {
-  mutating func trimSuffix<Consumer: BidirectionalCollectionConsumer>(
+  mutating func _trimSuffix<Consumer: BidirectionalCollectionConsumer>(
     _ consumer: Consumer
   ) where Consumer.Consumed == SubSequence
   {
     _ = consumer.consumeBack(&self)
   }
 
-  mutating func trim<Consumer: BidirectionalCollectionConsumer>(
+  mutating func _trim<Consumer: BidirectionalCollectionConsumer>(
     _ consumer: Consumer
   ) where Consumer.Consumed == Self {
-    trimPrefix(consumer)
-    trimSuffix(consumer)
+    _trimPrefix(consumer)
+    _trimSuffix(consumer)
   }
 }
 
 extension RangeReplaceableCollection where Self: BidirectionalCollection {
   @_disfavoredOverload
-  mutating func trimSuffix<Consumer: BidirectionalCollectionConsumer>(
+  mutating func _trimSuffix<Consumer: BidirectionalCollectionConsumer>(
     _ consumer: Consumer
   ) where Consumer.Consumed == Self
   {
@@ -91,11 +91,11 @@ extension RangeReplaceableCollection where Self: BidirectionalCollection {
   }
   
   @_disfavoredOverload
-  mutating func trim<Consumer: BidirectionalCollectionConsumer>(
+  mutating func _trim<Consumer: BidirectionalCollectionConsumer>(
     _ consumer: Consumer
   ) where Consumer.Consumed == Self {
-    trimSuffix(consumer)
-    trimPrefix(consumer)
+    _trimSuffix(consumer)
+    _trimPrefix(consumer)
   }
 }
 
@@ -137,49 +137,49 @@ extension RangeReplaceableCollection {
 }
 
 extension BidirectionalCollection {
-  func trimmingSuffix(
+  func _trimmingSuffix(
     while predicate: @escaping (Element) -> Bool
   ) -> SubSequence {
-    trimmingSuffix(ManyConsumer(base: PredicateConsumer(predicate: predicate)))
+    _trimmingSuffix(ManyConsumer(base: PredicateConsumer(predicate: predicate)))
   }
   
-  func trimming(
+  func _trimming(
     while predicate: @escaping (Element) -> Bool
   ) -> SubSequence {
-    trimming(ManyConsumer(base: PredicateConsumer(predicate: predicate)))
+    _trimming(ManyConsumer(base: PredicateConsumer(predicate: predicate)))
   }
 }
 
 extension BidirectionalCollection where SubSequence == Self {
-  mutating func trimSuffix(
+  mutating func _trimSuffix(
     while predicate: @escaping (Element) -> Bool
   ) {
-    trimSuffix(ManyConsumer(
+    _trimSuffix(ManyConsumer(
       base: PredicateConsumer<SubSequence>(predicate: predicate)))
   }
 
-  mutating func trim(while predicate: @escaping (Element) -> Bool) {
+  mutating func _trim(while predicate: @escaping (Element) -> Bool) {
     let consumer = ManyConsumer(
       base: PredicateConsumer<SubSequence>(predicate: predicate))
-    trimPrefix(consumer)
-    trimSuffix(consumer)
+    _trimPrefix(consumer)
+    _trimSuffix(consumer)
   }
 }
 
 extension RangeReplaceableCollection where Self: BidirectionalCollection {
   @_disfavoredOverload
-  mutating func trimSuffix(
+  mutating func _trimSuffix(
     while predicate: @escaping (Element) -> Bool
   ) {
-    trimSuffix(ManyConsumer(base: PredicateConsumer(predicate: predicate)))
+    _trimSuffix(ManyConsumer(base: PredicateConsumer(predicate: predicate)))
   }
   
   @_disfavoredOverload
-  mutating func trim(while predicate: @escaping (Element) -> Bool) {
+  mutating func _trim(while predicate: @escaping (Element) -> Bool) {
     let consumer = ManyConsumer(
       base: PredicateConsumer<Self>(predicate: predicate))
-    trimPrefix(consumer)
-    trimSuffix(consumer)
+    _trimPrefix(consumer)
+    _trimSuffix(consumer)
   }
 }
 
@@ -197,7 +197,7 @@ extension Collection where Element: Equatable {
   public func trimmingPrefix<Prefix: Sequence>(
     _ prefix: Prefix
   ) -> SubSequence where Prefix.Element == Element {
-    trimmingPrefix(FixedPatternConsumer(pattern: prefix))
+    _trimmingPrefix(FixedPatternConsumer(pattern: prefix))
   }
 }
 
@@ -211,7 +211,7 @@ extension Collection where SubSequence == Self, Element: Equatable {
   public mutating func trimPrefix<Prefix: Sequence>(
     _ prefix: Prefix
   ) where Prefix.Element == Element {
-    trimPrefix(FixedPatternConsumer<SubSequence, Prefix>(pattern: prefix))
+    _trimPrefix(FixedPatternConsumer<SubSequence, Prefix>(pattern: prefix))
   }
 }
 
@@ -226,39 +226,39 @@ extension RangeReplaceableCollection where Element: Equatable {
   public mutating func trimPrefix<Prefix: Sequence>(
     _ prefix: Prefix
   ) where Prefix.Element == Element {
-    trimPrefix(FixedPatternConsumer(pattern: prefix))
+    _trimPrefix(FixedPatternConsumer(pattern: prefix))
   }
 }
 
 extension BidirectionalCollection where Element: Equatable {
-  func trimmingSuffix<Suffix: BidirectionalCollection>(
+  func _trimmingSuffix<Suffix: BidirectionalCollection>(
     _ suffix: Suffix
   ) -> SubSequence where Suffix.Element == Element {
-    trimmingSuffix(FixedPatternConsumer(pattern: suffix))
+    _trimmingSuffix(FixedPatternConsumer(pattern: suffix))
   }
   
-  func trimming<Pattern: BidirectionalCollection>(
+  func _trimming<Pattern: BidirectionalCollection>(
     _ pattern: Pattern
   ) -> SubSequence where Pattern.Element == Element {
-    trimming(FixedPatternConsumer(pattern: pattern))
+    _trimming(FixedPatternConsumer(pattern: pattern))
   }
 }
 
 extension BidirectionalCollection
   where SubSequence == Self, Element: Equatable
 {
-  mutating func trimSuffix<Suffix: BidirectionalCollection>(
+  mutating func _trimSuffix<Suffix: BidirectionalCollection>(
     _ suffix: Suffix
   ) where Suffix.Element == Element {
-    trimSuffix(FixedPatternConsumer<SubSequence, Suffix>(pattern: suffix))
+    _trimSuffix(FixedPatternConsumer<SubSequence, Suffix>(pattern: suffix))
   }
   
-  mutating func trim<Pattern: BidirectionalCollection>(
+  mutating func _trim<Pattern: BidirectionalCollection>(
     _ pattern: Pattern
   ) where Pattern.Element == Element {
     let consumer = FixedPatternConsumer<SubSequence, Pattern>(pattern: pattern)
-    trimPrefix(consumer)
-    trimSuffix(consumer)
+    _trimPrefix(consumer)
+    _trimSuffix(consumer)
   }
 }
 
@@ -266,19 +266,19 @@ extension RangeReplaceableCollection
   where Self: BidirectionalCollection, Element: Equatable
 {
   @_disfavoredOverload
-  mutating func trimSuffix<Suffix: BidirectionalCollection>(
+  mutating func _trimSuffix<Suffix: BidirectionalCollection>(
     _ prefix: Suffix
   ) where Suffix.Element == Element {
-    trimSuffix(FixedPatternConsumer(pattern: prefix))
+    _trimSuffix(FixedPatternConsumer(pattern: prefix))
   }
   
   @_disfavoredOverload
-  mutating func trim<Pattern: BidirectionalCollection>(
+  mutating func _trim<Pattern: BidirectionalCollection>(
     _ pattern: Pattern
   ) where Pattern.Element == Element {
     let consumer = FixedPatternConsumer<Self, Pattern>(pattern: pattern)
-    trimPrefix(consumer)
-    trimSuffix(consumer)
+    _trimPrefix(consumer)
+    _trimSuffix(consumer)
   }
 }
 
@@ -292,17 +292,17 @@ extension BidirectionalCollection where SubSequence == Substring {
   /// `prefix` from the start.
   @available(SwiftStdlib 5.7, *)
   public func trimmingPrefix<R: RegexComponent>(_ regex: R) -> SubSequence {
-    trimmingPrefix(RegexConsumer(regex))
+    _trimmingPrefix(RegexConsumer(regex))
   }
 
   @available(SwiftStdlib 5.7, *)
-  func trimmingSuffix<R: RegexComponent>(_ regex: R) -> SubSequence {
-    trimmingSuffix(RegexConsumer(regex))
+  func _trimmingSuffix<R: RegexComponent>(_ regex: R) -> SubSequence {
+    _trimmingSuffix(RegexConsumer(regex))
   }
 
   @available(SwiftStdlib 5.7, *)
-  func trimming<R: RegexComponent>(_ regex: R) -> SubSequence {
-    trimming(RegexConsumer(regex))
+  func _trimming<R: RegexComponent>(_ regex: R) -> SubSequence {
+    _trimming(RegexConsumer(regex))
   }
 }
 
@@ -313,37 +313,37 @@ extension RangeReplaceableCollection
   /// - Parameter regex: The regex to remove from this collection.
   @available(SwiftStdlib 5.7, *)
   public mutating func trimPrefix<R: RegexComponent>(_ regex: R) {
-    trimPrefix(RegexConsumer(regex))
+    _trimPrefix(RegexConsumer(regex))
   }
 
   @available(SwiftStdlib 5.7, *)
-  mutating func trimSuffix<R: RegexComponent>(_ regex: R) {
-    trimSuffix(RegexConsumer(regex))
+  mutating func _trimSuffix<R: RegexComponent>(_ regex: R) {
+    _trimSuffix(RegexConsumer(regex))
   }
 
   @available(SwiftStdlib 5.7, *)
-  mutating func trim<R: RegexComponent>(_ regex: R) {
+  mutating func _trim<R: RegexComponent>(_ regex: R) {
     let consumer = RegexConsumer<R, Self>(regex)
-    trimPrefix(consumer)
-    trimSuffix(consumer)
+    _trimPrefix(consumer)
+    _trimSuffix(consumer)
   }
 }
 
 extension Substring {
   @available(SwiftStdlib 5.7, *)
-  mutating func trimPrefix<R: RegexComponent>(_ regex: R) {
-    trimPrefix(RegexConsumer(regex))
+  mutating func _trimPrefix<R: RegexComponent>(_ regex: R) {
+    _trimPrefix(RegexConsumer(regex))
   }
 
   @available(SwiftStdlib 5.7, *)
-  mutating func trimSuffix<R: RegexComponent>(_ regex: R) {
-    trimSuffix(RegexConsumer(regex))
+  mutating func _trimSuffix<R: RegexComponent>(_ regex: R) {
+    _trimSuffix(RegexConsumer(regex))
   }
 
   @available(SwiftStdlib 5.7, *)
-  mutating func trim<R: RegexComponent>(_ regex: R) {
+  mutating func _trim<R: RegexComponent>(_ regex: R) {
     let consumer = RegexConsumer<R, Self>(regex)
-    trimPrefix(consumer)
-    trimSuffix(consumer)
+    _trimPrefix(consumer)
+    _trimSuffix(consumer)
   }
 }

--- a/Sources/_StringProcessing/Algorithms/Matching/FirstMatch.swift
+++ b/Sources/_StringProcessing/Algorithms/Matching/FirstMatch.swift
@@ -12,7 +12,7 @@
 // MARK: `CollectionSearcher` algorithms
 
 extension Collection {
-  func firstMatch<S: MatchingCollectionSearcher>(
+  func _firstMatch<S: MatchingCollectionSearcher>(
     of searcher: S
   ) -> _MatchResult<S>? where S.Searched == Self {
     var state = searcher.state(for: self, in: startIndex..<endIndex)
@@ -43,7 +43,7 @@ extension BidirectionalCollection where SubSequence == Substring {
   func firstMatch<R: RegexComponent>(
     of regex: R
   ) -> _MatchResult<RegexConsumer<R, Self>>? {
-    firstMatch(of: RegexConsumer(regex))
+    _firstMatch(of: RegexConsumer(regex))
   }
 
   @available(SwiftStdlib 5.7, *)

--- a/Sources/_StringProcessing/Algorithms/Matching/MatchReplace.swift
+++ b/Sources/_StringProcessing/Algorithms/Matching/MatchReplace.swift
@@ -12,7 +12,7 @@
 // MARK: `MatchingCollectionSearcher` algorithms
 
 extension RangeReplaceableCollection {
-  func replacing<
+  func _replacing<
     Searcher: MatchingCollectionSearcher, Replacement: Collection
   >(
     _ searcher: Searcher,
@@ -28,7 +28,7 @@ extension RangeReplaceableCollection {
     var result = Self()
     result.append(contentsOf: self[..<index])
 
-    for match in self[subrange].matches(of: searcher)
+    for match in self[subrange]._matches(of: searcher)
           .prefix(maxReplacements)
     {
       result.append(contentsOf: self[index..<match.range.lowerBound])
@@ -40,7 +40,7 @@ extension RangeReplaceableCollection {
     return result
   }
 
-  func replacing<
+  func _replacing<
     Searcher: MatchingCollectionSearcher, Replacement: Collection
   >(
     _ searcher: Searcher,
@@ -49,14 +49,14 @@ extension RangeReplaceableCollection {
   ) rethrows -> Self where Searcher.Searched == SubSequence,
                            Replacement.Element == Element
   {
-    try replacing(
+    try _replacing(
       searcher,
       with: replacement,
       subrange: startIndex..<endIndex,
       maxReplacements: maxReplacements)
   }
 
-  mutating func replace<
+  mutating func _replace<
     Searcher: MatchingCollectionSearcher, Replacement: Collection
   >(
     _ searcher: Searcher,
@@ -65,7 +65,7 @@ extension RangeReplaceableCollection {
   ) rethrows where Searcher.Searched == SubSequence,
                    Replacement.Element == Element
   {
-    self = try replacing(
+    self = try _replacing(
       searcher,
       with: replacement,
       maxReplacements: maxReplacements)
@@ -76,13 +76,13 @@ extension RangeReplaceableCollection {
 
 extension RangeReplaceableCollection where SubSequence == Substring {
   @available(SwiftStdlib 5.7, *)
-  func replacing<R: RegexComponent, Replacement: Collection>(
+  func _replacing<R: RegexComponent, Replacement: Collection>(
     _ regex: R,
     with replacement: (_MatchResult<RegexConsumer<R, Substring>>) throws -> Replacement,
     subrange: Range<Index>,
     maxReplacements: Int = .max
   ) rethrows -> Self where Replacement.Element == Element {
-    try replacing(
+    try _replacing(
       RegexConsumer(regex),
       with: replacement,
       subrange: subrange,
@@ -90,12 +90,12 @@ extension RangeReplaceableCollection where SubSequence == Substring {
   }
 
   @available(SwiftStdlib 5.7, *)
-  func replacing<R: RegexComponent, Replacement: Collection>(
+  func _replacing<R: RegexComponent, Replacement: Collection>(
     _ regex: R,
     with replacement: (_MatchResult<RegexConsumer<R, Substring>>) throws -> Replacement,
     maxReplacements: Int = .max
   ) rethrows -> Self where Replacement.Element == Element {
-    try replacing(
+    try _replacing(
       regex,
       with: replacement,
       subrange: startIndex..<endIndex,
@@ -103,12 +103,12 @@ extension RangeReplaceableCollection where SubSequence == Substring {
   }
 
   @available(SwiftStdlib 5.7, *)
-  mutating func replace<R: RegexComponent, Replacement: Collection>(
+  mutating func _replace<R: RegexComponent, Replacement: Collection>(
     _ regex: R,
     with replacement: (_MatchResult<RegexConsumer<R, Substring>>) throws -> Replacement,
     maxReplacements: Int = .max
   ) rethrows where Replacement.Element == Element {
-    self = try replacing(
+    self = try _replacing(
       regex,
       with: replacement,
       maxReplacements: maxReplacements)

--- a/Sources/_StringProcessing/Algorithms/Matching/Matches.swift
+++ b/Sources/_StringProcessing/Algorithms/Matching/Matches.swift
@@ -166,7 +166,7 @@ extension ReversedMatchesCollection: Sequence {
 // MARK: `CollectionSearcher` algorithms
 
 extension Collection {
-  func matches<S: MatchingCollectionSearcher>(
+  func _matches<S: MatchingCollectionSearcher>(
     of searcher: S
   ) -> MatchesCollection<S> where S.Searched == Self {
     MatchesCollection(base: self, searcher: searcher)
@@ -174,7 +174,7 @@ extension Collection {
 }
 
 extension BidirectionalCollection {
-  func matchesFromBack<S: BackwardMatchingCollectionSearcher>(
+  func _matchesFromBack<S: BackwardMatchingCollectionSearcher>(
     of searcher: S
   ) -> ReversedMatchesCollection<S> where S.BackwardSearched == Self {
     ReversedMatchesCollection(base: self, searcher: searcher)
@@ -186,17 +186,17 @@ extension BidirectionalCollection {
 extension BidirectionalCollection where SubSequence == Substring {
   @available(SwiftStdlib 5.7, *)
   @_disfavoredOverload
-  func matches<R: RegexComponent>(
+  func _matches<R: RegexComponent>(
     of regex: R
   ) -> MatchesCollection<RegexConsumer<R, Self>> {
-    matches(of: RegexConsumer(regex))
+    _matches(of: RegexConsumer(regex))
   }
 
   @available(SwiftStdlib 5.7, *)
-  func matchesFromBack<R: RegexComponent>(
+  func _matchesFromBack<R: RegexComponent>(
     of regex: R
   ) -> ReversedMatchesCollection<RegexConsumer<R, Self>> {
-    matchesFromBack(of: RegexConsumer(regex))
+    _matchesFromBack(of: RegexConsumer(regex))
   }
 
   // FIXME: Return `some Collection<Regex<R.Output>.Match> for SE-0346

--- a/Sources/_StringProcessing/Algorithms/Matching/Matches.swift
+++ b/Sources/_StringProcessing/Algorithms/Matching/Matches.swift
@@ -213,14 +213,22 @@ extension BidirectionalCollection where SubSequence == Substring {
     let regex = r.regex
 
     var result = [Regex<R.RegexOutput>.Match]()
-    while start < end {
+    while start <= end {
       guard let match = try? regex._firstMatch(
         slice.base, in: start..<end
       ) else {
         break
       }
       result.append(match)
-      start = match.range.upperBound
+      if match.range.isEmpty {
+        if match.range.upperBound == end {
+          break
+        }
+        // FIXME: semantic level
+        start = slice.index(after: match.range.upperBound)
+      } else {
+        start = match.range.upperBound
+      }
     }
     return result
   }

--- a/Sources/_StringProcessing/Algorithms/Searchers/TwoWaySearcher.swift
+++ b/Sources/_StringProcessing/Algorithms/Searchers/TwoWaySearcher.swift
@@ -24,7 +24,7 @@ struct TwoWaySearcher<Searched: BidirectionalCollection>
     let (criticalIndex, periodOfSecondPart) = pattern._criticalFactorization(<)
     let periodIsExact = pattern[criticalIndex...]
       .prefix(periodOfSecondPart)
-      .ends(with: pattern[..<criticalIndex])
+      ._ends(with: pattern[..<criticalIndex])
     
     self.pattern = pattern
     self.criticalIndex = criticalIndex

--- a/Sources/_StringProcessing/ByteCodeGen.swift
+++ b/Sources/_StringProcessing/ByteCodeGen.swift
@@ -35,6 +35,9 @@ extension Compiler.ByteCodeGen {
       builder.buildUnresolvedReference(id: id)
 
     case let .changeMatchingOptions(optionSequence):
+      if !builder.hasReceivedInstructions {
+        builder.initialOptions.apply(optionSequence.ast)
+      }
       options.apply(optionSequence.ast)
 
     case let .unconverted(astAtom):
@@ -378,6 +381,9 @@ extension Compiler.ByteCodeGen {
       throw Unreachable("These should produce a capture node")
 
     case .changeMatchingOptions(let optionSequence):
+      if !builder.hasReceivedInstructions {
+        builder.initialOptions.apply(optionSequence)
+      }
       options.apply(optionSequence)
       try emitNode(child)
 

--- a/Sources/_StringProcessing/ConsumerInterface.swift
+++ b/Sources/_StringProcessing/ConsumerInterface.swift
@@ -326,7 +326,7 @@ extension DSLTree.CustomCharacterClass.Member {
     case .quotedLiteral(let s):
       if opts.isCaseInsensitive {
         return { input, bounds in
-          guard s.lowercased().contains(input[bounds.lowerBound].lowercased()) else {
+          guard s.lowercased()._contains(input[bounds.lowerBound].lowercased()) else {
             return nil
           }
           return input.index(after: bounds.lowerBound)

--- a/Sources/_StringProcessing/Engine/MEBuilder.swift
+++ b/Sources/_StringProcessing/Engine/MEBuilder.swift
@@ -39,6 +39,7 @@ extension MEProgram where Input.Element: Hashable {
     var failAddressToken: AddressToken? = nil
 
     var captureList = CaptureList()
+    var initialOptions = MatchingOptions()
 
     // Symbolic reference resolution
     var unresolvedReferences: [ReferenceID: [InstructionAddress]] = [:]
@@ -76,6 +77,11 @@ extension MEProgram.Builder {
 
   var lastInstructionAddress: InstructionAddress {
     .init(instructions.endIndex - 1)
+  }
+  
+  /// `true` if the builder has received any instructions.
+  var hasReceivedInstructions: Bool {
+    !instructions.isEmpty
   }
 
   mutating func buildNop(_ r: StringRegister? = nil) {
@@ -353,7 +359,8 @@ extension MEProgram.Builder {
       registerInfo: regInfo,
       captureList: captureList,
       referencedCaptureOffsets: referencedCaptureOffsets,
-      namedCaptureOffsets: namedCaptureOffsets)
+      namedCaptureOffsets: namedCaptureOffsets,
+      initialOptions: initialOptions)
   }
 
   mutating func reset() { self = Self() }

--- a/Sources/_StringProcessing/Engine/MEProgram.swift
+++ b/Sources/_StringProcessing/Engine/MEProgram.swift
@@ -37,6 +37,8 @@ struct MEProgram<Input: Collection> where Input.Element: Equatable {
   let captureList: CaptureList
   let referencedCaptureOffsets: [ReferenceID: Int]
   let namedCaptureOffsets: [String: Int]
+  
+  var initialOptions: MatchingOptions
 }
 
 extension MEProgram: CustomStringConvertible {

--- a/Sources/_StringProcessing/MatchingOptions.swift
+++ b/Sources/_StringProcessing/MatchingOptions.swift
@@ -54,6 +54,13 @@ extension MatchingOptions {
     stack[stack.count - 1].apply(sequence)
     _invariantCheck()
   }
+  
+  // @testable
+  /// Returns true if the options at the top of `stack` are equal to those
+  /// for `other`.
+  func _equal(to other: MatchingOptions) -> Bool {
+    stack.last == other.stack.last
+  }
 }
 
 // MARK: Matching behavior API
@@ -127,6 +134,7 @@ extension MatchingOptions {
   }
 }
 
+// MARK: - Implementation
 extension MatchingOptions {
   /// An option that changes the behavior of a regular expression.
   fileprivate enum Option: Int {

--- a/Sources/_StringProcessing/PrintAsPattern.swift
+++ b/Sources/_StringProcessing/PrintAsPattern.swift
@@ -469,7 +469,7 @@ extension PrettyPrinter {
 extension String {
   // TODO: Escaping?
   fileprivate var _quoted: String {
-    "\"\(self.replacing("\"", with: "\\\""))\""
+    "\"\(self._replacing("\"", with: "\\\""))\""
   }
 }
 

--- a/Sources/_StringProcessing/Regex/ASTConversion.swift
+++ b/Sources/_StringProcessing/Regex/ASTConversion.swift
@@ -13,15 +13,7 @@
 
 extension AST {
   var dslTree: DSLTree {
-    return DSLTree(
-      root.dslTreeNode, options: globalOptions?.dslTreeOptions)
-  }
-}
-
-extension AST.GlobalMatchingOptionSequence {
-  var dslTreeOptions: DSLTree.Options {
-    // TODO: map options
-    return .init()
+    return DSLTree(root.dslTreeNode)
   }
 }
 

--- a/Sources/_StringProcessing/Regex/Core.swift
+++ b/Sources/_StringProcessing/Regex/Core.swift
@@ -91,6 +91,18 @@ extension Regex {
       self.tree = tree
     }
   }
+  
+  /// The set of matching options that applies to the start of this regex.
+  ///
+  /// Note that the initial options may not apply to the entire regex. For
+  /// example, in this regex, only case insensitivity (`i`) and Unicode scalar
+  /// semantics (set by API) apply to the entire regex, while ASCII character
+  /// classes (`P`) is part of `initialOptions` but not global:
+  ///
+  ///     let regex = /(?i)(?P:\d+\s*)abc/.semanticLevel(.unicodeScalar)
+  var initialOptions: MatchingOptions {
+    program.loweredProgram.initialOptions
+  }
 }
 
 @available(SwiftStdlib 5.7, *)
@@ -102,6 +114,6 @@ extension Regex {
 
   @_spi(RegexBuilder)
   public init(node: DSLTree.Node) {
-    self.program = Program(tree: .init(node, options: nil))
+    self.program = Program(tree: .init(node))
   }
 }

--- a/Sources/_StringProcessing/Regex/DSLTree.swift
+++ b/Sources/_StringProcessing/Regex/DSLTree.swift
@@ -14,11 +14,9 @@
 @_spi(RegexBuilder)
 public struct DSLTree {
   var root: Node
-  var options: Options?
 
-  init(_ r: Node, options: Options?) {
+  init(_ r: Node) {
     self.root = r
-    self.options = options
   }
 }
 

--- a/Sources/_StringProcessing/Regex/Match.swift
+++ b/Sources/_StringProcessing/Regex/Match.swift
@@ -158,8 +158,12 @@ extension Regex {
       if let m = try _match(input, in: low..<high, mode: .partialFromFront) {
         return m
       }
-      if low == high { return nil }
-      input.formIndex(after: &low)
+      if low >= high { return nil }
+      if regex.initialOptions.semanticLevel == .graphemeCluster {
+        input.formIndex(after: &low)
+      } else {
+        input.unicodeScalars.formIndex(after: &low)
+      }
     }
   }
 }

--- a/Sources/_StringProcessing/Regex/Match.swift
+++ b/Sources/_StringProcessing/Regex/Match.swift
@@ -154,13 +154,13 @@ extension Regex {
 
     var low = inputRange.lowerBound
     let high = inputRange.upperBound
-    while low < high {
+    while true {
       if let m = try _match(input, in: low..<high, mode: .partialFromFront) {
         return m
       }
+      if low == high { return nil }
       input.formIndex(after: &low)
     }
-    return nil
   }
 }
 

--- a/Tests/RegexTests/AlgorithmsInternalsTests.swift
+++ b/Tests/RegexTests/AlgorithmsInternalsTests.swift
@@ -24,7 +24,7 @@ extension AlgorithmTests {
 
     let str = "a string with the letter b in it"
     let first = str.firstRange(of: r)
-    let last = str.lastRange(of: r)
+    let last = str._lastRange(of: r)
     let (expectFirst, expectLast) = (
       str.index(atOffset: 0)..<str.index(atOffset: 1),
       str.index(atOffset: 25)..<str.index(atOffset: 26))
@@ -38,10 +38,10 @@ extension AlgorithmTests {
       [expectFirst, expectLast], Array(str.ranges(of: r)))
 
     XCTAssertTrue(str.starts(with: r))
-    XCTAssertFalse(str.ends(with: r))
+    XCTAssertFalse(str._ends(with: r))
 
     XCTAssertEqual(str.dropFirst(), str.trimmingPrefix(r))
-    XCTAssertEqual("x", "axb".trimming(r))
-    XCTAssertEqual("x", "axbb".trimming(r))
+    XCTAssertEqual("x", "axb"._trimming(r))
+    XCTAssertEqual("x", "axbb"._trimming(r))
   }
 }

--- a/Tests/RegexTests/AlgorithmsTests.swift
+++ b/Tests/RegexTests/AlgorithmsTests.swift
@@ -67,6 +67,9 @@ class AlgorithmTests: XCTestCase {
       let actualCol: [Range<Int>] = string[...].ranges(of: regex)[...].map(string.offsets(of:))
       XCTAssertEqual(actualCol, expected, file: file, line: line)
       
+      let matchRanges = string.matches(of: regex).map { string.offsets(of: $0.range) }
+      XCTAssertEqual(matchRanges, expected, file: file, line: line)
+
       let firstRange = string.firstRange(of: regex).map(string.offsets(of:))
       XCTAssertEqual(firstRange, expected.first, file: file, line: line)
     }
@@ -332,6 +335,11 @@ class AlgorithmTests: XCTestCase {
     XCTAssertEqual(
       s2.matches(of: regex).map(\.0),
       ["aa"])
+    
+    XCTAssertEqual(
+      s2.matches(of: try Regex("a*?")).map { s2.offsets(of: $0.range) }, [0..<0, 1..<1, 2..<2])
+    XCTAssertEqual(
+      s2.ranges(of: try Regex("a*?")).map(s2.offsets(of:)), [0..<0, 1..<1, 2..<2])
   }
 
   func testSwitches() {

--- a/Tests/RegexTests/CompileTests.swift
+++ b/Tests/RegexTests/CompileTests.swift
@@ -88,4 +88,51 @@ extension RegexTests {
       try testCompilationEquivalence(row)
     }
   }
+  
+  func testCompileInitialOptions() throws {
+    func expectInitialOptions<T>(
+      _ regex: Regex<T>,
+      _ optionSequence: AST.MatchingOptionSequence,
+      file: StaticString = #file,
+      line: UInt = #line
+    ) throws {
+      var options = MatchingOptions()
+      options.apply(optionSequence)
+      
+      XCTAssertTrue(
+        regex.program.loweredProgram.initialOptions._equal(to: options),
+        file: file, line: line)
+    }
+    
+    func expectInitialOptions(
+      _ pattern: String,
+      _ optionSequence: AST.MatchingOptionSequence,
+      file: StaticString = #file,
+      line: UInt = #line
+    ) throws {
+      let regex = try Regex(pattern)
+      try expectInitialOptions(regex, optionSequence, file: file, line: line)
+    }
+
+    try expectInitialOptions(".", matchingOptions())
+    try expectInitialOptions("(?i)(?-i).", matchingOptions())
+
+    try expectInitialOptions("(?i).", matchingOptions(adding: [.caseInsensitive]))
+    try expectInitialOptions("(?i).(?-i)", matchingOptions(adding: [.caseInsensitive]))
+
+    try expectInitialOptions(
+      "(?im)(?s).",
+      matchingOptions(adding: [.caseInsensitive, .multiline, .singleLine]))
+    try expectInitialOptions(".", matchingOptions())
+    try expectInitialOptions(
+      "(?im)(?s).(?u)",
+      matchingOptions(adding: [.caseInsensitive, .multiline, .singleLine]))
+    
+    try expectInitialOptions(
+      "(?i:.)",
+      matchingOptions(adding: [.caseInsensitive]))
+    try expectInitialOptions(
+      "(?i:.)(?m:.)",
+      matchingOptions(adding: [.caseInsensitive]))
+  }
 }

--- a/Tests/RegexTests/MatchTests.swift
+++ b/Tests/RegexTests/MatchTests.swift
@@ -1612,5 +1612,15 @@ extension RegexTests {
   
   // TODO: Add test for grapheme boundaries at start/end of match
 
+  func testCase() {
+    let regex = try! Regex(#".\N{SPARKLING HEART}."#)
+    let input = "🧟‍♀️💖🧠 or 🧠💖☕️"
+    let characterMatches = input.matches(of: regex)
+    XCTAssertEqual(characterMatches.map { $0.0 }, ["🧟‍♀️💖🧠", "🧠💖☕️"])
+
+    let scalarMatches = input.matches(of: regex.matchingSemantics(.unicodeScalar))
+    let scalarExpected: [Substring] = ["\u{FE0F}💖🧠", "🧠💖☕"]
+    XCTAssertEqual(scalarMatches.map { $0.0 }, scalarExpected)
+  }
 }
 


### PR DESCRIPTION
This is a cherry-pick of three algorithms implementation improvements:
- #415 resolves an infinite loop when `matches(of:)` is called with a regex that matches an empty subsequence
- #414 is an NFC change that underscores internal algorithms methods to simplify disambiguation
- #412 adds a step during regex compilation that tracks the initial options, so that searching can honor the regex's semantic level