### PR TITLE
Fully generalize "whole match" in the engine and enable transforming custom types

### DIFF
--- a/Sources/RegexBuilder/Variadics.swift
+++ b/Sources/RegexBuilder/Variadics.swift
@@ -2608,28 +2608,23 @@ extension Capture {
   @_disfavoredOverload
   public init<R: RegexComponent, W, NewCapture>(
     _ component: R,
-    transform: @escaping (Substring) throws -> NewCapture
+    transform: @escaping (W) throws -> NewCapture
   ) where RegexOutput == (Substring, NewCapture), R.RegexOutput == W {
-    self.init(node: .capture(.transform(
-      CaptureTransform(resultType: NewCapture.self) {
-        try transform($0) as Any
-      },
-      component.regex.root)))
+    self.init(node: .capture(
+      component.regex.root,
+      CaptureTransform(transform)))
   }
 
   @_disfavoredOverload
   public init<R: RegexComponent, W, NewCapture>(
     _ component: R,
     as reference: Reference<NewCapture>,
-    transform: @escaping (Substring) throws -> NewCapture
+    transform: @escaping (W) throws -> NewCapture
   ) where RegexOutput == (Substring, NewCapture), R.RegexOutput == W {
     self.init(node: .capture(
       reference: reference.id,
-      .transform(
-        CaptureTransform(resultType: NewCapture.self) {
-          try transform($0) as Any
-        },
-        component.regex.root)))
+      component.regex.root,
+      CaptureTransform(transform)))
   }
 }
 
@@ -2638,28 +2633,23 @@ extension TryCapture {
   @_disfavoredOverload
   public init<R: RegexComponent, W, NewCapture>(
     _ component: R,
-    transform: @escaping (Substring) throws -> NewCapture?
+    transform: @escaping (W) throws -> NewCapture?
   ) where RegexOutput == (Substring, NewCapture), R.RegexOutput == W {
-    self.init(node: .capture(.transform(
-      CaptureTransform(resultType: NewCapture.self) {
-        try transform($0) as Any?
-      },
-      component.regex.root)))
+    self.init(node: .capture(
+    component.regex.root,
+    CaptureTransform(transform)))
   }
 
   @_disfavoredOverload
   public init<R: RegexComponent, W, NewCapture>(
     _ component: R,
     as reference: Reference<NewCapture>,
-    transform: @escaping (Substring) throws -> NewCapture?
+    transform: @escaping (W) throws -> NewCapture?
   ) where RegexOutput == (Substring, NewCapture), R.RegexOutput == W {
     self.init(node: .capture(
       reference: reference.id,
-      .transform(
-        CaptureTransform(resultType: NewCapture.self) {
-          try transform($0) as Any?
-        },
-        component.regex.root)))
+      component.regex.root,
+      CaptureTransform(transform)))
   }
 }
 
@@ -2687,28 +2677,23 @@ extension Capture {
   @_disfavoredOverload
   public init<R: RegexComponent, W, NewCapture>(
     @RegexComponentBuilder _ component: () -> R,
-    transform: @escaping (Substring) throws -> NewCapture
+    transform: @escaping (W) throws -> NewCapture
   ) where RegexOutput == (Substring, NewCapture), R.RegexOutput == W {
-    self.init(node: .capture(.transform(
-      CaptureTransform(resultType: NewCapture.self) {
-        try transform($0) as Any
-      },
-      component().regex.root)))
+    self.init(node: .capture(
+      component().regex.root,
+      CaptureTransform(transform)))
   }
 
   @_disfavoredOverload
   public init<R: RegexComponent, W, NewCapture>(
     as reference: Reference<NewCapture>,
     @RegexComponentBuilder _ component: () -> R,
-    transform: @escaping (Substring) throws -> NewCapture
+    transform: @escaping (W) throws -> NewCapture
   ) where RegexOutput == (Substring, NewCapture), R.RegexOutput == W {
     self.init(node: .capture(
       reference: reference.id,
-      .transform(
-        CaptureTransform(resultType: NewCapture.self) {
-          try transform($0) as Any
-        },
-        component().regex.root)))
+      component().regex.root,
+      CaptureTransform(transform)))
   }
 }
 
@@ -2717,28 +2702,23 @@ extension TryCapture {
   @_disfavoredOverload
   public init<R: RegexComponent, W, NewCapture>(
     @RegexComponentBuilder _ component: () -> R,
-    transform: @escaping (Substring) throws -> NewCapture?
+    transform: @escaping (W) throws -> NewCapture?
   ) where RegexOutput == (Substring, NewCapture), R.RegexOutput == W {
-    self.init(node: .capture(.transform(
-      CaptureTransform(resultType: NewCapture.self) {
-        try transform($0) as Any?
-      },
-      component().regex.root)))
+    self.init(node: .capture(
+      component().regex.root,
+      CaptureTransform(transform)))
   }
 
   @_disfavoredOverload
   public init<R: RegexComponent, W, NewCapture>(
     as reference: Reference<NewCapture>,
     @RegexComponentBuilder _ component: () -> R,
-    transform: @escaping (Substring) throws -> NewCapture?
+    transform: @escaping (W) throws -> NewCapture?
   ) where RegexOutput == (Substring, NewCapture), R.RegexOutput == W {
     self.init(node: .capture(
       reference: reference.id,
-      .transform(
-        CaptureTransform(resultType: NewCapture.self) {
-          try transform($0) as Any?
-        },
-        component().regex.root)))
+      component().regex.root,
+      CaptureTransform(transform)))
   }
 }
 
@@ -2760,27 +2740,22 @@ extension Capture {
 
   public init<R: RegexComponent, W, C1, NewCapture>(
     _ component: R,
-    transform: @escaping (Substring) throws -> NewCapture
+    transform: @escaping (W) throws -> NewCapture
   ) where RegexOutput == (Substring, NewCapture, C1), R.RegexOutput == (W, C1) {
-    self.init(node: .capture(.transform(
-      CaptureTransform(resultType: NewCapture.self) {
-        try transform($0) as Any
-      },
-      component.regex.root)))
+    self.init(node: .capture(
+      component.regex.root,
+      CaptureTransform(transform)))
   }
 
   public init<R: RegexComponent, W, C1, NewCapture>(
     _ component: R,
     as reference: Reference<NewCapture>,
-    transform: @escaping (Substring) throws -> NewCapture
+    transform: @escaping (W) throws -> NewCapture
   ) where RegexOutput == (Substring, NewCapture, C1), R.RegexOutput == (W, C1) {
     self.init(node: .capture(
       reference: reference.id,
-      .transform(
-        CaptureTransform(resultType: NewCapture.self) {
-          try transform($0) as Any
-        },
-        component.regex.root)))
+      component.regex.root,
+      CaptureTransform(transform)))
   }
 }
 
@@ -2788,27 +2763,22 @@ extension Capture {
 extension TryCapture {
   public init<R: RegexComponent, W, C1, NewCapture>(
     _ component: R,
-    transform: @escaping (Substring) throws -> NewCapture?
+    transform: @escaping (W) throws -> NewCapture?
   ) where RegexOutput == (Substring, NewCapture, C1), R.RegexOutput == (W, C1) {
-    self.init(node: .capture(.transform(
-      CaptureTransform(resultType: NewCapture.self) {
-        try transform($0) as Any?
-      },
-      component.regex.root)))
+    self.init(node: .capture(
+    component.regex.root,
+    CaptureTransform(transform)))
   }
 
   public init<R: RegexComponent, W, C1, NewCapture>(
     _ component: R,
     as reference: Reference<NewCapture>,
-    transform: @escaping (Substring) throws -> NewCapture?
+    transform: @escaping (W) throws -> NewCapture?
   ) where RegexOutput == (Substring, NewCapture, C1), R.RegexOutput == (W, C1) {
     self.init(node: .capture(
       reference: reference.id,
-      .transform(
-        CaptureTransform(resultType: NewCapture.self) {
-          try transform($0) as Any?
-        },
-        component.regex.root)))
+      component.regex.root,
+      CaptureTransform(transform)))
   }
 }
 
@@ -2833,27 +2803,22 @@ extension Capture {
 
   public init<R: RegexComponent, W, C1, NewCapture>(
     @RegexComponentBuilder _ component: () -> R,
-    transform: @escaping (Substring) throws -> NewCapture
+    transform: @escaping (W) throws -> NewCapture
   ) where RegexOutput == (Substring, NewCapture, C1), R.RegexOutput == (W, C1) {
-    self.init(node: .capture(.transform(
-      CaptureTransform(resultType: NewCapture.self) {
-        try transform($0) as Any
-      },
-      component().regex.root)))
+    self.init(node: .capture(
+      component().regex.root,
+      CaptureTransform(transform)))
   }
 
   public init<R: RegexComponent, W, C1, NewCapture>(
     as reference: Reference<NewCapture>,
     @RegexComponentBuilder _ component: () -> R,
-    transform: @escaping (Substring) throws -> NewCapture
+    transform: @escaping (W) throws -> NewCapture
   ) where RegexOutput == (Substring, NewCapture, C1), R.RegexOutput == (W, C1) {
     self.init(node: .capture(
       reference: reference.id,
-      .transform(
-        CaptureTransform(resultType: NewCapture.self) {
-          try transform($0) as Any
-        },
-        component().regex.root)))
+      component().regex.root,
+      CaptureTransform(transform)))
   }
 }
 
@@ -2861,27 +2826,22 @@ extension Capture {
 extension TryCapture {
   public init<R: RegexComponent, W, C1, NewCapture>(
     @RegexComponentBuilder _ component: () -> R,
-    transform: @escaping (Substring) throws -> NewCapture?
+    transform: @escaping (W) throws -> NewCapture?
   ) where RegexOutput == (Substring, NewCapture, C1), R.RegexOutput == (W, C1) {
-    self.init(node: .capture(.transform(
-      CaptureTransform(resultType: NewCapture.self) {
-        try transform($0) as Any?
-      },
-      component().regex.root)))
+    self.init(node: .capture(
+      component().regex.root,
+      CaptureTransform(transform)))
   }
 
   public init<R: RegexComponent, W, C1, NewCapture>(
     as reference: Reference<NewCapture>,
     @RegexComponentBuilder _ component: () -> R,
-    transform: @escaping (Substring) throws -> NewCapture?
+    transform: @escaping (W) throws -> NewCapture?
   ) where RegexOutput == (Substring, NewCapture, C1), R.RegexOutput == (W, C1) {
     self.init(node: .capture(
       reference: reference.id,
-      .transform(
-        CaptureTransform(resultType: NewCapture.self) {
-          try transform($0) as Any?
-        },
-        component().regex.root)))
+      component().regex.root,
+      CaptureTransform(transform)))
   }
 }
 
@@ -2903,27 +2863,22 @@ extension Capture {
 
   public init<R: RegexComponent, W, C1, C2, NewCapture>(
     _ component: R,
-    transform: @escaping (Substring) throws -> NewCapture
+    transform: @escaping (W) throws -> NewCapture
   ) where RegexOutput == (Substring, NewCapture, C1, C2), R.RegexOutput == (W, C1, C2) {
-    self.init(node: .capture(.transform(
-      CaptureTransform(resultType: NewCapture.self) {
-        try transform($0) as Any
-      },
-      component.regex.root)))
+    self.init(node: .capture(
+      component.regex.root,
+      CaptureTransform(transform)))
   }
 
   public init<R: RegexComponent, W, C1, C2, NewCapture>(
     _ component: R,
     as reference: Reference<NewCapture>,
-    transform: @escaping (Substring) throws -> NewCapture
+    transform: @escaping (W) throws -> NewCapture
   ) where RegexOutput == (Substring, NewCapture, C1, C2), R.RegexOutput == (W, C1, C2) {
     self.init(node: .capture(
       reference: reference.id,
-      .transform(
-        CaptureTransform(resultType: NewCapture.self) {
-          try transform($0) as Any
-        },
-        component.regex.root)))
+      component.regex.root,
+      CaptureTransform(transform)))
   }
 }
 
