### PR TITLE
[Printer] Unconditionally print a regex block for concatenations

### DIFF
--- a/Sources/_StringProcessing/PrintAsPattern.swift
+++ b/Sources/_StringProcessing/PrintAsPattern.swift
@@ -71,8 +71,15 @@ extension PrettyPrinter {
       print("let \(namedCapture) = Reference(Substring.self)")
     }
     
-    printBlock("Regex") { printer in
-      printer.printAsPattern(convertedFromAST: node)
+    switch node {
+    case .concatenation(_):
+      printAsPattern(convertedFromAST: node)
+    case .convertedRegexLiteral(.concatenation(_), _):
+      printAsPattern(convertedFromAST: node)
+    default:
+      printBlock("Regex") { printer in
+        printer.printAsPattern(convertedFromAST: node)
+      }
     }
   }
 
@@ -99,8 +106,10 @@ extension PrettyPrinter {
       }
 
     case let .concatenation(c):
-      c.forEach {
-        printAsPattern(convertedFromAST: $0)
+      printBlock("Regex") { printer in
+        c.forEach {
+          printer.printAsPattern(convertedFromAST: $0)
+        }
       }
 
     case let .nonCapturingGroup(kind, child):

--- a/Tests/RegexTests/RenderDSLTests.swift
+++ b/Tests/RegexTests/RenderDSLTests.swift
@@ -97,19 +97,17 @@ extension RenderDSLTests {
       }
       """)
     
-    try XCTExpectFailure("Concatenations in alternations aren't grouped") {
-      try testConversion(#"\da|b"#, """
-        Regex {
-          ChoiceOf {
-            Regex {
-              .digit
-              "a"
-            }
-            "bc"
+    try testConversion(#"\da|bc"#, """
+      Regex {
+        ChoiceOf {
+          Regex {
+            One(.digit)
+            "a"
           }
+          "bc"
         }
-        """)
-    }
+      }
+      """)
   }
   
   func testQuoting() throws {


### PR DESCRIPTION
We weren't printing regex blocks around concatenations which caused issues like `/a|\dc/` to be printed as if it were `/a|\d|c/`, which is obviously not the same regex. Just unconditionally print regex blocks around all concatenations.