### PR TITLE
Fix _RegexParser build when using 5.6 host tools

### DIFF
--- a/Sources/_RegexParser/Utility/TypeConstruction.swift
+++ b/Sources/_RegexParser/Utility/TypeConstruction.swift
@@ -60,7 +60,7 @@ public enum TypeConstruction {
       flags |= 0x10000
     }
     
-    let result = elementTypes.withContiguousStorageIfAvailable { elementTypesBuffer in
+    let result = elementTypes.withContiguousStorageIfAvailable { elementTypesBuffer -> (value: Any.Type, state: Int) in
       if let labels = labels {
         return labels.withCString { labelsPtr in
           swift_getTupleTypeMetadata(


### PR DESCRIPTION
Add a type annotation to allow a `--bootstrap=hosttools` compiler build to work with a Swift 5.6 compiler.

Resolves #451