### PR TITLE
Fix `\o` crasher and allow `(?)`

### DIFF
--- a/Sources/_RegexParser/Regex/Parse/LexicalAnalysis.swift
+++ b/Sources/_RegexParser/Regex/Parse/LexicalAnalysis.swift
@@ -802,6 +802,11 @@ extension Source {
   mutating func lexMatchingOptionSequence(
     context: ParsingContext
   ) throws -> AST.MatchingOptionSequence? {
+    // PCRE accepts '(?)'
+    // TODO: This is a no-op, should we warn?
+    if peek() == ")" {
+      return .init(caretLoc: nil, adding: [], minusLoc: nil, removing: [])
+    }
     let ateCaret = recordLoc { $0.tryEat("^") }
 
     // TODO: Warn on duplicate options, and options appearing in both adding

--- a/Tests/RegexTests/LexTests.swift
+++ b/Tests/RegexTests/LexTests.swift
@@ -61,41 +61,6 @@ extension RegexTests {
       _ = try src.lexNumber()
     }
 
-    func diagnoseUniScalarOverflow(_ input: String, base: Character) {
-      let scalars = input.first == "{"
-                  ? String(input.dropFirst().dropLast())
-                  : input
-      diagnose(
-        input,
-        expecting: .numberOverflow(scalars)
-      ) { src in
-        _ = try src.expectUnicodeScalar(escapedCharacter: base)
-      }
-    }
-    func diagnoseUniScalar(
-      _ input: String,
-      base: Character,
-      expectedDigits numDigits: Int
-    ) {
-      let scalars = input.first == "{"
-                  ? String(input.dropFirst().dropLast())
-                  : input
-      diagnose(
-        input,
-        expecting: .expectedNumDigits(scalars, numDigits)
-      ) { src in
-        _ = try src.expectUnicodeScalar(escapedCharacter: base)
-      }
-      _ = scalars
-    }
-
-    diagnoseUniScalar(
-      "12", base: "u", expectedDigits: 4)
-    diagnoseUniScalar(
-      "12", base: "U", expectedDigits: 8)
-    diagnoseUniScalarOverflow("{123456789}", base: "u")
-    diagnoseUniScalarOverflow("{123456789}", base: "x")
-
     // TODO: want to dummy print out source ranges, etc, test that.
   }
 

--- a/Tests/RegexTests/ParseTests.swift
+++ b/Tests/RegexTests/ParseTests.swift
@@ -1002,6 +1002,9 @@ extension RegexTests {
               concat("a", atomicScriptRun("b"), "c"), throwsError: .unsupported)
 
     // Matching option changing groups.
+    parseTest("(?)", changeMatchingOptions(
+      matchingOptions()
+    ))
     parseTest("(?-)", changeMatchingOptions(
       matchingOptions()
     ))

--- a/Tests/RegexTests/ParseTests.swift
+++ b/Tests/RegexTests/ParseTests.swift
@@ -2669,6 +2669,8 @@ extension RegexTests {
 
     diagnosticTest("\\", .expectedEscape)
 
+    diagnosticTest(#"\o"#, .invalidEscape("o"))
+
     // TODO: Custom diagnostic for control sequence
     diagnosticTest(#"\c"#, .unexpectedEndOfInput)
 

--- a/Tests/RegexTests/ParseTests.swift
+++ b/Tests/RegexTests/ParseTests.swift
@@ -2877,6 +2877,11 @@ extension RegexTests {
     diagnosticTest(#"[\d--\u{a b}]"#, .unsupported("scalar sequence in custom character class"))
     diagnosticTest(#"[\d--[\u{a b}]]"#, .unsupported("scalar sequence in custom character class"))
 
+    diagnosticTest(#"\u12"#, .expectedNumDigits("12", 4))
+    diagnosticTest(#"\U12"#, .expectedNumDigits("12", 8))
+    diagnosticTest(#"\u{123456789}"#, .numberOverflow("123456789"))
+    diagnosticTest(#"\x{123456789}"#, .numberOverflow("123456789"))
+
     // MARK: Matching options
 
     diagnosticTest(#"(?^-"#, .cannotRemoveMatchingOptionsAfterCaret)


### PR DESCRIPTION
Separate these changes off https://github.com/apple/swift-experimental-string-processing/pull/481 so they can be independently cherry-picked to 5.7:

- Fix a crash that occurred with `\o` if it was not followed by `{`.
- Allow `(?)`, which is permitted by PCRE (but is a no-op).

Resolves #472