@@ -2931,27 +2886,22 @@ extension Capture {
 extension TryCapture {
   public init<R: RegexComponent, W, C1, C2, NewCapture>(
     _ component: R,
-    transform: @escaping (Substring) throws -> NewCapture?
+    transform: @escaping (W) throws -> NewCapture?
   ) where RegexOutput == (Substring, NewCapture, C1, C2), R.RegexOutput == (W, C1, C2) {
-    self.init(node: .capture(.transform(
-      CaptureTransform(resultType: NewCapture.self) {
-        try transform($0) as Any?
-      },
-      component.regex.root)))
+    self.init(node: .capture(
+    component.regex.root,
+    CaptureTransform(transform)))
   }
 
   public init<R: RegexComponent, W, C1, C2, NewCapture>(
     _ component: R,
     as reference: Reference<NewCapture>,
-    transform: @escaping (Substring) throws -> NewCapture?
+    transform: @escaping (W) throws -> NewCapture?
   ) where RegexOutput == (Substring, NewCapture, C1, C2), R.RegexOutput == (W, C1, C2) {
     self.init(node: .capture(
       reference: reference.id,
-      .transform(
-        CaptureTransform(resultType: NewCapture.self) {
-          try transform($0) as Any?
-        },
-        component.regex.root)))
+      component.regex.root,
+      CaptureTransform(transform)))
   }
 }
 
@@ -2976,27 +2926,22 @@ extension Capture {
 
   public init<R: RegexComponent, W, C1, C2, NewCapture>(
     @RegexComponentBuilder _ component: () -> R,
-    transform: @escaping (Substring) throws -> NewCapture
+    transform: @escaping (W) throws -> NewCapture
   ) where RegexOutput == (Substring, NewCapture, C1, C2), R.RegexOutput == (W, C1, C2) {
-    self.init(node: .capture(.transform(
-      CaptureTransform(resultType: NewCapture.self) {
-        try transform($0) as Any
-      },
-      component().regex.root)))
+    self.init(node: .capture(
+      component().regex.root,
+      CaptureTransform(transform)))
   }
 
   public init<R: RegexComponent, W, C1, C2, NewCapture>(
     as reference: Reference<NewCapture>,
     @RegexComponentBuilder _ component: () -> R,
-    transform: @escaping (Substring) throws -> NewCapture
+    transform: @escaping (W) throws -> NewCapture
   ) where RegexOutput == (Substring, NewCapture, C1, C2), R.RegexOutput == (W, C1, C2) {
     self.init(node: .capture(
       reference: reference.id,
-      .transform(
-        CaptureTransform(resultType: NewCapture.self) {
-          try transform($0) as Any
-        },
-        component().regex.root)))
+      component().regex.root,
+      CaptureTransform(transform)))
   }
 }
 
@@ -3004,27 +2949,22 @@ extension Capture {
 extension TryCapture {
   public init<R: RegexComponent, W, C1, C2, NewCapture>(
     @RegexComponentBuilder _ component: () -> R,
-    transform: @escaping (Substring) throws -> NewCapture?
+    transform: @escaping (W) throws -> NewCapture?
   ) where RegexOutput == (Substring, NewCapture, C1, C2), R.RegexOutput == (W, C1, C2) {
-    self.init(node: .capture(.transform(
-      CaptureTransform(resultType: NewCapture.self) {
-        try transform($0) as Any?
-      },
-      component().regex.root)))
+    self.init(node: .capture(
+      component().regex.root,
+      CaptureTransform(transform)))
   }
 
   public init<R: RegexComponent, W, C1, C2, NewCapture>(
     as reference: Reference<NewCapture>,
     @RegexComponentBuilder _ component: () -> R,
-    transform: @escaping (Substring) throws -> NewCapture?
+    transform: @escaping (W) throws -> NewCapture?
   ) where RegexOutput == (Substring, NewCapture, C1, C2), R.RegexOutput == (W, C1, C2) {
     self.init(node: .capture(
       reference: reference.id,
-      .transform(
-        CaptureTransform(resultType: NewCapture.self) {
-          try transform($0) as Any?
-        },
-        component().regex.root)))
+      component().regex.root,
+      CaptureTransform(transform)))
   }
 }
 
@@ -3046,27 +2986,22 @@ extension Capture {
 
   public init<R: RegexComponent, W, C1, C2, C3, NewCapture>(
     _ component: R,
-    transform: @escaping (Substring) throws -> NewCapture
+    transform: @escaping (W) throws -> NewCapture
   ) where RegexOutput == (Substring, NewCapture, C1, C2, C3), R.RegexOutput == (W, C1, C2, C3) {
-    self.init(node: .capture(.transform(
-      CaptureTransform(resultType: NewCapture.self) {
-        try transform($0) as Any
-      },
-      component.regex.root)))
+    self.init(node: .capture(
+      component.regex.root,
+      CaptureTransform(transform)))
   }
 
   public init<R: RegexComponent, W, C1, C2, C3, NewCapture>(
     _ component: R,
     as reference: Reference<NewCapture>,
-    transform: @escaping (Substring) throws -> NewCapture
+    transform: @escaping (W) throws -> NewCapture
   ) where RegexOutput == (Substring, NewCapture, C1, C2, C3), R.RegexOutput == (W, C1, C2, C3) {
     self.init(node: .capture(
       reference: reference.id,
-      .transform(
-        CaptureTransform(resultType: NewCapture.self) {
-          try transform($0) as Any
-        },
-        component.regex.root)))
+      component.regex.root,
+      CaptureTransform(transform)))
   }
 }
 
@@ -3074,27 +3009,22 @@ extension Capture {
 extension TryCapture {
   public init<R: RegexComponent, W, C1, C2, C3, NewCapture>(
     _ component: R,
-    transform: @escaping (Substring) throws -> NewCapture?
+    transform: @escaping (W) throws -> NewCapture?
   ) where RegexOutput == (Substring, NewCapture, C1, C2, C3), R.RegexOutput == (W, C1, C2, C3) {
-    self.init(node: .capture(.transform(
-      CaptureTransform(resultType: NewCapture.self) {
-        try transform($0) as Any?
-      },
-      component.regex.root)))
+    self.init(node: .capture(
+    component.regex.root,
+    CaptureTransform(transform)))
   }
 
   public init<R: RegexComponent, W, C1, C2, C3, NewCapture>(
     _ component: R,
     as reference: Reference<NewCapture>,
-    transform: @escaping (Substring) throws -> NewCapture?
+    transform: @escaping (W) throws -> NewCapture?
   ) where RegexOutput == (Substring, NewCapture, C1, C2, C3), R.RegexOutput == (W, C1, C2, C3) {
     self.init(node: .capture(
       reference: reference.id,
-      .transform(
-        CaptureTransform(resultType: NewCapture.self) {
-          try transform($0) as Any?
-        },
-        component.regex.root)))
+      component.regex.root,
+      CaptureTransform(transform)))
   }
 }
 
@@ -3119,27 +3049,22 @@ extension Capture {
 
   public init<R: RegexComponent, W, C1, C2, C3, NewCapture>(
     @RegexComponentBuilder _ component: () -> R,
-    transform: @escaping (Substring) throws -> NewCapture
+    transform: @escaping (W) throws -> NewCapture
   ) where RegexOutput == (Substring, NewCapture, C1, C2, C3), R.RegexOutput == (W, C1, C2, C3) {
-    self.init(node: .capture(.transform(
-      CaptureTransform(resultType: NewCapture.self) {
-        try transform($0) as Any
-      },
-      component().regex.root)))
+    self.init(node: .capture(
+      component().regex.root,
+      CaptureTransform(transform)))
   }
 
   public init<R: RegexComponent, W, C1, C2, C3, NewCapture>(
     as reference: Reference<NewCapture>,
     @RegexComponentBuilder _ component: () -> R,
-    transform: @escaping (Substring) throws -> NewCapture
+    transform: @escaping (W) throws -> NewCapture
   ) where RegexOutput == (Substring, NewCapture, C1, C2, C3), R.RegexOutput == (W, C1, C2, C3) {
     self.init(node: .capture(
       reference: reference.id,
-      .transform(
-        CaptureTransform(resultType: NewCapture.self) {
-          try transform($0) as Any
-        },
-        component().regex.root)))
+      component().regex.root,
+      CaptureTransform(transform)))
   }
 }
 
@@ -3147,27 +3072,22 @@ extension Capture {
 extension TryCapture {
   public init<R: RegexComponent, W, C1, C2, C3, NewCapture>(
     @RegexComponentBuilder _ component: () -> R,
-    transform: @escaping (Substring) throws -> NewCapture?
+    transform: @escaping (W) throws -> NewCapture?
   ) where RegexOutput == (Substring, NewCapture, C1, C2, C3), R.RegexOutput == (W, C1, C2, C3) {
-    self.init(node: .capture(.transform(
-      CaptureTransform(resultType: NewCapture.self) {
-        try transform($0) as Any?
-      },
-      component().regex.root)))
+    self.init(node: .capture(
+      component().regex.root,
+      CaptureTransform(transform)))
   }
 
   public init<R: RegexComponent, W, C1, C2, C3, NewCapture>(
     as reference: Reference<NewCapture>,
     @RegexComponentBuilder _ component: () -> R,
-    transform: @escaping (Substring) throws -> NewCapture?
+    transform: @escaping (W) throws -> NewCapture?
   ) where RegexOutput == (Substring, NewCapture, C1, C2, C3), R.RegexOutput == (W, C1, C2, C3) {
     self.init(node: .capture(
       reference: reference.id,
-      .transform(
-        CaptureTransform(resultType: NewCapture.self) {
-          try transform($0) as Any?
-        },
-        component().regex.root)))
+      component().regex.root,
+      CaptureTransform(transform)))
   }
 }
 
@@ -3189,27 +3109,22 @@ extension Capture {
 
   public init<R: RegexComponent, W, C1, C2, C3, C4, NewCapture>(
     _ component: R,
-    transform: @escaping (Substring) throws -> NewCapture
+    transform: @escaping (W) throws -> NewCapture
   ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4), R.RegexOutput == (W, C1, C2, C3, C4) {
-    self.init(node: .capture(.transform(
-      CaptureTransform(resultType: NewCapture.self) {
-        try transform($0) as Any
-      },
-      component.regex.root)))
+    self.init(node: .capture(
+      component.regex.root,
+      CaptureTransform(transform)))
   }
 
   public init<R: RegexComponent, W, C1, C2, C3, C4, NewCapture>(
     _ component: R,
     as reference: Reference<NewCapture>,
-    transform: @escaping (Substring) throws -> NewCapture
+    transform: @escaping (W) throws -> NewCapture
   ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4), R.RegexOutput == (W, C1, C2, C3, C4) {
     self.init(node: .capture(
       reference: reference.id,
-      .transform(
-        CaptureTransform(resultType: NewCapture.self) {
-          try transform($0) as Any
-        },
-        component.regex.root)))
+      component.regex.root,
+      CaptureTransform(transform)))
   }
 }
 
