### PR TITLE
Implement template-string based replacement methods

### DIFF
--- a/Sources/_StringProcessing/Algorithms/Matching/MatchReplace.swift
+++ b/Sources/_StringProcessing/Algorithms/Matching/MatchReplace.swift
@@ -263,6 +263,32 @@ extension RangeReplaceableCollection where SubSequence == Substring {
     result.append(contentsOf: self[index...])
     return result
   }
+  
+  @available(SwiftStdlib 5.7, *)
+  public func replacing(
+    _ regex: some RegexComponent,
+    withTemplate templateString: String,
+    maxReplacements: Int = .max
+  ) -> Self {
+    replacing(
+      regex,
+      withTemplate: templateString,
+      subrange: startIndex..<endIndex,
+      maxReplacements: maxReplacements)
+  }
+
+  @available(SwiftStdlib 5.7, *)
+  public mutating func replace(
+    _ regex: some RegexComponent,
+    withTemplate templateString: String,
+    maxReplacements: Int = .max
+  ) {
+    self = replacing(
+      regex,
+      withTemplate: templateString,
+      subrange: startIndex..<endIndex,
+      maxReplacements: maxReplacements)
+  }
 
   /// Replaces all occurrences of the sequence matching the given regex with
   /// a given collection.

--- a/Sources/_StringProcessing/Algorithms/Matching/MatchReplace.swift
+++ b/Sources/_StringProcessing/Algorithms/Matching/MatchReplace.swift
@@ -229,7 +229,8 @@ extension RangeReplaceableCollection where SubSequence == Substring {
         return nil
       }
     
