### PR TITLE
Keep substring bounds when searching in Regex.wholeMatch

### DIFF
--- a/Sources/_StringProcessing/Regex/Match.swift
+++ b/Sources/_StringProcessing/Regex/Match.swift
@@ -177,7 +177,7 @@ extension BidirectionalCollection where SubSequence == Substring {
   public func wholeMatch<R: RegexComponent>(
     of r: R
   ) -> Regex<R.RegexOutput>.Match? {
-    try? r.regex.wholeMatch(in: self[...].base)
+    try? r.regex.wholeMatch(in: self[...])
   }
 
   /// Checks for a match against the string, starting at its beginning.

--- a/Tests/RegexBuilderTests/AlgorithmsTests.swift
+++ b/Tests/RegexBuilderTests/AlgorithmsTests.swift
@@ -229,6 +229,16 @@ class AlgorithmsResultBuilderTests: XCTestCase {
   }
 
   func testMatches() throws {
+    do {
+      let regex = Regex { OneOrMore(.any) }
+      XCTAssertEqual("abc".wholeMatch(of: regex)!.0, "abc")
+      XCTAssertEqual("abc".prefixMatch(of: regex)!.0, "abc")
+      XCTAssertEqual("abc".firstMatch(of: regex)!.0, "abc")
+      XCTAssertEqual("abc".suffix(1).wholeMatch(of: regex)!.0, "c")
+      XCTAssertEqual("abc".suffix(1).prefixMatch(of: regex)!.0, "c")
+      XCTAssertEqual("abc".suffix(1).firstMatch(of: regex)!.0, "c")
+    }
+    
     let int = Capture(OneOrMore(.digit)) { Int($0)! }
 
     // Test syntax


### PR DESCRIPTION
Resolves #420.