### PR TITLE
[5.7] Make `RegexCompilationError` internal

### DIFF
--- a/Sources/_StringProcessing/Compiler.swift
+++ b/Sources/_StringProcessing/Compiler.swift
@@ -44,11 +44,11 @@ func _compileRegex(
 }
 
 // An error produced when compiling a regular expression.
-public enum RegexCompilationError: Error, CustomStringConvertible {
+enum RegexCompilationError: Error, CustomStringConvertible {
   // TODO: Source location?
   case uncapturedReference
 
-  public var description: String {
+  var description: String {
     switch self {
     case .uncapturedReference:
       return "Found a reference used before it captured any match."


### PR DESCRIPTION
*5.7 cherry-pick of https://github.com/apple/swift-experimental-string-processing/pull/438*

`RegexCompilationError` was not meant to be exposed as API.