@@ -3217,27 +3132,22 @@ extension Capture {
 extension TryCapture {
   public init<R: RegexComponent, W, C1, C2, C3, C4, NewCapture>(
     _ component: R,
-    transform: @escaping (Substring) throws -> NewCapture?
+    transform: @escaping (W) throws -> NewCapture?
   ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4), R.RegexOutput == (W, C1, C2, C3, C4) {
-    self.init(node: .capture(.transform(
-      CaptureTransform(resultType: NewCapture.self) {
-        try transform($0) as Any?
-      },
-      component.regex.root)))
+    self.init(node: .capture(
+    component.regex.root,
+    CaptureTransform(transform)))
   }
 
   public init<R: RegexComponent, W, C1, C2, C3, C4, NewCapture>(
     _ component: R,
     as reference: Reference<NewCapture>,
-    transform: @escaping (Substring) throws -> NewCapture?
+    transform: @escaping (W) throws -> NewCapture?
   ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4), R.RegexOutput == (W, C1, C2, C3, C4) {
     self.init(node: .capture(
       reference: reference.id,
-      .transform(
-        CaptureTransform(resultType: NewCapture.self) {
-          try transform($0) as Any?
-        },
-        component.regex.root)))
+      component.regex.root,
+      CaptureTransform(transform)))
   }
 }
 
@@ -3262,27 +3172,22 @@ extension Capture {
 
   public init<R: RegexComponent, W, C1, C2, C3, C4, NewCapture>(
     @RegexComponentBuilder _ component: () -> R,
-    transform: @escaping (Substring) throws -> NewCapture
+    transform: @escaping (W) throws -> NewCapture
   ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4), R.RegexOutput == (W, C1, C2, C3, C4) {
-    self.init(node: .capture(.transform(
-      CaptureTransform(resultType: NewCapture.self) {
-        try transform($0) as Any
-      },
-      component().regex.root)))
+    self.init(node: .capture(
+      component().regex.root,
+      CaptureTransform(transform)))
   }
 
   public init<R: RegexComponent, W, C1, C2, C3, C4, NewCapture>(
     as reference: Reference<NewCapture>,
     @RegexComponentBuilder _ component: () -> R,
-    transform: @escaping (Substring) throws -> NewCapture
+    transform: @escaping (W) throws -> NewCapture
   ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4), R.RegexOutput == (W, C1, C2, C3, C4) {
     self.init(node: .capture(
       reference: reference.id,
-      .transform(
-        CaptureTransform(resultType: NewCapture.self) {
-          try transform($0) as Any
-        },
-        component().regex.root)))
+      component().regex.root,
+      CaptureTransform(transform)))
   }
 }
 
@@ -3290,27 +3195,22 @@ extension Capture {
 extension TryCapture {
   public init<R: RegexComponent, W, C1, C2, C3, C4, NewCapture>(
     @RegexComponentBuilder _ component: () -> R,
-    transform: @escaping (Substring) throws -> NewCapture?
+    transform: @escaping (W) throws -> NewCapture?
   ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4), R.RegexOutput == (W, C1, C2, C3, C4) {
-    self.init(node: .capture(.transform(
-      CaptureTransform(resultType: NewCapture.self) {
-        try transform($0) as Any?
-      },
-      component().regex.root)))
+    self.init(node: .capture(
+      component().regex.root,
+      CaptureTransform(transform)))
   }
 
   public init<R: RegexComponent, W, C1, C2, C3, C4, NewCapture>(
     as reference: Reference<NewCapture>,
     @RegexComponentBuilder _ component: () -> R,
-    transform: @escaping (Substring) throws -> NewCapture?
+    transform: @escaping (W) throws -> NewCapture?
   ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4), R.RegexOutput == (W, C1, C2, C3, C4) {
     self.init(node: .capture(
       reference: reference.id,
-      .transform(
-        CaptureTransform(resultType: NewCapture.self) {
-          try transform($0) as Any?
-        },
-        component().regex.root)))
+      component().regex.root,
+      CaptureTransform(transform)))
   }
 }
 
@@ -3332,27 +3232,22 @@ extension Capture {
 
   public init<R: RegexComponent, W, C1, C2, C3, C4, C5, NewCapture>(
     _ component: R,
-    transform: @escaping (Substring) throws -> NewCapture
+    transform: @escaping (W) throws -> NewCapture
   ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5), R.RegexOutput == (W, C1, C2, C3, C4, C5) {
-    self.init(node: .capture(.transform(
-      CaptureTransform(resultType: NewCapture.self) {
-        try transform($0) as Any
-      },
-      component.regex.root)))
+    self.init(node: .capture(
+      component.regex.root,
+      CaptureTransform(transform)))
   }
 
   public init<R: RegexComponent, W, C1, C2, C3, C4, C5, NewCapture>(
     _ component: R,
     as reference: Reference<NewCapture>,
-    transform: @escaping (Substring) throws -> NewCapture
+    transform: @escaping (W) throws -> NewCapture
   ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5), R.RegexOutput == (W, C1, C2, C3, C4, C5) {
     self.init(node: .capture(
       reference: reference.id,
-      .transform(
-        CaptureTransform(resultType: NewCapture.self) {
-          try transform($0) as Any
-        },
-        component.regex.root)))
+      component.regex.root,
+      CaptureTransform(transform)))
   }
 }
 
@@ -3360,27 +3255,22 @@ extension Capture {
 extension TryCapture {
   public init<R: RegexComponent, W, C1, C2, C3, C4, C5, NewCapture>(
     _ component: R,
-    transform: @escaping (Substring) throws -> NewCapture?
+    transform: @escaping (W) throws -> NewCapture?
   ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5), R.RegexOutput == (W, C1, C2, C3, C4, C5) {
-    self.init(node: .capture(.transform(
-      CaptureTransform(resultType: NewCapture.self) {
-        try transform($0) as Any?
-      },
-      component.regex.root)))
+    self.init(node: .capture(
+    component.regex.root,
+    CaptureTransform(transform)))
   }
 
   public init<R: RegexComponent, W, C1, C2, C3, C4, C5, NewCapture>(
     _ component: R,
     as reference: Reference<NewCapture>,
-    transform: @escaping (Substring) throws -> NewCapture?
+    transform: @escaping (W) throws -> NewCapture?
   ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5), R.RegexOutput == (W, C1, C2, C3, C4, C5) {
     self.init(node: .capture(
       reference: reference.id,
-      .transform(
-        CaptureTransform(resultType: NewCapture.self) {
-          try transform($0) as Any?
-        },
-        component.regex.root)))
+      component.regex.root,
+      CaptureTransform(transform)))
   }
 }
 
@@ -3405,27 +3295,22 @@ extension Capture {
 
   public init<R: RegexComponent, W, C1, C2, C3, C4, C5, NewCapture>(
     @RegexComponentBuilder _ component: () -> R,
-    transform: @escaping (Substring) throws -> NewCapture
+    transform: @escaping (W) throws -> NewCapture
   ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5), R.RegexOutput == (W, C1, C2, C3, C4, C5) {
-    self.init(node: .capture(.transform(
-      CaptureTransform(resultType: NewCapture.self) {
-        try transform($0) as Any
-      },
-      component().regex.root)))
+    self.init(node: .capture(
+      component().regex.root,
+      CaptureTransform(transform)))
   }
 
   public init<R: RegexComponent, W, C1, C2, C3, C4, C5, NewCapture>(
     as reference: Reference<NewCapture>,
     @RegexComponentBuilder _ component: () -> R,
-    transform: @escaping (Substring) throws -> NewCapture
+    transform: @escaping (W) throws -> NewCapture
   ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5), R.RegexOutput == (W, C1, C2, C3, C4, C5) {
     self.init(node: .capture(
       reference: reference.id,
-      .transform(
-        CaptureTransform(resultType: NewCapture.self) {
-          try transform($0) as Any
-        },
-        component().regex.root)))
+      component().regex.root,
+      CaptureTransform(transform)))
   }
 }
 
@@ -3433,27 +3318,22 @@ extension Capture {
 extension TryCapture {
   public init<R: RegexComponent, W, C1, C2, C3, C4, C5, NewCapture>(
     @RegexComponentBuilder _ component: () -> R,
-    transform: @escaping (Substring) throws -> NewCapture?
+    transform: @escaping (W) throws -> NewCapture?
   ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5), R.RegexOutput == (W, C1, C2, C3, C4, C5) {
-    self.init(node: .capture(.transform(
-      CaptureTransform(resultType: NewCapture.self) {
-        try transform($0) as Any?
-      },
-      component().regex.root)))
+    self.init(node: .capture(
+      component().regex.root,
+      CaptureTransform(transform)))
   }
 
   public init<R: RegexComponent, W, C1, C2, C3, C4, C5, NewCapture>(
     as reference: Reference<NewCapture>,
     @RegexComponentBuilder _ component: () -> R,
-    transform: @escaping (Substring) throws -> NewCapture?
+    transform: @escaping (W) throws -> NewCapture?
   ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5), R.RegexOutput == (W, C1, C2, C3, C4, C5) {
     self.init(node: .capture(
       reference: reference.id,
-      .transform(
-        CaptureTransform(resultType: NewCapture.self) {
-          try transform($0) as Any?
-        },
-        component().regex.root)))
+      component().regex.root,
+      CaptureTransform(transform)))
   }
 }
 
@@ -3475,27 +3355,22 @@ extension Capture {
 
   public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, NewCapture>(
     _ component: R,
-    transform: @escaping (Substring) throws -> NewCapture
+    transform: @escaping (W) throws -> NewCapture
   ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6) {
-    self.init(node: .capture(.transform(
-      CaptureTransform(resultType: NewCapture.self) {
-        try transform($0) as Any
-      },
-      component.regex.root)))
+    self.init(node: .capture(
+      component.regex.root,
+      CaptureTransform(transform)))
   }
 
   public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, NewCapture>(
     _ component: R,
     as reference: Reference<NewCapture>,
-    transform: @escaping (Substring) throws -> NewCapture
+    transform: @escaping (W) throws -> NewCapture
   ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6) {
     self.init(node: .capture(
       reference: reference.id,
-      .transform(
-        CaptureTransform(resultType: NewCapture.self) {
-          try transform($0) as Any
-        },
-        component.regex.root)))
+      component.regex.root,
+      CaptureTransform(transform)))
   }
 }
 
@@ -3503,27 +3378,22 @@ extension Capture {
 extension TryCapture {
   public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, NewCapture>(
     _ component: R,
-    transform: @escaping (Substring) throws -> NewCapture?
+    transform: @escaping (W) throws -> NewCapture?
   ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6) {
-    self.init(node: .capture(.transform(
-      CaptureTransform(resultType: NewCapture.self) {
-        try transform($0) as Any?
-      },
-      component.regex.root)))
+    self.init(node: .capture(
+    component.regex.root,
+    CaptureTransform(transform)))
   }
 
   public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, NewCapture>(
     _ component: R,
     as reference: Reference<NewCapture>,
-    transform: @escaping (Substring) throws -> NewCapture?
+    transform: @escaping (W) throws -> NewCapture?
   ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6) {
     self.init(node: .capture(
       reference: reference.id,
-      .transform(
-        CaptureTransform(resultType: NewCapture.self) {
-          try transform($0) as Any?
-        },
-        component.regex.root)))
+      component.regex.root,
+      CaptureTransform(transform)))
   }
 }
 
