### PR TITLE
[5.7] Implement .as for Regex and Unify Match and AnyRegexOutput

### DIFF
--- a/Sources/_RegexParser/Utility/TypeConstruction.swift
+++ b/Sources/_RegexParser/Utility/TypeConstruction.swift
@@ -17,19 +17,7 @@
 //                              const Metadata * const *elements,
 //                              const char *labels,
 //                              const ValueWitnessTable *proposedWitnesses);
-//
-//   SWIFT_RUNTIME_EXPORT SWIFT_CC(swift)
-//   MetadataResponse
-//   swift_getTupleTypeMetadata2(MetadataRequest request,
-//                               const Metadata *elt0, const Metadata *elt1,
-//                               const char *labels,
-//                               const ValueWitnessTable *proposedWitnesses);
-//   SWIFT_RUNTIME_EXPORT SWIFT_CC(swift)
-//   MetadataResponse
-//   swift_getTupleTypeMetadata3(MetadataRequest request,
-//                               const Metadata *elt0, const Metadata *elt1,
-//                               const Metadata *elt2, const char *labels,
-//                               const ValueWitnessTable *proposedWitnesses);
+
 
 @_silgen_name("swift_getTupleTypeMetadata")
 private func swift_getTupleTypeMetadata(
@@ -40,31 +28,13 @@ private func swift_getTupleTypeMetadata(
   proposedWitnesses: UnsafeRawPointer?
 ) -> (value: Any.Type, state: Int)
 
-@_silgen_name("swift_getTupleTypeMetadata2")
-private func swift_getTupleTypeMetadata2(
-  request: Int,
-  element1: Any.Type,
-  element2: Any.Type,
-  labels: UnsafePointer<Int8>?,
-  proposedWitnesses: UnsafeRawPointer?
-) -> (value: Any.Type, state: Int)
-
-@_silgen_name("swift_getTupleTypeMetadata3")
-private func swift_getTupleTypeMetadata3(
-  request: Int,
-  element1: Any.Type,
-  element2: Any.Type,
-  element3: Any.Type,
-  labels: UnsafePointer<Int8>?,
-  proposedWitnesses: UnsafeRawPointer?
-) -> (value: Any.Type, state: Int)
-
 public enum TypeConstruction {
   /// Returns a tuple metatype of the given element types.
   public static func tupleType<
     ElementTypes: BidirectionalCollection
   >(
-    of elementTypes: __owned ElementTypes
+    of elementTypes: __owned ElementTypes,
+    labels: String? = nil
   ) -> Any.Type where ElementTypes.Element == Any.Type {
     // From swift/ABI/Metadata.h:
     //   template <typename int_type>
@@ -78,39 +48,50 @@ public enum TypeConstruction {
     let elementCountFlag = 0x0000FFFF
     assert(elementTypes.count != 1, "A one-element tuple is not a realistic Swift type")
     assert(elementTypes.count <= elementCountFlag, "Tuple size exceeded \(elementCountFlag)")
-    switch elementTypes.count {
-    case 2:
-      return swift_getTupleTypeMetadata2(
-        request: 0,
-        element1: elementTypes[elementTypes.startIndex],
-        element2: elementTypes[elementTypes.index(elementTypes.startIndex, offsetBy: 1)],
-        labels: nil,
-        proposedWitnesses: nil).value
-    case 3:
-      return swift_getTupleTypeMetadata3(
-        request: 0,
-        element1: elementTypes[elementTypes.startIndex],
-        element2: elementTypes[elementTypes.index(elementTypes.startIndex, offsetBy: 1)],
-        element3: elementTypes[elementTypes.index(elementTypes.startIndex, offsetBy: 2)],
-        labels: nil,
-        proposedWitnesses: nil).value
-    default:
-      let result = elementTypes.withContiguousStorageIfAvailable { elementTypesBuffer in
-        swift_getTupleTypeMetadata(
+    
+    var flags = elementTypes.count
+    
+    // If we have labels to provide, then say the label pointer is not constant
+    // because the lifetime of said pointer will only be vaild for the lifetime
+    // of the 'swift_getTupleTypeMetadata' call. If we don't have labels, then
+    // our label pointer will be empty and constant.
+    if labels != nil {
+      // Has non constant labels
+      flags |= 0x10000
+    }
+    
+    let result = elementTypes.withContiguousStorageIfAvailable { elementTypesBuffer in
+      if let labels = labels {
+        return labels.withCString { labelsPtr in
+          swift_getTupleTypeMetadata(
+            request: 0,
+            flags: flags,
+            elements: elementTypesBuffer.baseAddress,
+            labels: labelsPtr,
+            proposedWitnesses: nil
+          )
+        }
+      } else {
+        return swift_getTupleTypeMetadata(
           request: 0,
-          flags: elementTypesBuffer.count,
+          flags: flags,
           elements: elementTypesBuffer.baseAddress,
           labels: nil,
-          proposedWitnesses: nil).value
+          proposedWitnesses: nil
+        )
       }
-      guard let result = result else {
-        fatalError("""
-          The collection of element types does not support an internal representation of
-          contiguous storage
-          """)
-      }
-      return result
     }
+    
+    guard let result = result else {
+      fatalError(
+        """
+        The collection of element types does not support an internal representation of
+        contiguous storage
+        """
+      )
+    }
+    
+    return result.value
   }
 
   /// Creates a type-erased tuple with the given elements.

--- a/Sources/_StringProcessing/Capture.swift
+++ b/Sources/_StringProcessing/Capture.swift
@@ -61,26 +61,30 @@ func constructExistentialOutputComponent(
   return underlying
 }
 
-extension StructuredCapture {
+@available(SwiftStdlib 5.7, *)
+extension AnyRegexOutput.Element {
   func existentialOutputComponent(
     from input: Substring
   ) -> Any {
     constructExistentialOutputComponent(
       from: input,
-      in: storedCapture?.range,
-      value: storedCapture?.value,
-      optionalCount: optionalCount)
+      in: range,
+      value: value,
+      optionalCount: optionalDepth
+    )
   }
 
   func slice(from input: String) -> Substring? {
-    guard let r = storedCapture?.range else { return nil }
+    guard let r = range else { return nil }
     return input[r]
   }
 }
 
-extension Sequence where Element == StructuredCapture {
+@available(SwiftStdlib 5.7, *)
+extension Sequence where Element == AnyRegexOutput.Element {
   // FIXME: This is a stop gap where we still slice the input
   // and traffic through existentials
+  @available(SwiftStdlib 5.7, *)
   func existentialOutput(
     from input: Substring
   ) -> Any {

--- a/Sources/_StringProcessing/Capture.swift
+++ b/Sources/_StringProcessing/Capture.swift
@@ -11,27 +11,6 @@
 
 @_implementationOnly import _RegexParser
 
-/// A structured capture
-struct StructuredCapture {
-  /// The `.optional` height of the result
-  var optionalCount = 0
-
-  var storedCapture: StoredCapture?
-
-  var someCount: Int {
-    storedCapture == nil ? optionalCount - 1 : optionalCount
-  }
-}
-
-/// A storage form for a successful capture
-struct StoredCapture {
-  // TODO: drop optional when engine tracks all ranges
-  var range: Range<String.Index>?
-
-  // If strongly typed, value is set
-  var value: Any? = nil
-}
-
 // TODO: Where should this live? Inside TypeConstruction?
 func constructExistentialOutputComponent(
   from input: Substring,

--- a/Sources/_StringProcessing/Engine/Structuralize.swift
+++ b/Sources/_StringProcessing/Engine/Structuralize.swift
@@ -1,20 +1,25 @@
 @_implementationOnly import _RegexParser
-
 extension CaptureList {
-  func structuralize(
+  @available(SwiftStdlib 5.7, *)
+  func createElements(
     _ list: MECaptureList,
     _ input: String
-  ) -> [StructuredCapture] {
+  ) -> [AnyRegexOutput.ElementRepresentation] {
     assert(list.values.count == captures.count)
-
-    var result = [StructuredCapture]()
-    for (cap, meStored) in zip(self.captures, list.values) {
-      let stored = StoredCapture(
-        range: meStored.latest, value: meStored.latestValue)
-
-      result.append(.init(
-        optionalCount: cap.optionalDepth, storedCapture: stored))
+    
+    var result = [AnyRegexOutput.ElementRepresentation]()
+    
+    for (cap, meStored) in zip(captures, list.values) {
+      let element = AnyRegexOutput.ElementRepresentation(
+        optionalDepth: cap.optionalDepth,
+        bounds: meStored.latest,
+        name: cap.name,
+        value: meStored.latestValue
+      )
+      
+      result.append(element)
     }
+    
     return result
   }
 }

--- a/Sources/_StringProcessing/Engine/Structuralize.swift
+++ b/Sources/_StringProcessing/Engine/Structuralize.swift
@@ -1,4 +1,5 @@
 @_implementationOnly import _RegexParser
+
 extension CaptureList {
   @available(SwiftStdlib 5.7, *)
   func createElements(
@@ -9,11 +10,12 @@ extension CaptureList {
     
     var result = [AnyRegexOutput.ElementRepresentation]()
     
-    for (cap, meStored) in zip(captures, list.values) {
+    for (i, (cap, meStored)) in zip(captures, list.values).enumerated() {
       let element = AnyRegexOutput.ElementRepresentation(
         optionalDepth: cap.optionalDepth,
         bounds: meStored.latest,
         name: cap.name,
+        referenceID: list.referencedCaptureOffsets.first { $1 == i }?.key,
         value: meStored.latestValue
       )
       

--- a/Sources/_StringProcessing/Executor.swift
+++ b/Sources/_StringProcessing/Executor.swift
@@ -41,7 +41,7 @@ struct Executor {
       namedCaptureOffsets: engine.program.namedCaptureOffsets)
 
     let range = inputRange.lowerBound..<endIdx
-    let caps = engine.program.captureList.structuralize(capList, input)
+    let caps = engine.program.captureList.createElements(capList, input)
 
     // FIXME: This is a workaround for not tracking (or
     // specially compiling) whole-match values.
@@ -58,7 +58,6 @@ struct Executor {
     
     let anyRegexOutput = AnyRegexOutput(
       input: input,
-      namedCaptureOffsets: capList.namedCaptureOffsets,
       elements: caps
     )
     

--- a/Sources/_StringProcessing/Executor.swift
+++ b/Sources/_StringProcessing/Executor.swift
@@ -64,7 +64,6 @@ struct Executor {
     return .init(
       anyRegexOutput: anyRegexOutput,
       range: range,
-      referencedCaptureOffsets: capList.referencedCaptureOffsets,
       value: value
     )
   }

--- a/Sources/_StringProcessing/Executor.swift
+++ b/Sources/_StringProcessing/Executor.swift
@@ -55,14 +55,19 @@ struct Executor {
     } else {
       value = nil
     }
-
-    return .init(
+    
+    let anyRegexOutput = AnyRegexOutput(
       input: input,
-      range: range,
-      rawCaptures: caps,
-      referencedCaptureOffsets: capList.referencedCaptureOffsets,
       namedCaptureOffsets: capList.namedCaptureOffsets,
-      value: value)
+      elements: caps
+    )
+    
+    return .init(
+      anyRegexOutput: anyRegexOutput,
+      range: range,
+      referencedCaptureOffsets: capList.referencedCaptureOffsets,
+      value: value
+    )
   }
 
   @available(SwiftStdlib 5.7, *)

--- a/Sources/_StringProcessing/Regex/AnyRegexOutput.swift
+++ b/Sources/_StringProcessing/Regex/AnyRegexOutput.swift
@@ -41,11 +41,11 @@ extension Regex.Match where Output == AnyRegexOutput {
   public subscript(
     dynamicMember keyPath: KeyPath<(Substring, _doNotUse: ()), Substring>
   ) -> Substring {
-    input[range]
+    anyRegexOutput.input[range]
   }
 
   public subscript(name: String) -> AnyRegexOutput.Element? {
-    namedCaptureOffsets[name].map { self[$0 + 1] }
+    anyRegexOutput.namedCaptureOffsets[name].map { self[$0 + 1] }
   }
 }
 
@@ -54,17 +54,19 @@ extension Regex.Match where Output == AnyRegexOutput {
 public struct AnyRegexOutput {
   let input: String
   let namedCaptureOffsets: [String: Int]
-  fileprivate let _elements: [ElementRepresentation]
+  let _elements: [ElementRepresentation]
 
   /// The underlying representation of the element of a type-erased regex
   /// output.
-  fileprivate struct ElementRepresentation {
+  internal struct ElementRepresentation {
     /// The depth of `Optioals`s wrapping the underlying value. For example,
     /// `Substring` has optional depth `0`, and `Int??` has optional depth `2`.
     let optionalDepth: Int
 
     /// The bounds of the output element.
     let bounds: Range<String.Index>?
+    /// If the output vaule is strongly typed, then this will be set.
+    var value: Any? = nil
   }
 }
 
@@ -75,14 +77,7 @@ extension AnyRegexOutput {
   /// Use this initializer to fit a regex with strongly typed captures into the
   /// use site of a dynamic regex, like one that was created from a string.
   public init<Output>(_ match: Regex<Output>.Match) {
-    // Note: We use type equality instead of `match.output as? ...` to prevent
-    // unexpected optional flattening.
-    if Output.self == AnyRegexOutput.self {
-      self = match.output as! AnyRegexOutput
-      return
-    }
-    fatalError("FIXME: Not implemented")
-    // self.init(input: match.input, _elements: <elements of output tuple>)
+    self = match.anyRegexOutput
   }
 
   /// Returns a typed output by converting the underlying value to the specified
@@ -92,11 +87,8 @@ extension AnyRegexOutput {
   /// - Returns: The output, if the underlying value can be converted to the
   ///   output type; otherwise `nil`.
   public func `as`<Output>(_ type: Output.Type = Output.self) -> Output? {
-    let elements = _elements.map {
-      StructuredCapture(
-        optionalCount: $0.optionalDepth,
-        storedCapture: .init(range: $0.bounds)
-      ).existentialOutputComponent(from: input[...])
+    let elements = map {
+      $0.existentialOutputComponent(from: input[...])
     }
     return TypeConstruction.tuple(of: elements) as? Output
   }
@@ -110,7 +102,8 @@ extension AnyRegexOutput {
     self.init(
       input: input,
       namedCaptureOffsets: namedCaptureOffsets,
-      _elements: elements.map(ElementRepresentation.init))
+      _elements: elements.map(ElementRepresentation.init)
+    )
   }
 }
 
@@ -119,7 +112,9 @@ extension AnyRegexOutput.ElementRepresentation {
   init(_ element: StructuredCapture) {
     self.init(
       optionalDepth: element.optionalCount,
-      bounds: element.storedCapture.flatMap(\.range))
+      bounds: element.storedCapture.flatMap(\.range),
+      value: element.storedCapture.flatMap(\.value)
+    )
   }
 
   func value(forInput input: String) -> Any {
@@ -142,6 +137,10 @@ extension AnyRegexOutput: RandomAccessCollection {
   public struct Element {
     fileprivate let representation: ElementRepresentation
     let input: String
+    
+    var optionalDepth: Int {
+      representation.optionalDepth
+    }
 
     /// The range over which a value was captured. `nil` for no-capture.
     public var range: Range<String.Index>? {
@@ -155,7 +154,7 @@ extension AnyRegexOutput: RandomAccessCollection {
 
     /// The captured value, `nil` for no-capture
     public var value: Any? {
-      fatalError()
+      representation.value
     }
   }
 
@@ -198,19 +197,12 @@ extension Regex.Match where Output == AnyRegexOutput {
   /// Use this initializer to fit a regex match with strongly typed captures into the
   /// use site of a dynamic regex match, like one that was created from a string.
   public init<Output>(_ match: Regex<Output>.Match) {
-    fatalError("FIXME: Not implemented")
-  }
-
-  /// Returns a typed match by converting the underlying values to the specified
-  /// types.
-  ///
-  /// - Parameter type: The expected output type.
-  /// - Returns: A match generic over the output type, if the underlying values
-  ///   can be converted to the output type; otherwise, `nil`.
-  public func `as`<Output>(
-    _ type: Output.Type = Output.self
-  ) -> Regex<Output>.Match? {
-    fatalError("FIXME: Not implemented")
+    self.init(
+      anyRegexOutput: match.anyRegexOutput,
+      range: match.range,
+      referencedCaptureOffsets: match.referencedCaptureOffsets,
+      value: match.value
+    )
   }
 }
 

--- a/Sources/_StringProcessing/Regex/AnyRegexOutput.swift
+++ b/Sources/_StringProcessing/Regex/AnyRegexOutput.swift
@@ -70,6 +70,9 @@ public struct AnyRegexOutput {
     /// The name of the capture.
     var name: String? = nil
     
+    /// The capture reference this element refers to.
+    var referenceID: ReferenceID? = nil
+    
     /// If the output vaule is strongly typed, then this will be set.
     var value: Any? = nil
   }
@@ -145,7 +148,11 @@ extension AnyRegexOutput: RandomAccessCollection {
     public var range: Range<String.Index>? {
       representation.bounds
     }
-
+    
+    var referenceID: ReferenceID? {
+      representation.referenceID
+    }
+    
     /// The slice of the input over which a value was captured. `nil` for no-capture.
     public var substring: Substring? {
       range.map { input[$0] }
@@ -201,7 +208,6 @@ extension Regex.Match where Output == AnyRegexOutput {
     self.init(
       anyRegexOutput: match.anyRegexOutput,
       range: match.range,
-      referencedCaptureOffsets: match.referencedCaptureOffsets,
       value: match.value
     )
   }

--- a/Sources/_StringProcessing/Regex/AnyRegexOutput.swift
+++ b/Sources/_StringProcessing/Regex/AnyRegexOutput.swift
@@ -231,7 +231,7 @@ extension Regex where Output == AnyRegexOutput {
   /// Use this initializer to fit a regex with strongly typed captures into the
   /// use site of a dynamic regex, i.e. one that was created from a string.
   public init<Output>(_ regex: Regex<Output>) {
-    fatalError("FIXME: Not implemented")
+    self.init(node: regex.root)
   }
 
   /// Returns a typed regex by converting the underlying types.
@@ -242,6 +242,12 @@ extension Regex where Output == AnyRegexOutput {
   public func `as`<Output>(
     _ type: Output.Type = Output.self
   ) -> Regex<Output>? {
-    fatalError("FIXME: Not implemented")
+    let result = Regex<Output>(node: root)
+    
+    guard result._verifyType() else {
+      return nil
+    }
+    
+    return result
   }
 }

--- a/Sources/_StringProcessing/Regex/Match.swift
+++ b/Sources/_StringProcessing/Regex/Match.swift
@@ -22,8 +22,6 @@ extension Regex {
     /// The range of the overall match.
     public let range: Range<String.Index>
 
-    let referencedCaptureOffsets: [ReferenceID: Int]
-
     let value: Any?
   }
 }
@@ -35,8 +33,7 @@ extension Regex.Match {
     if Output.self == AnyRegexOutput.self {
       let wholeMatchCapture = AnyRegexOutput.ElementRepresentation(
         optionalDepth: 0,
-        bounds: range,
-        value: nil
+        bounds: range
       )
       
       let output = AnyRegexOutput(
@@ -79,11 +76,13 @@ extension Regex.Match {
 
   @_spi(RegexBuilder)
   public subscript<Capture>(_ id: ReferenceID) -> Capture {
-    guard let offset = referencedCaptureOffsets[id] else {
-      preconditionFailure(
-        "Reference did not capture any match in the regex")
+    guard let element = anyRegexOutput.first(
+      where: { $0.referenceID == id }
+    ) else {
+      preconditionFailure("Reference did not capture any match in the regex")
     }
-    return anyRegexOutput[offset].existentialOutputComponent(
+    
+    return element.existentialOutputComponent(
       from: anyRegexOutput.input[...]
     ) as! Capture
   }

--- a/Sources/_StringProcessing/Regex/Match.swift
+++ b/Sources/_StringProcessing/Regex/Match.swift
@@ -41,7 +41,6 @@ extension Regex.Match {
       
       let output = AnyRegexOutput(
         input: anyRegexOutput.input,
-        namedCaptureOffsets: anyRegexOutput.namedCaptureOffsets,
         _elements: [wholeMatchCapture] + anyRegexOutput._elements
       )
       

--- a/Sources/_StringProcessing/Utility/TypeVerification.swift
+++ b/Sources/_StringProcessing/Utility/TypeVerification.swift
@@ -1,0 +1,50 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+@_implementationOnly import _RegexParser
+
+@available(SwiftStdlib 5.7, *)
+extension Regex {
+  internal func _verifyType() -> Bool {
+    var tupleElements: [Any.Type] = [Substring.self]
+    var labels = " "
+    
+    for capture in program.tree.root._captureList.captures {
+      var captureType: Any.Type = capture.type ?? Substring.self
+      var i = capture.optionalDepth
+      
+      while i != 0 {
+        captureType = TypeConstruction.optionalType(of: captureType)
+        i -= 1
+      }
+      
+      tupleElements.append(captureType)
+      
+      if let name = capture.name {
+        labels += name
+      }
+      
+      labels.unicodeScalars.append(" ")
+    }
+    
+    // If we have no captures, then our Regex must be Regex<Substring>.
+    if tupleElements.count == 1 {
+      return Output.self == Substring.self
+    }
+    
+    let createdType = TypeConstruction.tupleType(
+      of: tupleElements,
+      labels: labels
+    )
+    
+    return Output.self == createdType
+  }
+}

--- a/Sources/_StringProcessing/Utility/TypeVerification.swift
+++ b/Sources/_StringProcessing/Utility/TypeVerification.swift
@@ -42,7 +42,10 @@ extension Regex {
     
     let createdType = TypeConstruction.tupleType(
       of: tupleElements,
-      labels: labels
+      
+      // If all of our labels are spaces, that means no actual label was added
+      // to the tuple. In that case, don't pass a label string.
+      labels: labels.all { $0 == " " } ? nil : labels
     )
     
     return Output.self == createdType

--- a/Tests/RegexTests/CaptureTests.swift
+++ b/Tests/RegexTests/CaptureTests.swift
@@ -55,20 +55,20 @@ extension CaptureList {
   }
 }
 
-extension StructuredCapture {
+extension AnyRegexOutput.Element {
   func formatStringCapture(input: String) -> String {
-    var res = String(repeating: "some(", count: someCount)
-    if let r = self.storedCapture?.range {
+    var res = String(repeating: "some(", count: optionalDepth)
+    if let r = range {
       res += input[r]
     } else {
       res += "none"
     }
-    res += String(repeating: ")", count: someCount)
+    res += String(repeating: ")", count: optionalDepth)
     return res
   }
 }
 
-extension Sequence where Element == StructuredCapture {
+extension AnyRegexOutput {
   func formatStringCaptures(input: String) -> String {
     var res = "["
     res += self.map {
@@ -118,13 +118,13 @@ extension StringCapture: CustomStringConvertible {
 
 extension StringCapture {
   func isEqual(
-    to structCap: StructuredCapture,
+    to structCap: AnyRegexOutput.Element,
     in input: String
   ) -> Bool {
-    guard optionalCount == structCap.optionalCount else {
+    guard optionalCount == structCap.optionalDepth else {
       return false
     }
-    guard let r = structCap.storedCapture?.range else {
+    guard let r = structCap.range else {
       return contents == nil
     }
     guard let s = contents else {
@@ -201,7 +201,7 @@ func captureTest(
       return
     }
 
-    let caps = result.rawCaptures
+    let caps = result.anyRegexOutput
     guard caps.count == output.count else {
       XCTFail("""
       Mismatch capture count:
@@ -212,7 +212,7 @@ func captureTest(
       """)
       continue
     }
-
+    
     guard output.elementsEqual(caps, by: {
       $0.isEqual(to: $1, in: input)
     }) else {

--- a/Tests/RegexTests/CaptureTests.swift
+++ b/Tests/RegexTests/CaptureTests.swift
@@ -461,17 +461,17 @@ extension RegexTests {
   
   func testTypeVerification() throws {
     let opaque1 = try Regex("abc")
-    let concrete1 = try XCTUnwrap(opaque1.as(Substring.self))
+    _ = try XCTUnwrap(opaque1.as(Substring.self))
     XCTAssertNil(opaque1.as((Substring, Substring).self))
     XCTAssertNil(opaque1.as(Int.self))
     
     let opaque2 = try Regex("(abc)")
-    let concrete2 = try XCTUnwrap(opaque2.as((Substring, Substring).self))
+    _ = try XCTUnwrap(opaque2.as((Substring, Substring).self))
     XCTAssertNil(opaque2.as(Substring.self))
     XCTAssertNil(opaque2.as((Substring, Int).self))
     
     let opaque3 = try Regex("(?<someLabel>abc)")
-    let concrete3 = try XCTUnwrap(opaque3.as((Substring, someLabel: Substring).self))
+    _ = try XCTUnwrap(opaque3.as((Substring, someLabel: Substring).self))
     XCTAssertNil(opaque3.as((Substring, Substring).self))
     XCTAssertNil(opaque3.as(Substring.self))
   }

--- a/Tests/RegexTests/CaptureTests.swift
+++ b/Tests/RegexTests/CaptureTests.swift
@@ -474,6 +474,16 @@ extension RegexTests {
     _ = try XCTUnwrap(opaque3.as((Substring, someLabel: Substring).self))
     XCTAssertNil(opaque3.as((Substring, Substring).self))
     XCTAssertNil(opaque3.as(Substring.self))
+    
+    let opaque4 = try Regex("(?<somethingHere>abc)?")
+    _ = try XCTUnwrap(opaque4.as((Substring, somethingHere: Substring?).self))
+    XCTAssertNil(opaque4.as((Substring, somethignHere: Substring).self))
+    XCTAssertNil(opaque4.as((Substring, Substring?).self))
+    
+    let opaque5 = try Regex("((a)?bc)?")
+    _ = try XCTUnwrap(opaque5.as((Substring, Substring?, Substring??).self))
+    XCTAssertNil(opaque5.as((Substring, somethingHere: Substring?, here: Substring??).self))
+    XCTAssertNil(opaque5.as((Substring, Substring?, Substring?).self))
   }
 }
 

--- a/Tests/RegexTests/CaptureTests.swift
+++ b/Tests/RegexTests/CaptureTests.swift
@@ -458,7 +458,23 @@ extension RegexTests {
     //    TODO: "((a|b)|c)*"
 
   }
-
+  
+  func testTypeVerification() throws {
+    let opaque1 = try Regex("abc")
+    let concrete1 = try XCTUnwrap(opaque1.as(Substring.self))
+    XCTAssertNil(opaque1.as((Substring, Substring).self))
+    XCTAssertNil(opaque1.as(Int.self))
+    
+    let opaque2 = try Regex("(abc)")
+    let concrete2 = try XCTUnwrap(opaque2.as((Substring, Substring).self))
+    XCTAssertNil(opaque2.as(Substring.self))
+    XCTAssertNil(opaque2.as((Substring, Int).self))
+    
+    let opaque3 = try Regex("(?<someLabel>abc)")
+    let concrete3 = try XCTUnwrap(opaque3.as((Substring, someLabel: Substring).self))
+    XCTAssertNil(opaque3.as((Substring, Substring).self))
+    XCTAssertNil(opaque3.as(Substring.self))
+  }
 }
 
 

--- a/Tests/RegexTests/MatchTests.swift
+++ b/Tests/RegexTests/MatchTests.swift
@@ -35,7 +35,7 @@ extension Executor {
         in: start..<input.endIndex,
         .partialFromFront
       ) {
-        let caps = result.rawCaptures.slices(from: input)
+        let caps = result.anyRegexOutput.slices(from: input)
         return (input[result.range], caps)
       } else if start == input.endIndex {
         throw MatchError("match not found for \(regex) in \(input)")


### PR DESCRIPTION
*5.7 cherry-pick of https://github.com/apple/swift-experimental-string-processing/pull/376*