-    return replacing(regex, subrange: subrange) { match in
+    return replacing(regex, subrange: subrange, maxReplacements: maxReplacements) {
+      match in
       let erasedMatch = Regex<AnyRegexOutput>.Match(match)
       var result = Self()
       var index = templateString.startIndex

--- a/Tests/RegexTests/AlgorithmsTests.swift
+++ b/Tests/RegexTests/AlgorithmsTests.swift
@@ -361,6 +361,11 @@ class AlgorithmTests: XCTestCase {
     expectReplace("100 200 31 4", #"\d+"#, #"\$$0"#, "$100 $200 $31 $4")
     expectReplace("100 200 31 4", #"\d+"#, "\\$0$0", "$0100 $0200 $031 $04")
     expectReplace("100 200 31 4", #"\d+"#, "\\$0${0}", "$0100 $0200 $031 $04")
+    
+    // Other funny business
+    expectReplace("100 200 31 4", #"\d+"#, "${0", "${0 ${0 ${0 ${0")
+    expectReplace("100 200 31 4", #"\d+"#, "${0 }", "${0 } ${0 } ${0 } ${0 }")
+    expectReplace("100 200 31 4", #"(?<digits>\d+)"#, "${ digits }", "${ digits } ${ digits } ${ digits } ${ digits }")
   }
 
   func testSubstring() throws {

--- a/Tests/RegexTests/AlgorithmsTests.swift
+++ b/Tests/RegexTests/AlgorithmsTests.swift
@@ -300,6 +300,19 @@ class AlgorithmTests: XCTestCase {
     expectReplace("aab", "a", "X", "XXb")
     expectReplace("aab", "a+", "X", "Xb")
     expectReplace("aab", "a*", "X", "XXbX")
+    
+    XCTAssertEqual(
+      "a:b abc:123".replacing(try! Regex(#"(\w+):(\w+)"#), withTemplate: "$2:$1"),
+      "b:a 123:abc")
+    XCTAssertEqual(
+      "a:b abc:123".replacing(try! Regex(#"(\w+):(\w+)"#), withTemplate: "$2:$1$9"),
+      "b:a 123:abc")
+    XCTAssertEqual(
+      "100 200 31 4".replacing(try! Regex(#"\d+"#), withTemplate: "${0}0"),
+      "1000 2000 310 40")
+    XCTAssertEqual(
+      "100 200 31 4".replacing(try! Regex(#"\d+"#), withTemplate: "$00"),
+      "100 200 31 4")
   }
 
   func testSubstring() throws {

--- a/Tests/RegexTests/AlgorithmsTests.swift
+++ b/Tests/RegexTests/AlgorithmsTests.swift
@@ -287,6 +287,18 @@ class AlgorithmTests: XCTestCase {
       let regex = try! Regex(regex)
       let actual = string.replacing(regex, with: replacement)
       XCTAssertEqual(actual, expected, file: file, line: line)
+      
+      var inplace = string
+      inplace.replace(regex, with: replacement)
+      XCTAssertEqual(inplace, expected, file: file, line: line)
+      
+      let tripled = String(repeating: string, count: 3)
+      let substring = tripled.dropFirst(string.count).dropLast(string.count)
+      let replaced = tripled.replacing(
+        regex,
+        with: replacement,
+        subrange: substring.startIndex..<substring.endIndex)
+      XCTAssertEqual(replaced, string + actual + string)
     }
     
     expectReplace("", "", "X", "X")
@@ -300,19 +312,55 @@ class AlgorithmTests: XCTestCase {
     expectReplace("aab", "a", "X", "XXb")
     expectReplace("aab", "a+", "X", "Xb")
     expectReplace("aab", "a*", "X", "XXbX")
+  }
+  
+  func testReplaceTemplate() {
+    func expectReplace(
+      _ string: String,
+      _ regex: String,
+      _ replacement: String,
+      _ expected: String,
+      file: StaticString = #file, line: UInt = #line
+    ) {
+      let regex = try! Regex(regex)
+      let actual = string.replacing(regex, withTemplate: replacement)
+      XCTAssertEqual(actual, expected, file: file, line: line)
+      
+      var inplace = string
+      inplace.replace(regex, withTemplate: replacement)
+      XCTAssertEqual(inplace, expected, file: file, line: line)
+
+      let tripled = String(repeating: string, count: 3)
+      let substring = tripled.dropFirst(string.count).dropLast(string.count)
+      let replaced = tripled.replacing(
+        regex,
+        withTemplate: replacement,
+        subrange: substring.startIndex..<substring.endIndex)
+      XCTAssertEqual(replaced, string + actual + string)
+    }
+
+    // Numbered replacements
+    expectReplace("a:b abc:123", #"(\w+):(\w+)"#, "$2:$1", "b:a 123:abc")
+    // Numbered replacements w/ named captures
+    expectReplace("a:b abc:123", #"(?<value>\w+):(?<key>\w+)"#, "$2:$1", "b:a 123:abc")
+    // Named replacements
+    expectReplace("a:b abc:123", #"(?<value>\w+):(?<key>\w+)"#, "${key}:${value}", "b:a 123:abc")
+
+    // Elide extra numbered replacements
+    expectReplace("a:b abc:123", #"(\w+):(\w+)"#, "$2:$1$9", "b:a 123:abc")
+    expectReplace("a:b abc:123", #"(\w+):(\w+)"#, "$2:$1${9}", "b:a 123:abc")
+    // Elide extra named replacements
+    expectReplace("a:b abc:123", #"(?<value>\w+):(?<key>\w+)"#, "${key}:${value}${nocap}", "b:a 123:abc")
     
-    XCTAssertEqual(
-      "a:b abc:123".replacing(try! Regex(#"(\w+):(\w+)"#), withTemplate: "$2:$1"),
-      "b:a 123:abc")
-    XCTAssertEqual(
-      "a:b abc:123".replacing(try! Regex(#"(\w+):(\w+)"#), withTemplate: "$2:$1$9"),
-      "b:a 123:abc")
-    XCTAssertEqual(
-      "100 200 31 4".replacing(try! Regex(#"\d+"#), withTemplate: "${0}0"),
-      "1000 2000 310 40")
-    XCTAssertEqual(
-      "100 200 31 4".replacing(try! Regex(#"\d+"#), withTemplate: "$00"),
-      "100 200 31 4")
+    // Whole replacement
+    expectReplace("100 200 31 4", #"\d+"#, "${0}0", "1000 2000 310 40")
+    expectReplace("100 200 31 4", #"\d+"#, "$00", "100 200 31 4")
+    
+    // Escaped '$' handling
+    expectReplace("100 200 31 4", #"\d+"#, "\\$$0", "$100 $200 $31 $4")
+    expectReplace("100 200 31 4", #"\d+"#, #"\$$0"#, "$100 $200 $31 $4")
+    expectReplace("100 200 31 4", #"\d+"#, "\\$0$0", "$0100 $0200 $031 $04")
+    expectReplace("100 200 31 4", #"\d+"#, "\\$0${0}", "$0100 $0200 $031 $04")
   }
 
   func testSubstring() throws {


### PR DESCRIPTION
These alternative `replace`/`replacing` methods let you pass a template string with `$`-prefixed replacement tokens.

```swift
let str = "a:b c:d"
let swapped = str.replacing(/(\w+):(\w+)/, withTemplate: "$2:$1")
// swapped = "b:a d:c"
```

Tokens can be written as:
- `/\$\d+/`: one or more consecutive digits are read into a single number
- `/\${\d+}/`: you can use this if the token is followed by literal numbers
- `/\${\w+}/`: using a capture by name

Here's surely an uncontroversial design decision: Unrecognized tokens are silently omitted from the output. Other approaches are to include them in the output, or to trap.

`\$` escapes the dollar sign into the output; needs to be written as `\\$` in a regular string literal, where `\$` is an invalid escape sequence.