@@ -3548,27 +3418,22 @@ extension Capture {
 
   public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, NewCapture>(
     @RegexComponentBuilder _ component: () -> R,
-    transform: @escaping (Substring) throws -> NewCapture
+    transform: @escaping (W) throws -> NewCapture
   ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6) {
-    self.init(node: .capture(.transform(
-      CaptureTransform(resultType: NewCapture.self) {
-        try transform($0) as Any
-      },
-      component().regex.root)))
+    self.init(node: .capture(
+      component().regex.root,
+      CaptureTransform(transform)))
   }
 
   public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, NewCapture>(
     as reference: Reference<NewCapture>,
     @RegexComponentBuilder _ component: () -> R,
-    transform: @escaping (Substring) throws -> NewCapture
+    transform: @escaping (W) throws -> NewCapture
   ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6) {
     self.init(node: .capture(
       reference: reference.id,
-      .transform(
-        CaptureTransform(resultType: NewCapture.self) {
-          try transform($0) as Any
-        },
-        component().regex.root)))
+      component().regex.root,
+      CaptureTransform(transform)))
   }
 }
 
@@ -3576,27 +3441,22 @@ extension Capture {
 extension TryCapture {
   public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, NewCapture>(
     @RegexComponentBuilder _ component: () -> R,
-    transform: @escaping (Substring) throws -> NewCapture?
+    transform: @escaping (W) throws -> NewCapture?
   ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6) {
-    self.init(node: .capture(.transform(
-      CaptureTransform(resultType: NewCapture.self) {
-        try transform($0) as Any?
-      },
-      component().regex.root)))
+    self.init(node: .capture(
+      component().regex.root,
+      CaptureTransform(transform)))
   }
 
   public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, NewCapture>(
     as reference: Reference<NewCapture>,
     @RegexComponentBuilder _ component: () -> R,
-    transform: @escaping (Substring) throws -> NewCapture?
+    transform: @escaping (W) throws -> NewCapture?
   ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6) {
     self.init(node: .capture(
       reference: reference.id,
-      .transform(
-        CaptureTransform(resultType: NewCapture.self) {
-          try transform($0) as Any?
-        },
-        component().regex.root)))
+      component().regex.root,
+      CaptureTransform(transform)))
   }
 }
 
@@ -3618,27 +3478,22 @@ extension Capture {
 
   public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, C7, NewCapture>(
     _ component: R,
-    transform: @escaping (Substring) throws -> NewCapture
+    transform: @escaping (W) throws -> NewCapture
   ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6, C7), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7) {
-    self.init(node: .capture(.transform(
-      CaptureTransform(resultType: NewCapture.self) {
-        try transform($0) as Any
-      },
-      component.regex.root)))
+    self.init(node: .capture(
+      component.regex.root,
+      CaptureTransform(transform)))
   }
 
   public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, C7, NewCapture>(
     _ component: R,
     as reference: Reference<NewCapture>,
-    transform: @escaping (Substring) throws -> NewCapture
+    transform: @escaping (W) throws -> NewCapture
   ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6, C7), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7) {
     self.init(node: .capture(
       reference: reference.id,
-      .transform(
-        CaptureTransform(resultType: NewCapture.self) {
-          try transform($0) as Any
-        },
-        component.regex.root)))
+      component.regex.root,
+      CaptureTransform(transform)))
   }
 }
 
@@ -3646,27 +3501,22 @@ extension Capture {
 extension TryCapture {
   public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, C7, NewCapture>(
     _ component: R,
-    transform: @escaping (Substring) throws -> NewCapture?
+    transform: @escaping (W) throws -> NewCapture?
   ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6, C7), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7) {
-    self.init(node: .capture(.transform(
-      CaptureTransform(resultType: NewCapture.self) {
-        try transform($0) as Any?
-      },
-      component.regex.root)))
+    self.init(node: .capture(
+    component.regex.root,
+    CaptureTransform(transform)))
   }
 
   public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, C7, NewCapture>(
     _ component: R,
     as reference: Reference<NewCapture>,
-    transform: @escaping (Substring) throws -> NewCapture?
+    transform: @escaping (W) throws -> NewCapture?
   ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6, C7), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7) {
     self.init(node: .capture(
       reference: reference.id,
-      .transform(
-        CaptureTransform(resultType: NewCapture.self) {
-          try transform($0) as Any?
-        },
-        component.regex.root)))
+      component.regex.root,
+      CaptureTransform(transform)))
   }
 }
 
@@ -3691,27 +3541,22 @@ extension Capture {
 
   public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, C7, NewCapture>(
     @RegexComponentBuilder _ component: () -> R,
-    transform: @escaping (Substring) throws -> NewCapture
+    transform: @escaping (W) throws -> NewCapture
   ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6, C7), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7) {
-    self.init(node: .capture(.transform(
-      CaptureTransform(resultType: NewCapture.self) {
-        try transform($0) as Any
-      },
-      component().regex.root)))
+    self.init(node: .capture(
+      component().regex.root,
+      CaptureTransform(transform)))
   }
 
   public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, C7, NewCapture>(
     as reference: Reference<NewCapture>,
     @RegexComponentBuilder _ component: () -> R,
-    transform: @escaping (Substring) throws -> NewCapture
+    transform: @escaping (W) throws -> NewCapture
   ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6, C7), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7) {
     self.init(node: .capture(
       reference: reference.id,
-      .transform(
-        CaptureTransform(resultType: NewCapture.self) {
-          try transform($0) as Any
-        },
-        component().regex.root)))
+      component().regex.root,
+      CaptureTransform(transform)))
   }
 }
 
@@ -3719,27 +3564,22 @@ extension Capture {
 extension TryCapture {
   public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, C7, NewCapture>(
     @RegexComponentBuilder _ component: () -> R,
-    transform: @escaping (Substring) throws -> NewCapture?
+    transform: @escaping (W) throws -> NewCapture?
   ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6, C7), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7) {
-    self.init(node: .capture(.transform(
-      CaptureTransform(resultType: NewCapture.self) {
-        try transform($0) as Any?
-      },
-      component().regex.root)))
+    self.init(node: .capture(
+      component().regex.root,
+      CaptureTransform(transform)))
   }
 
   public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, C7, NewCapture>(
     as reference: Reference<NewCapture>,
     @RegexComponentBuilder _ component: () -> R,
-    transform: @escaping (Substring) throws -> NewCapture?
+    transform: @escaping (W) throws -> NewCapture?
   ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6, C7), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7) {
     self.init(node: .capture(
       reference: reference.id,
-      .transform(
-        CaptureTransform(resultType: NewCapture.self) {
-          try transform($0) as Any?
-        },
-        component().regex.root)))
+      component().regex.root,
+      CaptureTransform(transform)))
   }
 }
 
@@ -3761,27 +3601,22 @@ extension Capture {
 
   public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, C7, C8, NewCapture>(
     _ component: R,
-    transform: @escaping (Substring) throws -> NewCapture
+    transform: @escaping (W) throws -> NewCapture
   ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6, C7, C8), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8) {
-    self.init(node: .capture(.transform(
-      CaptureTransform(resultType: NewCapture.self) {
-        try transform($0) as Any
-      },
-      component.regex.root)))
+    self.init(node: .capture(
+      component.regex.root,
+      CaptureTransform(transform)))
   }
 
   public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, C7, C8, NewCapture>(
     _ component: R,
     as reference: Reference<NewCapture>,
-    transform: @escaping (Substring) throws -> NewCapture
+    transform: @escaping (W) throws -> NewCapture
   ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6, C7, C8), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8) {
     self.init(node: .capture(
       reference: reference.id,
-      .transform(
-        CaptureTransform(resultType: NewCapture.self) {
-          try transform($0) as Any
-        },
-        component.regex.root)))
+      component.regex.root,
+      CaptureTransform(transform)))
   }
 }
 
@@ -3789,27 +3624,22 @@ extension Capture {
 extension TryCapture {
   public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, C7, C8, NewCapture>(
     _ component: R,
-    transform: @escaping (Substring) throws -> NewCapture?
+    transform: @escaping (W) throws -> NewCapture?
   ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6, C7, C8), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8) {
-    self.init(node: .capture(.transform(
-      CaptureTransform(resultType: NewCapture.self) {
-        try transform($0) as Any?
-      },
-      component.regex.root)))
+    self.init(node: .capture(
+    component.regex.root,
+    CaptureTransform(transform)))
   }
 
   public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, C7, C8, NewCapture>(
     _ component: R,
     as reference: Reference<NewCapture>,
-    transform: @escaping (Substring) throws -> NewCapture?
+    transform: @escaping (W) throws -> NewCapture?
   ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6, C7, C8), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8) {
     self.init(node: .capture(
       reference: reference.id,
-      .transform(
-        CaptureTransform(resultType: NewCapture.self) {
-          try transform($0) as Any?
-        },
-        component.regex.root)))
+      component.regex.root,
+      CaptureTransform(transform)))
   }
 }
 
@@ -3834,27 +3664,22 @@ extension Capture {
 
   public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, C7, C8, NewCapture>(
     @RegexComponentBuilder _ component: () -> R,
-    transform: @escaping (Substring) throws -> NewCapture
+    transform: @escaping (W) throws -> NewCapture
   ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6, C7, C8), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8) {
-    self.init(node: .capture(.transform(
-      CaptureTransform(resultType: NewCapture.self) {
-        try transform($0) as Any
-      },
-      component().regex.root)))
+    self.init(node: .capture(
+      component().regex.root,
+      CaptureTransform(transform)))
   }
 
   public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, C7, C8, NewCapture>(
     as reference: Reference<NewCapture>,
     @RegexComponentBuilder _ component: () -> R,
-    transform: @escaping (Substring) throws -> NewCapture
+    transform: @escaping (W) throws -> NewCapture
   ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6, C7, C8), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8) {
     self.init(node: .capture(
       reference: reference.id,
-      .transform(
-        CaptureTransform(resultType: NewCapture.self) {
-          try transform($0) as Any
-        },
-        component().regex.root)))
+      component().regex.root,
+      CaptureTransform(transform)))
   }
 }
 
@@ -3862,27 +3687,22 @@ extension Capture {
 extension TryCapture {
   public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, C7, C8, NewCapture>(
     @RegexComponentBuilder _ component: () -> R,
-    transform: @escaping (Substring) throws -> NewCapture?
+    transform: @escaping (W) throws -> NewCapture?
   ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6, C7, C8), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8) {
-    self.init(node: .capture(.transform(
-      CaptureTransform(resultType: NewCapture.self) {
-        try transform($0) as Any?
-      },
-      component().regex.root)))
+    self.init(node: .capture(
+      component().regex.root,
+      CaptureTransform(transform)))
   }
 
   public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, C7, C8, NewCapture>(
     as reference: Reference<NewCapture>,
     @RegexComponentBuilder _ component: () -> R,
-    transform: @escaping (Substring) throws -> NewCapture?
+    transform: @escaping (W) throws -> NewCapture?
   ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6, C7, C8), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8) {
     self.init(node: .capture(
       reference: reference.id,
-      .transform(
-        CaptureTransform(resultType: NewCapture.self) {
-          try transform($0) as Any?
-        },
-        component().regex.root)))
+      component().regex.root,
+      CaptureTransform(transform)))
   }
 }
 
