### PR TITLE
Remove `buildEither`.

### DIFF
--- a/Sources/RegexBuilder/Builder.swift
+++ b/Sources/RegexBuilder/Builder.swift
@@ -25,12 +25,4 @@ public enum RegexComponentBuilder {
   public static func buildExpression<R: RegexComponent>(_ regex: R) -> R {
     regex
   }
-
-  public static func buildEither<R: RegexComponent>(first component: R) -> R {
-    component
-  }
-
-  public static func buildEither<R: RegexComponent>(second component: R) -> R {
-    component
-  }
 }

--- a/Sources/RegexBuilder/DSL.swift
+++ b/Sources/RegexBuilder/DSL.swift
@@ -211,14 +211,6 @@ public struct AlternationBuilder {
   public static func buildExpression<R: RegexComponent>(_ regex: R) -> R {
     regex
   }
-
-  public static func buildEither<R: RegexComponent>(first component: R) -> R {
-    component
-  }
-
-  public static func buildEither<R: RegexComponent>(second component: R) -> R {
-    component
-  }
 }
 
 @available(SwiftStdlib 5.7, *)


### PR DESCRIPTION
`buildEither` was removed from the regex builder DSL proposal. See apple/swift-evolution#1634.