### PR TITLE
Add regex-specific Matches and Ranges collections

### DIFF
--- a/Sources/_StringProcessing/Algorithms/Algorithms/Ranges.swift
+++ b/Sources/_StringProcessing/Algorithms/Algorithms/Ranges.swift
@@ -226,17 +226,38 @@ extension BidirectionalCollection where Element: Comparable {
 //  }
 }
 
+@available(SwiftStdlib 5.7, *)
+struct RegexRangesCollection<Output> {
+  let base: RegexMatchesCollection<Output>
+  
+  init(string: Substring, regex: Regex<Output>) {
+    self.base = RegexMatchesCollection(base: string, regex: regex)
+  }
+}
+  
+@available(SwiftStdlib 5.7, *)
+extension RegexRangesCollection: Collection {
+  typealias Index = RegexMatchesCollection<Output>.Index
+
+  var startIndex: Index { base.startIndex }
+  var endIndex: Index { base.endIndex }
+  func index(after i: Index) -> Index { base.index(after: i) }
+  subscript(position: Index) -> Range<String.Index> { base[position].range }
+}
+
 // MARK: Regex algorithms
 
-extension BidirectionalCollection where SubSequence == Substring {
+extension Collection where SubSequence == Substring {
   @available(SwiftStdlib 5.7, *)
   @_disfavoredOverload
   func _ranges<R: RegexComponent>(
     of regex: R
-  ) -> RangesCollection<RegexConsumer<R, Self>> {
-    _ranges(of: RegexConsumer(regex))
+  ) -> RegexRangesCollection<R.RegexOutput> {
+    RegexRangesCollection(string: self[...], regex: regex.regex)
   }
+}
 
+extension BidirectionalCollection where SubSequence == Substring {
   @available(SwiftStdlib 5.7, *)
   func _rangesFromBack<R: RegexComponent>(
     of regex: R

--- a/Sources/_StringProcessing/Algorithms/Algorithms/Ranges.swift
+++ b/Sources/_StringProcessing/Algorithms/Algorithms/Ranges.swift
@@ -234,7 +234,22 @@ struct RegexRangesCollection<Output> {
     self.base = RegexMatchesCollection(base: string, regex: regex)
   }
 }
+
+@available(SwiftStdlib 5.7, *)
+extension RegexRangesCollection: Sequence {
+  struct Iterator: IteratorProtocol {
+    var matchesBase: RegexMatchesCollection<Output>.Iterator
+    
+    mutating func next() -> Range<String.Index>? {
+      matchesBase.next().map(\.range)
+    }
+  }
   
+  func makeIterator() -> Iterator {
+    Iterator(matchesBase: base.makeIterator())
+  }
+}
+
 @available(SwiftStdlib 5.7, *)
 extension RegexRangesCollection: Collection {
   typealias Index = RegexMatchesCollection<Output>.Index

--- a/Sources/_StringProcessing/Algorithms/Algorithms/Replace.swift
+++ b/Sources/_StringProcessing/Algorithms/Algorithms/Replace.swift
@@ -12,12 +12,12 @@
 // MARK: `CollectionSearcher` algorithms
 
 extension RangeReplaceableCollection {
-  func _replacing<Searcher: CollectionSearcher, Replacement: Collection>(
-    _ searcher: Searcher,
+  func _replacing<Ranges: Collection, Replacement: Collection>(
+    _ ranges: Ranges,
     with replacement: Replacement,
     subrange: Range<Index>,
     maxReplacements: Int = .max
-  ) -> Self where Searcher.Searched == SubSequence,
+  ) -> Self where Ranges.Element == Range<Index>,
                   Replacement.Element == Element
   {
     precondition(maxReplacements >= 0)
@@ -26,7 +26,7 @@ extension RangeReplaceableCollection {
     var result = Self()
     result.append(contentsOf: self[..<index])
     
-    for range in self[subrange]._ranges(of: searcher).prefix(maxReplacements) {
+    for range in ranges.prefix(maxReplacements) {
       result.append(contentsOf: self[index..<range.lowerBound])
       result.append(contentsOf: replacement)
       index = range.upperBound
@@ -36,29 +36,29 @@ extension RangeReplaceableCollection {
     return result
   }
   
-  func _replacing<Searcher: CollectionSearcher, Replacement: Collection>(
-    _ searcher: Searcher,
+  func _replacing<Ranges: Collection, Replacement: Collection>(
+    _ ranges: Ranges,
     with replacement: Replacement,
     maxReplacements: Int = .max
-  ) -> Self where Searcher.Searched == SubSequence,
+  ) -> Self where Ranges.Element == Range<Index>,
                   Replacement.Element == Element
   {
     _replacing(
-      searcher,
+      ranges,
       with: replacement,
       subrange: startIndex..<endIndex,
       maxReplacements: maxReplacements)
   }
   
   mutating func _replace<
-    Searcher: CollectionSearcher, Replacement: Collection
+    Ranges: Collection, Replacement: Collection
   >(
-    _ searcher: Searcher,
+    _ ranges: Ranges,
     with replacement: Replacement,
     maxReplacements: Int = .max
-  ) where Searcher.Searched == SubSequence, Replacement.Element == Element {
+  ) where Ranges.Element == Range<Index>, Replacement.Element == Element {
     self = _replacing(
-      searcher,
+      ranges,
       with: replacement,
       maxReplacements: maxReplacements)
   }
@@ -85,7 +85,7 @@ extension RangeReplaceableCollection where Element: Equatable {
     maxReplacements: Int = .max
   ) -> Self where C.Element == Element, Replacement.Element == Element {
     _replacing(
-      ZSearcher(pattern: Array(other), by: ==),
+      _ranges(of: other),
       with: replacement,
       subrange: subrange,
       maxReplacements: maxReplacements)
@@ -143,7 +143,7 @@ extension RangeReplaceableCollection
     maxReplacements: Int = .max
   ) -> Self where C.Element == Element, Replacement.Element == Element {
     _replacing(
-      PatternOrEmpty(searcher: TwoWaySearcher(pattern: Array(other))),
+      _ranges(of: other),
       with: replacement,
       subrange: subrange,
       maxReplacements: maxReplacements)
@@ -195,7 +195,7 @@ extension RangeReplaceableCollection where SubSequence == Substring {
     maxReplacements: Int = .max
   ) -> Self where Replacement.Element == Element {
     _replacing(
-      RegexConsumer(regex),
+      _ranges(of: regex),
       with: replacement,
       subrange: subrange,
       maxReplacements: maxReplacements)

--- a/Sources/_StringProcessing/Algorithms/Algorithms/Replace.swift
+++ b/Sources/_StringProcessing/Algorithms/Algorithms/Replace.swift
@@ -15,16 +15,14 @@ extension RangeReplaceableCollection {
   func _replacing<Ranges: Collection, Replacement: Collection>(
     _ ranges: Ranges,
     with replacement: Replacement,
-    subrange: Range<Index>,
     maxReplacements: Int = .max
   ) -> Self where Ranges.Element == Range<Index>,
                   Replacement.Element == Element
   {
     precondition(maxReplacements >= 0)
     
-    var index = subrange.lowerBound
     var result = Self()
-    result.append(contentsOf: self[..<index])
+    var index = startIndex
     
     for range in ranges.prefix(maxReplacements) {
       result.append(contentsOf: self[index..<range.lowerBound])
@@ -34,20 +32,6 @@ extension RangeReplaceableCollection {
     
     result.append(contentsOf: self[index...])
     return result
-  }
-  
-  func _replacing<Ranges: Collection, Replacement: Collection>(
-    _ ranges: Ranges,
-    with replacement: Replacement,
-    maxReplacements: Int = .max
-  ) -> Self where Ranges.Element == Range<Index>,
-                  Replacement.Element == Element
-  {
-    _replacing(
-      ranges,
-      with: replacement,
-      subrange: startIndex..<endIndex,
-      maxReplacements: maxReplacements)
   }
   
   mutating func _replace<
@@ -85,9 +69,8 @@ extension RangeReplaceableCollection where Element: Equatable {
     maxReplacements: Int = .max
   ) -> Self where C.Element == Element, Replacement.Element == Element {
     _replacing(
-      _ranges(of: other),
+      self[subrange]._ranges(of: other),
       with: replacement,
-      subrange: subrange,
       maxReplacements: maxReplacements)
   }
 
@@ -143,9 +126,8 @@ extension RangeReplaceableCollection
     maxReplacements: Int = .max
   ) -> Self where C.Element == Element, Replacement.Element == Element {
     _replacing(
-      _ranges(of: other),
+      self[subrange]._ranges(of: other),
       with: replacement,
-      subrange: subrange,
       maxReplacements: maxReplacements)
   }
       
@@ -195,9 +177,8 @@ extension RangeReplaceableCollection where SubSequence == Substring {
     maxReplacements: Int = .max
   ) -> Self where Replacement.Element == Element {
     _replacing(
-      _ranges(of: regex),
+      self[subrange]._ranges(of: regex),
       with: replacement,
-      subrange: subrange,
       maxReplacements: maxReplacements)
   }
 

--- a/Sources/_StringProcessing/Algorithms/Algorithms/Replace.swift
+++ b/Sources/_StringProcessing/Algorithms/Algorithms/Replace.swift
@@ -24,7 +24,9 @@ extension RangeReplaceableCollection {
     var result = Self()
     var index = startIndex
     
-    for range in ranges.prefix(maxReplacements) {
+    // `maxRanges` is a workaround for https://github.com/apple/swift/issues/59522
+    let maxRanges = ranges.prefix(maxReplacements)
+    for range in maxRanges {
       result.append(contentsOf: self[index..<range.lowerBound])
       result.append(contentsOf: replacement)
       index = range.upperBound

--- a/Sources/_StringProcessing/Algorithms/Matching/Matches.swift
+++ b/Sources/_StringProcessing/Algorithms/Matching/Matches.swift
@@ -222,23 +222,22 @@ extension RegexMatchesCollection: Sequence {
     let base: RegexMatchesCollection
     
     // Because `RegexMatchesCollection` eagerly computes the first match for
-    // its `startIndex`, the iterator begins with this current match populated.
-    // For subsequent calls to `next()`, this value is `nil`, and `nextStart`
-    // is used to search for the next match.
-    var currentMatch: Regex<Output>.Match?
+    // its `startIndex`, the iterator can use that match for its initial
+    // iteration. For subsequent calls to `next()`, this value is `false`, and
+    // `nextStart` is used to search for the next match.
+    var initialIteration = true
     var nextStart: String.Index?
     
     init(_ matches: RegexMatchesCollection) {
       self.base = matches
-      self.currentMatch = matches.startIndex.match
-      self.nextStart = currentMatch.flatMap(base.searchIndex(after:))
+      self.nextStart = base.startIndex.match.flatMap(base.searchIndex(after:))
     }
     
     mutating func next() -> Regex<Output>.Match? {
       // Initial case with pre-computed first match
-      if let match = currentMatch {
-        currentMatch = nil
-        return match
+      if initialIteration {
+        initialIteration = false
+        return base.startIndex.match
       }
       
       // `nextStart` is `nil` when iteration has completed

--- a/Sources/_StringProcessing/Algorithms/Matching/Matches.swift
+++ b/Sources/_StringProcessing/Algorithms/Matching/Matches.swift
@@ -246,7 +246,7 @@ extension RegexMatchesCollection: Sequence {
       }
       
       // Otherwise, find the next match (if any) and compute `nextStart`
-      let match = try! base.regex.firstMatch(in: base.input[start...])
+      let match = try? base.regex.firstMatch(in: base.input[start...])
       nextStart = match.flatMap(base.searchIndex(after:))
       return match
     }

--- a/Sources/_StringProcessing/Algorithms/Matching/Matches.swift
+++ b/Sources/_StringProcessing/Algorithms/Matching/Matches.swift
@@ -310,7 +310,7 @@ extension RegexMatchesCollection: Collection {
     
     guard
       let start = searchIndex(after: currentMatch),
-      let nextMatch = try! regex.firstMatch(in: input[start...])
+      let nextMatch = try? regex.firstMatch(in: input[start...])
     else {
       return .end
     }

--- a/Tests/RegexTests/AlgorithmsInternalsTests.swift
+++ b/Tests/RegexTests/AlgorithmsInternalsTests.swift
@@ -44,4 +44,39 @@ extension AlgorithmTests {
     XCTAssertEqual("x", "axb"._trimming(r))
     XCTAssertEqual("x", "axbb"._trimming(r))
   }
+  
+  func testMatchesCollection() {
+    let r = try! Regex("a|b+|c*", as: Substring.self)
+    
+    let str = "zaabbbbbbcde"
+    let matches = str._matches(of: r)
+    let expected: [Substring] = [
+      "", // before 'z'
+      "a",
+      "a",
+      "bbbbbb",
+      "c",
+      "", // after 'c'
+      "", // after 'd'
+      "", // after 'e'
+    ]
+
+    // Make sure we're getting the right collection type
+    let _: RegexMatchesCollection<Substring> = matches
+
+    XCTAssertEqual(matches.map(\.output), expected)
+    
+    let i = matches.index(matches.startIndex, offsetBy: 3)
+    XCTAssertEqual(matches[i].output, expected[3])
+    let j = matches.index(i, offsetBy: 5)
+    XCTAssertEqual(j, matches.endIndex)
+    
+    var index = matches.startIndex
+    while index < matches.endIndex {
+      XCTAssertEqual(
+        matches[index].output,
+        expected[matches.distance(from: matches.startIndex, to: index)])
+      matches.formIndex(after: &index)
+    }
+  }
 }

--- a/Tests/RegexTests/AlgorithmsTests.swift
+++ b/Tests/RegexTests/AlgorithmsTests.swift
@@ -499,8 +499,8 @@ class AlgorithmTests: XCTestCase {
   }
 
   func testUnicodeScalarSemantics() throws {
-    let regex = try Regex(#"(?u)."#, as: Substring.self)
-    let emptyRegex = try Regex(#"(?u)z?"#, as: Substring.self)
+    let regex = try Regex(#"."#, as: Substring.self).matchingSemantics(.unicodeScalar)
+    let emptyRegex = try Regex(#"z?"#, as: Substring.self).matchingSemantics(.unicodeScalar)
     
     XCTAssertEqual("".matches(of: regex).map(\.output), [])
     XCTAssertEqual("Café".matches(of: regex).map(\.output), ["C", "a", "f", "é"])

--- a/Tests/RegexTests/AlgorithmsTests.swift
+++ b/Tests/RegexTests/AlgorithmsTests.swift
@@ -498,6 +498,25 @@ class AlgorithmTests: XCTestCase {
       s2.ranges(of: try Regex("a*?")).map(s2.offsets(of:)), [0..<0, 1..<1, 2..<2])
   }
 
+  func testUnicodeScalarSemantics() throws {
+    let regex = try Regex(#"(?u)."#, as: Substring.self)
+    let emptyRegex = try Regex(#"(?u)z?"#, as: Substring.self)
+    
+    XCTAssertEqual("".matches(of: regex).map(\.output), [])
+    XCTAssertEqual("Café".matches(of: regex).map(\.output), ["C", "a", "f", "é"])
+    XCTAssertEqual("Cafe\u{301}".matches(of: regex).map(\.output), ["C", "a", "f", "e", "\u{301}"])
+    XCTAssertEqual("Cafe\u{301}".matches(of: emptyRegex).count, 6)
+
+    XCTAssertEqual("Café".ranges(of: regex).count, 4)
+    XCTAssertEqual("Cafe\u{301}".ranges(of: regex).count, 5)
+    XCTAssertEqual("Cafe\u{301}".ranges(of: emptyRegex).count, 6)
+    
+    XCTAssertEqual("Café".replacing(regex, with: "-"), "----")
+    XCTAssertEqual("Cafe\u{301}".replacing(regex, with: "-"), "-----")
+    XCTAssertEqual("Café".replacing(emptyRegex, with: "-"), "-C-a-f-é-")
+    XCTAssertEqual("Cafe\u{301}".replacing(emptyRegex, with: "-"), "-C-a-f-e-\u{301}-")
+  }
+  
   func testSwitches() {
     switch "abcde" {
     case try! Regex("a.*f"):


### PR DESCRIPTION
This prepares for adopting an opaque result type for `matches(of:)`. The old, `CollectionConsumer`-based model moves index-by-index, and isn't aware of the regex's semantic level, which results in inaccurate results for regexes that match at a mid-character index.

The lazy range collection had the same issue, so this includes a wrapper for the new `RegexMatchesCollection` that just returns ranges, and modifies the `replace`/`replacing` methods to operate over a collection of ranges instead of a collection searcher.