@@ -3904,27 +3724,22 @@ extension Capture {
 
   public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, C7, C8, C9, NewCapture>(
     _ component: R,
-    transform: @escaping (Substring) throws -> NewCapture
+    transform: @escaping (W) throws -> NewCapture
   ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6, C7, C8, C9), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
-    self.init(node: .capture(.transform(
-      CaptureTransform(resultType: NewCapture.self) {
-        try transform($0) as Any
-      },
-      component.regex.root)))
+    self.init(node: .capture(
+      component.regex.root,
+      CaptureTransform(transform)))
   }
 
   public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, C7, C8, C9, NewCapture>(
     _ component: R,
     as reference: Reference<NewCapture>,
-    transform: @escaping (Substring) throws -> NewCapture
+    transform: @escaping (W) throws -> NewCapture
   ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6, C7, C8, C9), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
     self.init(node: .capture(
       reference: reference.id,
-      .transform(
-        CaptureTransform(resultType: NewCapture.self) {
-          try transform($0) as Any
-        },
-        component.regex.root)))
+      component.regex.root,
+      CaptureTransform(transform)))
   }
 }
 
@@ -3932,27 +3747,22 @@ extension Capture {
 extension TryCapture {
   public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, C7, C8, C9, NewCapture>(
     _ component: R,
-    transform: @escaping (Substring) throws -> NewCapture?
+    transform: @escaping (W) throws -> NewCapture?
   ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6, C7, C8, C9), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
-    self.init(node: .capture(.transform(
-      CaptureTransform(resultType: NewCapture.self) {
-        try transform($0) as Any?
-      },
-      component.regex.root)))
+    self.init(node: .capture(
+    component.regex.root,
+    CaptureTransform(transform)))
   }
 
   public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, C7, C8, C9, NewCapture>(
     _ component: R,
     as reference: Reference<NewCapture>,
-    transform: @escaping (Substring) throws -> NewCapture?
+    transform: @escaping (W) throws -> NewCapture?
   ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6, C7, C8, C9), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
     self.init(node: .capture(
       reference: reference.id,
-      .transform(
-        CaptureTransform(resultType: NewCapture.self) {
-          try transform($0) as Any?
-        },
-        component.regex.root)))
+      component.regex.root,
+      CaptureTransform(transform)))
   }
 }
 
@@ -3977,27 +3787,22 @@ extension Capture {
 
   public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, C7, C8, C9, NewCapture>(
     @RegexComponentBuilder _ component: () -> R,
-    transform: @escaping (Substring) throws -> NewCapture
+    transform: @escaping (W) throws -> NewCapture
   ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6, C7, C8, C9), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
-    self.init(node: .capture(.transform(
-      CaptureTransform(resultType: NewCapture.self) {
-        try transform($0) as Any
-      },
-      component().regex.root)))
+    self.init(node: .capture(
+      component().regex.root,
+      CaptureTransform(transform)))
   }
 
   public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, C7, C8, C9, NewCapture>(
     as reference: Reference<NewCapture>,
     @RegexComponentBuilder _ component: () -> R,
-    transform: @escaping (Substring) throws -> NewCapture
+    transform: @escaping (W) throws -> NewCapture
   ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6, C7, C8, C9), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
     self.init(node: .capture(
       reference: reference.id,
-      .transform(
-        CaptureTransform(resultType: NewCapture.self) {
-          try transform($0) as Any
-        },
-        component().regex.root)))
+      component().regex.root,
+      CaptureTransform(transform)))
   }
 }
 
@@ -4005,27 +3810,22 @@ extension Capture {
 extension TryCapture {
   public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, C7, C8, C9, NewCapture>(
     @RegexComponentBuilder _ component: () -> R,
-    transform: @escaping (Substring) throws -> NewCapture?
+    transform: @escaping (W) throws -> NewCapture?
   ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6, C7, C8, C9), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
-    self.init(node: .capture(.transform(
-      CaptureTransform(resultType: NewCapture.self) {
-        try transform($0) as Any?
-      },
-      component().regex.root)))
+    self.init(node: .capture(
+      component().regex.root,
+      CaptureTransform(transform)))
   }
 
   public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, C7, C8, C9, NewCapture>(
     as reference: Reference<NewCapture>,
     @RegexComponentBuilder _ component: () -> R,
-    transform: @escaping (Substring) throws -> NewCapture?
+    transform: @escaping (W) throws -> NewCapture?
   ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6, C7, C8, C9), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
     self.init(node: .capture(
       reference: reference.id,
-      .transform(
-        CaptureTransform(resultType: NewCapture.self) {
-          try transform($0) as Any?
-        },
-        component().regex.root)))
+      component().regex.root,
+      CaptureTransform(transform)))
   }
 }
 
@@ -4047,27 +3847,22 @@ extension Capture {
 
   public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, NewCapture>(
     _ component: R,
-    transform: @escaping (Substring) throws -> NewCapture
+    transform: @escaping (W) throws -> NewCapture
   ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10) {
-    self.init(node: .capture(.transform(
-      CaptureTransform(resultType: NewCapture.self) {
-        try transform($0) as Any
-      },
-      component.regex.root)))
+    self.init(node: .capture(
+      component.regex.root,
+      CaptureTransform(transform)))
   }
 
   public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, NewCapture>(
     _ component: R,
     as reference: Reference<NewCapture>,
-    transform: @escaping (Substring) throws -> NewCapture
+    transform: @escaping (W) throws -> NewCapture
   ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10) {
     self.init(node: .capture(
       reference: reference.id,
-      .transform(
-        CaptureTransform(resultType: NewCapture.self) {
-          try transform($0) as Any
-        },
-        component.regex.root)))
+      component.regex.root,
+      CaptureTransform(transform)))
   }
 }
 
@@ -4075,27 +3870,22 @@ extension Capture {
 extension TryCapture {
   public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, NewCapture>(
     _ component: R,
-    transform: @escaping (Substring) throws -> NewCapture?
+    transform: @escaping (W) throws -> NewCapture?
   ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10) {
-    self.init(node: .capture(.transform(
-      CaptureTransform(resultType: NewCapture.self) {
-        try transform($0) as Any?
-      },
-      component.regex.root)))
+    self.init(node: .capture(
+    component.regex.root,
+    CaptureTransform(transform)))
   }
 
   public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, NewCapture>(
     _ component: R,
     as reference: Reference<NewCapture>,
-    transform: @escaping (Substring) throws -> NewCapture?
+    transform: @escaping (W) throws -> NewCapture?
   ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10) {
     self.init(node: .capture(
       reference: reference.id,
-      .transform(
-        CaptureTransform(resultType: NewCapture.self) {
-          try transform($0) as Any?
-        },
-        component.regex.root)))
+      component.regex.root,
+      CaptureTransform(transform)))
   }
 }
 
@@ -4120,27 +3910,22 @@ extension Capture {
 
   public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, NewCapture>(
     @RegexComponentBuilder _ component: () -> R,
-    transform: @escaping (Substring) throws -> NewCapture
+    transform: @escaping (W) throws -> NewCapture
   ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10) {
-    self.init(node: .capture(.transform(
-      CaptureTransform(resultType: NewCapture.self) {
-        try transform($0) as Any
-      },
-      component().regex.root)))
+    self.init(node: .capture(
+      component().regex.root,
+      CaptureTransform(transform)))
   }
 
   public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, NewCapture>(
     as reference: Reference<NewCapture>,
     @RegexComponentBuilder _ component: () -> R,
-    transform: @escaping (Substring) throws -> NewCapture
+    transform: @escaping (W) throws -> NewCapture
   ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10) {
     self.init(node: .capture(
       reference: reference.id,
-      .transform(
-        CaptureTransform(resultType: NewCapture.self) {
-          try transform($0) as Any
-        },
-        component().regex.root)))
+      component().regex.root,
+      CaptureTransform(transform)))
   }
 }
 
@@ -4148,27 +3933,22 @@ extension Capture {
 extension TryCapture {
   public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, NewCapture>(
     @RegexComponentBuilder _ component: () -> R,
-    transform: @escaping (Substring) throws -> NewCapture?
+    transform: @escaping (W) throws -> NewCapture?
   ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10) {
-    self.init(node: .capture(.transform(
-      CaptureTransform(resultType: NewCapture.self) {
-        try transform($0) as Any?
-      },
-      component().regex.root)))
+    self.init(node: .capture(
+      component().regex.root,
+      CaptureTransform(transform)))
   }
 
   public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, NewCapture>(
     as reference: Reference<NewCapture>,
     @RegexComponentBuilder _ component: () -> R,
-    transform: @escaping (Substring) throws -> NewCapture?
+    transform: @escaping (W) throws -> NewCapture?
   ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10) {
     self.init(node: .capture(
       reference: reference.id,
-      .transform(
-        CaptureTransform(resultType: NewCapture.self) {
-          try transform($0) as Any?
-        },
-        component().regex.root)))
+      component().regex.root,
+      CaptureTransform(transform)))
   }
 }
 

--- a/Sources/VariadicsGenerator/VariadicsGenerator.swift
+++ b/Sources/VariadicsGenerator/VariadicsGenerator.swift
@@ -646,28 +646,23 @@ struct VariadicsGenerator: ParsableCommand {
       \(disfavored)\
         public init<\(genericParams), NewCapture>(
           _ component: R,
-          transform: @escaping (Substring) throws -> NewCapture
+          transform: @escaping (W) throws -> NewCapture
         ) \(whereClauseTransformed) {
-          self.init(node: .capture(.transform(
-            CaptureTransform(resultType: NewCapture.self) {
-              try transform($0) as Any
-            },
-            component.regex.root)))
+          self.init(node: .capture(
+            component.regex.root,
+            CaptureTransform(transform)))
         }
 
       \(disfavored)\
         public init<\(genericParams), NewCapture>(
           _ component: R,
           as reference: Reference<NewCapture>,
-          transform: @escaping (Substring) throws -> NewCapture
+          transform: @escaping (W) throws -> NewCapture
         ) \(whereClauseTransformed) {
           self.init(node: .capture(
             reference: reference.id,
-            .transform(
-              CaptureTransform(resultType: NewCapture.self) {
-                try transform($0) as Any
-              },
-              component.regex.root)))
+            component.regex.root,
+            CaptureTransform(transform)))
         }
       }
 
@@ -676,28 +671,23 @@ struct VariadicsGenerator: ParsableCommand {
       \(disfavored)\
         public init<\(genericParams), NewCapture>(
           _ component: R,
-          transform: @escaping (Substring) throws -> NewCapture?
+          transform: @escaping (W) throws -> NewCapture?
         ) \(whereClauseTransformed) {
-          self.init(node: .capture(.transform(
-            CaptureTransform(resultType: NewCapture.self) {
-              try transform($0) as Any?
-            },
-            component.regex.root)))
+          self.init(node: .capture(
+          component.regex.root,
+          CaptureTransform(transform)))
         }
 
       \(disfavored)\
         public init<\(genericParams), NewCapture>(
           _ component: R,
           as reference: Reference<NewCapture>,
-          transform: @escaping (Substring) throws -> NewCapture?
+          transform: @escaping (W) throws -> NewCapture?
         ) \(whereClauseTransformed) {
           self.init(node: .capture(
             reference: reference.id,
-            .transform(
-              CaptureTransform(resultType: NewCapture.self) {
-                try transform($0) as Any?
-              },
-              component.regex.root)))
+            component.regex.root,
+            CaptureTransform(transform)))
         }
       }
 
