### PR TITLE
Implement named backreferences

### DIFF
--- a/Sources/_RegexParser/Regex/Parse/CaptureList.swift
+++ b/Sources/_RegexParser/Regex/Parse/CaptureList.swift
@@ -42,6 +42,21 @@ extension CaptureList {
   }
 }
 
+extension CaptureList {
+  /// Retrieve the capture index of a given named capture, or `nil` if there is
+  /// no such capture.
+  public func indexOfCapture(named name: String) -> Int? {
+    // Named references are guaranteed to be unique for literal ASTs by Sema.
+    // The DSL tree does not use named references.
+    captures.indices.first(where: { captures[$0].name == name })
+  }
+
+  /// Whether the capture list has a given named capture.
+  public func hasCapture(named name: String) -> Bool {
+    indexOfCapture(named: name) != nil
+  }
+}
+
 // MARK: Generating from AST
 
 extension AST.Node {

--- a/Sources/_RegexParser/Regex/Parse/Diagnostics.swift
+++ b/Sources/_RegexParser/Regex/Parse/Diagnostics.swift
@@ -86,6 +86,7 @@ enum ParseError: Error, Hashable {
   case unsupported(String)
   case deprecatedUnicode(String)
   case invalidReference(Int)
+  case invalidNamedReference(String)
   case duplicateNamedCapture(String)
   case invalidCharacterClassRangeOperand
   case invalidQuantifierRange(Int, Int)
@@ -211,6 +212,8 @@ extension ParseError: CustomStringConvertible {
       return "\(kind) is a deprecated Unicode property, and is not supported"
     case let .invalidReference(i):
       return "no capture numbered \(i)"
+    case let .invalidNamedReference(name):
+      return "no capture named '\(name)'"
     case let .duplicateNamedCapture(str):
       return "group named '\(str)' already exists"
     case let .invalidQuantifierRange(lhs, rhs):

--- a/Sources/_RegexParser/Regex/Parse/Sema.swift
+++ b/Sources/_RegexParser/Regex/Parse/Sema.swift
@@ -72,20 +72,20 @@ extension RegexValidator {
   }
 
   func validateReference(_ ref: AST.Reference) throws {
+    if let recLevel = ref.recursionLevel {
+      throw error(.unsupported("recursion level"), at: recLevel.location)
+    }
     switch ref.kind {
     case .absolute(let i):
       guard i <= captures.captures.count else {
         throw error(.invalidReference(i), at: ref.innerLoc)
       }
+    case .named(let name):
+      guard captures.hasCapture(named: name) else {
+        throw error(.invalidNamedReference(name), at: ref.innerLoc)
+      }
     case .relative:
       throw error(.unsupported("relative capture reference"), at: ref.innerLoc)
-    case .named:
-      // TODO: This could be implemented by querying the capture list for an
-      // index.
-      throw error(.unsupported("named capture reference"), at: ref.innerLoc)
-    }
-    if let recLevel = ref.recursionLevel {
-      throw error(.unsupported("recursion level"), at: recLevel.location)
     }
   }
 

--- a/Sources/_StringProcessing/ByteCodeGen.swift
+++ b/Sources/_StringProcessing/ByteCodeGen.swift
@@ -5,6 +5,11 @@ extension Compiler {
     var options: MatchingOptions
     var builder = Program.Builder()
 
+    init(options: MatchingOptions, captureList: CaptureList) {
+      self.options = options
+      self.builder.captureList = captureList
+    }
+
     mutating func finish(
     ) throws -> Program {
       builder.buildAccept()
@@ -62,7 +67,9 @@ extension Compiler.ByteCodeGen {
     case .absolute(let i):
       // Backreferences number starting at 1
       builder.buildBackreference(.init(i-1))
-    case .relative, .named:
+    case .named(let name):
+      try builder.buildNamedReference(name)
+    case .relative:
       throw Unsupported("Backreference kind: \(ref)")
     }
   }

--- a/Sources/_StringProcessing/Compiler.swift
+++ b/Sources/_StringProcessing/Compiler.swift
@@ -27,8 +27,9 @@ class Compiler {
 
   __consuming func emit() throws -> Program {
     // TODO: Handle global options
-    var codegen = ByteCodeGen(options: options)
-    codegen.builder.captureList = tree.root._captureList
+    var codegen = ByteCodeGen(
+      options: options, captureList: tree.root._captureList
+    )
     try codegen.emitNode(tree.root)
     let program = try codegen.finish()
     return program

--- a/Sources/_StringProcessing/Engine/MEBuilder.swift
+++ b/Sources/_StringProcessing/Engine/MEBuilder.swift
@@ -366,7 +366,6 @@ extension MEProgram.Builder {
       registerInfo: regInfo,
       captureList: captureList,
       referencedCaptureOffsets: referencedCaptureOffsets,
-      namedCaptureOffsets: namedCaptureOffsets,
       initialOptions: initialOptions)
   }
 

--- a/Sources/_StringProcessing/Engine/MECapture.swift
+++ b/Sources/_StringProcessing/Engine/MECapture.swift
@@ -145,7 +145,6 @@ extension Processor._StoredCapture: CustomStringConvertible {
 struct MECaptureList {
   var values: Array<Processor<String>._StoredCapture>
   var referencedCaptureOffsets: [ReferenceID: Int]
-  var namedCaptureOffsets: [String: Int]
 
 //  func extract(from s: String) -> Array<Array<Substring>> {
 //    caps.map { $0.map { s[$0] }  }

--- a/Sources/_StringProcessing/Engine/MEProgram.swift
+++ b/Sources/_StringProcessing/Engine/MEProgram.swift
@@ -36,7 +36,6 @@ struct MEProgram<Input: Collection> where Input.Element: Equatable {
 
   let captureList: CaptureList
   let referencedCaptureOffsets: [ReferenceID: Int]
-  let namedCaptureOffsets: [String: Int]
   
   var initialOptions: MatchingOptions
 }

--- a/Sources/_StringProcessing/Executor.swift
+++ b/Sources/_StringProcessing/Executor.swift
@@ -37,8 +37,7 @@ struct Executor {
 
     let capList = MECaptureList(
       values: cpu.storedCaptures,
-      referencedCaptureOffsets: engine.program.referencedCaptureOffsets,
-      namedCaptureOffsets: engine.program.namedCaptureOffsets)
+      referencedCaptureOffsets: engine.program.referencedCaptureOffsets)
 
     let range = inputRange.lowerBound..<endIdx
     let caps = engine.program.captureList.createElements(capList, input)

--- a/Tests/RegexTests/MatchTests.swift
+++ b/Tests/RegexTests/MatchTests.swift
@@ -1142,7 +1142,6 @@ extension RegexTests {
   }
 
   func testMatchReferences() {
-    // TODO: Implement backreference/subpattern matching.
     firstMatchTest(
       #"(.)\1"#,
       input: "112", match: "11")
@@ -1151,14 +1150,24 @@ extension RegexTests {
       input: "aaaaaaaaabbc", match: "aaaaaaaaabb")
 
     firstMatchTest(
+      #"(.)(.)(.)(.)(.)(.)(.)(.)(.)(?<a1>.)(?P=a1)"#,
+      input: "aaaaaaaaabbc", match: "aaaaaaaaabb")
+
+    firstMatchTest(
       #"(.)\g001"#,
       input: "112", match: "11")
 
-    firstMatchTest(#"(.)(.)\g-02"#, input: "abac", match: "aba", xfail: true)
-    firstMatchTest(#"(?<a>.)(.)\k<a>"#, input: "abac", match: "aba", xfail: true)
-    firstMatchTest(#"\g'+2'(.)(.)"#, input: "abac", match: "aba", xfail: true)
+    firstMatchTest(#"(?<a>.)(.)\k<a>"#, input: "abac", match: "aba")
+
+    firstMatchTest(#"(?<a>.)(?<b>.)(?<c>.)\k<c>\k<a>\k<b>"#,
+                   input: "xyzzxy", match: "xyzzxy")
 
     firstMatchTest(#"\1(.)"#, input: "112", match: nil)
+    firstMatchTest(#"\k<a>(?<a>.)"#, input: "112", match: nil)
+
+    // TODO: Implement subpattern matching.
+    firstMatchTest(#"(.)(.)\g-02"#, input: "abac", match: "aba", xfail: true)
+    firstMatchTest(#"\g'+2'(.)(.)"#, input: "abac", match: "aba", xfail: true)
   }
   
   func testMatchExamples() {

--- a/Tests/RegexTests/ParseTests.swift
+++ b/Tests/RegexTests/ParseTests.swift
@@ -1242,16 +1242,37 @@ extension RegexTests {
     parseTest(#"\k'-3'"#, backreference(.relative(-3)), throwsError: .unsupported)
     parseTest(#"\k'1'"#, backreference(.absolute(1)), throwsError: .invalid)
 
-    parseTest(#"\k{a0}"#, backreference(.named("a0")), throwsError: .unsupported)
-    parseTest(#"\k<bc>"#, backreference(.named("bc")), throwsError: .unsupported)
-    parseTest(#"\g{abc}"#, backreference(.named("abc")), throwsError: .unsupported)
-    parseTest(#"(?P=abc)"#, backreference(.named("abc")), throwsError: .unsupported)
+    parseTest(
+      #"(?<a>)\k<a>"#, concat(
+        namedCapture("a", empty()), backreference(.named("a"))
+      ), captures: [.named("a")]
+    )
+    parseTest(
+      #"(?<a>)\k{a}"#, concat(
+        namedCapture("a", empty()), backreference(.named("a"))
+      ), captures: [.named("a")]
+    )
+    parseTest(
+      #"(?<a>)\g{a}"#, concat(
+        namedCapture("a", empty()), backreference(.named("a"))
+      ), captures: [.named("a")]
+    )
+    parseTest(
+      #"(?<a>)(?P=a)"#, concat(
+        namedCapture("a", empty()), backreference(.named("a"))
+      ), captures: [.named("a")]
+    )
+
+    parseTest(#"\k{a0}"#, backreference(.named("a0")), throwsError: .invalid)
+    parseTest(#"\k<bc>"#, backreference(.named("bc")), throwsError: .invalid)
+    parseTest(#"\g{abc}"#, backreference(.named("abc")), throwsError: .invalid)
+    parseTest(#"(?P=abc)"#, backreference(.named("abc")), throwsError: .invalid)
 
     // Oniguruma recursion levels.
     parseTest(#"\k<bc-0>"#, backreference(.named("bc"), recursionLevel: 0), throwsError: .unsupported)
     parseTest(#"\k<a+0>"#, backreference(.named("a"), recursionLevel: 0), throwsError: .unsupported)
-    parseTest(#"\k<1+1>"#, backreference(.absolute(1), recursionLevel: 1), throwsError: .invalid)
-    parseTest(#"\k<3-8>"#, backreference(.absolute(3), recursionLevel: -8), throwsError: .invalid)
+    parseTest(#"\k<1+1>"#, backreference(.absolute(1), recursionLevel: 1), throwsError: .unsupported)
+    parseTest(#"\k<3-8>"#, backreference(.absolute(3), recursionLevel: -8), throwsError: .unsupported)
     parseTest(#"\k'-3-8'"#, backreference(.relative(-3), recursionLevel: -8), throwsError: .unsupported)
     parseTest(#"\k'bc-8'"#, backreference(.named("bc"), recursionLevel: -8), throwsError: .unsupported)
     parseTest(#"\k'+3-8'"#, backreference(.relative(3), recursionLevel: -8), throwsError: .unsupported)
@@ -2167,7 +2188,7 @@ extension RegexTests {
       throwsError: .unsupported
     )
     parseWithDelimitersTest(
-      #"re'a\k'b0A''"#, concat("a", backreference(.named("b0A"))), throwsError: .unsupported)
+      #"re'a\k'b0A''"#, concat("a", backreference(.named("b0A"))), throwsError: .invalid)
     parseWithDelimitersTest(
       #"re'\k'+2-1''"#, backreference(.relative(2), recursionLevel: -1),
       throwsError: .unsupported
@@ -2810,6 +2831,12 @@ extension RegexTests {
     diagnosticTest(#"\2()"#, .invalidReference(2))
     diagnosticTest(#"(?:)()\2"#, .invalidReference(2))
     diagnosticTest(#"(?:)(?:)\2"#, .invalidReference(2))
+
+    diagnosticTest(#"\k<a>"#, .invalidNamedReference("a"))
+    diagnosticTest(#"(?:)\k<a>"#, .invalidNamedReference("a"))
+    diagnosticTest(#"()\k<a>"#, .invalidNamedReference("a"))
+    diagnosticTest(#"()\k<a>()"#, .invalidNamedReference("a"))
+    diagnosticTest(#"(?<b>)\k<a>()"#, .invalidNamedReference("a"))
 
     // MARK: Conditionals
 


### PR DESCRIPTION
Use the CaptureList as the source of truth on which index a name corresponds to, and query it when emitting a named backreference.

Resolves #388