### PR TITLE
Implement Regex.mapOutput

### DIFF
--- a/Sources/_StringProcessing/Capture.swift
+++ b/Sources/_StringProcessing/Capture.swift
@@ -72,6 +72,11 @@ extension Sequence where Element == AnyRegexOutput.Element {
     caps.append(contentsOf: self.map {
       $0.existentialOutputComponent(from: input)
     })
+    
+    if caps.count == 1 {
+      return input
+    }
+    
     return TypeConstruction.tuple(of: caps)
   }
 

--- a/Sources/_StringProcessing/Executor.swift
+++ b/Sources/_StringProcessing/Executor.swift
@@ -50,7 +50,6 @@ struct Executor {
        caps.isEmpty
     {
       value = cpu.registers.values.first
-      assert(value != nil, "hmm, what would this mean?")
     } else {
       value = nil
     }

--- a/Sources/_StringProcessing/Regex/Core.swift
+++ b/Sources/_StringProcessing/Regex/Core.swift
@@ -29,7 +29,9 @@ public protocol RegexComponent {
 @available(SwiftStdlib 5.7, *)
 public struct Regex<Output>: RegexComponent {
   let program: Program
-
+  
+  var outputTransform: ((Any) -> Output)?
+  
   var hasCapture: Bool {
     program.tree.hasCapture
   }

--- a/Sources/_StringProcessing/Regex/MapOutput.swift
+++ b/Sources/_StringProcessing/Regex/MapOutput.swift
@@ -1,0 +1,30 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+@available(SwiftStdlib 5.7, *)
+extension Regex {
+  @available(SwiftStdlib 5.7, *)
+  public func mapOutput<NewOutput>(
+    _ body: @escaping (Output) -> NewOutput
+  ) -> Regex<NewOutput> {
+    let transform: (Any) -> NewOutput = {
+      if let previousTransform = outputTransform {
+        return body(previousTransform($0))
+      } else {
+        return body($0 as! Output)
+      }
+    }
+    
+    var regex = Regex<NewOutput>(node: root)
+    regex.outputTransform = transform
+    return regex
+  }
+}

--- a/Tests/RegexTests/MapOutputTests.swift
+++ b/Tests/RegexTests/MapOutputTests.swift
@@ -1,0 +1,51 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2021-2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+@testable import _RegexParser
+
+import XCTest
+@testable import _StringProcessing
+
+enum Transaction: String {
+  case credit
+  case debit
+}
+
+extension RegexTests {
+  func testMapOutput() throws {
+    let regex0: Regex<(Substring, Substring)> = try Regex(#"Transaction: (credit|debit)"#)
+    let string0 = "Transaction: credit"
+    
+    let regex1 = regex0.mapOutput {
+      ($0, transaction: Transaction(rawValue: String($1)))
+    }
+    
+    let match0 = try XCTUnwrap(string0.firstMatch(of: regex1)?.output)
+    XCTAssertTrue(match0 == ("Transaction: credit", .credit))
+    
+    let regex2 = regex1.mapOutput {
+      $1
+    }
+    
+    let match1 = try XCTUnwrap(string0.firstMatch(of: regex2)?.output)
+    XCTAssertEqual(match1, .credit)
+    
+    let regex3: Regex<Substring> = try Regex(#"Hello"#)
+    let string1 = "Hello"
+    
+    let regex4 = regex3.mapOutput {
+      "\($0) world!"[...]
+    }
+    
+    let match2 = try XCTUnwrap(string1.firstMatch(of: regex4)?.output)
+    XCTAssertEqual(match2, "Hello world!")
+  }
+}


### PR DESCRIPTION
This implements `mapOutput` on Regex from: https://github.com/apple/swift-evolution/blob/d2b03bf572c7d13c575067641a5d9d1d52cb1750/proposals/0351-regex-builder.md#mapping-output