@@ -725,28 +715,23 @@ struct VariadicsGenerator: ParsableCommand {
       \(disfavored)\
         public init<\(genericParams), NewCapture>(
           @\(concatBuilderName) _ component: () -> R,
-          transform: @escaping (Substring) throws -> NewCapture
+          transform: @escaping (W) throws -> NewCapture
         ) \(whereClauseTransformed) {
-          self.init(node: .capture(.transform(
-            CaptureTransform(resultType: NewCapture.self) {
-              try transform($0) as Any
-            },
-            component().regex.root)))
+          self.init(node: .capture(
+            component().regex.root,
+            CaptureTransform(transform)))
         }
 
       \(disfavored)\
         public init<\(genericParams), NewCapture>(
           as reference: Reference<NewCapture>,
           @\(concatBuilderName) _ component: () -> R,
-          transform: @escaping (Substring) throws -> NewCapture
+          transform: @escaping (W) throws -> NewCapture
         ) \(whereClauseTransformed) {
           self.init(node: .capture(
             reference: reference.id,
-            .transform(
-              CaptureTransform(resultType: NewCapture.self) {
-                try transform($0) as Any
-              },
-              component().regex.root)))
+            component().regex.root,
+            CaptureTransform(transform)))
         }
       }
 
@@ -755,28 +740,23 @@ struct VariadicsGenerator: ParsableCommand {
       \(disfavored)\
         public init<\(genericParams), NewCapture>(
           @\(concatBuilderName) _ component: () -> R,
-          transform: @escaping (Substring) throws -> NewCapture?
+          transform: @escaping (W) throws -> NewCapture?
         ) \(whereClauseTransformed) {
-          self.init(node: .capture(.transform(
-            CaptureTransform(resultType: NewCapture.self) {
-              try transform($0) as Any?
-            },
-            component().regex.root)))
+          self.init(node: .capture(
+            component().regex.root,
+            CaptureTransform(transform)))
         }
 
       \(disfavored)\
         public init<\(genericParams), NewCapture>(
           as reference: Reference<NewCapture>,
           @\(concatBuilderName) _ component: () -> R,
-          transform: @escaping (Substring) throws -> NewCapture?
+          transform: @escaping (W) throws -> NewCapture?
         ) \(whereClauseTransformed) {
           self.init(node: .capture(
             reference: reference.id,
-            .transform(
-              CaptureTransform(resultType: NewCapture.self) {
-                try transform($0) as Any?
-              },
-              component().regex.root)))
+            component().regex.root,
+            CaptureTransform(transform)))
         }
       }
 

