### PR TITLE
Parse .NET character class subtractions

### DIFF
--- a/Sources/_RegexParser/Regex/AST/CustomCharClass.swift
+++ b/Sources/_RegexParser/Regex/AST/CustomCharClass.swift
@@ -67,6 +67,9 @@ extension AST {
       case subtraction = "--"
       case intersection = "&&"
       case symmetricDifference = "~~"
+
+      // A .NET subtraction that may be used with a custom character class RHS.
+      case dotNetSubtraction = "-"
     }
     public enum Start: String, Hashable {
       case normal = "["

--- a/Sources/_RegexParser/Regex/Parse/Diagnostics.swift
+++ b/Sources/_RegexParser/Regex/Parse/Diagnostics.swift
@@ -60,6 +60,7 @@ enum ParseError: Error, Hashable {
   case cannotRemoveMatchingOptionsAfterCaret
 
   case expectedCustomCharacterClassMembers
+  case dotNetSubtractionMustBeLast
 
   case emptyProperty
   case unknownProperty(key: String?, value: String)
@@ -173,6 +174,8 @@ extension ParseError: CustomStringConvertible {
       return "expected ASCII for '\(c)'"
     case .expectedCustomCharacterClassMembers:
       return "expected custom character class members"
+    case .dotNetSubtractionMustBeLast:
+      return "character class members may not appear after .NET subtraction"
     case .invalidCharacterClassRangeOperand:
       return "invalid character class range"
     case .emptyProperty:

--- a/Sources/_StringProcessing/Regex/ASTConversion.swift
+++ b/Sources/_StringProcessing/Regex/ASTConversion.swift
@@ -190,7 +190,7 @@ extension AST.CustomCharacterClass {
           isInverted: false)
 
         switch op.value {
-        case .subtraction:
+        case .subtraction, .dotNetSubtraction:
           return .subtraction(lhs, rhs)
         case .intersection:
           return .intersection(lhs, rhs)

--- a/Tests/RegexTests/MatchTests.swift
+++ b/Tests/RegexTests/MatchTests.swift
@@ -692,6 +692,25 @@ extension RegexTests {
     firstMatchTest(
       "~~*", input: "123~~~xyz", match: "~~~")
 
+    firstMatchTest(
+      #"[d-w--[m-o]]+"#,
+      input: "abcmnoxyzdefghijklpqrstuvw", match: "defghijklpqrstuvw"
+    )
+
+    firstMatchTest(
+      #"[a-z--[d-w--[m-o]]]+"#,
+      input: "defghijklpqrstuvwabcmnoxyz", match: "abcmnoxyz"
+    )
+
+    firstMatchTest(
+      #"[a-z-[d-w-[m-o]]]+"#,
+      input: "defghijklpqrstuvwabcmnoxyz", match: "abcmnoxyz"
+    )
+
+    firstMatchTest(
+      #"(?x)[ a - z - [ d - w - [ m - o ] ] ]+"#,
+      input: " defghijklpqrstuvwabcmnoxyz", match: "abcmnoxyz"
+    )
 
     // Quotes in character classes.
     firstMatchTest(#"[\Qabc\E]"#, input: "QEa", match: "a")


### PR DESCRIPTION
This is similar to `--`, but is spelled `-`, and only takes effect when the RHS is a nested custom character class. It additionally must appear as the last member of the custom character class.