### PR TITLE
Escape backslashes properly when converting to the DSL

### DIFF
--- a/Sources/_StringProcessing/PrintAsPattern.swift
+++ b/Sources/_StringProcessing/PrintAsPattern.swift
@@ -578,7 +578,7 @@ extension PrettyPrinter {
 extension String {
   // TODO: Escaping?
   fileprivate var _quoted: String {
-    "\"\(self._replacing("\"", with: "\\\""))\""
+    "\"\(self._replacing("\\", with: "\\\\")._replacing("\"", with: "\\\""))\""
   }
 }
 

--- a/Sources/_StringProcessing/PrintAsPattern.swift
+++ b/Sources/_StringProcessing/PrintAsPattern.swift
@@ -578,7 +578,7 @@ extension PrettyPrinter {
 extension String {
   // TODO: Escaping?
   fileprivate var _quoted: String {
-    "\"\(self._replacing("\\", with: "\\\\")._replacing("\"", with: "\\\""))\""
+    "\"\(self._replacing(#"\"#, with: #"\\"#)._replacing(#"""#, with: #"\""#))\""
   }
 }
 

--- a/Tests/RegexTests/RenderDSLTests.swift
+++ b/Tests/RegexTests/RenderDSLTests.swift
@@ -114,4 +114,12 @@ extension RenderDSLTests {
         """)
     }
   }
+  
+  func testQuoting() throws {
+    try testConversion(#"\\\"a\""#, #"""
+      Regex {
+        "\\\"a\""
+      }
+      """#)
+  }
 }

--- a/Tests/RegexTests/RenderDSLTests.swift
+++ b/Tests/RegexTests/RenderDSLTests.swift
@@ -116,7 +116,7 @@ extension RenderDSLTests {
   }
   
   func testQuoting() throws {
-    try testConversion(#"\\\"a\""#, #"""
+    try testConversion(#"\\"a""#, #"""
       Regex {
         "\\\"a\""
       }


### PR DESCRIPTION
Fix an issue where we weren't properly escaping backslashes in quote strings when converting to the DSL.