### PR TITLE
Obtain match output elements without materializing the output.

### DIFF
--- a/Sources/_StringProcessing/Regex/AnyRegexOutput.swift
+++ b/Sources/_StringProcessing/Regex/AnyRegexOutput.swift
@@ -62,9 +62,11 @@ extension AnyRegexOutput: RandomAccessCollection {
 
     /// The captured value, `nil` for no-capture
     public var value: Any? {
-      // FIXME: Should this return the substring for default-typed
-      // values?
-      representation.value
+      representation.value ?? substring
+    }
+
+    internal var type: Any.Type {
+      representation.type
     }
 
     /// The name of this capture, if it has one, otherwise `nil`.
@@ -262,5 +264,10 @@ extension AnyRegexOutput.ElementRepresentation {
       value: nil,
       optionalCount: optionalDepth
     )
+  }
+
+  var type: Any.Type {
+    value.map { Swift.type(of: $0) }
+      ?? TypeConstruction.optionalType(of: Substring.self, depth: optionalDepth)
   }
 }

--- a/Tests/RegexBuilderTests/RegexDSLTests.swift
+++ b/Tests/RegexBuilderTests/RegexDSLTests.swift
@@ -427,7 +427,19 @@ class RegexDSLTests: XCTestCase {
         CharacterClass.digit
       }
     }
-    
+
+    try _testDSLCaptures(
+      ("abcdef2", ("abcdef2", "f")),
+      matchType: (Substring, Substring??).self, ==)
+    {
+      Optionally {
+        ZeroOrMore {
+          Capture(CharacterClass.word)
+        }
+        CharacterClass.digit
+      }
+    }
+
     try _testDSLCaptures(
       ("aaabbbcccdddeeefff", "aaabbbcccdddeeefff"),
       ("aaaabbbcccdddeeefff", nil),


### PR DESCRIPTION
Resolves #267.