### PR TITLE
Make unary builder return `Regex` type consistently

### DIFF
--- a/Sources/RegexBuilder/Builder.swift
+++ b/Sources/RegexBuilder/Builder.swift
@@ -18,8 +18,10 @@ public enum RegexComponentBuilder {
     .init(node: .empty)
   }
 
-  public static func buildPartialBlock<R: RegexComponent>(first: R ) -> R {
-    first
+  public static func buildPartialBlock<R: RegexComponent>(
+    first component: R
+  ) -> Regex<R.RegexOutput> {
+    component.regex
   }
 
   public static func buildExpression<R: RegexComponent>(_ regex: R) -> R {

--- a/Tests/RegexBuilderTests/RegexDSLTests.swift
+++ b/Tests/RegexBuilderTests/RegexDSLTests.swift
@@ -1015,7 +1015,7 @@ class RegexDSLTests: XCTestCase {
       XCTAssertEqual(str.wholeMatch(of: parser)?.1, version)
     }
   }
-  
+
   func testZeroWidthConsumer() throws {
     struct Trace: CustomConsumingRegexComponent {
       typealias RegexOutput = Void
@@ -1050,6 +1050,26 @@ class RegexDSLTests: XCTestCase {
             ^
       
       """)
+  }
+
+  func testRegexComponentBuilderResultType() {
+    // Test that the user can declare a closure or computed property marked with
+    // `@RegexComponentBuilder` with `Regex` as the result type.
+    @RegexComponentBuilder
+    var unaryWithSingleNonRegex: Regex<Substring> {
+      OneOrMore("a")
+    }
+    @RegexComponentBuilder
+    var multiComponent: Regex<Substring> {
+      OneOrMore("a")
+      "b"
+    }
+    struct MyCustomRegex: RegexComponent {
+      @RegexComponentBuilder
+      var regex: Regex<Substring> {
+        OneOrMore("a")
+      }
+    }
   }
 }
 


### PR DESCRIPTION
Currently, unary regex component builders simply forward the component's base type. However, this is inconsistent with non-unary builder results. The current behavior may lead to surprising results when the user marks a property with `@RegexComponentBuilder`.

This patch makes `RegexComponentBuilder.buildPartialBlock<R>(first: R)` return a `Regex<R.RegexOutput>` rather than `R` itself.

---

Before:

```swift
// error: cannot convert value of type 'OneOrMore<Substring>' to specified type 'Regex<Substring>'
@RegexComponentBuilder
var r: Regex<Substring> {
  OneOrMore("a")
  // Adding other components below will make the error go away.
}

struct MyCustomRegex: RegexComponent {
  // error: cannot convert value of type 'OneOrMore<Substring>' to specified type 'Regex<Substring>'
  @RegexComponentBuilder
  var regex: Regex<Substring> {
    OneOrMore("a")
  }
}
```

After: No errors.