--- a/Sources/_RegexParser/Regex/Parse/CaptureList.swift
+++ b/Sources/_RegexParser/Regex/Parse/CaptureList.swift
@@ -24,13 +24,13 @@ public struct CaptureList {
 extension CaptureList {
   public struct Capture {
     public var name: String?
-    public var type: Any.Type?
+    public var type: Any.Type
     public var optionalDepth: Int
     public var location: SourceLocation
 
     public init(
       name: String? = nil,
-      type: Any.Type? = nil,
+      type: Any.Type = Substring.self,
       optionalDepth: Int,
       _ location: SourceLocation
     ) {
@@ -122,18 +122,15 @@ extension AST.Node {
       break
     }
   }
-
-  public var _captureList: CaptureList {
-    var caps = CaptureList()
-    self._addCaptures(to: &caps, optionalNesting: 0)
-    return caps
-  }
 }
 
 extension AST {
-  /// Get the capture list for this AST
+  /// The capture list (including the whole match) of this AST.
   public var captureList: CaptureList {
-    root._captureList
+    var caps = CaptureList()
+    caps.append(.init(optionalDepth: 0, .fake))
+    root._addCaptures(to: &caps, optionalNesting: 0)
+    return caps
   }
 }
 
@@ -151,12 +148,7 @@ extension CaptureList: Equatable {}
 
 extension CaptureList.Capture: CustomStringConvertible {
   public var description: String {
-    let typeStr: String
-    if let ty = type {
-      typeStr = "\(ty)"
-    } else {
-      typeStr = "Substring"
-    }
+    let typeStr = String(describing: type)
     let suffix = String(repeating: "?", count: optionalDepth)
     return typeStr + suffix
   }

--- a/Sources/_RegexParser/Regex/Parse/CaptureStructure.swift
+++ b/Sources/_RegexParser/Regex/Parse/CaptureStructure.swift
@@ -225,7 +225,7 @@ extension CaptureStructure: CustomStringConvertible {
 extension AST {
   /// The capture structure of this AST for compiler communication.
   var captureStructure: CaptureStructure {
-    root._captureList._captureStructure(nestOptionals: true)
+    captureList._captureStructure(nestOptionals: true)
   }
 }
 
@@ -246,10 +246,7 @@ extension CaptureList {
 extension CaptureList.Capture {
   func _captureStructure(nestOptionals: Bool) -> CaptureStructure {
     if optionalDepth == 0 {
-      if let ty = type {
-        return .atom(name: name, type: .init(ty))
-      }
-      return .atom(name: name)
+      return .atom(name: name, type: type == Substring.self ? nil : .init(type))
     }
     var copy = self
     copy.optionalDepth = 0

--- a/Sources/_RegexParser/Regex/Parse/Sema.swift
+++ b/Sources/_RegexParser/Regex/Parse/Sema.swift
@@ -77,7 +77,7 @@ extension RegexValidator {
     }
     switch ref.kind {
     case .absolute(let i):
-      guard i <= captures.captures.count else {
+      guard i < captures.captures.count else {
         throw error(.invalidReference(i), at: ref.innerLoc)
       }
     case .named(let name):

--- a/Sources/_StringProcessing/ByteCodeGen.swift
+++ b/Sources/_StringProcessing/ByteCodeGen.swift
@@ -4,32 +4,44 @@ extension Compiler {
   struct ByteCodeGen {
     var options: MatchingOptions
     var builder = Program.Builder()
+    /// A Boolean indicating whether the first matchable atom has been emitted.
+    /// This is used to determine whether to apply initial options.
+    var hasEmittedFirstMatchableAtom = false
 
     init(options: MatchingOptions, captureList: CaptureList) {
       self.options = options
       self.builder.captureList = captureList
     }
-
-    mutating func finish(
-    ) throws -> Program {
-      builder.buildAccept()
-      return try builder.assemble()
-    }
   }
 }
 
 extension Compiler.ByteCodeGen {
+  mutating func emitRoot(_ root: DSLTree.Node) throws -> Program {
+    // The whole match (`.0` element of output) is equivalent to an implicit
+    // capture over the entire regex.
+    try emitNode(.capture(name: nil, reference: nil, root))
+    builder.buildAccept()
+    return try builder.assemble()
+  }
+}
+
+fileprivate extension Compiler.ByteCodeGen {
   mutating func emitAtom(_ a: DSLTree.Atom) throws {
+    defer {
+      if a.isMatchable {
+        hasEmittedFirstMatchableAtom = true
+      }
+    }
     switch a {
     case .any:
       emitAny()
 
     case let .char(c):
       try emitCharacter(c)
-      
+
     case let .scalar(s):
       try emitScalar(s)
-      
+
     case let .assertion(kind):
       try emitAssertion(kind.ast)
 
@@ -40,7 +52,7 @@ extension Compiler.ByteCodeGen {
       builder.buildUnresolvedReference(id: id)
 
     case let .changeMatchingOptions(optionSequence):
-      if !builder.hasReceivedInstructions {
+      if !hasEmittedFirstMatchableAtom {
         builder.initialOptions.apply(optionSequence.ast)
       }
       options.apply(optionSequence.ast)
@@ -65,8 +77,7 @@ extension Compiler.ByteCodeGen {
 
     switch ref.kind {
     case .absolute(let i):
-      // Backreferences number starting at 1
-      builder.buildBackreference(.init(i-1))
+      builder.buildBackreference(.init(i))
     case .named(let name):
       try builder.buildNamedReference(name)
     case .relative:
@@ -329,9 +340,8 @@ extension Compiler.ByteCodeGen {
   }
 
   mutating func emitMatcher(
-    _ matcher: @escaping _MatcherInterface,
-    into capture: CaptureRegister? = nil
-  ) {
+    _ matcher: @escaping _MatcherInterface
+  ) -> ValueRegister {
 
     // TODO: Consider emitting consumer interface if
     // not captured. This may mean we should store
@@ -343,26 +353,7 @@ extension Compiler.ByteCodeGen {
 
     let valReg = builder.makeValueRegister()
     builder.buildMatcher(matcher, into: valReg)
-
-    // TODO: Instruction to store directly
-    if let cap = capture {
-      builder.buildMove(valReg, into: cap)
-    }
-  }
-
-  mutating func emitTransform(
-    _ t: CaptureTransform,
-    _ child: DSLTree.Node,
-    into cap: CaptureRegister
-  ) throws {
-    let transform = builder.makeTransformFunction {
-      input, range in
-      try t(input[range])
-    }
-    builder.buildBeginCapture(cap)
-    try emitNode(child)
-    builder.buildEndCapture(cap)
-    builder.buildTransformCapture(cap, transform)
+    return valReg
   }
 
   mutating func emitNoncapturingGroup(
@@ -388,7 +379,7 @@ extension Compiler.ByteCodeGen {
       throw Unreachable("These should produce a capture node")
 
     case .changeMatchingOptions(let optionSequence):
-      if !builder.hasReceivedInstructions {
+      if !hasEmittedFirstMatchableAtom {
         builder.initialOptions.apply(optionSequence)
       }
       options.apply(optionSequence)
@@ -612,7 +603,8 @@ extension Compiler.ByteCodeGen {
     builder.buildConsume(by: consumer)
   }
 
-  mutating func emitNode(_ node: DSLTree.Node) throws {
+  @discardableResult
+  mutating func emitNode(_ node: DSLTree.Node) throws -> ValueRegister? {
     switch node {
       
     case let .orderedChoice(children):
@@ -623,20 +615,34 @@ extension Compiler.ByteCodeGen {
         try emitConcatenationComponent(child)
       }
 
-    case let .capture(name, refId, child):
+    case let .capture(name, refId, child, transform):
       options.beginScope()
       defer { options.endScope() }
 
       let cap = builder.makeCapture(id: refId, name: name)
-      switch child {
-      case let .matcher(_, m):
-        emitMatcher(m, into: cap)
-      case let .transform(t, child):
-        try emitTransform(t, child, into: cap)
-      default:
-        builder.buildBeginCapture(cap)
-        try emitNode(child)
-        builder.buildEndCapture(cap)
+      builder.buildBeginCapture(cap)
+      let value = try emitNode(child)
+      builder.buildEndCapture(cap)
+      // If the child node produced a custom capture value, e.g. the result of
+      // a matcher, this should override the captured substring.
+      if let value {
+        builder.buildMove(value, into: cap)
+      }
+      // If there's a capture transform, apply it now.
+      if let transform = transform {
+        let fn = builder.makeTransformFunction { input, storedCapture in
+          // If it's a substring capture with no custom value, apply the
+          // transform directly to the substring to avoid existential traffic.
+          if let cap = storedCapture.latest, cap.value == nil {
+            return try transform(input[cap.range])
+          }
+          let value = constructExistentialOutputComponent(
+             from: input,
+             component: storedCapture.latest,
+             optionalCount: 0)
+          return try transform(value)
+        }
+        builder.buildTransformCapture(cap, fn)
       }
 
     case let .nonCapturingGroup(kind, child):
@@ -704,10 +710,10 @@ extension Compiler.ByteCodeGen {
       }
 
     case let .regexLiteral(l):
-      try emitNode(l.ast.dslTreeNode)
+      return try emitNode(l.ast.dslTreeNode)
 
     case let .convertedRegexLiteral(n, _):
-      try emitNode(n)
+      return try emitNode(n)
 
     case .absentFunction:
       throw Unsupported("absent function")
@@ -715,18 +721,14 @@ extension Compiler.ByteCodeGen {
       throw Unsupported("consumer")
 
     case let .matcher(_, f):
-      emitMatcher(f)
-
-    case .transform:
-      throw Unreachable(
-        "Transforms only directly inside captures")
+      return emitMatcher(f)
 
     case .characterPredicate:
       throw Unsupported("character predicates")
 
     case .trivia, .empty:
-      return
+      return nil
     }
+    return nil
   }
 }
-

--- a/Sources/_StringProcessing/Capture.swift
+++ b/Sources/_StringProcessing/Capture.swift
@@ -13,18 +13,14 @@
 
 // TODO: Where should this live? Inside TypeConstruction?
 func constructExistentialOutputComponent(
-  from input: Substring,
-  in range: Range<String.Index>?,
-  value: Any?,
+  from input: String,
+  component: (range: Range<String.Index>, value: Any?)?,
   optionalCount: Int
 ) -> Any {
   let someCount: Int
   var underlying: Any
-  if let v = value {
-    underlying = v
-    someCount = optionalCount
-  } else if let r = range {
-    underlying = input[r]
+  if let component = component {
+    underlying = component.value ?? input[component.range]
     someCount = optionalCount
   } else {
     // Ok since we Any-box every step up the ladder
@@ -43,12 +39,11 @@ func constructExistentialOutputComponent(
 @available(SwiftStdlib 5.7, *)
 extension AnyRegexOutput.Element {
   func existentialOutputComponent(
-    from input: Substring
+    from input: String
   ) -> Any {
     constructExistentialOutputComponent(
       from: input,
-      in: range,
-      value: value,
+      component: representation.content,
       optionalCount: representation.optionalDepth
     )
   }
@@ -64,15 +59,13 @@ extension Sequence where Element == AnyRegexOutput.Element {
   // FIXME: This is a stop gap where we still slice the input
   // and traffic through existentials
   @available(SwiftStdlib 5.7, *)
-  func existentialOutput(
-    from input: Substring
-  ) -> Any {
-    var caps = Array<Any>()
-    caps.append(input)
-    caps.append(contentsOf: self.map {
+  func existentialOutput(from input: String) -> Any {
+    let elements = map {
       $0.existentialOutputComponent(from: input)
-    })
-    return TypeConstruction.tuple(of: caps)
+    }
+    return elements.count == 1
+      ? elements[0]
+      : TypeConstruction.tuple(of: elements)
   }
 
   func slices(from input: String) -> [Substring?] {

--- a/Sources/_StringProcessing/Compiler.swift
+++ b/Sources/_StringProcessing/Compiler.swift
@@ -28,11 +28,9 @@ class Compiler {
   __consuming func emit() throws -> Program {
     // TODO: Handle global options
     var codegen = ByteCodeGen(
-      options: options, captureList: tree.root._captureList
+      options: options, captureList: tree.captureList
     )
-    try codegen.emitNode(tree.root)
-    let program = try codegen.finish()
-    return program
+    return try codegen.emitRoot(tree.root)
   }
 }
 

--- a/Sources/_StringProcessing/ConsumerInterface.swift
+++ b/Sources/_StringProcessing/ConsumerInterface.swift
@@ -45,8 +45,6 @@ extension DSLTree.Node {
       fatalError("FIXME: Is this where we handle them?")
     case .matcher:
       fatalError("FIXME: Is this where we handle them?")
-    case .transform:
-      fatalError("FIXME: Is this where we handle them?")
     case .characterPredicate:
       fatalError("FIXME: Is this where we handle them?")
     }

--- a/Sources/_StringProcessing/Engine/MEBuilder.swift
+++ b/Sources/_StringProcessing/Engine/MEBuilder.swift
@@ -78,11 +78,6 @@ extension MEProgram.Builder {
   var lastInstructionAddress: InstructionAddress {
     .init(instructions.endIndex - 1)
   }
-  
-  /// `true` if the builder has received any instructions.
-  var hasReceivedInstructions: Bool {
-    !instructions.isEmpty
-  }
 
   mutating func buildNop(_ r: StringRegister? = nil) {
     instructions.append(.init(.nop, .init(optionalString: r)))

--- a/Sources/_StringProcessing/Engine/MEProgram.swift
+++ b/Sources/_StringProcessing/Engine/MEProgram.swift
@@ -11,12 +11,12 @@
 
 @_implementationOnly import _RegexParser
 
-struct MEProgram<Input: Collection> where Input.Element: Equatable {
+struct MEProgram<Input: BidirectionalCollection> where Input.Element: Equatable {
   typealias ConsumeFunction = (Input, Range<Input.Index>) -> Input.Index?
   typealias AssertionFunction =
     (Input, Input.Index, Range<Input.Index>) throws -> Bool
   typealias TransformFunction =
-    (Input, Range<Input.Index>) throws -> Any?
+    (Input, Processor<Input>._StoredCapture) throws -> Any?
   typealias MatcherFunction =
     (Input, Input.Index, Range<Input.Index>) throws -> (Input.Index, Any)?
 

--- a/Sources/_StringProcessing/Engine/Processor.swift
+++ b/Sources/_StringProcessing/Engine/Processor.swift
@@ -419,7 +419,7 @@ extension Processor {
       //   Should we assert it's not finished yet?
       //   What's the behavior there?
       let cap = storedCaptures[capNum]
-      guard let range = cap.latest else {
+      guard let range = cap.latest?.range else {
         signalFailure()
         return
       }
@@ -446,13 +446,9 @@ extension Processor {
       let transform = registers[trans]
       let capNum = Int(asserting: cap.rawValue)
 
-      guard let range = storedCaptures[capNum].latest else {
-        fatalError(
-          "Unreachable: transforming without a capture")
-      }
       do {
         // FIXME: Pass input or the slice?
-        guard let value = try transform(input, range) else {
+        guard let value = try transform(input, storedCaptures[capNum]) else {
           signalFailure()
           return
         }

--- a/Sources/_StringProcessing/Engine/Registers.swift
+++ b/Sources/_StringProcessing/Engine/Registers.swift
@@ -177,7 +177,6 @@ extension MEProgram {
     var positionStackAddresses = 0
     var savePointAddresses = 0
     var captures = 0
-
   }
 }
 

--- a/Sources/_StringProcessing/Engine/Structuralize.swift
+++ b/Sources/_StringProcessing/Engine/Structuralize.swift
@@ -3,8 +3,7 @@
 extension CaptureList {
   @available(SwiftStdlib 5.7, *)
   func createElements(
-    _ list: MECaptureList,
-    _ input: String
+    _ list: MECaptureList
   ) -> [AnyRegexOutput.ElementRepresentation] {
     assert(list.values.count == captures.count)
     
@@ -13,10 +12,9 @@ extension CaptureList {
     for (i, (cap, meStored)) in zip(captures, list.values).enumerated() {
       let element = AnyRegexOutput.ElementRepresentation(
         optionalDepth: cap.optionalDepth,
-        bounds: meStored.latest,
+        content: meStored.latest,
         name: cap.name,
-        referenceID: list.referencedCaptureOffsets.first { $1 == i }?.key,
-        value: meStored.latestValue
+        referenceID: list.referencedCaptureOffsets.first { $1 == i }?.key
       )
       
       result.append(element)

--- a/Sources/_StringProcessing/Executor.swift
+++ b/Sources/_StringProcessing/Executor.swift
@@ -40,31 +40,10 @@ struct Executor {
       referencedCaptureOffsets: engine.program.referencedCaptureOffsets)
 
     let range = inputRange.lowerBound..<endIdx
-    let caps = engine.program.captureList.createElements(capList, input)
+    let caps = engine.program.captureList.createElements(capList)
 
-    // FIXME: This is a workaround for not tracking (or
-    // specially compiling) whole-match values.
-    let value: Any?
-    if Output.self != Substring.self,
-       Output.self != AnyRegexOutput.self,
-       caps.isEmpty
-    {
-      value = cpu.registers.values.first
-      assert(value != nil, "hmm, what would this mean?")
-    } else {
-      value = nil
-    }
-    
-    let anyRegexOutput = AnyRegexOutput(
-      input: input,
-      elements: caps
-    )
-    
-    return .init(
-      anyRegexOutput: anyRegexOutput,
-      range: range,
-      value: value
-    )
+    let anyRegexOutput = AnyRegexOutput(input: input, elements: caps)
+    return .init(anyRegexOutput: anyRegexOutput, range: range)
   }
 
   @available(SwiftStdlib 5.7, *)

--- a/Sources/_StringProcessing/PrintAsPattern.swift
+++ b/Sources/_StringProcessing/PrintAsPattern.swift
@@ -114,7 +114,7 @@ extension PrettyPrinter {
         printAsPattern(convertedFromAST: child)
       }
 
-    case let .capture(name, _, child):
+    case let .capture(name, _, child, _):
       var cap = "Capture"
       if let n = name {
         cap += "(as: \(n))"
@@ -225,8 +225,6 @@ extension PrettyPrinter {
     case let .customCharacterClass(ccc):
       printAsPattern(ccc)
 
-    case .transform:
-      print("/* TODO: transforms */")
     case .consumer:
       print("/* TODO: consumers */")
     case .matcher:
@@ -1120,11 +1118,9 @@ extension DSLTree.Node {
     var result: [String] = []
     
     switch self {
-    case .capture(let name, _, _):
-      if let name = name {
-        result.append(name)
-      }
-      
+    case .capture(let name?, _, _, _):
+      result.append(name)
+
     case .concatenation(let nodes):
       for node in nodes {
         result += node.getNamedCaptures()

--- a/Sources/_StringProcessing/Regex/Match.swift
+++ b/Sources/_StringProcessing/Regex/Match.swift
@@ -21,8 +21,6 @@ extension Regex {
 
     /// The range of the overall match.
     public let range: Range<String.Index>
-
-    let value: Any?
   }
 }
 
@@ -35,38 +33,12 @@ extension Regex.Match {
   /// The output produced from the match operation.
   public var output: Output {
     if Output.self == AnyRegexOutput.self {
-      let wholeMatchCapture = AnyRegexOutput.ElementRepresentation(
-        optionalDepth: 0,
-        bounds: range
-      )
-      
-      let output = AnyRegexOutput(
-        input: input,
-        elements: [wholeMatchCapture] + anyRegexOutput._elements
-      )
-      
-      return output as! Output
-    } else if Output.self == Substring.self {
-      // FIXME: Plumb whole match (`.0`) through the matching engine.
-      return input[range] as! Output
-    } else if anyRegexOutput.isEmpty, let value {
-      // FIXME: This is a workaround for whole-match values not
-      // being modeled as part of captures. We might want to
-      // switch to a model where results are alongside captures
-      return value as! Output
-    } else {
-      guard value == nil else {
-        fatalError("FIXME: what would this mean?")
-      }
-      let typeErasedMatch = anyRegexOutput.existentialOutput(
-        from: input[range]
-      )
-      return typeErasedMatch as! Output
+      return anyRegexOutput as! Output
     }
-  }
-
-  var wholeMatchType: Any.Type {
-    value.map { type(of: $0) } ?? Substring.self
+    let typeErasedMatch = anyRegexOutput.existentialOutput(
+      from: anyRegexOutput.input
+    )
+    return typeErasedMatch as! Output
   }
 
   /// Accesses a capture by its name or number.
@@ -74,15 +46,11 @@ extension Regex.Match {
     // Note: We should be able to get the element offset from the key path
     // itself even at compile time. We need a better way of doing this.
     guard let outputTupleOffset = MemoryLayout.tupleElementIndex(
-      of: keyPath, elementTypes: [wholeMatchType] + anyRegexOutput.map(\.type)
+      of: keyPath, elementTypes: anyRegexOutput.map(\.type)
     ) else {
       return output[keyPath: keyPath]
     }
-    if outputTupleOffset == 0 {
-      return value.map { $0 as! T } ?? (input[range] as! T)
-    } else {
-      return anyRegexOutput[outputTupleOffset - 1].value as! T
-    }
+    return anyRegexOutput[outputTupleOffset].value as! T
   }
 
   /// Accesses a capture using the `.0` syntax, even when the match isn't a tuple.
@@ -100,9 +68,8 @@ extension Regex.Match {
     ) else {
       preconditionFailure("Reference did not capture any match in the regex")
     }
-    
     return element.existentialOutputComponent(
-      from: input[...]
+      from: input
     ) as! Capture
   }
 }

--- a/Sources/_StringProcessing/Utility/TypeVerification.swift
+++ b/Sources/_StringProcessing/Utility/TypeVerification.swift
@@ -18,10 +18,10 @@ extension Regex {
       return true
     }
     
-    var tupleElements: [Any.Type] = [Substring.self]
-    var labels = " "
+    var tupleElements: [Any.Type] = []
+    var labels = ""
     
-    for capture in program.tree.root._captureList.captures {
+    for capture in program.tree.captureList.captures {
       var captureType: Any.Type = capture.type ?? Substring.self
       var i = capture.optionalDepth
       
@@ -41,7 +41,7 @@ extension Regex {
     
     // If we have no captures, then our Regex must be Regex<Substring>.
     if tupleElements.count == 1 {
-      return Output.self == Substring.self
+      return Output.self == program.tree.root.wholeMatchType
     }
     
     let createdType = TypeConstruction.tupleType(

--- a/Sources/_StringProcessing/Utility/TypedIndex.swift
+++ b/Sources/_StringProcessing/Utility/TypedIndex.swift
@@ -78,11 +78,11 @@ extension TypedIndex: BidirectionalCollection where C: BidirectionalCollection {
 // failure in the Swift repo.
 #if false
 extension TypedIndex: RangeReplaceableCollection where C: RangeReplaceableCollection {
-  init() { rawValue = C() }
+  init() { content = C() }
 
   mutating func replaceSubrange<C>(_ subrange: Range<Index>, with newElements: C) where C : Collection, C.Element == Element {
-    let rawRange = subrange.lowerBound.rawValue ..< subrange.upperBound.rawValue
-    rawValue.replaceSubrange(rawRange, with: newElements)
+    let rawRange = subrange.lowerBound.content ..< subrange.upperBound.content
+    content.replaceSubrange(rawRange, with: newElements)
   }
 
   // TODO: append, and all the other customization hooks...

--- a/Tests/RegexBuilderTests/RegexDSLTests.swift
+++ b/Tests/RegexBuilderTests/RegexDSLTests.swift
@@ -598,10 +598,10 @@ class RegexDSLTests: XCTestCase {
     let regex3 = Regex {
       OneOrMore("a")
       Capture {
-        TryCapture("b") { Int($0) }
-        ZeroOrMore {
-          TryCapture("c") { Double($0) }
-        }
+        TryCapture("b", transform: { Int($0) })
+        ZeroOrMore(
+          TryCapture("c", transform: { Double($0) })
+        )
         Optionally("e")
       }
     }
@@ -909,57 +909,64 @@ class RegexDSLTests: XCTestCase {
       }
     }
   }
-  
-  func testSemanticVersionExample() {
-    struct SemanticVersion: Equatable {
-      var major: Int
-      var minor: Int
-      var patch: Int
-      var dev: String?
-    }
-    struct SemanticVersionParser: CustomConsumingRegexComponent {
-      typealias RegexOutput = SemanticVersion
-      func consuming(
-        _ input: String,
-        startingAt index: String.Index,
-        in bounds: Range<String.Index>
-      ) throws -> (upperBound: String.Index, output: SemanticVersion)? {
-        let regex = Regex {
-          TryCapture(OneOrMore(.digit)) { Int($0) }
+
+  struct SemanticVersion: Equatable {
+    var major: Int
+    var minor: Int
+    var patch: Int
+    var dev: String?
+  }
+  struct SemanticVersionParser: CustomConsumingRegexComponent {
+    typealias RegexOutput = SemanticVersion
+    func consuming(
+      _ input: String,
+      startingAt index: String.Index,
+      in bounds: Range<String.Index>
+    ) throws -> (upperBound: String.Index, output: SemanticVersion)? {
+      let regex = Regex {
+        TryCapture(OneOrMore(.digit)) { Int($0) }
+        "."
+        TryCapture(OneOrMore(.digit)) { Int($0) }
+        Optionally {
           "."
           TryCapture(OneOrMore(.digit)) { Int($0) }
-          Optionally {
-            "."
-            TryCapture(OneOrMore(.digit)) { Int($0) }
-          }
-          Optionally {
-            "-"
-            Capture(OneOrMore(.word))
-          }
         }
+        Optionally {
+          "-"
+          Capture(OneOrMore(.word))
+        }
+      }
 
-        guard let match = input[index..<bounds.upperBound].firstMatch(of: regex),
-              match.range.lowerBound == index
-        else { return nil }
+      guard let match = input[index..<bounds.upperBound].firstMatch(of: regex),
+            match.range.lowerBound == index
+      else { return nil }
 
-        let result = SemanticVersion(
-          major: match.output.1,
-          minor: match.output.2,
-          patch: match.output.3 ?? 0,
-          dev: match.output.4.map(String.init))
-        return (match.range.upperBound, result)
+      let result = SemanticVersion(
+        major: match.output.1,
+        minor: match.output.2,
+        patch: match.output.3 ?? 0,
+        dev: match.output.4.map(String.init))
+      return (match.range.upperBound, result)
+    }
+  }
+
+  func testTransformCapturedMatcherOutput() {
+    let versions = [
+      ("version: 1.0", "1.0.0"),
+      ("version: 1.0.1", "1.0.1"),
+      ("version: 12.100.5-dev", "12.100.5-dev"),
+    ]
+    let parser = Regex {
+      "version:"
+      OneOrMore(.whitespace)
+      Capture {
+        SemanticVersionParser()
+      } transform: {
+        "\($0.major).\($0.minor).\($0.patch)\($0.dev.map { "-\($0)" } ?? "")"
       }
     }
-
-    let versions = [
-      ("1.0", SemanticVersion(major: 1, minor: 0, patch: 0)),
-      ("1.0.1", SemanticVersion(major: 1, minor: 0, patch: 1)),
-      ("12.100.5-dev", SemanticVersion(major: 12, minor: 100, patch: 5, dev: "dev")),
-    ]
-
-    let parser = SemanticVersionParser()
     for (str, version) in versions {
-      XCTAssertEqual(str.wholeMatch(of: parser)?.output, version)
+      XCTAssertEqual(str.wholeMatch(of: parser)?.1, version)
     }
   }
 }

--- a/Tests/RegexTests/CaptureTests.swift
+++ b/Tests/RegexTests/CaptureTests.swift
@@ -159,7 +159,9 @@ func captureTest(
   line: UInt = #line
 ) {
   let ast = try! parse(regex, .semantic, .traditional)
-  let capList = ast.root._captureList.withoutLocs
+  var capList = ast.captureList.withoutLocs
+  // Peel off the whole match element.
+  capList.captures.removeFirst()
   guard capList == expected else {
     XCTFail("""
       Expected:
@@ -173,7 +175,9 @@ func captureTest(
   }
 
   // Ensure DSLTree preserves literal captures
-  let dslCapList = ast.dslTree.root._captureList
+  var dslCapList = ast.dslTree.captureList
+  // Peel off the whole match element.
+  dslCapList.captures.removeFirst()
   guard dslCapList == capList else {
     XCTFail("""
       DSLTree did not preserve structure:
@@ -202,7 +206,9 @@ func captureTest(
       return
     }
 
-    let caps = result.anyRegexOutput
+    var caps = result.anyRegexOutput
+    // Peel off the whole match element.
+    caps._elements.removeFirst()
     guard caps.count == output.count else {
       XCTFail("""
       Mismatch capture count:

--- a/Tests/RegexTests/CompileTests.swift
+++ b/Tests/RegexTests/CompileTests.swift
@@ -134,5 +134,8 @@ extension RegexTests {
     try expectInitialOptions(
       "(?i:.)(?m:.)",
       matchingOptions(adding: [.caseInsensitive]))
+    try expectInitialOptions(
+      "((?i:.))",
+      matchingOptions(adding: [.caseInsensitive]))
   }
 }

--- a/Tests/RegexTests/MatchTests.swift
+++ b/Tests/RegexTests/MatchTests.swift
@@ -74,7 +74,7 @@ func flatCaptureTest(
 ) {
   for (test, expect) in tests {
     do {
-      guard let (_, caps) = try? _firstMatch(
+      guard var (_, caps) = try? _firstMatch(
         regex,
         input: test,
         syntax: syntax,
@@ -86,6 +86,8 @@ func flatCaptureTest(
           throw MatchError("Match failed")
         }
       }
+      // Peel off the whole match.
+      caps.removeFirst()
       guard let expect = expect else {
         throw MatchError("""
             Match of \(test) succeeded where failure expected in \(regex)

--- a/Tests/RegexTests/ParseTests.swift
+++ b/Tests/RegexTests/ParseTests.swift
@@ -94,7 +94,9 @@ func parseTest(
             file: file, line: line)
     return
   }
-  let captures = ast.captureList.withoutLocs
+  var captures = ast.captureList.withoutLocs
+  // Peel off the whole match.
+  captures.captures.removeFirst()
   guard captures == expectedCaptures else {
     XCTFail("""
 


### PR DESCRIPTION
* Track the whole match as an element of the "capture list" in the matching engine. Do so by emitting code as an implicit `capture` around the root node.
* No longer handle `matcher` as a special case within `capture` lowering, because the matcher can be arbitrarily nested within "output-forwarding" nodes, such as a `changeMatchingOptions` non-capturing group. Instead, make the bytecode emitter carry a result value so that a custom output can be propagated through any forwarding nodes.
  ```swift
  Regex {
    Capture(
      SemanticVersionParser()
        .ignoringCase()
        .matchingSemantics(.unicodeScalar)
    ) // This would not work previously.
  }
  ```
* Collapse DSLTree node `transform` into `capture`, because a transform can never be standalone (without a `capture` parent). This greatly simplifies `capture` lowering.
* Make the bytecode's capture transform use type `(Input, _StoredCapture) -> Any` so that it can transform any whole match, not just `Substring`. This means you can now transform any captured value, including a custom-consuming regex component's result!
  ```swift
  Regex {
    "version:"
    OneOrMore(.whitespace)
    Capture {
      SemanticVersionParser() // Regex<SemanticVersion>
    } transform: {
      // (SemanticVersion) -> SomethingElse
    }
  }
  ```
  The transforms of `Capture` and `TryCapture` are now generalized from taking `Substring` to taking generic parameter `W` (the whole match).
* Fix an issue where initial options were applied based solely on whether the bytecode had any instructions, failing examples such as `((?i:.))`. It now checks whether the first matchable atom has been emitted.