### PR TITLE
Make variadic builder overloads AEIC (take 2)

### DIFF
--- a/Sources/RegexBuilder/DSL.swift
+++ b/Sources/RegexBuilder/DSL.swift
@@ -140,6 +140,7 @@ public struct One<Output>: RegexComponent {
 public struct OneOrMore<Output>: _BuiltinRegexComponent {
   public var regex: Regex<Output>
 
+  @usableFromInline
   internal init(_ regex: Regex<Output>) {
     self.regex = regex
   }
@@ -152,6 +153,7 @@ public struct OneOrMore<Output>: _BuiltinRegexComponent {
 public struct ZeroOrMore<Output>: _BuiltinRegexComponent {
   public var regex: Regex<Output>
 
+  @usableFromInline
   internal init(_ regex: Regex<Output>) {
     self.regex = regex
   }
@@ -164,6 +166,7 @@ public struct ZeroOrMore<Output>: _BuiltinRegexComponent {
 public struct Optionally<Output>: _BuiltinRegexComponent {
   public var regex: Regex<Output>
 
+  @usableFromInline
   internal init(_ regex: Regex<Output>) {
     self.regex = regex
   }
@@ -176,6 +179,7 @@ public struct Optionally<Output>: _BuiltinRegexComponent {
 public struct Repeat<Output>: _BuiltinRegexComponent {
   public var regex: Regex<Output>
 
+  @usableFromInline
   internal init(_ regex: Regex<Output>) {
     self.regex = regex
   }
@@ -217,6 +221,7 @@ public struct AlternationBuilder {
 public struct ChoiceOf<Output>: _BuiltinRegexComponent {
   public var regex: Regex<Output>
 
+  @usableFromInline
   internal init(_ regex: Regex<Output>) {
     self.regex = regex
   }
@@ -232,6 +237,7 @@ public struct ChoiceOf<Output>: _BuiltinRegexComponent {
 public struct Capture<Output>: _BuiltinRegexComponent {
   public var regex: Regex<Output>
 
+  @usableFromInline
   internal init(_ regex: Regex<Output>) {
     self.regex = regex
   }
@@ -243,6 +249,7 @@ public struct Capture<Output>: _BuiltinRegexComponent {
 public struct TryCapture<Output>: _BuiltinRegexComponent {
   public var regex: Regex<Output>
 
+  @usableFromInline
   internal init(_ regex: Regex<Output>) {
     self.regex = regex
   }
@@ -260,6 +267,7 @@ public struct TryCapture<Output>: _BuiltinRegexComponent {
 public struct Local<Output>: _BuiltinRegexComponent {
   public var regex: Regex<Output>
 
+  @usableFromInline
   internal init(_ regex: Regex<Output>) {
     self.regex = regex
   }

--- a/Sources/RegexBuilder/RegexFactory.swift
+++ b/Sources/RegexBuilder/RegexFactory.swift
@@ -1,0 +1,157 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2021-2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+@_spi(RegexBuilder) import _StringProcessing
+
+@usableFromInline
+enum _RegexFactory {
+  @usableFromInline
+  struct _Node {
+    let node: DSLTree.Node
+    
+    @usableFromInline
+    func appending(_ other: _Node) -> _Node {
+      node.appending(other.node).factory
+    }
+    
+    @usableFromInline
+    func appendingAlternationCase(_ other: _Node) -> _Node {
+      node.appendingAlternationCase(other.node).factory
+    }
+  }
+  
+  @available(SwiftStdlib 5.7, *)
+  @usableFromInline
+  static func node<Output>(_ node: _Node) -> Regex<Output> {
+    .init(node: node.node)
+  }
+  
+  @available(SwiftStdlib 5.7, *)
+  @usableFromInline
+  static func zeroOrOne<Output>(
+    _ behavior: RegexRepetitionBehavior?,
+    _ node: _Node
+  ) -> Regex<Output> {
+    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
+    return .init(node: .quantification(.zeroOrOne, kind, node.node))
+  }
+  
+  @available(SwiftStdlib 5.7, *)
+  @usableFromInline
+  static func zeroOrMore<Output>(
+    _ behavior: RegexRepetitionBehavior?,
+    _ node: _Node
+  ) -> Regex<Output> {
+    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
+    return .init(node: .quantification(.zeroOrMore, kind, node.node))
+  }
+  
+  @available(SwiftStdlib 5.7, *)
+  @usableFromInline
+  static func oneOrMore<Output>(
+    _ behavior: RegexRepetitionBehavior?,
+    _ node: _Node
+  ) -> Regex<Output> {
+    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
+    return .init(node: .quantification(.oneOrMore, kind, node.node))
+  }
+  
+  @available(SwiftStdlib 5.7, *)
+  @usableFromInline
+  static func exactly<Output>(
+    _ count: Int,
+    _ node: _Node
+  ) -> Regex<Output> {
+    .init(node: .quantification(.exactly(count), .default, node.node))
+  }
+  
+  @available(SwiftStdlib 5.7, *)
+  @usableFromInline
+  static func repeating<Output>(
+    _ range: Range<Int>,
+    _ behavior: RegexRepetitionBehavior?,
+    _ node: _Node
+  ) -> Regex<Output> {
+    .init(node: .repeating(range, behavior, node.node))
+  }
+  
+  @available(SwiftStdlib 5.7, *)
+  @usableFromInline
+  static func atomicNonCapturing<Output>(_ node: _Node) -> Regex<Output> {
+    .init(node: .nonCapturingGroup(.atomicNonCapturing, node.node))
+  }
+  
+  @available(SwiftStdlib 5.7, *)
+  @usableFromInline
+  static func orderedChoice<Output>(_ node: _Node) -> Regex<Output> {
+    .init(node: .orderedChoice([node.node]))
+  }
+  
+  @available(SwiftStdlib 5.7, *)
+  @usableFromInline
+  static func capture<Output>(
+    _ node: _Node
+  ) -> Regex<Output> {
+    .init(node: .capture(node.node))
+  }
+  
+  @available(SwiftStdlib 5.7, *)
+  @usableFromInline
+  static func capture<Output, W>(
+    _ node: _Node,
+    _ reference: Reference<W>? = nil
+  ) -> Regex<Output> {
+    .init(node: .capture(reference: reference?.id, node.node))
+  }
+  
+  @available(SwiftStdlib 5.7, *)
+  @usableFromInline
+  static func capture<Output, W, NewCapture>(
+    _ node: _Node,
+    _ reference: Reference<NewCapture>? = nil,
+    _ transform: @escaping (W) throws -> NewCapture
+  ) -> Regex<Output> {
+    .init(node: .capture(
+      reference: reference?.id,
+      node.node,
+      CaptureTransform(transform)
+    ))
+  }
+  
+  @available(SwiftStdlib 5.7, *)
+  @usableFromInline
+  static func captureOptional<Output, W, NewCapture>(
+    _ node: _Node,
+    _ reference: Reference<NewCapture>? = nil,
+    _ transform: @escaping (W) throws -> NewCapture?
+  ) -> Regex<Output> {
+    .init(node: .capture(
+      reference: reference?.id,
+      node.node,
+      CaptureTransform(transform)
+    ))
+  }
+}
+
+@available(SwiftStdlib 5.7, *)
+extension Regex {
+  @usableFromInline
+  var _root: _RegexFactory._Node {
+    root.factory
+  }
+}
+
+extension DSLTree.Node {
+  @usableFromInline
+  var factory: _RegexFactory._Node {
+    _RegexFactory._Node(node: self)
+  }
+}

--- a/Sources/RegexBuilder/RegexFactory.swift
+++ b/Sources/RegexBuilder/RegexFactory.swift
@@ -107,9 +107,9 @@ enum _RegexFactory {
   @usableFromInline
   static func capture<Output, W>(
     _ node: _Node,
-    _ reference: Reference<W>? = nil
+    _ reference: Reference<W>
   ) -> Regex<Output> {
-    .init(node: .capture(reference: reference?.id, node.node))
+    .init(node: .capture(reference: reference.id, node.node))
   }
   
   @available(SwiftStdlib 5.7, *)

--- a/Sources/RegexBuilder/Variadics.swift
+++ b/Sources/RegexBuilder/Variadics.swift
@@ -15,541 +15,739 @@
 
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<W0, W1, C1, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C1)>  where R0.RegexOutput == W0, R1.RegexOutput == (W1, C1) {
-    .init(node: accumulated.regex.root.appending(next.regex.root))
+    _RegexFactory.node(
+      accumulated.regex._root.appending(next.regex._root)
+    )
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<W0, W1, C1, C2, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C1, C2)>  where R0.RegexOutput == W0, R1.RegexOutput == (W1, C1, C2) {
-    .init(node: accumulated.regex.root.appending(next.regex.root))
+    _RegexFactory.node(
+      accumulated.regex._root.appending(next.regex._root)
+    )
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<W0, W1, C1, C2, C3, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C1, C2, C3)>  where R0.RegexOutput == W0, R1.RegexOutput == (W1, C1, C2, C3) {
-    .init(node: accumulated.regex.root.appending(next.regex.root))
+    _RegexFactory.node(
+      accumulated.regex._root.appending(next.regex._root)
+    )
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C1, C2, C3, C4)>  where R0.RegexOutput == W0, R1.RegexOutput == (W1, C1, C2, C3, C4) {
-    .init(node: accumulated.regex.root.appending(next.regex.root))
+    _RegexFactory.node(
+      accumulated.regex._root.appending(next.regex._root)
+    )
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, C5, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C1, C2, C3, C4, C5)>  where R0.RegexOutput == W0, R1.RegexOutput == (W1, C1, C2, C3, C4, C5) {
-    .init(node: accumulated.regex.root.appending(next.regex.root))
+    _RegexFactory.node(
+      accumulated.regex._root.appending(next.regex._root)
+    )
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, C5, C6, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C1, C2, C3, C4, C5, C6)>  where R0.RegexOutput == W0, R1.RegexOutput == (W1, C1, C2, C3, C4, C5, C6) {
-    .init(node: accumulated.regex.root.appending(next.regex.root))
+    _RegexFactory.node(
+      accumulated.regex._root.appending(next.regex._root)
+    )
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, C5, C6, C7, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C1, C2, C3, C4, C5, C6, C7)>  where R0.RegexOutput == W0, R1.RegexOutput == (W1, C1, C2, C3, C4, C5, C6, C7) {
-    .init(node: accumulated.regex.root.appending(next.regex.root))
+    _RegexFactory.node(
+      accumulated.regex._root.appending(next.regex._root)
+    )
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, C5, C6, C7, C8, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C1, C2, C3, C4, C5, C6, C7, C8)>  where R0.RegexOutput == W0, R1.RegexOutput == (W1, C1, C2, C3, C4, C5, C6, C7, C8) {
-    .init(node: accumulated.regex.root.appending(next.regex.root))
+    _RegexFactory.node(
+      accumulated.regex._root.appending(next.regex._root)
+    )
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, C5, C6, C7, C8, C9, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C1, C2, C3, C4, C5, C6, C7, C8, C9)>  where R0.RegexOutput == W0, R1.RegexOutput == (W1, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
-    .init(node: accumulated.regex.root.appending(next.regex.root))
+    _RegexFactory.node(
+      accumulated.regex._root.appending(next.regex._root)
+    )
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10)>  where R0.RegexOutput == W0, R1.RegexOutput == (W1, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10) {
-    .init(node: accumulated.regex.root.appending(next.regex.root))
+    _RegexFactory.node(
+      accumulated.regex._root.appending(next.regex._root)
+    )
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<W0, W1, C1, C2, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C1, C2)>  where R0.RegexOutput == (W0, C1), R1.RegexOutput == (W1, C2) {
-    .init(node: accumulated.regex.root.appending(next.regex.root))
+    _RegexFactory.node(
+      accumulated.regex._root.appending(next.regex._root)
+    )
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<W0, W1, C1, C2, C3, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C1, C2, C3)>  where R0.RegexOutput == (W0, C1), R1.RegexOutput == (W1, C2, C3) {
-    .init(node: accumulated.regex.root.appending(next.regex.root))
+    _RegexFactory.node(
+      accumulated.regex._root.appending(next.regex._root)
+    )
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C1, C2, C3, C4)>  where R0.RegexOutput == (W0, C1), R1.RegexOutput == (W1, C2, C3, C4) {
-    .init(node: accumulated.regex.root.appending(next.regex.root))
+    _RegexFactory.node(
+      accumulated.regex._root.appending(next.regex._root)
+    )
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, C5, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C1, C2, C3, C4, C5)>  where R0.RegexOutput == (W0, C1), R1.RegexOutput == (W1, C2, C3, C4, C5) {
-    .init(node: accumulated.regex.root.appending(next.regex.root))
+    _RegexFactory.node(
+      accumulated.regex._root.appending(next.regex._root)
+    )
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, C5, C6, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C1, C2, C3, C4, C5, C6)>  where R0.RegexOutput == (W0, C1), R1.RegexOutput == (W1, C2, C3, C4, C5, C6) {
-    .init(node: accumulated.regex.root.appending(next.regex.root))
+    _RegexFactory.node(
+      accumulated.regex._root.appending(next.regex._root)
+    )
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, C5, C6, C7, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C1, C2, C3, C4, C5, C6, C7)>  where R0.RegexOutput == (W0, C1), R1.RegexOutput == (W1, C2, C3, C4, C5, C6, C7) {
-    .init(node: accumulated.regex.root.appending(next.regex.root))
+    _RegexFactory.node(
+      accumulated.regex._root.appending(next.regex._root)
+    )
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, C5, C6, C7, C8, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C1, C2, C3, C4, C5, C6, C7, C8)>  where R0.RegexOutput == (W0, C1), R1.RegexOutput == (W1, C2, C3, C4, C5, C6, C7, C8) {
-    .init(node: accumulated.regex.root.appending(next.regex.root))
+    _RegexFactory.node(
+      accumulated.regex._root.appending(next.regex._root)
+    )
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, C5, C6, C7, C8, C9, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C1, C2, C3, C4, C5, C6, C7, C8, C9)>  where R0.RegexOutput == (W0, C1), R1.RegexOutput == (W1, C2, C3, C4, C5, C6, C7, C8, C9) {
-    .init(node: accumulated.regex.root.appending(next.regex.root))
+    _RegexFactory.node(
+      accumulated.regex._root.appending(next.regex._root)
+    )
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10)>  where R0.RegexOutput == (W0, C1), R1.RegexOutput == (W1, C2, C3, C4, C5, C6, C7, C8, C9, C10) {
-    .init(node: accumulated.regex.root.appending(next.regex.root))
+    _RegexFactory.node(
+      accumulated.regex._root.appending(next.regex._root)
+    )
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<W0, W1, C1, C2, C3, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C1, C2, C3)>  where R0.RegexOutput == (W0, C1, C2), R1.RegexOutput == (W1, C3) {
-    .init(node: accumulated.regex.root.appending(next.regex.root))
+    _RegexFactory.node(
+      accumulated.regex._root.appending(next.regex._root)
+    )
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C1, C2, C3, C4)>  where R0.RegexOutput == (W0, C1, C2), R1.RegexOutput == (W1, C3, C4) {
-    .init(node: accumulated.regex.root.appending(next.regex.root))
+    _RegexFactory.node(
+      accumulated.regex._root.appending(next.regex._root)
+    )
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, C5, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C1, C2, C3, C4, C5)>  where R0.RegexOutput == (W0, C1, C2), R1.RegexOutput == (W1, C3, C4, C5) {
-    .init(node: accumulated.regex.root.appending(next.regex.root))
+    _RegexFactory.node(
+      accumulated.regex._root.appending(next.regex._root)
+    )
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, C5, C6, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C1, C2, C3, C4, C5, C6)>  where R0.RegexOutput == (W0, C1, C2), R1.RegexOutput == (W1, C3, C4, C5, C6) {
-    .init(node: accumulated.regex.root.appending(next.regex.root))
+    _RegexFactory.node(
+      accumulated.regex._root.appending(next.regex._root)
+    )
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, C5, C6, C7, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C1, C2, C3, C4, C5, C6, C7)>  where R0.RegexOutput == (W0, C1, C2), R1.RegexOutput == (W1, C3, C4, C5, C6, C7) {
-    .init(node: accumulated.regex.root.appending(next.regex.root))
+    _RegexFactory.node(
+      accumulated.regex._root.appending(next.regex._root)
+    )
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, C5, C6, C7, C8, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C1, C2, C3, C4, C5, C6, C7, C8)>  where R0.RegexOutput == (W0, C1, C2), R1.RegexOutput == (W1, C3, C4, C5, C6, C7, C8) {
-    .init(node: accumulated.regex.root.appending(next.regex.root))
+    _RegexFactory.node(
+      accumulated.regex._root.appending(next.regex._root)
+    )
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, C5, C6, C7, C8, C9, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C1, C2, C3, C4, C5, C6, C7, C8, C9)>  where R0.RegexOutput == (W0, C1, C2), R1.RegexOutput == (W1, C3, C4, C5, C6, C7, C8, C9) {
-    .init(node: accumulated.regex.root.appending(next.regex.root))
+    _RegexFactory.node(
+      accumulated.regex._root.appending(next.regex._root)
+    )
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10)>  where R0.RegexOutput == (W0, C1, C2), R1.RegexOutput == (W1, C3, C4, C5, C6, C7, C8, C9, C10) {
-    .init(node: accumulated.regex.root.appending(next.regex.root))
+    _RegexFactory.node(
+      accumulated.regex._root.appending(next.regex._root)
+    )
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C1, C2, C3, C4)>  where R0.RegexOutput == (W0, C1, C2, C3), R1.RegexOutput == (W1, C4) {
-    .init(node: accumulated.regex.root.appending(next.regex.root))
+    _RegexFactory.node(
+      accumulated.regex._root.appending(next.regex._root)
+    )
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, C5, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C1, C2, C3, C4, C5)>  where R0.RegexOutput == (W0, C1, C2, C3), R1.RegexOutput == (W1, C4, C5) {
-    .init(node: accumulated.regex.root.appending(next.regex.root))
+    _RegexFactory.node(
+      accumulated.regex._root.appending(next.regex._root)
+    )
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, C5, C6, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C1, C2, C3, C4, C5, C6)>  where R0.RegexOutput == (W0, C1, C2, C3), R1.RegexOutput == (W1, C4, C5, C6) {
-    .init(node: accumulated.regex.root.appending(next.regex.root))
+    _RegexFactory.node(
+      accumulated.regex._root.appending(next.regex._root)
+    )
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, C5, C6, C7, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C1, C2, C3, C4, C5, C6, C7)>  where R0.RegexOutput == (W0, C1, C2, C3), R1.RegexOutput == (W1, C4, C5, C6, C7) {
-    .init(node: accumulated.regex.root.appending(next.regex.root))
+    _RegexFactory.node(
+      accumulated.regex._root.appending(next.regex._root)
+    )
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, C5, C6, C7, C8, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C1, C2, C3, C4, C5, C6, C7, C8)>  where R0.RegexOutput == (W0, C1, C2, C3), R1.RegexOutput == (W1, C4, C5, C6, C7, C8) {
-    .init(node: accumulated.regex.root.appending(next.regex.root))
+    _RegexFactory.node(
+      accumulated.regex._root.appending(next.regex._root)
+    )
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, C5, C6, C7, C8, C9, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C1, C2, C3, C4, C5, C6, C7, C8, C9)>  where R0.RegexOutput == (W0, C1, C2, C3), R1.RegexOutput == (W1, C4, C5, C6, C7, C8, C9) {
-    .init(node: accumulated.regex.root.appending(next.regex.root))
+    _RegexFactory.node(
+      accumulated.regex._root.appending(next.regex._root)
+    )
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10)>  where R0.RegexOutput == (W0, C1, C2, C3), R1.RegexOutput == (W1, C4, C5, C6, C7, C8, C9, C10) {
-    .init(node: accumulated.regex.root.appending(next.regex.root))
+    _RegexFactory.node(
+      accumulated.regex._root.appending(next.regex._root)
+    )
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, C5, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C1, C2, C3, C4, C5)>  where R0.RegexOutput == (W0, C1, C2, C3, C4), R1.RegexOutput == (W1, C5) {
-    .init(node: accumulated.regex.root.appending(next.regex.root))
+    _RegexFactory.node(
+      accumulated.regex._root.appending(next.regex._root)
+    )
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, C5, C6, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C1, C2, C3, C4, C5, C6)>  where R0.RegexOutput == (W0, C1, C2, C3, C4), R1.RegexOutput == (W1, C5, C6) {
-    .init(node: accumulated.regex.root.appending(next.regex.root))
+    _RegexFactory.node(
+      accumulated.regex._root.appending(next.regex._root)
+    )
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, C5, C6, C7, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C1, C2, C3, C4, C5, C6, C7)>  where R0.RegexOutput == (W0, C1, C2, C3, C4), R1.RegexOutput == (W1, C5, C6, C7) {
-    .init(node: accumulated.regex.root.appending(next.regex.root))
+    _RegexFactory.node(
+      accumulated.regex._root.appending(next.regex._root)
+    )
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, C5, C6, C7, C8, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C1, C2, C3, C4, C5, C6, C7, C8)>  where R0.RegexOutput == (W0, C1, C2, C3, C4), R1.RegexOutput == (W1, C5, C6, C7, C8) {
-    .init(node: accumulated.regex.root.appending(next.regex.root))
+    _RegexFactory.node(
+      accumulated.regex._root.appending(next.regex._root)
+    )
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, C5, C6, C7, C8, C9, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C1, C2, C3, C4, C5, C6, C7, C8, C9)>  where R0.RegexOutput == (W0, C1, C2, C3, C4), R1.RegexOutput == (W1, C5, C6, C7, C8, C9) {
-    .init(node: accumulated.regex.root.appending(next.regex.root))
+    _RegexFactory.node(
+      accumulated.regex._root.appending(next.regex._root)
+    )
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10)>  where R0.RegexOutput == (W0, C1, C2, C3, C4), R1.RegexOutput == (W1, C5, C6, C7, C8, C9, C10) {
-    .init(node: accumulated.regex.root.appending(next.regex.root))
+    _RegexFactory.node(
+      accumulated.regex._root.appending(next.regex._root)
+    )
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, C5, C6, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C1, C2, C3, C4, C5, C6)>  where R0.RegexOutput == (W0, C1, C2, C3, C4, C5), R1.RegexOutput == (W1, C6) {
-    .init(node: accumulated.regex.root.appending(next.regex.root))
+    _RegexFactory.node(
+      accumulated.regex._root.appending(next.regex._root)
+    )
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, C5, C6, C7, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C1, C2, C3, C4, C5, C6, C7)>  where R0.RegexOutput == (W0, C1, C2, C3, C4, C5), R1.RegexOutput == (W1, C6, C7) {
-    .init(node: accumulated.regex.root.appending(next.regex.root))
+    _RegexFactory.node(
+      accumulated.regex._root.appending(next.regex._root)
+    )
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, C5, C6, C7, C8, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C1, C2, C3, C4, C5, C6, C7, C8)>  where R0.RegexOutput == (W0, C1, C2, C3, C4, C5), R1.RegexOutput == (W1, C6, C7, C8) {
-    .init(node: accumulated.regex.root.appending(next.regex.root))
+    _RegexFactory.node(
+      accumulated.regex._root.appending(next.regex._root)
+    )
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, C5, C6, C7, C8, C9, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C1, C2, C3, C4, C5, C6, C7, C8, C9)>  where R0.RegexOutput == (W0, C1, C2, C3, C4, C5), R1.RegexOutput == (W1, C6, C7, C8, C9) {
-    .init(node: accumulated.regex.root.appending(next.regex.root))
+    _RegexFactory.node(
+      accumulated.regex._root.appending(next.regex._root)
+    )
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10)>  where R0.RegexOutput == (W0, C1, C2, C3, C4, C5), R1.RegexOutput == (W1, C6, C7, C8, C9, C10) {
-    .init(node: accumulated.regex.root.appending(next.regex.root))
+    _RegexFactory.node(
+      accumulated.regex._root.appending(next.regex._root)
+    )
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, C5, C6, C7, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C1, C2, C3, C4, C5, C6, C7)>  where R0.RegexOutput == (W0, C1, C2, C3, C4, C5, C6), R1.RegexOutput == (W1, C7) {
-    .init(node: accumulated.regex.root.appending(next.regex.root))
+    _RegexFactory.node(
+      accumulated.regex._root.appending(next.regex._root)
+    )
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, C5, C6, C7, C8, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C1, C2, C3, C4, C5, C6, C7, C8)>  where R0.RegexOutput == (W0, C1, C2, C3, C4, C5, C6), R1.RegexOutput == (W1, C7, C8) {
-    .init(node: accumulated.regex.root.appending(next.regex.root))
+    _RegexFactory.node(
+      accumulated.regex._root.appending(next.regex._root)
+    )
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, C5, C6, C7, C8, C9, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C1, C2, C3, C4, C5, C6, C7, C8, C9)>  where R0.RegexOutput == (W0, C1, C2, C3, C4, C5, C6), R1.RegexOutput == (W1, C7, C8, C9) {
-    .init(node: accumulated.regex.root.appending(next.regex.root))
+    _RegexFactory.node(
+      accumulated.regex._root.appending(next.regex._root)
+    )
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10)>  where R0.RegexOutput == (W0, C1, C2, C3, C4, C5, C6), R1.RegexOutput == (W1, C7, C8, C9, C10) {
-    .init(node: accumulated.regex.root.appending(next.regex.root))
+    _RegexFactory.node(
+      accumulated.regex._root.appending(next.regex._root)
+    )
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, C5, C6, C7, C8, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C1, C2, C3, C4, C5, C6, C7, C8)>  where R0.RegexOutput == (W0, C1, C2, C3, C4, C5, C6, C7), R1.RegexOutput == (W1, C8) {
-    .init(node: accumulated.regex.root.appending(next.regex.root))
+    _RegexFactory.node(
+      accumulated.regex._root.appending(next.regex._root)
+    )
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, C5, C6, C7, C8, C9, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C1, C2, C3, C4, C5, C6, C7, C8, C9)>  where R0.RegexOutput == (W0, C1, C2, C3, C4, C5, C6, C7), R1.RegexOutput == (W1, C8, C9) {
-    .init(node: accumulated.regex.root.appending(next.regex.root))
+    _RegexFactory.node(
+      accumulated.regex._root.appending(next.regex._root)
+    )
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10)>  where R0.RegexOutput == (W0, C1, C2, C3, C4, C5, C6, C7), R1.RegexOutput == (W1, C8, C9, C10) {
-    .init(node: accumulated.regex.root.appending(next.regex.root))
+    _RegexFactory.node(
+      accumulated.regex._root.appending(next.regex._root)
+    )
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, C5, C6, C7, C8, C9, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C1, C2, C3, C4, C5, C6, C7, C8, C9)>  where R0.RegexOutput == (W0, C1, C2, C3, C4, C5, C6, C7, C8), R1.RegexOutput == (W1, C9) {
-    .init(node: accumulated.regex.root.appending(next.regex.root))
+    _RegexFactory.node(
+      accumulated.regex._root.appending(next.regex._root)
+    )
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10)>  where R0.RegexOutput == (W0, C1, C2, C3, C4, C5, C6, C7, C8), R1.RegexOutput == (W1, C9, C10) {
-    .init(node: accumulated.regex.root.appending(next.regex.root))
+    _RegexFactory.node(
+      accumulated.regex._root.appending(next.regex._root)
+    )
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10)>  where R0.RegexOutput == (W0, C1, C2, C3, C4, C5, C6, C7, C8, C9), R1.RegexOutput == (W1, C10) {
-    .init(node: accumulated.regex.root.appending(next.regex.root))
+    _RegexFactory.node(
+      accumulated.regex._root.appending(next.regex._root)
+    )
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
   @available(SwiftStdlib 5.7, *)
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<W0, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<Substring> where R0.RegexOutput == W0  {
-    .init(node: accumulated.regex.root.appending(next.regex.root))
+    _RegexFactory.node(
+      accumulated.regex._root.appending(next.regex._root)
+    )
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
   @available(SwiftStdlib 5.7, *)
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<W0, C0, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C0)> where R0.RegexOutput == (W0, C0)  {
-    .init(node: accumulated.regex.root.appending(next.regex.root))
+    _RegexFactory.node(
+      accumulated.regex._root.appending(next.regex._root)
+    )
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
   @available(SwiftStdlib 5.7, *)
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<W0, C0, C1, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C0, C1)> where R0.RegexOutput == (W0, C0, C1)  {
-    .init(node: accumulated.regex.root.appending(next.regex.root))
+    _RegexFactory.node(
+      accumulated.regex._root.appending(next.regex._root)
+    )
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
   @available(SwiftStdlib 5.7, *)
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<W0, C0, C1, C2, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C0, C1, C2)> where R0.RegexOutput == (W0, C0, C1, C2)  {
-    .init(node: accumulated.regex.root.appending(next.regex.root))
+    _RegexFactory.node(
+      accumulated.regex._root.appending(next.regex._root)
+    )
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
   @available(SwiftStdlib 5.7, *)
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<W0, C0, C1, C2, C3, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C0, C1, C2, C3)> where R0.RegexOutput == (W0, C0, C1, C2, C3)  {
-    .init(node: accumulated.regex.root.appending(next.regex.root))
+    _RegexFactory.node(
+      accumulated.regex._root.appending(next.regex._root)
+    )
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
   @available(SwiftStdlib 5.7, *)
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<W0, C0, C1, C2, C3, C4, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C0, C1, C2, C3, C4)> where R0.RegexOutput == (W0, C0, C1, C2, C3, C4)  {
-    .init(node: accumulated.regex.root.appending(next.regex.root))
+    _RegexFactory.node(
+      accumulated.regex._root.appending(next.regex._root)
+    )
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
   @available(SwiftStdlib 5.7, *)
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<W0, C0, C1, C2, C3, C4, C5, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5)> where R0.RegexOutput == (W0, C0, C1, C2, C3, C4, C5)  {
-    .init(node: accumulated.regex.root.appending(next.regex.root))
+    _RegexFactory.node(
+      accumulated.regex._root.appending(next.regex._root)
+    )
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
   @available(SwiftStdlib 5.7, *)
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<W0, C0, C1, C2, C3, C4, C5, C6, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6)> where R0.RegexOutput == (W0, C0, C1, C2, C3, C4, C5, C6)  {
-    .init(node: accumulated.regex.root.appending(next.regex.root))
+    _RegexFactory.node(
+      accumulated.regex._root.appending(next.regex._root)
+    )
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
   @available(SwiftStdlib 5.7, *)
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<W0, C0, C1, C2, C3, C4, C5, C6, C7, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7)> where R0.RegexOutput == (W0, C0, C1, C2, C3, C4, C5, C6, C7)  {
-    .init(node: accumulated.regex.root.appending(next.regex.root))
+    _RegexFactory.node(
+      accumulated.regex._root.appending(next.regex._root)
+    )
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
   @available(SwiftStdlib 5.7, *)
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<W0, C0, C1, C2, C3, C4, C5, C6, C7, C8, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8)> where R0.RegexOutput == (W0, C0, C1, C2, C3, C4, C5, C6, C7, C8)  {
-    .init(node: accumulated.regex.root.appending(next.regex.root))
+    _RegexFactory.node(
+      accumulated.regex._root.appending(next.regex._root)
+    )
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
   @available(SwiftStdlib 5.7, *)
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<W0, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9)> where R0.RegexOutput == (W0, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9)  {
-    .init(node: accumulated.regex.root.appending(next.regex.root))
+    _RegexFactory.node(
+      accumulated.regex._root.appending(next.regex._root)
+    )
   }
 }
 
@@ -557,56 +755,57 @@ extension RegexComponentBuilder {
 @available(SwiftStdlib 5.7, *)
 extension Optionally {
   @_disfavoredOverload
+  @_alwaysEmitIntoClient
   public init<Component: RegexComponent>(
     _ component: Component,
     _ behavior: RegexRepetitionBehavior? = nil
   ) where RegexOutput == Substring {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
-    self.init(node: .quantification(.zeroOrOne, kind, component.regex.root))
+    self.init(_RegexFactory.zeroOrOne(behavior, component.regex._root))
   }
 }
 
 @available(SwiftStdlib 5.7, *)
 extension Optionally {
   @_disfavoredOverload
+  @_alwaysEmitIntoClient
   public init<Component: RegexComponent>(
     _ behavior: RegexRepetitionBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == Substring {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
-    self.init(node: .quantification(.zeroOrOne, kind, component().regex.root))
+    self.init(_RegexFactory.zeroOrOne(behavior, component().regex._root))
   }
 }
 
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @_alwaysEmitIntoClient
   public static func buildLimitedAvailability<Component: RegexComponent>(
     _ component: Component
   ) -> Regex<Substring>  {
-    .init(node: .quantification(.zeroOrOne, .default, component.regex.root))
+    _RegexFactory.zeroOrOne(nil, component.regex._root)
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension ZeroOrMore {
   @_disfavoredOverload
+  @_alwaysEmitIntoClient
   public init<Component: RegexComponent>(
     _ component: Component,
     _ behavior: RegexRepetitionBehavior? = nil
   ) where RegexOutput == Substring {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
-    self.init(node: .quantification(.zeroOrMore, kind, component.regex.root))
+    self.init(_RegexFactory.zeroOrMore(behavior, component.regex._root))
   }
 }
 
 @available(SwiftStdlib 5.7, *)
 extension ZeroOrMore {
   @_disfavoredOverload
+  @_alwaysEmitIntoClient
   public init<Component: RegexComponent>(
     _ behavior: RegexRepetitionBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == Substring {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
-    self.init(node: .quantification(.zeroOrMore, kind, component().regex.root))
+    self.init(_RegexFactory.zeroOrMore(behavior, component().regex._root))
   }
 }
 
@@ -614,24 +813,24 @@ extension ZeroOrMore {
 @available(SwiftStdlib 5.7, *)
 extension OneOrMore {
   @_disfavoredOverload
+  @_alwaysEmitIntoClient
   public init<Component: RegexComponent>(
     _ component: Component,
     _ behavior: RegexRepetitionBehavior? = nil
   ) where RegexOutput == Substring {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
-    self.init(node: .quantification(.oneOrMore, kind, component.regex.root))
+    self.init(_RegexFactory.oneOrMore(behavior, component.regex._root))
   }
 }
 
 @available(SwiftStdlib 5.7, *)
 extension OneOrMore {
   @_disfavoredOverload
+  @_alwaysEmitIntoClient
   public init<Component: RegexComponent>(
     _ behavior: RegexRepetitionBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == Substring {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
-    self.init(node: .quantification(.oneOrMore, kind, component().regex.root))
+    self.init(_RegexFactory.oneOrMore(behavior, component().regex._root))
   }
 }
 
@@ -639,1171 +838,1226 @@ extension OneOrMore {
 @available(SwiftStdlib 5.7, *)
 extension Repeat {
   @_disfavoredOverload
+  @_alwaysEmitIntoClient
   public init<Component: RegexComponent>(
     _ component: Component,
     count: Int
   ) where RegexOutput == Substring {
     assert(count > 0, "Must specify a positive count")
     // TODO: Emit a warning about `repeatMatch(count: 0)` or `repeatMatch(count: 1)`
-    self.init(node: .quantification(.exactly(count), .default, component.regex.root))
+    self.init(_RegexFactory.exactly(count, component.regex._root))
   }
 
   @_disfavoredOverload
+  @_alwaysEmitIntoClient
   public init<Component: RegexComponent>(
     count: Int,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == Substring {
     assert(count > 0, "Must specify a positive count")
     // TODO: Emit a warning about `repeatMatch(count: 0)` or `repeatMatch(count: 1)`
-    self.init(node: .quantification(.exactly(count), .default, component().regex.root))
+    self.init(_RegexFactory.exactly(count, component().regex._root))
   }
 
   @_disfavoredOverload
+  @_alwaysEmitIntoClient
   public init<Component: RegexComponent, R: RangeExpression>(
     _ component: Component,
     _ expression: R,
     _ behavior: RegexRepetitionBehavior? = nil
   ) where RegexOutput == Substring, R.Bound == Int {
-    self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component.regex.root))
+    self.init(_RegexFactory.repeating(expression.relative(to: 0..<Int.max), behavior, component.regex._root))
   }
 
   @_disfavoredOverload
+  @_alwaysEmitIntoClient
   public init<Component: RegexComponent, R: RangeExpression>(
     _ expression: R,
     _ behavior: RegexRepetitionBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == Substring, R.Bound == Int {
-    self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component().regex.root))
+    self.init(_RegexFactory.repeating(expression.relative(to: 0..<Int.max), behavior, component().regex._root))
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension Optionally {
+  @_alwaysEmitIntoClient
   public init<W, C1, Component: RegexComponent>(
     _ component: Component,
     _ behavior: RegexRepetitionBehavior? = nil
   ) where RegexOutput == (Substring, C1?), Component.RegexOutput == (W, C1) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
-    self.init(node: .quantification(.zeroOrOne, kind, component.regex.root))
+    self.init(_RegexFactory.zeroOrOne(behavior, component.regex._root))
   }
 }
 
 @available(SwiftStdlib 5.7, *)
 extension Optionally {
+  @_alwaysEmitIntoClient
   public init<W, C1, Component: RegexComponent>(
     _ behavior: RegexRepetitionBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C1?), Component.RegexOutput == (W, C1) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
-    self.init(node: .quantification(.zeroOrOne, kind, component().regex.root))
+    self.init(_RegexFactory.zeroOrOne(behavior, component().regex._root))
   }
 }
 
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @_alwaysEmitIntoClient
   public static func buildLimitedAvailability<W, C1, Component: RegexComponent>(
     _ component: Component
   ) -> Regex<(Substring, C1?)> where Component.RegexOutput == (W, C1) {
-    .init(node: .quantification(.zeroOrOne, .default, component.regex.root))
+    _RegexFactory.zeroOrOne(nil, component.regex._root)
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension ZeroOrMore {
+  @_alwaysEmitIntoClient
   public init<W, C1, Component: RegexComponent>(
     _ component: Component,
     _ behavior: RegexRepetitionBehavior? = nil
   ) where RegexOutput == (Substring, C1?), Component.RegexOutput == (W, C1) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
-    self.init(node: .quantification(.zeroOrMore, kind, component.regex.root))
+    self.init(_RegexFactory.zeroOrMore(behavior, component.regex._root))
   }
 }
 
 @available(SwiftStdlib 5.7, *)
 extension ZeroOrMore {
+  @_alwaysEmitIntoClient
   public init<W, C1, Component: RegexComponent>(
     _ behavior: RegexRepetitionBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C1?), Component.RegexOutput == (W, C1) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
-    self.init(node: .quantification(.zeroOrMore, kind, component().regex.root))
+    self.init(_RegexFactory.zeroOrMore(behavior, component().regex._root))
   }
 }
 
 
 @available(SwiftStdlib 5.7, *)
 extension OneOrMore {
+  @_alwaysEmitIntoClient
   public init<W, C1, Component: RegexComponent>(
     _ component: Component,
     _ behavior: RegexRepetitionBehavior? = nil
   ) where RegexOutput == (Substring, C1), Component.RegexOutput == (W, C1) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
-    self.init(node: .quantification(.oneOrMore, kind, component.regex.root))
+    self.init(_RegexFactory.oneOrMore(behavior, component.regex._root))
   }
 }
 
 @available(SwiftStdlib 5.7, *)
 extension OneOrMore {
+  @_alwaysEmitIntoClient
   public init<W, C1, Component: RegexComponent>(
     _ behavior: RegexRepetitionBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C1), Component.RegexOutput == (W, C1) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
-    self.init(node: .quantification(.oneOrMore, kind, component().regex.root))
+    self.init(_RegexFactory.oneOrMore(behavior, component().regex._root))
   }
 }
 
 
 @available(SwiftStdlib 5.7, *)
 extension Repeat {
+  @_alwaysEmitIntoClient
   public init<W, C1, Component: RegexComponent>(
     _ component: Component,
     count: Int
   ) where RegexOutput == (Substring, C1?), Component.RegexOutput == (W, C1) {
     assert(count > 0, "Must specify a positive count")
     // TODO: Emit a warning about `repeatMatch(count: 0)` or `repeatMatch(count: 1)`
-    self.init(node: .quantification(.exactly(count), .default, component.regex.root))
+    self.init(_RegexFactory.exactly(count, component.regex._root))
   }
 
+  @_alwaysEmitIntoClient
   public init<W, C1, Component: RegexComponent>(
     count: Int,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C1?), Component.RegexOutput == (W, C1) {
     assert(count > 0, "Must specify a positive count")
     // TODO: Emit a warning about `repeatMatch(count: 0)` or `repeatMatch(count: 1)`
-    self.init(node: .quantification(.exactly(count), .default, component().regex.root))
+    self.init(_RegexFactory.exactly(count, component().regex._root))
   }
 
+  @_alwaysEmitIntoClient
   public init<W, C1, Component: RegexComponent, R: RangeExpression>(
     _ component: Component,
     _ expression: R,
     _ behavior: RegexRepetitionBehavior? = nil
   ) where RegexOutput == (Substring, C1?), Component.RegexOutput == (W, C1), R.Bound == Int {
-    self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component.regex.root))
+    self.init(_RegexFactory.repeating(expression.relative(to: 0..<Int.max), behavior, component.regex._root))
   }
 
+  @_alwaysEmitIntoClient
   public init<W, C1, Component: RegexComponent, R: RangeExpression>(
     _ expression: R,
     _ behavior: RegexRepetitionBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C1?), Component.RegexOutput == (W, C1), R.Bound == Int {
-    self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component().regex.root))
+    self.init(_RegexFactory.repeating(expression.relative(to: 0..<Int.max), behavior, component().regex._root))
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension Optionally {
+  @_alwaysEmitIntoClient
   public init<W, C1, C2, Component: RegexComponent>(
     _ component: Component,
     _ behavior: RegexRepetitionBehavior? = nil
   ) where RegexOutput == (Substring, C1?, C2?), Component.RegexOutput == (W, C1, C2) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
-    self.init(node: .quantification(.zeroOrOne, kind, component.regex.root))
+    self.init(_RegexFactory.zeroOrOne(behavior, component.regex._root))
   }
 }
 
 @available(SwiftStdlib 5.7, *)
 extension Optionally {
+  @_alwaysEmitIntoClient
   public init<W, C1, C2, Component: RegexComponent>(
     _ behavior: RegexRepetitionBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C1?, C2?), Component.RegexOutput == (W, C1, C2) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
-    self.init(node: .quantification(.zeroOrOne, kind, component().regex.root))
+    self.init(_RegexFactory.zeroOrOne(behavior, component().regex._root))
   }
 }
 
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @_alwaysEmitIntoClient
   public static func buildLimitedAvailability<W, C1, C2, Component: RegexComponent>(
     _ component: Component
   ) -> Regex<(Substring, C1?, C2?)> where Component.RegexOutput == (W, C1, C2) {
-    .init(node: .quantification(.zeroOrOne, .default, component.regex.root))
+    _RegexFactory.zeroOrOne(nil, component.regex._root)
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension ZeroOrMore {
+  @_alwaysEmitIntoClient
   public init<W, C1, C2, Component: RegexComponent>(
     _ component: Component,
     _ behavior: RegexRepetitionBehavior? = nil
   ) where RegexOutput == (Substring, C1?, C2?), Component.RegexOutput == (W, C1, C2) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
-    self.init(node: .quantification(.zeroOrMore, kind, component.regex.root))
+    self.init(_RegexFactory.zeroOrMore(behavior, component.regex._root))
   }
 }
 
 @available(SwiftStdlib 5.7, *)
 extension ZeroOrMore {
+  @_alwaysEmitIntoClient
   public init<W, C1, C2, Component: RegexComponent>(
     _ behavior: RegexRepetitionBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C1?, C2?), Component.RegexOutput == (W, C1, C2) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
-    self.init(node: .quantification(.zeroOrMore, kind, component().regex.root))
+    self.init(_RegexFactory.zeroOrMore(behavior, component().regex._root))
   }
 }
 
 
 @available(SwiftStdlib 5.7, *)
 extension OneOrMore {
+  @_alwaysEmitIntoClient
   public init<W, C1, C2, Component: RegexComponent>(
     _ component: Component,
     _ behavior: RegexRepetitionBehavior? = nil
   ) where RegexOutput == (Substring, C1, C2), Component.RegexOutput == (W, C1, C2) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
-    self.init(node: .quantification(.oneOrMore, kind, component.regex.root))
+    self.init(_RegexFactory.oneOrMore(behavior, component.regex._root))
   }
 }
 
 @available(SwiftStdlib 5.7, *)
 extension OneOrMore {
+  @_alwaysEmitIntoClient
   public init<W, C1, C2, Component: RegexComponent>(
     _ behavior: RegexRepetitionBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C1, C2), Component.RegexOutput == (W, C1, C2) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
-    self.init(node: .quantification(.oneOrMore, kind, component().regex.root))
+    self.init(_RegexFactory.oneOrMore(behavior, component().regex._root))
   }
 }
 
 
 @available(SwiftStdlib 5.7, *)
 extension Repeat {
+  @_alwaysEmitIntoClient
   public init<W, C1, C2, Component: RegexComponent>(
     _ component: Component,
     count: Int
   ) where RegexOutput == (Substring, C1?, C2?), Component.RegexOutput == (W, C1, C2) {
     assert(count > 0, "Must specify a positive count")
     // TODO: Emit a warning about `repeatMatch(count: 0)` or `repeatMatch(count: 1)`
-    self.init(node: .quantification(.exactly(count), .default, component.regex.root))
+    self.init(_RegexFactory.exactly(count, component.regex._root))
   }
 
+  @_alwaysEmitIntoClient
   public init<W, C1, C2, Component: RegexComponent>(
     count: Int,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C1?, C2?), Component.RegexOutput == (W, C1, C2) {
     assert(count > 0, "Must specify a positive count")
     // TODO: Emit a warning about `repeatMatch(count: 0)` or `repeatMatch(count: 1)`
-    self.init(node: .quantification(.exactly(count), .default, component().regex.root))
+    self.init(_RegexFactory.exactly(count, component().regex._root))
   }
 
+  @_alwaysEmitIntoClient
   public init<W, C1, C2, Component: RegexComponent, R: RangeExpression>(
     _ component: Component,
     _ expression: R,
     _ behavior: RegexRepetitionBehavior? = nil
   ) where RegexOutput == (Substring, C1?, C2?), Component.RegexOutput == (W, C1, C2), R.Bound == Int {
-    self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component.regex.root))
+    self.init(_RegexFactory.repeating(expression.relative(to: 0..<Int.max), behavior, component.regex._root))
   }
 
+  @_alwaysEmitIntoClient
   public init<W, C1, C2, Component: RegexComponent, R: RangeExpression>(
     _ expression: R,
     _ behavior: RegexRepetitionBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C1?, C2?), Component.RegexOutput == (W, C1, C2), R.Bound == Int {
-    self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component().regex.root))
+    self.init(_RegexFactory.repeating(expression.relative(to: 0..<Int.max), behavior, component().regex._root))
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension Optionally {
+  @_alwaysEmitIntoClient
   public init<W, C1, C2, C3, Component: RegexComponent>(
     _ component: Component,
     _ behavior: RegexRepetitionBehavior? = nil
   ) where RegexOutput == (Substring, C1?, C2?, C3?), Component.RegexOutput == (W, C1, C2, C3) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
-    self.init(node: .quantification(.zeroOrOne, kind, component.regex.root))
+    self.init(_RegexFactory.zeroOrOne(behavior, component.regex._root))
   }
 }
 
 @available(SwiftStdlib 5.7, *)
 extension Optionally {
+  @_alwaysEmitIntoClient
   public init<W, C1, C2, C3, Component: RegexComponent>(
     _ behavior: RegexRepetitionBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C1?, C2?, C3?), Component.RegexOutput == (W, C1, C2, C3) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
-    self.init(node: .quantification(.zeroOrOne, kind, component().regex.root))
+    self.init(_RegexFactory.zeroOrOne(behavior, component().regex._root))
   }
 }
 
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @_alwaysEmitIntoClient
   public static func buildLimitedAvailability<W, C1, C2, C3, Component: RegexComponent>(
     _ component: Component
   ) -> Regex<(Substring, C1?, C2?, C3?)> where Component.RegexOutput == (W, C1, C2, C3) {
-    .init(node: .quantification(.zeroOrOne, .default, component.regex.root))
+    _RegexFactory.zeroOrOne(nil, component.regex._root)
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension ZeroOrMore {
+  @_alwaysEmitIntoClient
   public init<W, C1, C2, C3, Component: RegexComponent>(
     _ component: Component,
     _ behavior: RegexRepetitionBehavior? = nil
   ) where RegexOutput == (Substring, C1?, C2?, C3?), Component.RegexOutput == (W, C1, C2, C3) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
-    self.init(node: .quantification(.zeroOrMore, kind, component.regex.root))
+    self.init(_RegexFactory.zeroOrMore(behavior, component.regex._root))
   }
 }
 
 @available(SwiftStdlib 5.7, *)
 extension ZeroOrMore {
+  @_alwaysEmitIntoClient
   public init<W, C1, C2, C3, Component: RegexComponent>(
     _ behavior: RegexRepetitionBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C1?, C2?, C3?), Component.RegexOutput == (W, C1, C2, C3) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
-    self.init(node: .quantification(.zeroOrMore, kind, component().regex.root))
+    self.init(_RegexFactory.zeroOrMore(behavior, component().regex._root))
   }
 }
 
 
 @available(SwiftStdlib 5.7, *)
 extension OneOrMore {
+  @_alwaysEmitIntoClient
   public init<W, C1, C2, C3, Component: RegexComponent>(
     _ component: Component,
     _ behavior: RegexRepetitionBehavior? = nil
   ) where RegexOutput == (Substring, C1, C2, C3), Component.RegexOutput == (W, C1, C2, C3) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
-    self.init(node: .quantification(.oneOrMore, kind, component.regex.root))
+    self.init(_RegexFactory.oneOrMore(behavior, component.regex._root))
   }
 }
 
 @available(SwiftStdlib 5.7, *)
 extension OneOrMore {
+  @_alwaysEmitIntoClient
   public init<W, C1, C2, C3, Component: RegexComponent>(
     _ behavior: RegexRepetitionBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C1, C2, C3), Component.RegexOutput == (W, C1, C2, C3) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
-    self.init(node: .quantification(.oneOrMore, kind, component().regex.root))
+    self.init(_RegexFactory.oneOrMore(behavior, component().regex._root))
   }
 }
 
 
 @available(SwiftStdlib 5.7, *)
 extension Repeat {
+  @_alwaysEmitIntoClient
   public init<W, C1, C2, C3, Component: RegexComponent>(
     _ component: Component,
     count: Int
   ) where RegexOutput == (Substring, C1?, C2?, C3?), Component.RegexOutput == (W, C1, C2, C3) {
     assert(count > 0, "Must specify a positive count")
     // TODO: Emit a warning about `repeatMatch(count: 0)` or `repeatMatch(count: 1)`
-    self.init(node: .quantification(.exactly(count), .default, component.regex.root))
+    self.init(_RegexFactory.exactly(count, component.regex._root))
   }
 
+  @_alwaysEmitIntoClient
   public init<W, C1, C2, C3, Component: RegexComponent>(
     count: Int,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C1?, C2?, C3?), Component.RegexOutput == (W, C1, C2, C3) {
     assert(count > 0, "Must specify a positive count")
     // TODO: Emit a warning about `repeatMatch(count: 0)` or `repeatMatch(count: 1)`
-    self.init(node: .quantification(.exactly(count), .default, component().regex.root))
+    self.init(_RegexFactory.exactly(count, component().regex._root))
   }
 
+  @_alwaysEmitIntoClient
   public init<W, C1, C2, C3, Component: RegexComponent, R: RangeExpression>(
     _ component: Component,
     _ expression: R,
     _ behavior: RegexRepetitionBehavior? = nil
   ) where RegexOutput == (Substring, C1?, C2?, C3?), Component.RegexOutput == (W, C1, C2, C3), R.Bound == Int {
-    self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component.regex.root))
+    self.init(_RegexFactory.repeating(expression.relative(to: 0..<Int.max), behavior, component.regex._root))
   }
 
+  @_alwaysEmitIntoClient
   public init<W, C1, C2, C3, Component: RegexComponent, R: RangeExpression>(
     _ expression: R,
     _ behavior: RegexRepetitionBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C1?, C2?, C3?), Component.RegexOutput == (W, C1, C2, C3), R.Bound == Int {
-    self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component().regex.root))
+    self.init(_RegexFactory.repeating(expression.relative(to: 0..<Int.max), behavior, component().regex._root))
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension Optionally {
+  @_alwaysEmitIntoClient
   public init<W, C1, C2, C3, C4, Component: RegexComponent>(
     _ component: Component,
     _ behavior: RegexRepetitionBehavior? = nil
   ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?), Component.RegexOutput == (W, C1, C2, C3, C4) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
-    self.init(node: .quantification(.zeroOrOne, kind, component.regex.root))
+    self.init(_RegexFactory.zeroOrOne(behavior, component.regex._root))
   }
 }
 
 @available(SwiftStdlib 5.7, *)
 extension Optionally {
+  @_alwaysEmitIntoClient
   public init<W, C1, C2, C3, C4, Component: RegexComponent>(
     _ behavior: RegexRepetitionBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?), Component.RegexOutput == (W, C1, C2, C3, C4) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
-    self.init(node: .quantification(.zeroOrOne, kind, component().regex.root))
+    self.init(_RegexFactory.zeroOrOne(behavior, component().regex._root))
   }
 }
 
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @_alwaysEmitIntoClient
   public static func buildLimitedAvailability<W, C1, C2, C3, C4, Component: RegexComponent>(
     _ component: Component
   ) -> Regex<(Substring, C1?, C2?, C3?, C4?)> where Component.RegexOutput == (W, C1, C2, C3, C4) {
-    .init(node: .quantification(.zeroOrOne, .default, component.regex.root))
+    _RegexFactory.zeroOrOne(nil, component.regex._root)
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension ZeroOrMore {
+  @_alwaysEmitIntoClient
   public init<W, C1, C2, C3, C4, Component: RegexComponent>(
     _ component: Component,
     _ behavior: RegexRepetitionBehavior? = nil
   ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?), Component.RegexOutput == (W, C1, C2, C3, C4) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
-    self.init(node: .quantification(.zeroOrMore, kind, component.regex.root))
+    self.init(_RegexFactory.zeroOrMore(behavior, component.regex._root))
   }
 }
 
 @available(SwiftStdlib 5.7, *)
 extension ZeroOrMore {
+  @_alwaysEmitIntoClient
   public init<W, C1, C2, C3, C4, Component: RegexComponent>(
     _ behavior: RegexRepetitionBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?), Component.RegexOutput == (W, C1, C2, C3, C4) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
-    self.init(node: .quantification(.zeroOrMore, kind, component().regex.root))
+    self.init(_RegexFactory.zeroOrMore(behavior, component().regex._root))
   }
 }
 
 
 @available(SwiftStdlib 5.7, *)
 extension OneOrMore {
+  @_alwaysEmitIntoClient
   public init<W, C1, C2, C3, C4, Component: RegexComponent>(
     _ component: Component,
     _ behavior: RegexRepetitionBehavior? = nil
   ) where RegexOutput == (Substring, C1, C2, C3, C4), Component.RegexOutput == (W, C1, C2, C3, C4) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
-    self.init(node: .quantification(.oneOrMore, kind, component.regex.root))
+    self.init(_RegexFactory.oneOrMore(behavior, component.regex._root))
   }
 }
 
 @available(SwiftStdlib 5.7, *)
 extension OneOrMore {
+  @_alwaysEmitIntoClient
   public init<W, C1, C2, C3, C4, Component: RegexComponent>(
     _ behavior: RegexRepetitionBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C1, C2, C3, C4), Component.RegexOutput == (W, C1, C2, C3, C4) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
-    self.init(node: .quantification(.oneOrMore, kind, component().regex.root))
+    self.init(_RegexFactory.oneOrMore(behavior, component().regex._root))
   }
 }
 
 
 @available(SwiftStdlib 5.7, *)
 extension Repeat {
+  @_alwaysEmitIntoClient
   public init<W, C1, C2, C3, C4, Component: RegexComponent>(
     _ component: Component,
     count: Int
   ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?), Component.RegexOutput == (W, C1, C2, C3, C4) {
     assert(count > 0, "Must specify a positive count")
     // TODO: Emit a warning about `repeatMatch(count: 0)` or `repeatMatch(count: 1)`
-    self.init(node: .quantification(.exactly(count), .default, component.regex.root))
+    self.init(_RegexFactory.exactly(count, component.regex._root))
   }
 
+  @_alwaysEmitIntoClient
   public init<W, C1, C2, C3, C4, Component: RegexComponent>(
     count: Int,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?), Component.RegexOutput == (W, C1, C2, C3, C4) {
     assert(count > 0, "Must specify a positive count")
     // TODO: Emit a warning about `repeatMatch(count: 0)` or `repeatMatch(count: 1)`
-    self.init(node: .quantification(.exactly(count), .default, component().regex.root))
+    self.init(_RegexFactory.exactly(count, component().regex._root))
   }
 
+  @_alwaysEmitIntoClient
   public init<W, C1, C2, C3, C4, Component: RegexComponent, R: RangeExpression>(
     _ component: Component,
     _ expression: R,
     _ behavior: RegexRepetitionBehavior? = nil
   ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?), Component.RegexOutput == (W, C1, C2, C3, C4), R.Bound == Int {
-    self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component.regex.root))
+    self.init(_RegexFactory.repeating(expression.relative(to: 0..<Int.max), behavior, component.regex._root))
   }
 
+  @_alwaysEmitIntoClient
   public init<W, C1, C2, C3, C4, Component: RegexComponent, R: RangeExpression>(
     _ expression: R,
     _ behavior: RegexRepetitionBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?), Component.RegexOutput == (W, C1, C2, C3, C4), R.Bound == Int {
-    self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component().regex.root))
+    self.init(_RegexFactory.repeating(expression.relative(to: 0..<Int.max), behavior, component().regex._root))
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension Optionally {
+  @_alwaysEmitIntoClient
   public init<W, C1, C2, C3, C4, C5, Component: RegexComponent>(
     _ component: Component,
     _ behavior: RegexRepetitionBehavior? = nil
   ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?), Component.RegexOutput == (W, C1, C2, C3, C4, C5) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
-    self.init(node: .quantification(.zeroOrOne, kind, component.regex.root))
+    self.init(_RegexFactory.zeroOrOne(behavior, component.regex._root))
   }
 }
 
 @available(SwiftStdlib 5.7, *)
 extension Optionally {
+  @_alwaysEmitIntoClient
   public init<W, C1, C2, C3, C4, C5, Component: RegexComponent>(
     _ behavior: RegexRepetitionBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?), Component.RegexOutput == (W, C1, C2, C3, C4, C5) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
-    self.init(node: .quantification(.zeroOrOne, kind, component().regex.root))
+    self.init(_RegexFactory.zeroOrOne(behavior, component().regex._root))
   }
 }
 
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @_alwaysEmitIntoClient
   public static func buildLimitedAvailability<W, C1, C2, C3, C4, C5, Component: RegexComponent>(
     _ component: Component
   ) -> Regex<(Substring, C1?, C2?, C3?, C4?, C5?)> where Component.RegexOutput == (W, C1, C2, C3, C4, C5) {
-    .init(node: .quantification(.zeroOrOne, .default, component.regex.root))
+    _RegexFactory.zeroOrOne(nil, component.regex._root)
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension ZeroOrMore {
+  @_alwaysEmitIntoClient
   public init<W, C1, C2, C3, C4, C5, Component: RegexComponent>(
     _ component: Component,
     _ behavior: RegexRepetitionBehavior? = nil
   ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?), Component.RegexOutput == (W, C1, C2, C3, C4, C5) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
-    self.init(node: .quantification(.zeroOrMore, kind, component.regex.root))
+    self.init(_RegexFactory.zeroOrMore(behavior, component.regex._root))
   }
 }
 
 @available(SwiftStdlib 5.7, *)
 extension ZeroOrMore {
+  @_alwaysEmitIntoClient
   public init<W, C1, C2, C3, C4, C5, Component: RegexComponent>(
     _ behavior: RegexRepetitionBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?), Component.RegexOutput == (W, C1, C2, C3, C4, C5) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
-    self.init(node: .quantification(.zeroOrMore, kind, component().regex.root))
+    self.init(_RegexFactory.zeroOrMore(behavior, component().regex._root))
   }
 }
 
 
 @available(SwiftStdlib 5.7, *)
 extension OneOrMore {
+  @_alwaysEmitIntoClient
   public init<W, C1, C2, C3, C4, C5, Component: RegexComponent>(
     _ component: Component,
     _ behavior: RegexRepetitionBehavior? = nil
   ) where RegexOutput == (Substring, C1, C2, C3, C4, C5), Component.RegexOutput == (W, C1, C2, C3, C4, C5) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
-    self.init(node: .quantification(.oneOrMore, kind, component.regex.root))
+    self.init(_RegexFactory.oneOrMore(behavior, component.regex._root))
   }
 }
 
 @available(SwiftStdlib 5.7, *)
 extension OneOrMore {
+  @_alwaysEmitIntoClient
   public init<W, C1, C2, C3, C4, C5, Component: RegexComponent>(
     _ behavior: RegexRepetitionBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C1, C2, C3, C4, C5), Component.RegexOutput == (W, C1, C2, C3, C4, C5) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
-    self.init(node: .quantification(.oneOrMore, kind, component().regex.root))
+    self.init(_RegexFactory.oneOrMore(behavior, component().regex._root))
   }
 }
 
 
 @available(SwiftStdlib 5.7, *)
 extension Repeat {
+  @_alwaysEmitIntoClient
   public init<W, C1, C2, C3, C4, C5, Component: RegexComponent>(
     _ component: Component,
     count: Int
   ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?), Component.RegexOutput == (W, C1, C2, C3, C4, C5) {
     assert(count > 0, "Must specify a positive count")
     // TODO: Emit a warning about `repeatMatch(count: 0)` or `repeatMatch(count: 1)`
-    self.init(node: .quantification(.exactly(count), .default, component.regex.root))
+    self.init(_RegexFactory.exactly(count, component.regex._root))
   }
 
+  @_alwaysEmitIntoClient
   public init<W, C1, C2, C3, C4, C5, Component: RegexComponent>(
     count: Int,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?), Component.RegexOutput == (W, C1, C2, C3, C4, C5) {
     assert(count > 0, "Must specify a positive count")
     // TODO: Emit a warning about `repeatMatch(count: 0)` or `repeatMatch(count: 1)`
-    self.init(node: .quantification(.exactly(count), .default, component().regex.root))
+    self.init(_RegexFactory.exactly(count, component().regex._root))
   }
 
+  @_alwaysEmitIntoClient
   public init<W, C1, C2, C3, C4, C5, Component: RegexComponent, R: RangeExpression>(
     _ component: Component,
     _ expression: R,
     _ behavior: RegexRepetitionBehavior? = nil
   ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?), Component.RegexOutput == (W, C1, C2, C3, C4, C5), R.Bound == Int {
-    self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component.regex.root))
+    self.init(_RegexFactory.repeating(expression.relative(to: 0..<Int.max), behavior, component.regex._root))
   }
 
+  @_alwaysEmitIntoClient
   public init<W, C1, C2, C3, C4, C5, Component: RegexComponent, R: RangeExpression>(
     _ expression: R,
     _ behavior: RegexRepetitionBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?), Component.RegexOutput == (W, C1, C2, C3, C4, C5), R.Bound == Int {
-    self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component().regex.root))
+    self.init(_RegexFactory.repeating(expression.relative(to: 0..<Int.max), behavior, component().regex._root))
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension Optionally {
+  @_alwaysEmitIntoClient
   public init<W, C1, C2, C3, C4, C5, C6, Component: RegexComponent>(
     _ component: Component,
     _ behavior: RegexRepetitionBehavior? = nil
   ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?, C6?), Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
-    self.init(node: .quantification(.zeroOrOne, kind, component.regex.root))
+    self.init(_RegexFactory.zeroOrOne(behavior, component.regex._root))
   }
 }
 
 @available(SwiftStdlib 5.7, *)
 extension Optionally {
+  @_alwaysEmitIntoClient
   public init<W, C1, C2, C3, C4, C5, C6, Component: RegexComponent>(
     _ behavior: RegexRepetitionBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?, C6?), Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
-    self.init(node: .quantification(.zeroOrOne, kind, component().regex.root))
+    self.init(_RegexFactory.zeroOrOne(behavior, component().regex._root))
   }
 }
 
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @_alwaysEmitIntoClient
   public static func buildLimitedAvailability<W, C1, C2, C3, C4, C5, C6, Component: RegexComponent>(
     _ component: Component
   ) -> Regex<(Substring, C1?, C2?, C3?, C4?, C5?, C6?)> where Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6) {
-    .init(node: .quantification(.zeroOrOne, .default, component.regex.root))
+    _RegexFactory.zeroOrOne(nil, component.regex._root)
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension ZeroOrMore {
+  @_alwaysEmitIntoClient
   public init<W, C1, C2, C3, C4, C5, C6, Component: RegexComponent>(
     _ component: Component,
     _ behavior: RegexRepetitionBehavior? = nil
   ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?, C6?), Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
-    self.init(node: .quantification(.zeroOrMore, kind, component.regex.root))
+    self.init(_RegexFactory.zeroOrMore(behavior, component.regex._root))
   }
 }
 
 @available(SwiftStdlib 5.7, *)
 extension ZeroOrMore {
+  @_alwaysEmitIntoClient
   public init<W, C1, C2, C3, C4, C5, C6, Component: RegexComponent>(
     _ behavior: RegexRepetitionBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?, C6?), Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
-    self.init(node: .quantification(.zeroOrMore, kind, component().regex.root))
+    self.init(_RegexFactory.zeroOrMore(behavior, component().regex._root))
   }
 }
 
 
 @available(SwiftStdlib 5.7, *)
 extension OneOrMore {
+  @_alwaysEmitIntoClient
   public init<W, C1, C2, C3, C4, C5, C6, Component: RegexComponent>(
     _ component: Component,
     _ behavior: RegexRepetitionBehavior? = nil
   ) where RegexOutput == (Substring, C1, C2, C3, C4, C5, C6), Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
-    self.init(node: .quantification(.oneOrMore, kind, component.regex.root))
+    self.init(_RegexFactory.oneOrMore(behavior, component.regex._root))
   }
 }
 
 @available(SwiftStdlib 5.7, *)
 extension OneOrMore {
+  @_alwaysEmitIntoClient
   public init<W, C1, C2, C3, C4, C5, C6, Component: RegexComponent>(
     _ behavior: RegexRepetitionBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C1, C2, C3, C4, C5, C6), Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
-    self.init(node: .quantification(.oneOrMore, kind, component().regex.root))
+    self.init(_RegexFactory.oneOrMore(behavior, component().regex._root))
   }
 }
 
 
 @available(SwiftStdlib 5.7, *)
 extension Repeat {
+  @_alwaysEmitIntoClient
   public init<W, C1, C2, C3, C4, C5, C6, Component: RegexComponent>(
     _ component: Component,
     count: Int
   ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?, C6?), Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6) {
     assert(count > 0, "Must specify a positive count")
     // TODO: Emit a warning about `repeatMatch(count: 0)` or `repeatMatch(count: 1)`
-    self.init(node: .quantification(.exactly(count), .default, component.regex.root))
+    self.init(_RegexFactory.exactly(count, component.regex._root))
   }
 
+  @_alwaysEmitIntoClient
   public init<W, C1, C2, C3, C4, C5, C6, Component: RegexComponent>(
     count: Int,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?, C6?), Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6) {
     assert(count > 0, "Must specify a positive count")
     // TODO: Emit a warning about `repeatMatch(count: 0)` or `repeatMatch(count: 1)`
-    self.init(node: .quantification(.exactly(count), .default, component().regex.root))
+    self.init(_RegexFactory.exactly(count, component().regex._root))
   }
 
+  @_alwaysEmitIntoClient
   public init<W, C1, C2, C3, C4, C5, C6, Component: RegexComponent, R: RangeExpression>(
     _ component: Component,
     _ expression: R,
     _ behavior: RegexRepetitionBehavior? = nil
   ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?, C6?), Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6), R.Bound == Int {
-    self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component.regex.root))
+    self.init(_RegexFactory.repeating(expression.relative(to: 0..<Int.max), behavior, component.regex._root))
   }
 
+  @_alwaysEmitIntoClient
   public init<W, C1, C2, C3, C4, C5, C6, Component: RegexComponent, R: RangeExpression>(
     _ expression: R,
     _ behavior: RegexRepetitionBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?, C6?), Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6), R.Bound == Int {
-    self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component().regex.root))
+    self.init(_RegexFactory.repeating(expression.relative(to: 0..<Int.max), behavior, component().regex._root))
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension Optionally {
+  @_alwaysEmitIntoClient
   public init<W, C1, C2, C3, C4, C5, C6, C7, Component: RegexComponent>(
     _ component: Component,
     _ behavior: RegexRepetitionBehavior? = nil
   ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?, C6?, C7?), Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
-    self.init(node: .quantification(.zeroOrOne, kind, component.regex.root))
+    self.init(_RegexFactory.zeroOrOne(behavior, component.regex._root))
   }
 }
 
 @available(SwiftStdlib 5.7, *)
 extension Optionally {
+  @_alwaysEmitIntoClient
   public init<W, C1, C2, C3, C4, C5, C6, C7, Component: RegexComponent>(
     _ behavior: RegexRepetitionBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?, C6?, C7?), Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
-    self.init(node: .quantification(.zeroOrOne, kind, component().regex.root))
+    self.init(_RegexFactory.zeroOrOne(behavior, component().regex._root))
   }
 }
 
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @_alwaysEmitIntoClient
   public static func buildLimitedAvailability<W, C1, C2, C3, C4, C5, C6, C7, Component: RegexComponent>(
     _ component: Component
   ) -> Regex<(Substring, C1?, C2?, C3?, C4?, C5?, C6?, C7?)> where Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7) {
-    .init(node: .quantification(.zeroOrOne, .default, component.regex.root))
+    _RegexFactory.zeroOrOne(nil, component.regex._root)
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension ZeroOrMore {
+  @_alwaysEmitIntoClient
   public init<W, C1, C2, C3, C4, C5, C6, C7, Component: RegexComponent>(
     _ component: Component,
     _ behavior: RegexRepetitionBehavior? = nil
   ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?, C6?, C7?), Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
-    self.init(node: .quantification(.zeroOrMore, kind, component.regex.root))
+    self.init(_RegexFactory.zeroOrMore(behavior, component.regex._root))
   }
 }
 
 @available(SwiftStdlib 5.7, *)
 extension ZeroOrMore {
+  @_alwaysEmitIntoClient
   public init<W, C1, C2, C3, C4, C5, C6, C7, Component: RegexComponent>(
     _ behavior: RegexRepetitionBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?, C6?, C7?), Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
-    self.init(node: .quantification(.zeroOrMore, kind, component().regex.root))
+    self.init(_RegexFactory.zeroOrMore(behavior, component().regex._root))
   }
 }
 
 
 @available(SwiftStdlib 5.7, *)
 extension OneOrMore {
+  @_alwaysEmitIntoClient
   public init<W, C1, C2, C3, C4, C5, C6, C7, Component: RegexComponent>(
     _ component: Component,
     _ behavior: RegexRepetitionBehavior? = nil
   ) where RegexOutput == (Substring, C1, C2, C3, C4, C5, C6, C7), Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
-    self.init(node: .quantification(.oneOrMore, kind, component.regex.root))
+    self.init(_RegexFactory.oneOrMore(behavior, component.regex._root))
   }
 }
 
 @available(SwiftStdlib 5.7, *)
 extension OneOrMore {
+  @_alwaysEmitIntoClient
   public init<W, C1, C2, C3, C4, C5, C6, C7, Component: RegexComponent>(
     _ behavior: RegexRepetitionBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C1, C2, C3, C4, C5, C6, C7), Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
-    self.init(node: .quantification(.oneOrMore, kind, component().regex.root))
+    self.init(_RegexFactory.oneOrMore(behavior, component().regex._root))
   }
 }
 
 
 @available(SwiftStdlib 5.7, *)
 extension Repeat {
+  @_alwaysEmitIntoClient
   public init<W, C1, C2, C3, C4, C5, C6, C7, Component: RegexComponent>(
     _ component: Component,
     count: Int
   ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?, C6?, C7?), Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7) {
     assert(count > 0, "Must specify a positive count")
     // TODO: Emit a warning about `repeatMatch(count: 0)` or `repeatMatch(count: 1)`
-    self.init(node: .quantification(.exactly(count), .default, component.regex.root))
+    self.init(_RegexFactory.exactly(count, component.regex._root))
   }
 
+  @_alwaysEmitIntoClient
   public init<W, C1, C2, C3, C4, C5, C6, C7, Component: RegexComponent>(
     count: Int,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?, C6?, C7?), Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7) {
     assert(count > 0, "Must specify a positive count")
     // TODO: Emit a warning about `repeatMatch(count: 0)` or `repeatMatch(count: 1)`
-    self.init(node: .quantification(.exactly(count), .default, component().regex.root))
+    self.init(_RegexFactory.exactly(count, component().regex._root))
   }
 
+  @_alwaysEmitIntoClient
   public init<W, C1, C2, C3, C4, C5, C6, C7, Component: RegexComponent, R: RangeExpression>(
     _ component: Component,
     _ expression: R,
     _ behavior: RegexRepetitionBehavior? = nil
   ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?, C6?, C7?), Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7), R.Bound == Int {
-    self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component.regex.root))
+    self.init(_RegexFactory.repeating(expression.relative(to: 0..<Int.max), behavior, component.regex._root))
   }
 
+  @_alwaysEmitIntoClient
   public init<W, C1, C2, C3, C4, C5, C6, C7, Component: RegexComponent, R: RangeExpression>(
     _ expression: R,
     _ behavior: RegexRepetitionBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?, C6?, C7?), Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7), R.Bound == Int {
-    self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component().regex.root))
+    self.init(_RegexFactory.repeating(expression.relative(to: 0..<Int.max), behavior, component().regex._root))
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension Optionally {
+  @_alwaysEmitIntoClient
   public init<W, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexComponent>(
     _ component: Component,
     _ behavior: RegexRepetitionBehavior? = nil
   ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?), Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
-    self.init(node: .quantification(.zeroOrOne, kind, component.regex.root))
+    self.init(_RegexFactory.zeroOrOne(behavior, component.regex._root))
   }
 }
 
 @available(SwiftStdlib 5.7, *)
 extension Optionally {
+  @_alwaysEmitIntoClient
   public init<W, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexComponent>(
     _ behavior: RegexRepetitionBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?), Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
-    self.init(node: .quantification(.zeroOrOne, kind, component().regex.root))
+    self.init(_RegexFactory.zeroOrOne(behavior, component().regex._root))
   }
 }
 
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @_alwaysEmitIntoClient
   public static func buildLimitedAvailability<W, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexComponent>(
     _ component: Component
   ) -> Regex<(Substring, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?)> where Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8) {
-    .init(node: .quantification(.zeroOrOne, .default, component.regex.root))
+    _RegexFactory.zeroOrOne(nil, component.regex._root)
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension ZeroOrMore {
+  @_alwaysEmitIntoClient
   public init<W, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexComponent>(
     _ component: Component,
     _ behavior: RegexRepetitionBehavior? = nil
   ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?), Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
-    self.init(node: .quantification(.zeroOrMore, kind, component.regex.root))
+    self.init(_RegexFactory.zeroOrMore(behavior, component.regex._root))
   }
 }
 
 @available(SwiftStdlib 5.7, *)
 extension ZeroOrMore {
+  @_alwaysEmitIntoClient
   public init<W, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexComponent>(
     _ behavior: RegexRepetitionBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?), Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
-    self.init(node: .quantification(.zeroOrMore, kind, component().regex.root))
+    self.init(_RegexFactory.zeroOrMore(behavior, component().regex._root))
   }
 }
 
 
 @available(SwiftStdlib 5.7, *)
 extension OneOrMore {
+  @_alwaysEmitIntoClient
   public init<W, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexComponent>(
     _ component: Component,
     _ behavior: RegexRepetitionBehavior? = nil
   ) where RegexOutput == (Substring, C1, C2, C3, C4, C5, C6, C7, C8), Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
-    self.init(node: .quantification(.oneOrMore, kind, component.regex.root))
+    self.init(_RegexFactory.oneOrMore(behavior, component.regex._root))
   }
 }
 
 @available(SwiftStdlib 5.7, *)
 extension OneOrMore {
+  @_alwaysEmitIntoClient
   public init<W, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexComponent>(
     _ behavior: RegexRepetitionBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C1, C2, C3, C4, C5, C6, C7, C8), Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
-    self.init(node: .quantification(.oneOrMore, kind, component().regex.root))
+    self.init(_RegexFactory.oneOrMore(behavior, component().regex._root))
   }
 }
 
 
 @available(SwiftStdlib 5.7, *)
 extension Repeat {
+  @_alwaysEmitIntoClient
   public init<W, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexComponent>(
     _ component: Component,
     count: Int
   ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?), Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8) {
     assert(count > 0, "Must specify a positive count")
     // TODO: Emit a warning about `repeatMatch(count: 0)` or `repeatMatch(count: 1)`
-    self.init(node: .quantification(.exactly(count), .default, component.regex.root))
+    self.init(_RegexFactory.exactly(count, component.regex._root))
   }
 
+  @_alwaysEmitIntoClient
   public init<W, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexComponent>(
     count: Int,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?), Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8) {
     assert(count > 0, "Must specify a positive count")
     // TODO: Emit a warning about `repeatMatch(count: 0)` or `repeatMatch(count: 1)`
-    self.init(node: .quantification(.exactly(count), .default, component().regex.root))
+    self.init(_RegexFactory.exactly(count, component().regex._root))
   }
 
+  @_alwaysEmitIntoClient
   public init<W, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexComponent, R: RangeExpression>(
     _ component: Component,
     _ expression: R,
     _ behavior: RegexRepetitionBehavior? = nil
   ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?), Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8), R.Bound == Int {
-    self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component.regex.root))
+    self.init(_RegexFactory.repeating(expression.relative(to: 0..<Int.max), behavior, component.regex._root))
   }
 
+  @_alwaysEmitIntoClient
   public init<W, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexComponent, R: RangeExpression>(
     _ expression: R,
     _ behavior: RegexRepetitionBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?), Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8), R.Bound == Int {
-    self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component().regex.root))
+    self.init(_RegexFactory.repeating(expression.relative(to: 0..<Int.max), behavior, component().regex._root))
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension Optionally {
+  @_alwaysEmitIntoClient
   public init<W, C1, C2, C3, C4, C5, C6, C7, C8, C9, Component: RegexComponent>(
     _ component: Component,
     _ behavior: RegexRepetitionBehavior? = nil
   ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?), Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
-    self.init(node: .quantification(.zeroOrOne, kind, component.regex.root))
+    self.init(_RegexFactory.zeroOrOne(behavior, component.regex._root))
   }
 }
 
 @available(SwiftStdlib 5.7, *)
 extension Optionally {
+  @_alwaysEmitIntoClient
   public init<W, C1, C2, C3, C4, C5, C6, C7, C8, C9, Component: RegexComponent>(
     _ behavior: RegexRepetitionBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?), Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
-    self.init(node: .quantification(.zeroOrOne, kind, component().regex.root))
+    self.init(_RegexFactory.zeroOrOne(behavior, component().regex._root))
   }
 }
 
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @_alwaysEmitIntoClient
   public static func buildLimitedAvailability<W, C1, C2, C3, C4, C5, C6, C7, C8, C9, Component: RegexComponent>(
     _ component: Component
   ) -> Regex<(Substring, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?)> where Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
-    .init(node: .quantification(.zeroOrOne, .default, component.regex.root))
+    _RegexFactory.zeroOrOne(nil, component.regex._root)
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension ZeroOrMore {
+  @_alwaysEmitIntoClient
   public init<W, C1, C2, C3, C4, C5, C6, C7, C8, C9, Component: RegexComponent>(
     _ component: Component,
     _ behavior: RegexRepetitionBehavior? = nil
   ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?), Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
-    self.init(node: .quantification(.zeroOrMore, kind, component.regex.root))
+    self.init(_RegexFactory.zeroOrMore(behavior, component.regex._root))
   }
 }
 
 @available(SwiftStdlib 5.7, *)
 extension ZeroOrMore {
+  @_alwaysEmitIntoClient
   public init<W, C1, C2, C3, C4, C5, C6, C7, C8, C9, Component: RegexComponent>(
     _ behavior: RegexRepetitionBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?), Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
-    self.init(node: .quantification(.zeroOrMore, kind, component().regex.root))
+    self.init(_RegexFactory.zeroOrMore(behavior, component().regex._root))
   }
 }
 
 
 @available(SwiftStdlib 5.7, *)
 extension OneOrMore {
+  @_alwaysEmitIntoClient
   public init<W, C1, C2, C3, C4, C5, C6, C7, C8, C9, Component: RegexComponent>(
     _ component: Component,
     _ behavior: RegexRepetitionBehavior? = nil
   ) where RegexOutput == (Substring, C1, C2, C3, C4, C5, C6, C7, C8, C9), Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
-    self.init(node: .quantification(.oneOrMore, kind, component.regex.root))
+    self.init(_RegexFactory.oneOrMore(behavior, component.regex._root))
   }
 }
 
 @available(SwiftStdlib 5.7, *)
 extension OneOrMore {
+  @_alwaysEmitIntoClient
   public init<W, C1, C2, C3, C4, C5, C6, C7, C8, C9, Component: RegexComponent>(
     _ behavior: RegexRepetitionBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C1, C2, C3, C4, C5, C6, C7, C8, C9), Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
-    self.init(node: .quantification(.oneOrMore, kind, component().regex.root))
+    self.init(_RegexFactory.oneOrMore(behavior, component().regex._root))
   }
 }
 
 
 @available(SwiftStdlib 5.7, *)
 extension Repeat {
+  @_alwaysEmitIntoClient
   public init<W, C1, C2, C3, C4, C5, C6, C7, C8, C9, Component: RegexComponent>(
     _ component: Component,
     count: Int
   ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?), Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
     assert(count > 0, "Must specify a positive count")
     // TODO: Emit a warning about `repeatMatch(count: 0)` or `repeatMatch(count: 1)`
-    self.init(node: .quantification(.exactly(count), .default, component.regex.root))
+    self.init(_RegexFactory.exactly(count, component.regex._root))
   }
 
+  @_alwaysEmitIntoClient
   public init<W, C1, C2, C3, C4, C5, C6, C7, C8, C9, Component: RegexComponent>(
     count: Int,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?), Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
     assert(count > 0, "Must specify a positive count")
     // TODO: Emit a warning about `repeatMatch(count: 0)` or `repeatMatch(count: 1)`
-    self.init(node: .quantification(.exactly(count), .default, component().regex.root))
+    self.init(_RegexFactory.exactly(count, component().regex._root))
   }
 
+  @_alwaysEmitIntoClient
   public init<W, C1, C2, C3, C4, C5, C6, C7, C8, C9, Component: RegexComponent, R: RangeExpression>(
     _ component: Component,
     _ expression: R,
     _ behavior: RegexRepetitionBehavior? = nil
   ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?), Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8, C9), R.Bound == Int {
-    self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component.regex.root))
+    self.init(_RegexFactory.repeating(expression.relative(to: 0..<Int.max), behavior, component.regex._root))
   }
 
+  @_alwaysEmitIntoClient
   public init<W, C1, C2, C3, C4, C5, C6, C7, C8, C9, Component: RegexComponent, R: RangeExpression>(
     _ expression: R,
     _ behavior: RegexRepetitionBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?), Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8, C9), R.Bound == Int {
-    self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component().regex.root))
+    self.init(_RegexFactory.repeating(expression.relative(to: 0..<Int.max), behavior, component().regex._root))
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension Optionally {
+  @_alwaysEmitIntoClient
   public init<W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, Component: RegexComponent>(
     _ component: Component,
     _ behavior: RegexRepetitionBehavior? = nil
   ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?, C10?), Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
-    self.init(node: .quantification(.zeroOrOne, kind, component.regex.root))
+    self.init(_RegexFactory.zeroOrOne(behavior, component.regex._root))
   }
 }
 
 @available(SwiftStdlib 5.7, *)
 extension Optionally {
+  @_alwaysEmitIntoClient
   public init<W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, Component: RegexComponent>(
     _ behavior: RegexRepetitionBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?, C10?), Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
-    self.init(node: .quantification(.zeroOrOne, kind, component().regex.root))
+    self.init(_RegexFactory.zeroOrOne(behavior, component().regex._root))
   }
 }
 
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
+  @_alwaysEmitIntoClient
   public static func buildLimitedAvailability<W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, Component: RegexComponent>(
     _ component: Component
   ) -> Regex<(Substring, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?, C10?)> where Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10) {
-    .init(node: .quantification(.zeroOrOne, .default, component.regex.root))
+    _RegexFactory.zeroOrOne(nil, component.regex._root)
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension ZeroOrMore {
+  @_alwaysEmitIntoClient
   public init<W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, Component: RegexComponent>(
     _ component: Component,
     _ behavior: RegexRepetitionBehavior? = nil
   ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?, C10?), Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
-    self.init(node: .quantification(.zeroOrMore, kind, component.regex.root))
+    self.init(_RegexFactory.zeroOrMore(behavior, component.regex._root))
   }
 }
 
 @available(SwiftStdlib 5.7, *)
 extension ZeroOrMore {
+  @_alwaysEmitIntoClient
   public init<W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, Component: RegexComponent>(
     _ behavior: RegexRepetitionBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?, C10?), Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
-    self.init(node: .quantification(.zeroOrMore, kind, component().regex.root))
+    self.init(_RegexFactory.zeroOrMore(behavior, component().regex._root))
   }
 }
 
 
 @available(SwiftStdlib 5.7, *)
 extension OneOrMore {
+  @_alwaysEmitIntoClient
   public init<W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, Component: RegexComponent>(
     _ component: Component,
     _ behavior: RegexRepetitionBehavior? = nil
   ) where RegexOutput == (Substring, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10), Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
-    self.init(node: .quantification(.oneOrMore, kind, component.regex.root))
+    self.init(_RegexFactory.oneOrMore(behavior, component.regex._root))
   }
 }
 
 @available(SwiftStdlib 5.7, *)
 extension OneOrMore {
+  @_alwaysEmitIntoClient
   public init<W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, Component: RegexComponent>(
     _ behavior: RegexRepetitionBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10), Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10) {
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
-    self.init(node: .quantification(.oneOrMore, kind, component().regex.root))
+    self.init(_RegexFactory.oneOrMore(behavior, component().regex._root))
   }
 }
 
 
 @available(SwiftStdlib 5.7, *)
 extension Repeat {
+  @_alwaysEmitIntoClient
   public init<W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, Component: RegexComponent>(
     _ component: Component,
     count: Int
   ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?, C10?), Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10) {
     assert(count > 0, "Must specify a positive count")
     // TODO: Emit a warning about `repeatMatch(count: 0)` or `repeatMatch(count: 1)`
-    self.init(node: .quantification(.exactly(count), .default, component.regex.root))
+    self.init(_RegexFactory.exactly(count, component.regex._root))
   }
 
+  @_alwaysEmitIntoClient
   public init<W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, Component: RegexComponent>(
     count: Int,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?, C10?), Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10) {
     assert(count > 0, "Must specify a positive count")
     // TODO: Emit a warning about `repeatMatch(count: 0)` or `repeatMatch(count: 1)`
-    self.init(node: .quantification(.exactly(count), .default, component().regex.root))
+    self.init(_RegexFactory.exactly(count, component().regex._root))
   }
 
+  @_alwaysEmitIntoClient
   public init<W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, Component: RegexComponent, R: RangeExpression>(
     _ component: Component,
     _ expression: R,
     _ behavior: RegexRepetitionBehavior? = nil
   ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?, C10?), Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10), R.Bound == Int {
-    self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component.regex.root))
+    self.init(_RegexFactory.repeating(expression.relative(to: 0..<Int.max), behavior, component.regex._root))
   }
 
+  @_alwaysEmitIntoClient
   public init<W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, Component: RegexComponent, R: RangeExpression>(
     _ expression: R,
     _ behavior: RegexRepetitionBehavior? = nil,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?, C10?), Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10), R.Bound == Int {
-    self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component().regex.root))
+    self.init(_RegexFactory.repeating(expression.relative(to: 0..<Int.max), behavior, component().regex._root))
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension Local {
   @available(SwiftStdlib 5.7, *)
   @_disfavoredOverload
+  @_alwaysEmitIntoClient
   public init<Component: RegexComponent>(
     _ component: Component
   ) where RegexOutput == Substring {
-    self.init(node: .nonCapturingGroup(.atomicNonCapturing, component.regex.root))
+    self.init(_RegexFactory.atomicNonCapturing(component.regex._root))
   }
 }
 
@@ -1811,780 +2065,876 @@ extension Local {
 extension Local {
   @available(SwiftStdlib 5.7, *)
   @_disfavoredOverload
+  @_alwaysEmitIntoClient
   public init<Component: RegexComponent>(
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == Substring {
-    self.init(node: .nonCapturingGroup(.atomicNonCapturing, component().regex.root))
+    self.init(_RegexFactory.atomicNonCapturing(component().regex._root))
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension Local {
   @available(SwiftStdlib 5.7, *)
+  @_alwaysEmitIntoClient
   public init<W, C1, Component: RegexComponent>(
     _ component: Component
   ) where RegexOutput == (Substring, C1), Component.RegexOutput == (W, C1) {
-    self.init(node: .nonCapturingGroup(.atomicNonCapturing, component.regex.root))
+    self.init(_RegexFactory.atomicNonCapturing(component.regex._root))
   }
 }
 
 @available(SwiftStdlib 5.7, *)
 extension Local {
   @available(SwiftStdlib 5.7, *)
+  @_alwaysEmitIntoClient
   public init<W, C1, Component: RegexComponent>(
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C1), Component.RegexOutput == (W, C1) {
-    self.init(node: .nonCapturingGroup(.atomicNonCapturing, component().regex.root))
+    self.init(_RegexFactory.atomicNonCapturing(component().regex._root))
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension Local {
   @available(SwiftStdlib 5.7, *)
+  @_alwaysEmitIntoClient
   public init<W, C1, C2, Component: RegexComponent>(
     _ component: Component
   ) where RegexOutput == (Substring, C1, C2), Component.RegexOutput == (W, C1, C2) {
-    self.init(node: .nonCapturingGroup(.atomicNonCapturing, component.regex.root))
+    self.init(_RegexFactory.atomicNonCapturing(component.regex._root))
   }
 }
 
 @available(SwiftStdlib 5.7, *)
 extension Local {
   @available(SwiftStdlib 5.7, *)
+  @_alwaysEmitIntoClient
   public init<W, C1, C2, Component: RegexComponent>(
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C1, C2), Component.RegexOutput == (W, C1, C2) {
-    self.init(node: .nonCapturingGroup(.atomicNonCapturing, component().regex.root))
+    self.init(_RegexFactory.atomicNonCapturing(component().regex._root))
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension Local {
   @available(SwiftStdlib 5.7, *)
+  @_alwaysEmitIntoClient
   public init<W, C1, C2, C3, Component: RegexComponent>(
     _ component: Component
   ) where RegexOutput == (Substring, C1, C2, C3), Component.RegexOutput == (W, C1, C2, C3) {
-    self.init(node: .nonCapturingGroup(.atomicNonCapturing, component.regex.root))
+    self.init(_RegexFactory.atomicNonCapturing(component.regex._root))
   }
 }
 
 @available(SwiftStdlib 5.7, *)
 extension Local {
   @available(SwiftStdlib 5.7, *)
+  @_alwaysEmitIntoClient
   public init<W, C1, C2, C3, Component: RegexComponent>(
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C1, C2, C3), Component.RegexOutput == (W, C1, C2, C3) {
-    self.init(node: .nonCapturingGroup(.atomicNonCapturing, component().regex.root))
+    self.init(_RegexFactory.atomicNonCapturing(component().regex._root))
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension Local {
   @available(SwiftStdlib 5.7, *)
+  @_alwaysEmitIntoClient
   public init<W, C1, C2, C3, C4, Component: RegexComponent>(
     _ component: Component
   ) where RegexOutput == (Substring, C1, C2, C3, C4), Component.RegexOutput == (W, C1, C2, C3, C4) {
-    self.init(node: .nonCapturingGroup(.atomicNonCapturing, component.regex.root))
+    self.init(_RegexFactory.atomicNonCapturing(component.regex._root))
   }
 }
 
 @available(SwiftStdlib 5.7, *)
 extension Local {
   @available(SwiftStdlib 5.7, *)
+  @_alwaysEmitIntoClient
   public init<W, C1, C2, C3, C4, Component: RegexComponent>(
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C1, C2, C3, C4), Component.RegexOutput == (W, C1, C2, C3, C4) {
-    self.init(node: .nonCapturingGroup(.atomicNonCapturing, component().regex.root))
+    self.init(_RegexFactory.atomicNonCapturing(component().regex._root))
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension Local {
   @available(SwiftStdlib 5.7, *)
+  @_alwaysEmitIntoClient
   public init<W, C1, C2, C3, C4, C5, Component: RegexComponent>(
     _ component: Component
   ) where RegexOutput == (Substring, C1, C2, C3, C4, C5), Component.RegexOutput == (W, C1, C2, C3, C4, C5) {
-    self.init(node: .nonCapturingGroup(.atomicNonCapturing, component.regex.root))
+    self.init(_RegexFactory.atomicNonCapturing(component.regex._root))
   }
 }
 
 @available(SwiftStdlib 5.7, *)
 extension Local {
   @available(SwiftStdlib 5.7, *)
+  @_alwaysEmitIntoClient
   public init<W, C1, C2, C3, C4, C5, Component: RegexComponent>(
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C1, C2, C3, C4, C5), Component.RegexOutput == (W, C1, C2, C3, C4, C5) {
-    self.init(node: .nonCapturingGroup(.atomicNonCapturing, component().regex.root))
+    self.init(_RegexFactory.atomicNonCapturing(component().regex._root))
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension Local {
   @available(SwiftStdlib 5.7, *)
+  @_alwaysEmitIntoClient
   public init<W, C1, C2, C3, C4, C5, C6, Component: RegexComponent>(
     _ component: Component
   ) where RegexOutput == (Substring, C1, C2, C3, C4, C5, C6), Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6) {
-    self.init(node: .nonCapturingGroup(.atomicNonCapturing, component.regex.root))
+    self.init(_RegexFactory.atomicNonCapturing(component.regex._root))
   }
 }
 
 @available(SwiftStdlib 5.7, *)
 extension Local {
   @available(SwiftStdlib 5.7, *)
+  @_alwaysEmitIntoClient
   public init<W, C1, C2, C3, C4, C5, C6, Component: RegexComponent>(
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C1, C2, C3, C4, C5, C6), Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6) {
-    self.init(node: .nonCapturingGroup(.atomicNonCapturing, component().regex.root))
+    self.init(_RegexFactory.atomicNonCapturing(component().regex._root))
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension Local {
   @available(SwiftStdlib 5.7, *)
+  @_alwaysEmitIntoClient
   public init<W, C1, C2, C3, C4, C5, C6, C7, Component: RegexComponent>(
     _ component: Component
   ) where RegexOutput == (Substring, C1, C2, C3, C4, C5, C6, C7), Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7) {
-    self.init(node: .nonCapturingGroup(.atomicNonCapturing, component.regex.root))
+    self.init(_RegexFactory.atomicNonCapturing(component.regex._root))
   }
 }
 
 @available(SwiftStdlib 5.7, *)
 extension Local {
   @available(SwiftStdlib 5.7, *)
+  @_alwaysEmitIntoClient
   public init<W, C1, C2, C3, C4, C5, C6, C7, Component: RegexComponent>(
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C1, C2, C3, C4, C5, C6, C7), Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7) {
-    self.init(node: .nonCapturingGroup(.atomicNonCapturing, component().regex.root))
+    self.init(_RegexFactory.atomicNonCapturing(component().regex._root))
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension Local {
   @available(SwiftStdlib 5.7, *)
+  @_alwaysEmitIntoClient
   public init<W, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexComponent>(
     _ component: Component
   ) where RegexOutput == (Substring, C1, C2, C3, C4, C5, C6, C7, C8), Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8) {
-    self.init(node: .nonCapturingGroup(.atomicNonCapturing, component.regex.root))
+    self.init(_RegexFactory.atomicNonCapturing(component.regex._root))
   }
 }
 
 @available(SwiftStdlib 5.7, *)
 extension Local {
   @available(SwiftStdlib 5.7, *)
+  @_alwaysEmitIntoClient
   public init<W, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexComponent>(
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C1, C2, C3, C4, C5, C6, C7, C8), Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8) {
-    self.init(node: .nonCapturingGroup(.atomicNonCapturing, component().regex.root))
+    self.init(_RegexFactory.atomicNonCapturing(component().regex._root))
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension Local {
   @available(SwiftStdlib 5.7, *)
+  @_alwaysEmitIntoClient
   public init<W, C1, C2, C3, C4, C5, C6, C7, C8, C9, Component: RegexComponent>(
     _ component: Component
   ) where RegexOutput == (Substring, C1, C2, C3, C4, C5, C6, C7, C8, C9), Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
-    self.init(node: .nonCapturingGroup(.atomicNonCapturing, component.regex.root))
+    self.init(_RegexFactory.atomicNonCapturing(component.regex._root))
   }
 }
 
 @available(SwiftStdlib 5.7, *)
 extension Local {
   @available(SwiftStdlib 5.7, *)
+  @_alwaysEmitIntoClient
   public init<W, C1, C2, C3, C4, C5, C6, C7, C8, C9, Component: RegexComponent>(
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C1, C2, C3, C4, C5, C6, C7, C8, C9), Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
-    self.init(node: .nonCapturingGroup(.atomicNonCapturing, component().regex.root))
+    self.init(_RegexFactory.atomicNonCapturing(component().regex._root))
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension Local {
   @available(SwiftStdlib 5.7, *)
+  @_alwaysEmitIntoClient
   public init<W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, Component: RegexComponent>(
     _ component: Component
   ) where RegexOutput == (Substring, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10), Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10) {
-    self.init(node: .nonCapturingGroup(.atomicNonCapturing, component.regex.root))
+    self.init(_RegexFactory.atomicNonCapturing(component.regex._root))
   }
 }
 
 @available(SwiftStdlib 5.7, *)
 extension Local {
   @available(SwiftStdlib 5.7, *)
+  @_alwaysEmitIntoClient
   public init<W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, Component: RegexComponent>(
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10), Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10) {
-    self.init(node: .nonCapturingGroup(.atomicNonCapturing, component().regex.root))
+    self.init(_RegexFactory.atomicNonCapturing(component().regex._root))
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<R0, R1>(
     accumulated: R0, next: R1
   ) -> ChoiceOf<Substring> where R0: RegexComponent, R1: RegexComponent {
-    .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
+    .init(_RegexFactory.node(accumulated.regex._root.appendingAlternationCase(next.regex._root)))
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<R0, R1, W1, C0>(
     accumulated: R0, next: R1
   ) -> ChoiceOf<(Substring, C0?)> where R0: RegexComponent, R1: RegexComponent, R1.RegexOutput == (W1, C0) {
-    .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
+    .init(_RegexFactory.node(accumulated.regex._root.appendingAlternationCase(next.regex._root)))
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<R0, R1, W1, C0, C1>(
     accumulated: R0, next: R1
   ) -> ChoiceOf<(Substring, C0?, C1?)> where R0: RegexComponent, R1: RegexComponent, R1.RegexOutput == (W1, C0, C1) {
-    .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
+    .init(_RegexFactory.node(accumulated.regex._root.appendingAlternationCase(next.regex._root)))
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<R0, R1, W1, C0, C1, C2>(
     accumulated: R0, next: R1
   ) -> ChoiceOf<(Substring, C0?, C1?, C2?)> where R0: RegexComponent, R1: RegexComponent, R1.RegexOutput == (W1, C0, C1, C2) {
-    .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
+    .init(_RegexFactory.node(accumulated.regex._root.appendingAlternationCase(next.regex._root)))
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<R0, R1, W1, C0, C1, C2, C3>(
     accumulated: R0, next: R1
   ) -> ChoiceOf<(Substring, C0?, C1?, C2?, C3?)> where R0: RegexComponent, R1: RegexComponent, R1.RegexOutput == (W1, C0, C1, C2, C3) {
-    .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
+    .init(_RegexFactory.node(accumulated.regex._root.appendingAlternationCase(next.regex._root)))
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<R0, R1, W1, C0, C1, C2, C3, C4>(
     accumulated: R0, next: R1
   ) -> ChoiceOf<(Substring, C0?, C1?, C2?, C3?, C4?)> where R0: RegexComponent, R1: RegexComponent, R1.RegexOutput == (W1, C0, C1, C2, C3, C4) {
-    .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
+    .init(_RegexFactory.node(accumulated.regex._root.appendingAlternationCase(next.regex._root)))
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<R0, R1, W1, C0, C1, C2, C3, C4, C5>(
     accumulated: R0, next: R1
   ) -> ChoiceOf<(Substring, C0?, C1?, C2?, C3?, C4?, C5?)> where R0: RegexComponent, R1: RegexComponent, R1.RegexOutput == (W1, C0, C1, C2, C3, C4, C5) {
-    .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
+    .init(_RegexFactory.node(accumulated.regex._root.appendingAlternationCase(next.regex._root)))
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<R0, R1, W1, C0, C1, C2, C3, C4, C5, C6>(
     accumulated: R0, next: R1
   ) -> ChoiceOf<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?)> where R0: RegexComponent, R1: RegexComponent, R1.RegexOutput == (W1, C0, C1, C2, C3, C4, C5, C6) {
-    .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
+    .init(_RegexFactory.node(accumulated.regex._root.appendingAlternationCase(next.regex._root)))
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<R0, R1, W1, C0, C1, C2, C3, C4, C5, C6, C7>(
     accumulated: R0, next: R1
   ) -> ChoiceOf<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?)> where R0: RegexComponent, R1: RegexComponent, R1.RegexOutput == (W1, C0, C1, C2, C3, C4, C5, C6, C7) {
-    .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
+    .init(_RegexFactory.node(accumulated.regex._root.appendingAlternationCase(next.regex._root)))
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<R0, R1, W1, C0, C1, C2, C3, C4, C5, C6, C7, C8>(
     accumulated: R0, next: R1
   ) -> ChoiceOf<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?)> where R0: RegexComponent, R1: RegexComponent, R1.RegexOutput == (W1, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
-    .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
+    .init(_RegexFactory.node(accumulated.regex._root.appendingAlternationCase(next.regex._root)))
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<R0, R1, W1, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9>(
     accumulated: R0, next: R1
   ) -> ChoiceOf<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?)> where R0: RegexComponent, R1: RegexComponent, R1.RegexOutput == (W1, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
-    .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
+    .init(_RegexFactory.node(accumulated.regex._root.appendingAlternationCase(next.regex._root)))
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<R0, W0, C0, R1>(
     accumulated: R0, next: R1
   ) -> ChoiceOf<(Substring, C0)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0) {
-    .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
+    .init(_RegexFactory.node(accumulated.regex._root.appendingAlternationCase(next.regex._root)))
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<R0, W0, C0, R1, W1, C1>(
     accumulated: R0, next: R1
   ) -> ChoiceOf<(Substring, C0, C1?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0), R1.RegexOutput == (W1, C1) {
-    .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
+    .init(_RegexFactory.node(accumulated.regex._root.appendingAlternationCase(next.regex._root)))
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<R0, W0, C0, R1, W1, C1, C2>(
     accumulated: R0, next: R1
   ) -> ChoiceOf<(Substring, C0, C1?, C2?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0), R1.RegexOutput == (W1, C1, C2) {
-    .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
+    .init(_RegexFactory.node(accumulated.regex._root.appendingAlternationCase(next.regex._root)))
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<R0, W0, C0, R1, W1, C1, C2, C3>(
     accumulated: R0, next: R1
   ) -> ChoiceOf<(Substring, C0, C1?, C2?, C3?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0), R1.RegexOutput == (W1, C1, C2, C3) {
-    .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
+    .init(_RegexFactory.node(accumulated.regex._root.appendingAlternationCase(next.regex._root)))
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<R0, W0, C0, R1, W1, C1, C2, C3, C4>(
     accumulated: R0, next: R1
   ) -> ChoiceOf<(Substring, C0, C1?, C2?, C3?, C4?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0), R1.RegexOutput == (W1, C1, C2, C3, C4) {
-    .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
+    .init(_RegexFactory.node(accumulated.regex._root.appendingAlternationCase(next.regex._root)))
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<R0, W0, C0, R1, W1, C1, C2, C3, C4, C5>(
     accumulated: R0, next: R1
   ) -> ChoiceOf<(Substring, C0, C1?, C2?, C3?, C4?, C5?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0), R1.RegexOutput == (W1, C1, C2, C3, C4, C5) {
-    .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
+    .init(_RegexFactory.node(accumulated.regex._root.appendingAlternationCase(next.regex._root)))
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<R0, W0, C0, R1, W1, C1, C2, C3, C4, C5, C6>(
     accumulated: R0, next: R1
   ) -> ChoiceOf<(Substring, C0, C1?, C2?, C3?, C4?, C5?, C6?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0), R1.RegexOutput == (W1, C1, C2, C3, C4, C5, C6) {
-    .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
+    .init(_RegexFactory.node(accumulated.regex._root.appendingAlternationCase(next.regex._root)))
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<R0, W0, C0, R1, W1, C1, C2, C3, C4, C5, C6, C7>(
     accumulated: R0, next: R1
   ) -> ChoiceOf<(Substring, C0, C1?, C2?, C3?, C4?, C5?, C6?, C7?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0), R1.RegexOutput == (W1, C1, C2, C3, C4, C5, C6, C7) {
-    .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
+    .init(_RegexFactory.node(accumulated.regex._root.appendingAlternationCase(next.regex._root)))
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<R0, W0, C0, R1, W1, C1, C2, C3, C4, C5, C6, C7, C8>(
     accumulated: R0, next: R1
   ) -> ChoiceOf<(Substring, C0, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0), R1.RegexOutput == (W1, C1, C2, C3, C4, C5, C6, C7, C8) {
-    .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
+    .init(_RegexFactory.node(accumulated.regex._root.appendingAlternationCase(next.regex._root)))
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<R0, W0, C0, R1, W1, C1, C2, C3, C4, C5, C6, C7, C8, C9>(
     accumulated: R0, next: R1
   ) -> ChoiceOf<(Substring, C0, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0), R1.RegexOutput == (W1, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
-    .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
+    .init(_RegexFactory.node(accumulated.regex._root.appendingAlternationCase(next.regex._root)))
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<R0, W0, C0, C1, R1>(
     accumulated: R0, next: R1
   ) -> ChoiceOf<(Substring, C0, C1)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1) {
-    .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
+    .init(_RegexFactory.node(accumulated.regex._root.appendingAlternationCase(next.regex._root)))
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<R0, W0, C0, C1, R1, W1, C2>(
     accumulated: R0, next: R1
   ) -> ChoiceOf<(Substring, C0, C1, C2?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1), R1.RegexOutput == (W1, C2) {
-    .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
+    .init(_RegexFactory.node(accumulated.regex._root.appendingAlternationCase(next.regex._root)))
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<R0, W0, C0, C1, R1, W1, C2, C3>(
     accumulated: R0, next: R1
   ) -> ChoiceOf<(Substring, C0, C1, C2?, C3?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1), R1.RegexOutput == (W1, C2, C3) {
-    .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
+    .init(_RegexFactory.node(accumulated.regex._root.appendingAlternationCase(next.regex._root)))
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<R0, W0, C0, C1, R1, W1, C2, C3, C4>(
     accumulated: R0, next: R1
   ) -> ChoiceOf<(Substring, C0, C1, C2?, C3?, C4?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1), R1.RegexOutput == (W1, C2, C3, C4) {
-    .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
+    .init(_RegexFactory.node(accumulated.regex._root.appendingAlternationCase(next.regex._root)))
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<R0, W0, C0, C1, R1, W1, C2, C3, C4, C5>(
     accumulated: R0, next: R1
   ) -> ChoiceOf<(Substring, C0, C1, C2?, C3?, C4?, C5?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1), R1.RegexOutput == (W1, C2, C3, C4, C5) {
-    .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
+    .init(_RegexFactory.node(accumulated.regex._root.appendingAlternationCase(next.regex._root)))
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<R0, W0, C0, C1, R1, W1, C2, C3, C4, C5, C6>(
     accumulated: R0, next: R1
   ) -> ChoiceOf<(Substring, C0, C1, C2?, C3?, C4?, C5?, C6?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1), R1.RegexOutput == (W1, C2, C3, C4, C5, C6) {
-    .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
+    .init(_RegexFactory.node(accumulated.regex._root.appendingAlternationCase(next.regex._root)))
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<R0, W0, C0, C1, R1, W1, C2, C3, C4, C5, C6, C7>(
     accumulated: R0, next: R1
   ) -> ChoiceOf<(Substring, C0, C1, C2?, C3?, C4?, C5?, C6?, C7?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1), R1.RegexOutput == (W1, C2, C3, C4, C5, C6, C7) {
-    .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
+    .init(_RegexFactory.node(accumulated.regex._root.appendingAlternationCase(next.regex._root)))
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<R0, W0, C0, C1, R1, W1, C2, C3, C4, C5, C6, C7, C8>(
     accumulated: R0, next: R1
   ) -> ChoiceOf<(Substring, C0, C1, C2?, C3?, C4?, C5?, C6?, C7?, C8?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1), R1.RegexOutput == (W1, C2, C3, C4, C5, C6, C7, C8) {
-    .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
+    .init(_RegexFactory.node(accumulated.regex._root.appendingAlternationCase(next.regex._root)))
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<R0, W0, C0, C1, R1, W1, C2, C3, C4, C5, C6, C7, C8, C9>(
     accumulated: R0, next: R1
   ) -> ChoiceOf<(Substring, C0, C1, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1), R1.RegexOutput == (W1, C2, C3, C4, C5, C6, C7, C8, C9) {
-    .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
+    .init(_RegexFactory.node(accumulated.regex._root.appendingAlternationCase(next.regex._root)))
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<R0, W0, C0, C1, C2, R1>(
     accumulated: R0, next: R1
   ) -> ChoiceOf<(Substring, C0, C1, C2)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2) {
-    .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
+    .init(_RegexFactory.node(accumulated.regex._root.appendingAlternationCase(next.regex._root)))
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<R0, W0, C0, C1, C2, R1, W1, C3>(
     accumulated: R0, next: R1
   ) -> ChoiceOf<(Substring, C0, C1, C2, C3?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2), R1.RegexOutput == (W1, C3) {
-    .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
+    .init(_RegexFactory.node(accumulated.regex._root.appendingAlternationCase(next.regex._root)))
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<R0, W0, C0, C1, C2, R1, W1, C3, C4>(
     accumulated: R0, next: R1
   ) -> ChoiceOf<(Substring, C0, C1, C2, C3?, C4?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2), R1.RegexOutput == (W1, C3, C4) {
-    .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
+    .init(_RegexFactory.node(accumulated.regex._root.appendingAlternationCase(next.regex._root)))
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<R0, W0, C0, C1, C2, R1, W1, C3, C4, C5>(
     accumulated: R0, next: R1
   ) -> ChoiceOf<(Substring, C0, C1, C2, C3?, C4?, C5?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2), R1.RegexOutput == (W1, C3, C4, C5) {
-    .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
+    .init(_RegexFactory.node(accumulated.regex._root.appendingAlternationCase(next.regex._root)))
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<R0, W0, C0, C1, C2, R1, W1, C3, C4, C5, C6>(
     accumulated: R0, next: R1
   ) -> ChoiceOf<(Substring, C0, C1, C2, C3?, C4?, C5?, C6?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2), R1.RegexOutput == (W1, C3, C4, C5, C6) {
-    .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
+    .init(_RegexFactory.node(accumulated.regex._root.appendingAlternationCase(next.regex._root)))
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<R0, W0, C0, C1, C2, R1, W1, C3, C4, C5, C6, C7>(
     accumulated: R0, next: R1
   ) -> ChoiceOf<(Substring, C0, C1, C2, C3?, C4?, C5?, C6?, C7?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2), R1.RegexOutput == (W1, C3, C4, C5, C6, C7) {
-    .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
+    .init(_RegexFactory.node(accumulated.regex._root.appendingAlternationCase(next.regex._root)))
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<R0, W0, C0, C1, C2, R1, W1, C3, C4, C5, C6, C7, C8>(
     accumulated: R0, next: R1
   ) -> ChoiceOf<(Substring, C0, C1, C2, C3?, C4?, C5?, C6?, C7?, C8?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2), R1.RegexOutput == (W1, C3, C4, C5, C6, C7, C8) {
-    .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
+    .init(_RegexFactory.node(accumulated.regex._root.appendingAlternationCase(next.regex._root)))
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<R0, W0, C0, C1, C2, R1, W1, C3, C4, C5, C6, C7, C8, C9>(
     accumulated: R0, next: R1
   ) -> ChoiceOf<(Substring, C0, C1, C2, C3?, C4?, C5?, C6?, C7?, C8?, C9?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2), R1.RegexOutput == (W1, C3, C4, C5, C6, C7, C8, C9) {
-    .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
+    .init(_RegexFactory.node(accumulated.regex._root.appendingAlternationCase(next.regex._root)))
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<R0, W0, C0, C1, C2, C3, R1>(
     accumulated: R0, next: R1
   ) -> ChoiceOf<(Substring, C0, C1, C2, C3)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2, C3) {
-    .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
+    .init(_RegexFactory.node(accumulated.regex._root.appendingAlternationCase(next.regex._root)))
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<R0, W0, C0, C1, C2, C3, R1, W1, C4>(
     accumulated: R0, next: R1
   ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2, C3), R1.RegexOutput == (W1, C4) {
-    .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
+    .init(_RegexFactory.node(accumulated.regex._root.appendingAlternationCase(next.regex._root)))
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<R0, W0, C0, C1, C2, C3, R1, W1, C4, C5>(
     accumulated: R0, next: R1
   ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4?, C5?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2, C3), R1.RegexOutput == (W1, C4, C5) {
-    .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
+    .init(_RegexFactory.node(accumulated.regex._root.appendingAlternationCase(next.regex._root)))
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<R0, W0, C0, C1, C2, C3, R1, W1, C4, C5, C6>(
     accumulated: R0, next: R1
   ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4?, C5?, C6?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2, C3), R1.RegexOutput == (W1, C4, C5, C6) {
-    .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
+    .init(_RegexFactory.node(accumulated.regex._root.appendingAlternationCase(next.regex._root)))
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<R0, W0, C0, C1, C2, C3, R1, W1, C4, C5, C6, C7>(
     accumulated: R0, next: R1
   ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4?, C5?, C6?, C7?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2, C3), R1.RegexOutput == (W1, C4, C5, C6, C7) {
-    .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
+    .init(_RegexFactory.node(accumulated.regex._root.appendingAlternationCase(next.regex._root)))
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<R0, W0, C0, C1, C2, C3, R1, W1, C4, C5, C6, C7, C8>(
     accumulated: R0, next: R1
   ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4?, C5?, C6?, C7?, C8?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2, C3), R1.RegexOutput == (W1, C4, C5, C6, C7, C8) {
-    .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
+    .init(_RegexFactory.node(accumulated.regex._root.appendingAlternationCase(next.regex._root)))
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<R0, W0, C0, C1, C2, C3, R1, W1, C4, C5, C6, C7, C8, C9>(
     accumulated: R0, next: R1
   ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4?, C5?, C6?, C7?, C8?, C9?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2, C3), R1.RegexOutput == (W1, C4, C5, C6, C7, C8, C9) {
-    .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
+    .init(_RegexFactory.node(accumulated.regex._root.appendingAlternationCase(next.regex._root)))
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<R0, W0, C0, C1, C2, C3, C4, R1>(
     accumulated: R0, next: R1
   ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2, C3, C4) {
-    .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
+    .init(_RegexFactory.node(accumulated.regex._root.appendingAlternationCase(next.regex._root)))
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<R0, W0, C0, C1, C2, C3, C4, R1, W1, C5>(
     accumulated: R0, next: R1
   ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4, C5?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2, C3, C4), R1.RegexOutput == (W1, C5) {
-    .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
+    .init(_RegexFactory.node(accumulated.regex._root.appendingAlternationCase(next.regex._root)))
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<R0, W0, C0, C1, C2, C3, C4, R1, W1, C5, C6>(
     accumulated: R0, next: R1
   ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4, C5?, C6?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2, C3, C4), R1.RegexOutput == (W1, C5, C6) {
-    .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
+    .init(_RegexFactory.node(accumulated.regex._root.appendingAlternationCase(next.regex._root)))
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<R0, W0, C0, C1, C2, C3, C4, R1, W1, C5, C6, C7>(
     accumulated: R0, next: R1
   ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4, C5?, C6?, C7?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2, C3, C4), R1.RegexOutput == (W1, C5, C6, C7) {
-    .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
+    .init(_RegexFactory.node(accumulated.regex._root.appendingAlternationCase(next.regex._root)))
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<R0, W0, C0, C1, C2, C3, C4, R1, W1, C5, C6, C7, C8>(
     accumulated: R0, next: R1
   ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4, C5?, C6?, C7?, C8?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2, C3, C4), R1.RegexOutput == (W1, C5, C6, C7, C8) {
-    .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
+    .init(_RegexFactory.node(accumulated.regex._root.appendingAlternationCase(next.regex._root)))
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<R0, W0, C0, C1, C2, C3, C4, R1, W1, C5, C6, C7, C8, C9>(
     accumulated: R0, next: R1
   ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4, C5?, C6?, C7?, C8?, C9?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2, C3, C4), R1.RegexOutput == (W1, C5, C6, C7, C8, C9) {
-    .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
+    .init(_RegexFactory.node(accumulated.regex._root.appendingAlternationCase(next.regex._root)))
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<R0, W0, C0, C1, C2, C3, C4, C5, R1>(
     accumulated: R0, next: R1
   ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4, C5)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2, C3, C4, C5) {
-    .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
+    .init(_RegexFactory.node(accumulated.regex._root.appendingAlternationCase(next.regex._root)))
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<R0, W0, C0, C1, C2, C3, C4, C5, R1, W1, C6>(
     accumulated: R0, next: R1
   ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4, C5, C6?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2, C3, C4, C5), R1.RegexOutput == (W1, C6) {
-    .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
+    .init(_RegexFactory.node(accumulated.regex._root.appendingAlternationCase(next.regex._root)))
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<R0, W0, C0, C1, C2, C3, C4, C5, R1, W1, C6, C7>(
     accumulated: R0, next: R1
   ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4, C5, C6?, C7?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2, C3, C4, C5), R1.RegexOutput == (W1, C6, C7) {
-    .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
+    .init(_RegexFactory.node(accumulated.regex._root.appendingAlternationCase(next.regex._root)))
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<R0, W0, C0, C1, C2, C3, C4, C5, R1, W1, C6, C7, C8>(
     accumulated: R0, next: R1
   ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4, C5, C6?, C7?, C8?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2, C3, C4, C5), R1.RegexOutput == (W1, C6, C7, C8) {
-    .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
+    .init(_RegexFactory.node(accumulated.regex._root.appendingAlternationCase(next.regex._root)))
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<R0, W0, C0, C1, C2, C3, C4, C5, R1, W1, C6, C7, C8, C9>(
     accumulated: R0, next: R1
   ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4, C5, C6?, C7?, C8?, C9?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2, C3, C4, C5), R1.RegexOutput == (W1, C6, C7, C8, C9) {
-    .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
+    .init(_RegexFactory.node(accumulated.regex._root.appendingAlternationCase(next.regex._root)))
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<R0, W0, C0, C1, C2, C3, C4, C5, C6, R1>(
     accumulated: R0, next: R1
   ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4, C5, C6)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2, C3, C4, C5, C6) {
-    .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
+    .init(_RegexFactory.node(accumulated.regex._root.appendingAlternationCase(next.regex._root)))
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<R0, W0, C0, C1, C2, C3, C4, C5, C6, R1, W1, C7>(
     accumulated: R0, next: R1
   ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4, C5, C6, C7?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2, C3, C4, C5, C6), R1.RegexOutput == (W1, C7) {
-    .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
+    .init(_RegexFactory.node(accumulated.regex._root.appendingAlternationCase(next.regex._root)))
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<R0, W0, C0, C1, C2, C3, C4, C5, C6, R1, W1, C7, C8>(
     accumulated: R0, next: R1
   ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4, C5, C6, C7?, C8?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2, C3, C4, C5, C6), R1.RegexOutput == (W1, C7, C8) {
-    .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
+    .init(_RegexFactory.node(accumulated.regex._root.appendingAlternationCase(next.regex._root)))
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<R0, W0, C0, C1, C2, C3, C4, C5, C6, R1, W1, C7, C8, C9>(
     accumulated: R0, next: R1
   ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4, C5, C6, C7?, C8?, C9?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2, C3, C4, C5, C6), R1.RegexOutput == (W1, C7, C8, C9) {
-    .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
+    .init(_RegexFactory.node(accumulated.regex._root.appendingAlternationCase(next.regex._root)))
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<R0, W0, C0, C1, C2, C3, C4, C5, C6, C7, R1>(
     accumulated: R0, next: R1
   ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4, C5, C6, C7)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2, C3, C4, C5, C6, C7) {
-    .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
+    .init(_RegexFactory.node(accumulated.regex._root.appendingAlternationCase(next.regex._root)))
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<R0, W0, C0, C1, C2, C3, C4, C5, C6, C7, R1, W1, C8>(
     accumulated: R0, next: R1
   ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2, C3, C4, C5, C6, C7), R1.RegexOutput == (W1, C8) {
-    .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
+    .init(_RegexFactory.node(accumulated.regex._root.appendingAlternationCase(next.regex._root)))
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<R0, W0, C0, C1, C2, C3, C4, C5, C6, C7, R1, W1, C8, C9>(
     accumulated: R0, next: R1
   ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8?, C9?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2, C3, C4, C5, C6, C7), R1.RegexOutput == (W1, C8, C9) {
-    .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
+    .init(_RegexFactory.node(accumulated.regex._root.appendingAlternationCase(next.regex._root)))
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<R0, W0, C0, C1, C2, C3, C4, C5, C6, C7, C8, R1>(
     accumulated: R0, next: R1
   ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
-    .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
+    .init(_RegexFactory.node(accumulated.regex._root.appendingAlternationCase(next.regex._root)))
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<R0, W0, C0, C1, C2, C3, C4, C5, C6, C7, C8, R1, W1, C9>(
     accumulated: R0, next: R1
   ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2, C3, C4, C5, C6, C7, C8), R1.RegexOutput == (W1, C9) {
-    .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
+    .init(_RegexFactory.node(accumulated.regex._root.appendingAlternationCase(next.regex._root)))
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<R, W, C1>(first regex: R) -> ChoiceOf<(W, C1?)> where R: RegexComponent, R.RegexOutput == (W, C1) {
-    .init(node: .orderedChoice([regex.regex.root]))
+    .init(_RegexFactory.orderedChoice(regex.regex._root))
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<R, W, C1, C2>(first regex: R) -> ChoiceOf<(W, C1?, C2?)> where R: RegexComponent, R.RegexOutput == (W, C1, C2) {
-    .init(node: .orderedChoice([regex.regex.root]))
+    .init(_RegexFactory.orderedChoice(regex.regex._root))
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<R, W, C1, C2, C3>(first regex: R) -> ChoiceOf<(W, C1?, C2?, C3?)> where R: RegexComponent, R.RegexOutput == (W, C1, C2, C3) {
-    .init(node: .orderedChoice([regex.regex.root]))
+    .init(_RegexFactory.orderedChoice(regex.regex._root))
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<R, W, C1, C2, C3, C4>(first regex: R) -> ChoiceOf<(W, C1?, C2?, C3?, C4?)> where R: RegexComponent, R.RegexOutput == (W, C1, C2, C3, C4) {
-    .init(node: .orderedChoice([regex.regex.root]))
+    .init(_RegexFactory.orderedChoice(regex.regex._root))
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<R, W, C1, C2, C3, C4, C5>(first regex: R) -> ChoiceOf<(W, C1?, C2?, C3?, C4?, C5?)> where R: RegexComponent, R.RegexOutput == (W, C1, C2, C3, C4, C5) {
-    .init(node: .orderedChoice([regex.regex.root]))
+    .init(_RegexFactory.orderedChoice(regex.regex._root))
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<R, W, C1, C2, C3, C4, C5, C6>(first regex: R) -> ChoiceOf<(W, C1?, C2?, C3?, C4?, C5?, C6?)> where R: RegexComponent, R.RegexOutput == (W, C1, C2, C3, C4, C5, C6) {
-    .init(node: .orderedChoice([regex.regex.root]))
+    .init(_RegexFactory.orderedChoice(regex.regex._root))
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<R, W, C1, C2, C3, C4, C5, C6, C7>(first regex: R) -> ChoiceOf<(W, C1?, C2?, C3?, C4?, C5?, C6?, C7?)> where R: RegexComponent, R.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7) {
-    .init(node: .orderedChoice([regex.regex.root]))
+    .init(_RegexFactory.orderedChoice(regex.regex._root))
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<R, W, C1, C2, C3, C4, C5, C6, C7, C8>(first regex: R) -> ChoiceOf<(W, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?)> where R: RegexComponent, R.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8) {
-    .init(node: .orderedChoice([regex.regex.root]))
+    .init(_RegexFactory.orderedChoice(regex.regex._root))
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<R, W, C1, C2, C3, C4, C5, C6, C7, C8, C9>(first regex: R) -> ChoiceOf<(W, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?)> where R: RegexComponent, R.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
-    .init(node: .orderedChoice([regex.regex.root]))
+    .init(_RegexFactory.orderedChoice(regex.regex._root))
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<R, W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10>(first regex: R) -> ChoiceOf<(W, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?, C10?)> where R: RegexComponent, R.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10) {
-    .init(node: .orderedChoice([regex.regex.root]))
+    .init(_RegexFactory.orderedChoice(regex.regex._root))
   }
 }
 // MARK: - Non-builder capture arity 0
@@ -2592,64 +2942,60 @@ extension AlternationBuilder {
 @available(SwiftStdlib 5.7, *)
 extension Capture {
   @_disfavoredOverload
+  @_alwaysEmitIntoClient
   public init<R: RegexComponent, W>(
     _ component: R
   ) where RegexOutput == (Substring, W), R.RegexOutput == W {
-    self.init(node: .capture(component.regex.root))
+    self.init(_RegexFactory.capture(component.regex._root))
   }
 
   @_disfavoredOverload
+  @_alwaysEmitIntoClient
   public init<R: RegexComponent, W>(
     _ component: R, as reference: Reference<W>
   ) where RegexOutput == (Substring, W), R.RegexOutput == W {
-    self.init(node: .capture(reference: reference.id, component.regex.root))
+    self.init(_RegexFactory.capture(component.regex._root, reference))
   }
 
   @_disfavoredOverload
+  @_alwaysEmitIntoClient
   public init<R: RegexComponent, W, NewCapture>(
     _ component: R,
     transform: @escaping (W) throws -> NewCapture
   ) where RegexOutput == (Substring, NewCapture), R.RegexOutput == W {
-    self.init(node: .capture(
-      component.regex.root,
-      CaptureTransform(transform)))
+    self.init(_RegexFactory.capture(component.regex._root, nil, transform))
   }
 
   @_disfavoredOverload
+  @_alwaysEmitIntoClient
   public init<R: RegexComponent, W, NewCapture>(
     _ component: R,
     as reference: Reference<NewCapture>,
     transform: @escaping (W) throws -> NewCapture
   ) where RegexOutput == (Substring, NewCapture), R.RegexOutput == W {
-    self.init(node: .capture(
-      reference: reference.id,
-      component.regex.root,
-      CaptureTransform(transform)))
+    self.init(_RegexFactory.capture(component.regex._root, reference, transform))
   }
 }
 
 @available(SwiftStdlib 5.7, *)
 extension TryCapture {
   @_disfavoredOverload
+  @_alwaysEmitIntoClient
   public init<R: RegexComponent, W, NewCapture>(
     _ component: R,
     transform: @escaping (W) throws -> NewCapture?
   ) where RegexOutput == (Substring, NewCapture), R.RegexOutput == W {
-    self.init(node: .capture(
-    component.regex.root,
-    CaptureTransform(transform)))
+    self.init(_RegexFactory.captureOptional(component.regex._root, nil, transform))
   }
 
   @_disfavoredOverload
+  @_alwaysEmitIntoClient
   public init<R: RegexComponent, W, NewCapture>(
     _ component: R,
     as reference: Reference<NewCapture>,
     transform: @escaping (W) throws -> NewCapture?
   ) where RegexOutput == (Substring, NewCapture), R.RegexOutput == W {
-    self.init(node: .capture(
-      reference: reference.id,
-      component.regex.root,
-      CaptureTransform(transform)))
+    self.init(_RegexFactory.captureOptional(component.regex._root, reference, transform))
   }
 }
 
@@ -2658,67 +3004,61 @@ extension TryCapture {
 @available(SwiftStdlib 5.7, *)
 extension Capture {
   @_disfavoredOverload
+  @_alwaysEmitIntoClient
   public init<R: RegexComponent, W>(
     @RegexComponentBuilder _ component: () -> R
   ) where RegexOutput == (Substring, W), R.RegexOutput == W {
-    self.init(node: .capture(component().regex.root))
+    self.init(_RegexFactory.node(component().regex._root))
   }
 
   @_disfavoredOverload
+  @_alwaysEmitIntoClient
   public init<R: RegexComponent, W>(
     as reference: Reference<W>,
     @RegexComponentBuilder _ component: () -> R
   ) where RegexOutput == (Substring, W), R.RegexOutput == W {
-    self.init(node: .capture(
-      reference: reference.id,
-      component().regex.root))
+    self.init(_RegexFactory.capture(component().regex._root, reference))
   }
 
   @_disfavoredOverload
+  @_alwaysEmitIntoClient
   public init<R: RegexComponent, W, NewCapture>(
     @RegexComponentBuilder _ component: () -> R,
     transform: @escaping (W) throws -> NewCapture
   ) where RegexOutput == (Substring, NewCapture), R.RegexOutput == W {
-    self.init(node: .capture(
-      component().regex.root,
-      CaptureTransform(transform)))
+    self.init(_RegexFactory.capture(component().regex._root, nil, transform))
   }
 
-  @_disfavoredOverload
+    @_disfavoredOverload
+  @_alwaysEmitIntoClient
   public init<R: RegexComponent, W, NewCapture>(
     as reference: Reference<NewCapture>,
     @RegexComponentBuilder _ component: () -> R,
     transform: @escaping (W) throws -> NewCapture
   ) where RegexOutput == (Substring, NewCapture), R.RegexOutput == W {
-    self.init(node: .capture(
-      reference: reference.id,
-      component().regex.root,
-      CaptureTransform(transform)))
+    self.init(_RegexFactory.capture(component().regex._root, reference, transform))
   }
 }
 
 @available(SwiftStdlib 5.7, *)
 extension TryCapture {
   @_disfavoredOverload
+  @_alwaysEmitIntoClient
   public init<R: RegexComponent, W, NewCapture>(
     @RegexComponentBuilder _ component: () -> R,
     transform: @escaping (W) throws -> NewCapture?
   ) where RegexOutput == (Substring, NewCapture), R.RegexOutput == W {
-    self.init(node: .capture(
-      component().regex.root,
-      CaptureTransform(transform)))
+    self.init(_RegexFactory.captureOptional(component().regex._root, nil, transform))
   }
 
   @_disfavoredOverload
+  @_alwaysEmitIntoClient
   public init<R: RegexComponent, W, NewCapture>(
     as reference: Reference<NewCapture>,
     @RegexComponentBuilder _ component: () -> R,
     transform: @escaping (W) throws -> NewCapture?
   ) where RegexOutput == (Substring, NewCapture), R.RegexOutput == W {
-    self.init(node: .capture(
-      reference: reference.id,
-      component().regex.root,
-      CaptureTransform(transform)))
+    self.init(_RegexFactory.captureOptional(component().regex._root, reference, transform))
   }
 }
 
@@ -2726,59 +3066,55 @@ extension TryCapture {
 
 @available(SwiftStdlib 5.7, *)
 extension Capture {
+  @_alwaysEmitIntoClient
   public init<R: RegexComponent, W, C1>(
     _ component: R
   ) where RegexOutput == (Substring, W, C1), R.RegexOutput == (W, C1) {
-    self.init(node: .capture(component.regex.root))
+    self.init(_RegexFactory.capture(component.regex._root))
   }
 
+  @_alwaysEmitIntoClient
   public init<R: RegexComponent, W, C1>(
     _ component: R, as reference: Reference<W>
   ) where RegexOutput == (Substring, W, C1), R.RegexOutput == (W, C1) {
-    self.init(node: .capture(reference: reference.id, component.regex.root))
+    self.init(_RegexFactory.capture(component.regex._root, reference))
   }
 
+  @_alwaysEmitIntoClient
   public init<R: RegexComponent, W, C1, NewCapture>(
     _ component: R,
     transform: @escaping (W) throws -> NewCapture
   ) where RegexOutput == (Substring, NewCapture, C1), R.RegexOutput == (W, C1) {
-    self.init(node: .capture(
-      component.regex.root,
-      CaptureTransform(transform)))
+    self.init(_RegexFactory.capture(component.regex._root, nil, transform))
   }
 
+  @_alwaysEmitIntoClient
   public init<R: RegexComponent, W, C1, NewCapture>(
     _ component: R,
     as reference: Reference<NewCapture>,
     transform: @escaping (W) throws -> NewCapture
   ) where RegexOutput == (Substring, NewCapture, C1), R.RegexOutput == (W, C1) {
-    self.init(node: .capture(
-      reference: reference.id,
-      component.regex.root,
-      CaptureTransform(transform)))
+    self.init(_RegexFactory.capture(component.regex._root, reference, transform))
   }
 }
 
 @available(SwiftStdlib 5.7, *)
 extension TryCapture {
+  @_alwaysEmitIntoClient
   public init<R: RegexComponent, W, C1, NewCapture>(
     _ component: R,
     transform: @escaping (W) throws -> NewCapture?
   ) where RegexOutput == (Substring, NewCapture, C1), R.RegexOutput == (W, C1) {
-    self.init(node: .capture(
-    component.regex.root,
-    CaptureTransform(transform)))
+    self.init(_RegexFactory.captureOptional(component.regex._root, nil, transform))
   }
 
+  @_alwaysEmitIntoClient
   public init<R: RegexComponent, W, C1, NewCapture>(
     _ component: R,
     as reference: Reference<NewCapture>,
     transform: @escaping (W) throws -> NewCapture?
   ) where RegexOutput == (Substring, NewCapture, C1), R.RegexOutput == (W, C1) {
-    self.init(node: .capture(
-      reference: reference.id,
-      component.regex.root,
-      CaptureTransform(transform)))
+    self.init(_RegexFactory.captureOptional(component.regex._root, reference, transform))
   }
 }
 
@@ -2786,62 +3122,56 @@ extension TryCapture {
 
 @available(SwiftStdlib 5.7, *)
 extension Capture {
+  @_alwaysEmitIntoClient
   public init<R: RegexComponent, W, C1>(
     @RegexComponentBuilder _ component: () -> R
   ) where RegexOutput == (Substring, W, C1), R.RegexOutput == (W, C1) {
-    self.init(node: .capture(component().regex.root))
+    self.init(_RegexFactory.node(component().regex._root))
   }
 
+  @_alwaysEmitIntoClient
   public init<R: RegexComponent, W, C1>(
     as reference: Reference<W>,
     @RegexComponentBuilder _ component: () -> R
   ) where RegexOutput == (Substring, W, C1), R.RegexOutput == (W, C1) {
-    self.init(node: .capture(
-      reference: reference.id,
-      component().regex.root))
+    self.init(_RegexFactory.capture(component().regex._root, reference))
   }
 
+  @_alwaysEmitIntoClient
   public init<R: RegexComponent, W, C1, NewCapture>(
     @RegexComponentBuilder _ component: () -> R,
     transform: @escaping (W) throws -> NewCapture
   ) where RegexOutput == (Substring, NewCapture, C1), R.RegexOutput == (W, C1) {
-    self.init(node: .capture(
-      component().regex.root,
-      CaptureTransform(transform)))
+    self.init(_RegexFactory.capture(component().regex._root, nil, transform))
   }
 
+    @_alwaysEmitIntoClient
   public init<R: RegexComponent, W, C1, NewCapture>(
     as reference: Reference<NewCapture>,
     @RegexComponentBuilder _ component: () -> R,
     transform: @escaping (W) throws -> NewCapture
   ) where RegexOutput == (Substring, NewCapture, C1), R.RegexOutput == (W, C1) {
-    self.init(node: .capture(
-      reference: reference.id,
-      component().regex.root,
-      CaptureTransform(transform)))
+    self.init(_RegexFactory.capture(component().regex._root, reference, transform))
   }
 }
 
 @available(SwiftStdlib 5.7, *)
 extension TryCapture {
+  @_alwaysEmitIntoClient
   public init<R: RegexComponent, W, C1, NewCapture>(
     @RegexComponentBuilder _ component: () -> R,
     transform: @escaping (W) throws -> NewCapture?
   ) where RegexOutput == (Substring, NewCapture, C1), R.RegexOutput == (W, C1) {
-    self.init(node: .capture(
-      component().regex.root,
-      CaptureTransform(transform)))
+    self.init(_RegexFactory.captureOptional(component().regex._root, nil, transform))
   }
 
+  @_alwaysEmitIntoClient
   public init<R: RegexComponent, W, C1, NewCapture>(
     as reference: Reference<NewCapture>,
     @RegexComponentBuilder _ component: () -> R,
     transform: @escaping (W) throws -> NewCapture?
   ) where RegexOutput == (Substring, NewCapture, C1), R.RegexOutput == (W, C1) {
-    self.init(node: .capture(
-      reference: reference.id,
-      component().regex.root,
-      CaptureTransform(transform)))
+    self.init(_RegexFactory.captureOptional(component().regex._root, reference, transform))
   }
 }
 
@@ -2849,59 +3179,55 @@ extension TryCapture {
 
 @available(SwiftStdlib 5.7, *)
 extension Capture {
+  @_alwaysEmitIntoClient
   public init<R: RegexComponent, W, C1, C2>(
     _ component: R
   ) where RegexOutput == (Substring, W, C1, C2), R.RegexOutput == (W, C1, C2) {
-    self.init(node: .capture(component.regex.root))
+    self.init(_RegexFactory.capture(component.regex._root))
   }
 
+  @_alwaysEmitIntoClient
   public init<R: RegexComponent, W, C1, C2>(
     _ component: R, as reference: Reference<W>
   ) where RegexOutput == (Substring, W, C1, C2), R.RegexOutput == (W, C1, C2) {
-    self.init(node: .capture(reference: reference.id, component.regex.root))
+    self.init(_RegexFactory.capture(component.regex._root, reference))
   }
 
+  @_alwaysEmitIntoClient
   public init<R: RegexComponent, W, C1, C2, NewCapture>(
     _ component: R,
     transform: @escaping (W) throws -> NewCapture
   ) where RegexOutput == (Substring, NewCapture, C1, C2), R.RegexOutput == (W, C1, C2) {
-    self.init(node: .capture(
-      component.regex.root,
-      CaptureTransform(transform)))
+    self.init(_RegexFactory.capture(component.regex._root, nil, transform))
   }
 
+  @_alwaysEmitIntoClient
   public init<R: RegexComponent, W, C1, C2, NewCapture>(
     _ component: R,
     as reference: Reference<NewCapture>,
     transform: @escaping (W) throws -> NewCapture
   ) where RegexOutput == (Substring, NewCapture, C1, C2), R.RegexOutput == (W, C1, C2) {
-    self.init(node: .capture(
-      reference: reference.id,
-      component.regex.root,
-      CaptureTransform(transform)))
+    self.init(_RegexFactory.capture(component.regex._root, reference, transform))
   }
 }
 
 @available(SwiftStdlib 5.7, *)
 extension TryCapture {
+  @_alwaysEmitIntoClient
   public init<R: RegexComponent, W, C1, C2, NewCapture>(
     _ component: R,
     transform: @escaping (W) throws -> NewCapture?
   ) where RegexOutput == (Substring, NewCapture, C1, C2), R.RegexOutput == (W, C1, C2) {
-    self.init(node: .capture(
-    component.regex.root,
-    CaptureTransform(transform)))
+    self.init(_RegexFactory.captureOptional(component.regex._root, nil, transform))
   }
 
+  @_alwaysEmitIntoClient
   public init<R: RegexComponent, W, C1, C2, NewCapture>(
     _ component: R,
     as reference: Reference<NewCapture>,
     transform: @escaping (W) throws -> NewCapture?
   ) where RegexOutput == (Substring, NewCapture, C1, C2), R.RegexOutput == (W, C1, C2) {
-    self.init(node: .capture(
-      reference: reference.id,
-      component.regex.root,
-      CaptureTransform(transform)))
+    self.init(_RegexFactory.captureOptional(component.regex._root, reference, transform))
   }
 }
 
@@ -2909,62 +3235,56 @@ extension TryCapture {
 
 @available(SwiftStdlib 5.7, *)
 extension Capture {
+  @_alwaysEmitIntoClient
   public init<R: RegexComponent, W, C1, C2>(
     @RegexComponentBuilder _ component: () -> R
   ) where RegexOutput == (Substring, W, C1, C2), R.RegexOutput == (W, C1, C2) {
-    self.init(node: .capture(component().regex.root))
+    self.init(_RegexFactory.node(component().regex._root))
   }
 
+  @_alwaysEmitIntoClient
   public init<R: RegexComponent, W, C1, C2>(
     as reference: Reference<W>,
     @RegexComponentBuilder _ component: () -> R
   ) where RegexOutput == (Substring, W, C1, C2), R.RegexOutput == (W, C1, C2) {
-    self.init(node: .capture(
-      reference: reference.id,
-      component().regex.root))
+    self.init(_RegexFactory.capture(component().regex._root, reference))
   }
 
+  @_alwaysEmitIntoClient
   public init<R: RegexComponent, W, C1, C2, NewCapture>(
     @RegexComponentBuilder _ component: () -> R,
     transform: @escaping (W) throws -> NewCapture
   ) where RegexOutput == (Substring, NewCapture, C1, C2), R.RegexOutput == (W, C1, C2) {
-    self.init(node: .capture(
-      component().regex.root,
-      CaptureTransform(transform)))
+    self.init(_RegexFactory.capture(component().regex._root, nil, transform))
   }
 
+    @_alwaysEmitIntoClient
   public init<R: RegexComponent, W, C1, C2, NewCapture>(
     as reference: Reference<NewCapture>,
     @RegexComponentBuilder _ component: () -> R,
     transform: @escaping (W) throws -> NewCapture
   ) where RegexOutput == (Substring, NewCapture, C1, C2), R.RegexOutput == (W, C1, C2) {
-    self.init(node: .capture(
-      reference: reference.id,
-      component().regex.root,
-      CaptureTransform(transform)))
+    self.init(_RegexFactory.capture(component().regex._root, reference, transform))
   }
 }
 
 @available(SwiftStdlib 5.7, *)
 extension TryCapture {
+  @_alwaysEmitIntoClient
   public init<R: RegexComponent, W, C1, C2, NewCapture>(
     @RegexComponentBuilder _ component: () -> R,
     transform: @escaping (W) throws -> NewCapture?
   ) where RegexOutput == (Substring, NewCapture, C1, C2), R.RegexOutput == (W, C1, C2) {
-    self.init(node: .capture(
-      component().regex.root,
-      CaptureTransform(transform)))
+    self.init(_RegexFactory.captureOptional(component().regex._root, nil, transform))
   }
 
+  @_alwaysEmitIntoClient
   public init<R: RegexComponent, W, C1, C2, NewCapture>(
     as reference: Reference<NewCapture>,
     @RegexComponentBuilder _ component: () -> R,
     transform: @escaping (W) throws -> NewCapture?
   ) where RegexOutput == (Substring, NewCapture, C1, C2), R.RegexOutput == (W, C1, C2) {
-    self.init(node: .capture(
-      reference: reference.id,
-      component().regex.root,
-      CaptureTransform(transform)))
+    self.init(_RegexFactory.captureOptional(component().regex._root, reference, transform))
   }
 }
 
@@ -2972,59 +3292,55 @@ extension TryCapture {
 
 @available(SwiftStdlib 5.7, *)
 extension Capture {
+  @_alwaysEmitIntoClient
   public init<R: RegexComponent, W, C1, C2, C3>(
     _ component: R
   ) where RegexOutput == (Substring, W, C1, C2, C3), R.RegexOutput == (W, C1, C2, C3) {
-    self.init(node: .capture(component.regex.root))
+    self.init(_RegexFactory.capture(component.regex._root))
   }
 
+  @_alwaysEmitIntoClient
   public init<R: RegexComponent, W, C1, C2, C3>(
     _ component: R, as reference: Reference<W>
   ) where RegexOutput == (Substring, W, C1, C2, C3), R.RegexOutput == (W, C1, C2, C3) {
-    self.init(node: .capture(reference: reference.id, component.regex.root))
+    self.init(_RegexFactory.capture(component.regex._root, reference))
   }
 
+  @_alwaysEmitIntoClient
   public init<R: RegexComponent, W, C1, C2, C3, NewCapture>(
     _ component: R,
     transform: @escaping (W) throws -> NewCapture
   ) where RegexOutput == (Substring, NewCapture, C1, C2, C3), R.RegexOutput == (W, C1, C2, C3) {
-    self.init(node: .capture(
-      component.regex.root,
-      CaptureTransform(transform)))
+    self.init(_RegexFactory.capture(component.regex._root, nil, transform))
   }
 
+  @_alwaysEmitIntoClient
   public init<R: RegexComponent, W, C1, C2, C3, NewCapture>(
     _ component: R,
     as reference: Reference<NewCapture>,
     transform: @escaping (W) throws -> NewCapture
   ) where RegexOutput == (Substring, NewCapture, C1, C2, C3), R.RegexOutput == (W, C1, C2, C3) {
-    self.init(node: .capture(
-      reference: reference.id,
-      component.regex.root,
-      CaptureTransform(transform)))
+    self.init(_RegexFactory.capture(component.regex._root, reference, transform))
   }
 }
 
 @available(SwiftStdlib 5.7, *)
 extension TryCapture {
+  @_alwaysEmitIntoClient
   public init<R: RegexComponent, W, C1, C2, C3, NewCapture>(
     _ component: R,
     transform: @escaping (W) throws -> NewCapture?
   ) where RegexOutput == (Substring, NewCapture, C1, C2, C3), R.RegexOutput == (W, C1, C2, C3) {
-    self.init(node: .capture(
-    component.regex.root,
-    CaptureTransform(transform)))
+    self.init(_RegexFactory.captureOptional(component.regex._root, nil, transform))
   }
 
+  @_alwaysEmitIntoClient
   public init<R: RegexComponent, W, C1, C2, C3, NewCapture>(
     _ component: R,
     as reference: Reference<NewCapture>,
     transform: @escaping (W) throws -> NewCapture?
   ) where RegexOutput == (Substring, NewCapture, C1, C2, C3), R.RegexOutput == (W, C1, C2, C3) {
-    self.init(node: .capture(
-      reference: reference.id,
-      component.regex.root,
-      CaptureTransform(transform)))
+    self.init(_RegexFactory.captureOptional(component.regex._root, reference, transform))
   }
 }
 
@@ -3032,62 +3348,56 @@ extension TryCapture {
 
 @available(SwiftStdlib 5.7, *)
 extension Capture {
+  @_alwaysEmitIntoClient
   public init<R: RegexComponent, W, C1, C2, C3>(
     @RegexComponentBuilder _ component: () -> R
   ) where RegexOutput == (Substring, W, C1, C2, C3), R.RegexOutput == (W, C1, C2, C3) {
-    self.init(node: .capture(component().regex.root))
+    self.init(_RegexFactory.node(component().regex._root))
   }
 
+  @_alwaysEmitIntoClient
   public init<R: RegexComponent, W, C1, C2, C3>(
     as reference: Reference<W>,
     @RegexComponentBuilder _ component: () -> R
   ) where RegexOutput == (Substring, W, C1, C2, C3), R.RegexOutput == (W, C1, C2, C3) {
-    self.init(node: .capture(
-      reference: reference.id,
-      component().regex.root))
+    self.init(_RegexFactory.capture(component().regex._root, reference))
   }
 
+  @_alwaysEmitIntoClient
   public init<R: RegexComponent, W, C1, C2, C3, NewCapture>(
     @RegexComponentBuilder _ component: () -> R,
     transform: @escaping (W) throws -> NewCapture
   ) where RegexOutput == (Substring, NewCapture, C1, C2, C3), R.RegexOutput == (W, C1, C2, C3) {
-    self.init(node: .capture(
-      component().regex.root,
-      CaptureTransform(transform)))
+    self.init(_RegexFactory.capture(component().regex._root, nil, transform))
   }
 
+    @_alwaysEmitIntoClient
   public init<R: RegexComponent, W, C1, C2, C3, NewCapture>(
     as reference: Reference<NewCapture>,
     @RegexComponentBuilder _ component: () -> R,
     transform: @escaping (W) throws -> NewCapture
   ) where RegexOutput == (Substring, NewCapture, C1, C2, C3), R.RegexOutput == (W, C1, C2, C3) {
-    self.init(node: .capture(
-      reference: reference.id,
-      component().regex.root,
-      CaptureTransform(transform)))
+    self.init(_RegexFactory.capture(component().regex._root, reference, transform))
   }
 }
 
 @available(SwiftStdlib 5.7, *)
 extension TryCapture {
+  @_alwaysEmitIntoClient
   public init<R: RegexComponent, W, C1, C2, C3, NewCapture>(
     @RegexComponentBuilder _ component: () -> R,
     transform: @escaping (W) throws -> NewCapture?
   ) where RegexOutput == (Substring, NewCapture, C1, C2, C3), R.RegexOutput == (W, C1, C2, C3) {
-    self.init(node: .capture(
-      component().regex.root,
-      CaptureTransform(transform)))
+    self.init(_RegexFactory.captureOptional(component().regex._root, nil, transform))
   }
 
+  @_alwaysEmitIntoClient
   public init<R: RegexComponent, W, C1, C2, C3, NewCapture>(
     as reference: Reference<NewCapture>,
     @RegexComponentBuilder _ component: () -> R,
     transform: @escaping (W) throws -> NewCapture?
   ) where RegexOutput == (Substring, NewCapture, C1, C2, C3), R.RegexOutput == (W, C1, C2, C3) {
-    self.init(node: .capture(
-      reference: reference.id,
-      component().regex.root,
-      CaptureTransform(transform)))
+    self.init(_RegexFactory.captureOptional(component().regex._root, reference, transform))
   }
 }
 
@@ -3095,59 +3405,55 @@ extension TryCapture {
 
 @available(SwiftStdlib 5.7, *)
 extension Capture {
+  @_alwaysEmitIntoClient
   public init<R: RegexComponent, W, C1, C2, C3, C4>(
     _ component: R
   ) where RegexOutput == (Substring, W, C1, C2, C3, C4), R.RegexOutput == (W, C1, C2, C3, C4) {
-    self.init(node: .capture(component.regex.root))
+    self.init(_RegexFactory.capture(component.regex._root))
   }
 
+  @_alwaysEmitIntoClient
   public init<R: RegexComponent, W, C1, C2, C3, C4>(
     _ component: R, as reference: Reference<W>
   ) where RegexOutput == (Substring, W, C1, C2, C3, C4), R.RegexOutput == (W, C1, C2, C3, C4) {
-    self.init(node: .capture(reference: reference.id, component.regex.root))
+    self.init(_RegexFactory.capture(component.regex._root, reference))
   }
 
+  @_alwaysEmitIntoClient
   public init<R: RegexComponent, W, C1, C2, C3, C4, NewCapture>(
     _ component: R,
     transform: @escaping (W) throws -> NewCapture
   ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4), R.RegexOutput == (W, C1, C2, C3, C4) {
-    self.init(node: .capture(
-      component.regex.root,
-      CaptureTransform(transform)))
+    self.init(_RegexFactory.capture(component.regex._root, nil, transform))
   }
 
+  @_alwaysEmitIntoClient
   public init<R: RegexComponent, W, C1, C2, C3, C4, NewCapture>(
     _ component: R,
     as reference: Reference<NewCapture>,
     transform: @escaping (W) throws -> NewCapture
   ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4), R.RegexOutput == (W, C1, C2, C3, C4) {
-    self.init(node: .capture(
-      reference: reference.id,
-      component.regex.root,
-      CaptureTransform(transform)))
+    self.init(_RegexFactory.capture(component.regex._root, reference, transform))
   }
 }
 
 @available(SwiftStdlib 5.7, *)
 extension TryCapture {
+  @_alwaysEmitIntoClient
   public init<R: RegexComponent, W, C1, C2, C3, C4, NewCapture>(
     _ component: R,
     transform: @escaping (W) throws -> NewCapture?
   ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4), R.RegexOutput == (W, C1, C2, C3, C4) {
-    self.init(node: .capture(
-    component.regex.root,
-    CaptureTransform(transform)))
+    self.init(_RegexFactory.captureOptional(component.regex._root, nil, transform))
   }
 
+  @_alwaysEmitIntoClient
   public init<R: RegexComponent, W, C1, C2, C3, C4, NewCapture>(
     _ component: R,
     as reference: Reference<NewCapture>,
     transform: @escaping (W) throws -> NewCapture?
   ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4), R.RegexOutput == (W, C1, C2, C3, C4) {
-    self.init(node: .capture(
-      reference: reference.id,
-      component.regex.root,
-      CaptureTransform(transform)))
+    self.init(_RegexFactory.captureOptional(component.regex._root, reference, transform))
   }
 }
 
@@ -3155,62 +3461,56 @@ extension TryCapture {
 
 @available(SwiftStdlib 5.7, *)
 extension Capture {
+  @_alwaysEmitIntoClient
   public init<R: RegexComponent, W, C1, C2, C3, C4>(
     @RegexComponentBuilder _ component: () -> R
   ) where RegexOutput == (Substring, W, C1, C2, C3, C4), R.RegexOutput == (W, C1, C2, C3, C4) {
-    self.init(node: .capture(component().regex.root))
+    self.init(_RegexFactory.node(component().regex._root))
   }
 
+  @_alwaysEmitIntoClient
   public init<R: RegexComponent, W, C1, C2, C3, C4>(
     as reference: Reference<W>,
     @RegexComponentBuilder _ component: () -> R
   ) where RegexOutput == (Substring, W, C1, C2, C3, C4), R.RegexOutput == (W, C1, C2, C3, C4) {
-    self.init(node: .capture(
-      reference: reference.id,
-      component().regex.root))
+    self.init(_RegexFactory.capture(component().regex._root, reference))
   }
 
+  @_alwaysEmitIntoClient
   public init<R: RegexComponent, W, C1, C2, C3, C4, NewCapture>(
     @RegexComponentBuilder _ component: () -> R,
     transform: @escaping (W) throws -> NewCapture
   ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4), R.RegexOutput == (W, C1, C2, C3, C4) {
-    self.init(node: .capture(
-      component().regex.root,
-      CaptureTransform(transform)))
+    self.init(_RegexFactory.capture(component().regex._root, nil, transform))
   }
 
+    @_alwaysEmitIntoClient
   public init<R: RegexComponent, W, C1, C2, C3, C4, NewCapture>(
     as reference: Reference<NewCapture>,
     @RegexComponentBuilder _ component: () -> R,
     transform: @escaping (W) throws -> NewCapture
   ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4), R.RegexOutput == (W, C1, C2, C3, C4) {
-    self.init(node: .capture(
-      reference: reference.id,
-      component().regex.root,
-      CaptureTransform(transform)))
+    self.init(_RegexFactory.capture(component().regex._root, reference, transform))
   }
 }
 
 @available(SwiftStdlib 5.7, *)
 extension TryCapture {
+  @_alwaysEmitIntoClient
   public init<R: RegexComponent, W, C1, C2, C3, C4, NewCapture>(
     @RegexComponentBuilder _ component: () -> R,
     transform: @escaping (W) throws -> NewCapture?
   ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4), R.RegexOutput == (W, C1, C2, C3, C4) {
-    self.init(node: .capture(
-      component().regex.root,
-      CaptureTransform(transform)))
+    self.init(_RegexFactory.captureOptional(component().regex._root, nil, transform))
   }
 
+  @_alwaysEmitIntoClient
   public init<R: RegexComponent, W, C1, C2, C3, C4, NewCapture>(
     as reference: Reference<NewCapture>,
     @RegexComponentBuilder _ component: () -> R,
     transform: @escaping (W) throws -> NewCapture?
   ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4), R.RegexOutput == (W, C1, C2, C3, C4) {
-    self.init(node: .capture(
-      reference: reference.id,
-      component().regex.root,
-      CaptureTransform(transform)))
+    self.init(_RegexFactory.captureOptional(component().regex._root, reference, transform))
   }
 }
 
@@ -3218,59 +3518,55 @@ extension TryCapture {
 
 @available(SwiftStdlib 5.7, *)
 extension Capture {
+  @_alwaysEmitIntoClient
   public init<R: RegexComponent, W, C1, C2, C3, C4, C5>(
     _ component: R
   ) where RegexOutput == (Substring, W, C1, C2, C3, C4, C5), R.RegexOutput == (W, C1, C2, C3, C4, C5) {
-    self.init(node: .capture(component.regex.root))
+    self.init(_RegexFactory.capture(component.regex._root))
   }
 
+  @_alwaysEmitIntoClient
   public init<R: RegexComponent, W, C1, C2, C3, C4, C5>(
     _ component: R, as reference: Reference<W>
   ) where RegexOutput == (Substring, W, C1, C2, C3, C4, C5), R.RegexOutput == (W, C1, C2, C3, C4, C5) {
-    self.init(node: .capture(reference: reference.id, component.regex.root))
+    self.init(_RegexFactory.capture(component.regex._root, reference))
   }
 
+  @_alwaysEmitIntoClient
   public init<R: RegexComponent, W, C1, C2, C3, C4, C5, NewCapture>(
     _ component: R,
     transform: @escaping (W) throws -> NewCapture
   ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5), R.RegexOutput == (W, C1, C2, C3, C4, C5) {
-    self.init(node: .capture(
-      component.regex.root,
-      CaptureTransform(transform)))
+    self.init(_RegexFactory.capture(component.regex._root, nil, transform))
   }
 
+  @_alwaysEmitIntoClient
   public init<R: RegexComponent, W, C1, C2, C3, C4, C5, NewCapture>(
     _ component: R,
     as reference: Reference<NewCapture>,
     transform: @escaping (W) throws -> NewCapture
   ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5), R.RegexOutput == (W, C1, C2, C3, C4, C5) {
-    self.init(node: .capture(
-      reference: reference.id,
-      component.regex.root,
-      CaptureTransform(transform)))
+    self.init(_RegexFactory.capture(component.regex._root, reference, transform))
   }
 }
 
 @available(SwiftStdlib 5.7, *)
 extension TryCapture {
+  @_alwaysEmitIntoClient
   public init<R: RegexComponent, W, C1, C2, C3, C4, C5, NewCapture>(
     _ component: R,
     transform: @escaping (W) throws -> NewCapture?
   ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5), R.RegexOutput == (W, C1, C2, C3, C4, C5) {
-    self.init(node: .capture(
-    component.regex.root,
-    CaptureTransform(transform)))
+    self.init(_RegexFactory.captureOptional(component.regex._root, nil, transform))
   }
 
+  @_alwaysEmitIntoClient
   public init<R: RegexComponent, W, C1, C2, C3, C4, C5, NewCapture>(
     _ component: R,
     as reference: Reference<NewCapture>,
     transform: @escaping (W) throws -> NewCapture?
   ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5), R.RegexOutput == (W, C1, C2, C3, C4, C5) {
-    self.init(node: .capture(
-      reference: reference.id,
-      component.regex.root,
-      CaptureTransform(transform)))
+    self.init(_RegexFactory.captureOptional(component.regex._root, reference, transform))
   }
 }
 
@@ -3278,62 +3574,56 @@ extension TryCapture {
 
 @available(SwiftStdlib 5.7, *)
 extension Capture {
+  @_alwaysEmitIntoClient
   public init<R: RegexComponent, W, C1, C2, C3, C4, C5>(
     @RegexComponentBuilder _ component: () -> R
   ) where RegexOutput == (Substring, W, C1, C2, C3, C4, C5), R.RegexOutput == (W, C1, C2, C3, C4, C5) {
-    self.init(node: .capture(component().regex.root))
+    self.init(_RegexFactory.node(component().regex._root))
   }
 
+  @_alwaysEmitIntoClient
   public init<R: RegexComponent, W, C1, C2, C3, C4, C5>(
     as reference: Reference<W>,
     @RegexComponentBuilder _ component: () -> R
   ) where RegexOutput == (Substring, W, C1, C2, C3, C4, C5), R.RegexOutput == (W, C1, C2, C3, C4, C5) {
-    self.init(node: .capture(
-      reference: reference.id,
-      component().regex.root))
+    self.init(_RegexFactory.capture(component().regex._root, reference))
   }
 
+  @_alwaysEmitIntoClient
   public init<R: RegexComponent, W, C1, C2, C3, C4, C5, NewCapture>(
     @RegexComponentBuilder _ component: () -> R,
     transform: @escaping (W) throws -> NewCapture
   ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5), R.RegexOutput == (W, C1, C2, C3, C4, C5) {
-    self.init(node: .capture(
-      component().regex.root,
-      CaptureTransform(transform)))
+    self.init(_RegexFactory.capture(component().regex._root, nil, transform))
   }
 
+    @_alwaysEmitIntoClient
   public init<R: RegexComponent, W, C1, C2, C3, C4, C5, NewCapture>(
     as reference: Reference<NewCapture>,
     @RegexComponentBuilder _ component: () -> R,
     transform: @escaping (W) throws -> NewCapture
   ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5), R.RegexOutput == (W, C1, C2, C3, C4, C5) {
-    self.init(node: .capture(
-      reference: reference.id,
-      component().regex.root,
-      CaptureTransform(transform)))
+    self.init(_RegexFactory.capture(component().regex._root, reference, transform))
   }
 }
 
 @available(SwiftStdlib 5.7, *)
 extension TryCapture {
+  @_alwaysEmitIntoClient
   public init<R: RegexComponent, W, C1, C2, C3, C4, C5, NewCapture>(
     @RegexComponentBuilder _ component: () -> R,
     transform: @escaping (W) throws -> NewCapture?
   ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5), R.RegexOutput == (W, C1, C2, C3, C4, C5) {
-    self.init(node: .capture(
-      component().regex.root,
-      CaptureTransform(transform)))
+    self.init(_RegexFactory.captureOptional(component().regex._root, nil, transform))
   }
 
+  @_alwaysEmitIntoClient
   public init<R: RegexComponent, W, C1, C2, C3, C4, C5, NewCapture>(
     as reference: Reference<NewCapture>,
     @RegexComponentBuilder _ component: () -> R,
     transform: @escaping (W) throws -> NewCapture?
   ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5), R.RegexOutput == (W, C1, C2, C3, C4, C5) {
-    self.init(node: .capture(
-      reference: reference.id,
-      component().regex.root,
-      CaptureTransform(transform)))
+    self.init(_RegexFactory.captureOptional(component().regex._root, reference, transform))
   }
 }
 
@@ -3341,59 +3631,55 @@ extension TryCapture {
 
 @available(SwiftStdlib 5.7, *)
 extension Capture {
+  @_alwaysEmitIntoClient
   public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6>(
     _ component: R
   ) where RegexOutput == (Substring, W, C1, C2, C3, C4, C5, C6), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6) {
-    self.init(node: .capture(component.regex.root))
+    self.init(_RegexFactory.capture(component.regex._root))
   }
 
+  @_alwaysEmitIntoClient
   public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6>(
     _ component: R, as reference: Reference<W>
   ) where RegexOutput == (Substring, W, C1, C2, C3, C4, C5, C6), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6) {
-    self.init(node: .capture(reference: reference.id, component.regex.root))
+    self.init(_RegexFactory.capture(component.regex._root, reference))
   }
 
+  @_alwaysEmitIntoClient
   public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, NewCapture>(
     _ component: R,
     transform: @escaping (W) throws -> NewCapture
   ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6) {
-    self.init(node: .capture(
-      component.regex.root,
-      CaptureTransform(transform)))
+    self.init(_RegexFactory.capture(component.regex._root, nil, transform))
   }
 
+  @_alwaysEmitIntoClient
   public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, NewCapture>(
     _ component: R,
     as reference: Reference<NewCapture>,
     transform: @escaping (W) throws -> NewCapture
   ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6) {
-    self.init(node: .capture(
-      reference: reference.id,
-      component.regex.root,
-      CaptureTransform(transform)))
+    self.init(_RegexFactory.capture(component.regex._root, reference, transform))
   }
 }
 
 @available(SwiftStdlib 5.7, *)
 extension TryCapture {
+  @_alwaysEmitIntoClient
   public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, NewCapture>(
     _ component: R,
     transform: @escaping (W) throws -> NewCapture?
   ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6) {
-    self.init(node: .capture(
-    component.regex.root,
-    CaptureTransform(transform)))
+    self.init(_RegexFactory.captureOptional(component.regex._root, nil, transform))
   }
 
+  @_alwaysEmitIntoClient
   public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, NewCapture>(
     _ component: R,
     as reference: Reference<NewCapture>,
     transform: @escaping (W) throws -> NewCapture?
   ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6) {
-    self.init(node: .capture(
-      reference: reference.id,
-      component.regex.root,
-      CaptureTransform(transform)))
+    self.init(_RegexFactory.captureOptional(component.regex._root, reference, transform))
   }
 }
 
@@ -3401,62 +3687,56 @@ extension TryCapture {
 
 @available(SwiftStdlib 5.7, *)
 extension Capture {
+  @_alwaysEmitIntoClient
   public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6>(
     @RegexComponentBuilder _ component: () -> R
   ) where RegexOutput == (Substring, W, C1, C2, C3, C4, C5, C6), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6) {
-    self.init(node: .capture(component().regex.root))
+    self.init(_RegexFactory.node(component().regex._root))
   }
 
+  @_alwaysEmitIntoClient
   public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6>(
     as reference: Reference<W>,
     @RegexComponentBuilder _ component: () -> R
   ) where RegexOutput == (Substring, W, C1, C2, C3, C4, C5, C6), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6) {
-    self.init(node: .capture(
-      reference: reference.id,
-      component().regex.root))
+    self.init(_RegexFactory.capture(component().regex._root, reference))
   }
 
+  @_alwaysEmitIntoClient
   public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, NewCapture>(
     @RegexComponentBuilder _ component: () -> R,
     transform: @escaping (W) throws -> NewCapture
   ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6) {
-    self.init(node: .capture(
-      component().regex.root,
-      CaptureTransform(transform)))
+    self.init(_RegexFactory.capture(component().regex._root, nil, transform))
   }
 
+    @_alwaysEmitIntoClient
   public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, NewCapture>(
     as reference: Reference<NewCapture>,
     @RegexComponentBuilder _ component: () -> R,
     transform: @escaping (W) throws -> NewCapture
   ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6) {
-    self.init(node: .capture(
-      reference: reference.id,
-      component().regex.root,
-      CaptureTransform(transform)))
+    self.init(_RegexFactory.capture(component().regex._root, reference, transform))
   }
 }
 
 @available(SwiftStdlib 5.7, *)
 extension TryCapture {
+  @_alwaysEmitIntoClient
   public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, NewCapture>(
     @RegexComponentBuilder _ component: () -> R,
     transform: @escaping (W) throws -> NewCapture?
   ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6) {
-    self.init(node: .capture(
-      component().regex.root,
-      CaptureTransform(transform)))
+    self.init(_RegexFactory.captureOptional(component().regex._root, nil, transform))
   }
 
+  @_alwaysEmitIntoClient
   public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, NewCapture>(
     as reference: Reference<NewCapture>,
     @RegexComponentBuilder _ component: () -> R,
     transform: @escaping (W) throws -> NewCapture?
   ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6) {
-    self.init(node: .capture(
-      reference: reference.id,
-      component().regex.root,
-      CaptureTransform(transform)))
+    self.init(_RegexFactory.captureOptional(component().regex._root, reference, transform))
   }
 }
 
@@ -3464,59 +3744,55 @@ extension TryCapture {
 
 @available(SwiftStdlib 5.7, *)
 extension Capture {
+  @_alwaysEmitIntoClient
   public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, C7>(
     _ component: R
   ) where RegexOutput == (Substring, W, C1, C2, C3, C4, C5, C6, C7), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7) {
-    self.init(node: .capture(component.regex.root))
+    self.init(_RegexFactory.capture(component.regex._root))
   }
 
+  @_alwaysEmitIntoClient
   public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, C7>(
     _ component: R, as reference: Reference<W>
   ) where RegexOutput == (Substring, W, C1, C2, C3, C4, C5, C6, C7), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7) {
-    self.init(node: .capture(reference: reference.id, component.regex.root))
+    self.init(_RegexFactory.capture(component.regex._root, reference))
   }
 
+  @_alwaysEmitIntoClient
   public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, C7, NewCapture>(
     _ component: R,
     transform: @escaping (W) throws -> NewCapture
   ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6, C7), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7) {
-    self.init(node: .capture(
-      component.regex.root,
-      CaptureTransform(transform)))
+    self.init(_RegexFactory.capture(component.regex._root, nil, transform))
   }
 
+  @_alwaysEmitIntoClient
   public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, C7, NewCapture>(
     _ component: R,
     as reference: Reference<NewCapture>,
     transform: @escaping (W) throws -> NewCapture
   ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6, C7), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7) {
-    self.init(node: .capture(
-      reference: reference.id,
-      component.regex.root,
-      CaptureTransform(transform)))
+    self.init(_RegexFactory.capture(component.regex._root, reference, transform))
   }
 }
 
 @available(SwiftStdlib 5.7, *)
 extension TryCapture {
+  @_alwaysEmitIntoClient
   public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, C7, NewCapture>(
     _ component: R,
     transform: @escaping (W) throws -> NewCapture?
   ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6, C7), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7) {
-    self.init(node: .capture(
-    component.regex.root,
-    CaptureTransform(transform)))
+    self.init(_RegexFactory.captureOptional(component.regex._root, nil, transform))
   }
 
+  @_alwaysEmitIntoClient
   public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, C7, NewCapture>(
     _ component: R,
     as reference: Reference<NewCapture>,
     transform: @escaping (W) throws -> NewCapture?
   ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6, C7), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7) {
-    self.init(node: .capture(
-      reference: reference.id,
-      component.regex.root,
-      CaptureTransform(transform)))
+    self.init(_RegexFactory.captureOptional(component.regex._root, reference, transform))
   }
 }
 
@@ -3524,62 +3800,56 @@ extension TryCapture {
 
 @available(SwiftStdlib 5.7, *)
 extension Capture {
+  @_alwaysEmitIntoClient
   public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, C7>(
     @RegexComponentBuilder _ component: () -> R
   ) where RegexOutput == (Substring, W, C1, C2, C3, C4, C5, C6, C7), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7) {
-    self.init(node: .capture(component().regex.root))
+    self.init(_RegexFactory.node(component().regex._root))
   }
 
+  @_alwaysEmitIntoClient
   public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, C7>(
     as reference: Reference<W>,
     @RegexComponentBuilder _ component: () -> R
   ) where RegexOutput == (Substring, W, C1, C2, C3, C4, C5, C6, C7), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7) {
-    self.init(node: .capture(
-      reference: reference.id,
-      component().regex.root))
+    self.init(_RegexFactory.capture(component().regex._root, reference))
   }
 
+  @_alwaysEmitIntoClient
   public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, C7, NewCapture>(
     @RegexComponentBuilder _ component: () -> R,
     transform: @escaping (W) throws -> NewCapture
   ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6, C7), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7) {
-    self.init(node: .capture(
-      component().regex.root,
-      CaptureTransform(transform)))
+    self.init(_RegexFactory.capture(component().regex._root, nil, transform))
   }
 
+    @_alwaysEmitIntoClient
   public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, C7, NewCapture>(
     as reference: Reference<NewCapture>,
     @RegexComponentBuilder _ component: () -> R,
     transform: @escaping (W) throws -> NewCapture
   ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6, C7), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7) {
-    self.init(node: .capture(
-      reference: reference.id,
-      component().regex.root,
-      CaptureTransform(transform)))
+    self.init(_RegexFactory.capture(component().regex._root, reference, transform))
   }
 }
 
 @available(SwiftStdlib 5.7, *)
 extension TryCapture {
+  @_alwaysEmitIntoClient
   public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, C7, NewCapture>(
     @RegexComponentBuilder _ component: () -> R,
     transform: @escaping (W) throws -> NewCapture?
   ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6, C7), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7) {
-    self.init(node: .capture(
-      component().regex.root,
-      CaptureTransform(transform)))
+    self.init(_RegexFactory.captureOptional(component().regex._root, nil, transform))
   }
 
+  @_alwaysEmitIntoClient
   public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, C7, NewCapture>(
     as reference: Reference<NewCapture>,
     @RegexComponentBuilder _ component: () -> R,
     transform: @escaping (W) throws -> NewCapture?
   ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6, C7), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7) {
-    self.init(node: .capture(
-      reference: reference.id,
-      component().regex.root,
-      CaptureTransform(transform)))
+    self.init(_RegexFactory.captureOptional(component().regex._root, reference, transform))
   }
 }
 
@@ -3587,59 +3857,55 @@ extension TryCapture {
 
 @available(SwiftStdlib 5.7, *)
 extension Capture {
+  @_alwaysEmitIntoClient
   public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, C7, C8>(
     _ component: R
   ) where RegexOutput == (Substring, W, C1, C2, C3, C4, C5, C6, C7, C8), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8) {
-    self.init(node: .capture(component.regex.root))
+    self.init(_RegexFactory.capture(component.regex._root))
   }
 
+  @_alwaysEmitIntoClient
   public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, C7, C8>(
     _ component: R, as reference: Reference<W>
   ) where RegexOutput == (Substring, W, C1, C2, C3, C4, C5, C6, C7, C8), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8) {
-    self.init(node: .capture(reference: reference.id, component.regex.root))
+    self.init(_RegexFactory.capture(component.regex._root, reference))
   }
 
+  @_alwaysEmitIntoClient
   public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, C7, C8, NewCapture>(
     _ component: R,
     transform: @escaping (W) throws -> NewCapture
   ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6, C7, C8), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8) {
-    self.init(node: .capture(
-      component.regex.root,
-      CaptureTransform(transform)))
+    self.init(_RegexFactory.capture(component.regex._root, nil, transform))
   }
 
+  @_alwaysEmitIntoClient
   public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, C7, C8, NewCapture>(
     _ component: R,
     as reference: Reference<NewCapture>,
     transform: @escaping (W) throws -> NewCapture
   ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6, C7, C8), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8) {
-    self.init(node: .capture(
-      reference: reference.id,
-      component.regex.root,
-      CaptureTransform(transform)))
+    self.init(_RegexFactory.capture(component.regex._root, reference, transform))
   }
 }
 
 @available(SwiftStdlib 5.7, *)
 extension TryCapture {
+  @_alwaysEmitIntoClient
   public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, C7, C8, NewCapture>(
     _ component: R,
     transform: @escaping (W) throws -> NewCapture?
   ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6, C7, C8), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8) {
-    self.init(node: .capture(
-    component.regex.root,
-    CaptureTransform(transform)))
+    self.init(_RegexFactory.captureOptional(component.regex._root, nil, transform))
   }
 
+  @_alwaysEmitIntoClient
   public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, C7, C8, NewCapture>(
     _ component: R,
     as reference: Reference<NewCapture>,
     transform: @escaping (W) throws -> NewCapture?
   ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6, C7, C8), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8) {
-    self.init(node: .capture(
-      reference: reference.id,
-      component.regex.root,
-      CaptureTransform(transform)))
+    self.init(_RegexFactory.captureOptional(component.regex._root, reference, transform))
   }
 }
 
@@ -3647,62 +3913,56 @@ extension TryCapture {
 
 @available(SwiftStdlib 5.7, *)
 extension Capture {
+  @_alwaysEmitIntoClient
   public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, C7, C8>(
     @RegexComponentBuilder _ component: () -> R
   ) where RegexOutput == (Substring, W, C1, C2, C3, C4, C5, C6, C7, C8), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8) {
-    self.init(node: .capture(component().regex.root))
+    self.init(_RegexFactory.node(component().regex._root))
   }
 
+  @_alwaysEmitIntoClient
   public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, C7, C8>(
     as reference: Reference<W>,
     @RegexComponentBuilder _ component: () -> R
   ) where RegexOutput == (Substring, W, C1, C2, C3, C4, C5, C6, C7, C8), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8) {
-    self.init(node: .capture(
-      reference: reference.id,
-      component().regex.root))
+    self.init(_RegexFactory.capture(component().regex._root, reference))
   }
 
+  @_alwaysEmitIntoClient
   public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, C7, C8, NewCapture>(
     @RegexComponentBuilder _ component: () -> R,
     transform: @escaping (W) throws -> NewCapture
   ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6, C7, C8), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8) {
-    self.init(node: .capture(
-      component().regex.root,
-      CaptureTransform(transform)))
+    self.init(_RegexFactory.capture(component().regex._root, nil, transform))
   }
 
+    @_alwaysEmitIntoClient
   public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, C7, C8, NewCapture>(
     as reference: Reference<NewCapture>,
     @RegexComponentBuilder _ component: () -> R,
     transform: @escaping (W) throws -> NewCapture
   ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6, C7, C8), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8) {
-    self.init(node: .capture(
-      reference: reference.id,
-      component().regex.root,
-      CaptureTransform(transform)))
+    self.init(_RegexFactory.capture(component().regex._root, reference, transform))
   }
 }
 
 @available(SwiftStdlib 5.7, *)
 extension TryCapture {
+  @_alwaysEmitIntoClient
   public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, C7, C8, NewCapture>(
     @RegexComponentBuilder _ component: () -> R,
     transform: @escaping (W) throws -> NewCapture?
   ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6, C7, C8), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8) {
-    self.init(node: .capture(
-      component().regex.root,
-      CaptureTransform(transform)))
+    self.init(_RegexFactory.captureOptional(component().regex._root, nil, transform))
   }
 
+  @_alwaysEmitIntoClient
   public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, C7, C8, NewCapture>(
     as reference: Reference<NewCapture>,
     @RegexComponentBuilder _ component: () -> R,
     transform: @escaping (W) throws -> NewCapture?
   ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6, C7, C8), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8) {
-    self.init(node: .capture(
-      reference: reference.id,
-      component().regex.root,
-      CaptureTransform(transform)))
+    self.init(_RegexFactory.captureOptional(component().regex._root, reference, transform))
   }
 }
 
@@ -3710,59 +3970,55 @@ extension TryCapture {
 
 @available(SwiftStdlib 5.7, *)
 extension Capture {
+  @_alwaysEmitIntoClient
   public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, C7, C8, C9>(
     _ component: R
   ) where RegexOutput == (Substring, W, C1, C2, C3, C4, C5, C6, C7, C8, C9), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
-    self.init(node: .capture(component.regex.root))
+    self.init(_RegexFactory.capture(component.regex._root))
   }
 
+  @_alwaysEmitIntoClient
   public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, C7, C8, C9>(
     _ component: R, as reference: Reference<W>
   ) where RegexOutput == (Substring, W, C1, C2, C3, C4, C5, C6, C7, C8, C9), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
-    self.init(node: .capture(reference: reference.id, component.regex.root))
+    self.init(_RegexFactory.capture(component.regex._root, reference))
   }
 
+  @_alwaysEmitIntoClient
   public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, C7, C8, C9, NewCapture>(
     _ component: R,
     transform: @escaping (W) throws -> NewCapture
   ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6, C7, C8, C9), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
-    self.init(node: .capture(
-      component.regex.root,
-      CaptureTransform(transform)))
+    self.init(_RegexFactory.capture(component.regex._root, nil, transform))
   }
 
+  @_alwaysEmitIntoClient
   public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, C7, C8, C9, NewCapture>(
     _ component: R,
     as reference: Reference<NewCapture>,
     transform: @escaping (W) throws -> NewCapture
   ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6, C7, C8, C9), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
-    self.init(node: .capture(
-      reference: reference.id,
-      component.regex.root,
-      CaptureTransform(transform)))
+    self.init(_RegexFactory.capture(component.regex._root, reference, transform))
   }
 }
 
 @available(SwiftStdlib 5.7, *)
 extension TryCapture {
+  @_alwaysEmitIntoClient
   public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, C7, C8, C9, NewCapture>(
     _ component: R,
     transform: @escaping (W) throws -> NewCapture?
   ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6, C7, C8, C9), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
-    self.init(node: .capture(
-    component.regex.root,
-    CaptureTransform(transform)))
+    self.init(_RegexFactory.captureOptional(component.regex._root, nil, transform))
   }
 
+  @_alwaysEmitIntoClient
   public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, C7, C8, C9, NewCapture>(
     _ component: R,
     as reference: Reference<NewCapture>,
     transform: @escaping (W) throws -> NewCapture?
   ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6, C7, C8, C9), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
-    self.init(node: .capture(
-      reference: reference.id,
-      component.regex.root,
-      CaptureTransform(transform)))
+    self.init(_RegexFactory.captureOptional(component.regex._root, reference, transform))
   }
 }
 
@@ -3770,62 +4026,56 @@ extension TryCapture {
 
 @available(SwiftStdlib 5.7, *)
 extension Capture {
+  @_alwaysEmitIntoClient
   public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, C7, C8, C9>(
     @RegexComponentBuilder _ component: () -> R
   ) where RegexOutput == (Substring, W, C1, C2, C3, C4, C5, C6, C7, C8, C9), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
-    self.init(node: .capture(component().regex.root))
+    self.init(_RegexFactory.node(component().regex._root))
   }
 
+  @_alwaysEmitIntoClient
   public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, C7, C8, C9>(
     as reference: Reference<W>,
     @RegexComponentBuilder _ component: () -> R
   ) where RegexOutput == (Substring, W, C1, C2, C3, C4, C5, C6, C7, C8, C9), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
-    self.init(node: .capture(
-      reference: reference.id,
-      component().regex.root))
+    self.init(_RegexFactory.capture(component().regex._root, reference))
   }
 
+  @_alwaysEmitIntoClient
   public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, C7, C8, C9, NewCapture>(
     @RegexComponentBuilder _ component: () -> R,
     transform: @escaping (W) throws -> NewCapture
   ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6, C7, C8, C9), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
-    self.init(node: .capture(
-      component().regex.root,
-      CaptureTransform(transform)))
+    self.init(_RegexFactory.capture(component().regex._root, nil, transform))
   }
 
+    @_alwaysEmitIntoClient
   public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, C7, C8, C9, NewCapture>(
     as reference: Reference<NewCapture>,
     @RegexComponentBuilder _ component: () -> R,
     transform: @escaping (W) throws -> NewCapture
   ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6, C7, C8, C9), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
-    self.init(node: .capture(
-      reference: reference.id,
-      component().regex.root,
-      CaptureTransform(transform)))
+    self.init(_RegexFactory.capture(component().regex._root, reference, transform))
   }
 }
 
 @available(SwiftStdlib 5.7, *)
 extension TryCapture {
+  @_alwaysEmitIntoClient
   public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, C7, C8, C9, NewCapture>(
     @RegexComponentBuilder _ component: () -> R,
     transform: @escaping (W) throws -> NewCapture?
   ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6, C7, C8, C9), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
-    self.init(node: .capture(
-      component().regex.root,
-      CaptureTransform(transform)))
+    self.init(_RegexFactory.captureOptional(component().regex._root, nil, transform))
   }
 
+  @_alwaysEmitIntoClient
   public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, C7, C8, C9, NewCapture>(
     as reference: Reference<NewCapture>,
     @RegexComponentBuilder _ component: () -> R,
     transform: @escaping (W) throws -> NewCapture?
   ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6, C7, C8, C9), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
-    self.init(node: .capture(
-      reference: reference.id,
-      component().regex.root,
-      CaptureTransform(transform)))
+    self.init(_RegexFactory.captureOptional(component().regex._root, reference, transform))
   }
 }
 
@@ -3833,59 +4083,55 @@ extension TryCapture {
 
 @available(SwiftStdlib 5.7, *)
 extension Capture {
+  @_alwaysEmitIntoClient
   public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10>(
     _ component: R
   ) where RegexOutput == (Substring, W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10) {
-    self.init(node: .capture(component.regex.root))
+    self.init(_RegexFactory.capture(component.regex._root))
   }
 
+  @_alwaysEmitIntoClient
   public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10>(
     _ component: R, as reference: Reference<W>
   ) where RegexOutput == (Substring, W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10) {
-    self.init(node: .capture(reference: reference.id, component.regex.root))
+    self.init(_RegexFactory.capture(component.regex._root, reference))
   }
 
+  @_alwaysEmitIntoClient
   public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, NewCapture>(
     _ component: R,
     transform: @escaping (W) throws -> NewCapture
   ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10) {
-    self.init(node: .capture(
-      component.regex.root,
-      CaptureTransform(transform)))
+    self.init(_RegexFactory.capture(component.regex._root, nil, transform))
   }
 
+  @_alwaysEmitIntoClient
   public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, NewCapture>(
     _ component: R,
     as reference: Reference<NewCapture>,
     transform: @escaping (W) throws -> NewCapture
   ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10) {
-    self.init(node: .capture(
-      reference: reference.id,
-      component.regex.root,
-      CaptureTransform(transform)))
+    self.init(_RegexFactory.capture(component.regex._root, reference, transform))
   }
 }
 
 @available(SwiftStdlib 5.7, *)
 extension TryCapture {
+  @_alwaysEmitIntoClient
   public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, NewCapture>(
     _ component: R,
     transform: @escaping (W) throws -> NewCapture?
   ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10) {
-    self.init(node: .capture(
-    component.regex.root,
-    CaptureTransform(transform)))
+    self.init(_RegexFactory.captureOptional(component.regex._root, nil, transform))
   }
 
+  @_alwaysEmitIntoClient
   public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, NewCapture>(
     _ component: R,
     as reference: Reference<NewCapture>,
     transform: @escaping (W) throws -> NewCapture?
   ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10) {
-    self.init(node: .capture(
-      reference: reference.id,
-      component.regex.root,
-      CaptureTransform(transform)))
+    self.init(_RegexFactory.captureOptional(component.regex._root, reference, transform))
   }
 }
 
@@ -3893,62 +4139,56 @@ extension TryCapture {
 
 @available(SwiftStdlib 5.7, *)
 extension Capture {
+  @_alwaysEmitIntoClient
   public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10>(
     @RegexComponentBuilder _ component: () -> R
   ) where RegexOutput == (Substring, W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10) {
-    self.init(node: .capture(component().regex.root))
+    self.init(_RegexFactory.node(component().regex._root))
   }
 
+  @_alwaysEmitIntoClient
   public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10>(
     as reference: Reference<W>,
     @RegexComponentBuilder _ component: () -> R
   ) where RegexOutput == (Substring, W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10) {
-    self.init(node: .capture(
-      reference: reference.id,
-      component().regex.root))
+    self.init(_RegexFactory.capture(component().regex._root, reference))
   }
 
+  @_alwaysEmitIntoClient
   public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, NewCapture>(
     @RegexComponentBuilder _ component: () -> R,
     transform: @escaping (W) throws -> NewCapture
   ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10) {
-    self.init(node: .capture(
-      component().regex.root,
-      CaptureTransform(transform)))
+    self.init(_RegexFactory.capture(component().regex._root, nil, transform))
   }
 
+    @_alwaysEmitIntoClient
   public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, NewCapture>(
     as reference: Reference<NewCapture>,
     @RegexComponentBuilder _ component: () -> R,
     transform: @escaping (W) throws -> NewCapture
   ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10) {
-    self.init(node: .capture(
-      reference: reference.id,
-      component().regex.root,
-      CaptureTransform(transform)))
+    self.init(_RegexFactory.capture(component().regex._root, reference, transform))
   }
 }
 
 @available(SwiftStdlib 5.7, *)
 extension TryCapture {
+  @_alwaysEmitIntoClient
   public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, NewCapture>(
     @RegexComponentBuilder _ component: () -> R,
     transform: @escaping (W) throws -> NewCapture?
   ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10) {
-    self.init(node: .capture(
-      component().regex.root,
-      CaptureTransform(transform)))
+    self.init(_RegexFactory.captureOptional(component().regex._root, nil, transform))
   }
 
+  @_alwaysEmitIntoClient
   public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, NewCapture>(
     as reference: Reference<NewCapture>,
     @RegexComponentBuilder _ component: () -> R,
     transform: @escaping (W) throws -> NewCapture?
   ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10) {
-    self.init(node: .capture(
-      reference: reference.id,
-      component().regex.root,
-      CaptureTransform(transform)))
+    self.init(_RegexFactory.captureOptional(component().regex._root, reference, transform))
   }
 }
 

--- a/Sources/RegexBuilder/Variadics.swift
+++ b/Sources/RegexBuilder/Variadics.swift
@@ -3008,7 +3008,7 @@ extension Capture {
   public init<R: RegexComponent, W>(
     @RegexComponentBuilder _ component: () -> R
   ) where RegexOutput == (Substring, W), R.RegexOutput == W {
-    self.init(_RegexFactory.node(component().regex._root))
+    self.init(_RegexFactory.capture(component().regex._root))
   }
 
   @_disfavoredOverload
@@ -3126,7 +3126,7 @@ extension Capture {
   public init<R: RegexComponent, W, C1>(
     @RegexComponentBuilder _ component: () -> R
   ) where RegexOutput == (Substring, W, C1), R.RegexOutput == (W, C1) {
-    self.init(_RegexFactory.node(component().regex._root))
+    self.init(_RegexFactory.capture(component().regex._root))
   }
 
   @_alwaysEmitIntoClient
@@ -3239,7 +3239,7 @@ extension Capture {
   public init<R: RegexComponent, W, C1, C2>(
     @RegexComponentBuilder _ component: () -> R
   ) where RegexOutput == (Substring, W, C1, C2), R.RegexOutput == (W, C1, C2) {
-    self.init(_RegexFactory.node(component().regex._root))
+    self.init(_RegexFactory.capture(component().regex._root))
   }
 
   @_alwaysEmitIntoClient
@@ -3352,7 +3352,7 @@ extension Capture {
   public init<R: RegexComponent, W, C1, C2, C3>(
     @RegexComponentBuilder _ component: () -> R
   ) where RegexOutput == (Substring, W, C1, C2, C3), R.RegexOutput == (W, C1, C2, C3) {
-    self.init(_RegexFactory.node(component().regex._root))
+    self.init(_RegexFactory.capture(component().regex._root))
   }
 
   @_alwaysEmitIntoClient
@@ -3465,7 +3465,7 @@ extension Capture {
   public init<R: RegexComponent, W, C1, C2, C3, C4>(
     @RegexComponentBuilder _ component: () -> R
   ) where RegexOutput == (Substring, W, C1, C2, C3, C4), R.RegexOutput == (W, C1, C2, C3, C4) {
-    self.init(_RegexFactory.node(component().regex._root))
+    self.init(_RegexFactory.capture(component().regex._root))
   }
 
   @_alwaysEmitIntoClient
@@ -3578,7 +3578,7 @@ extension Capture {
   public init<R: RegexComponent, W, C1, C2, C3, C4, C5>(
     @RegexComponentBuilder _ component: () -> R
   ) where RegexOutput == (Substring, W, C1, C2, C3, C4, C5), R.RegexOutput == (W, C1, C2, C3, C4, C5) {
-    self.init(_RegexFactory.node(component().regex._root))
+    self.init(_RegexFactory.capture(component().regex._root))
   }
 
   @_alwaysEmitIntoClient
@@ -3691,7 +3691,7 @@ extension Capture {
   public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6>(
     @RegexComponentBuilder _ component: () -> R
   ) where RegexOutput == (Substring, W, C1, C2, C3, C4, C5, C6), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6) {
-    self.init(_RegexFactory.node(component().regex._root))
+    self.init(_RegexFactory.capture(component().regex._root))
   }
 
   @_alwaysEmitIntoClient
@@ -3804,7 +3804,7 @@ extension Capture {
   public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, C7>(
     @RegexComponentBuilder _ component: () -> R
   ) where RegexOutput == (Substring, W, C1, C2, C3, C4, C5, C6, C7), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7) {
-    self.init(_RegexFactory.node(component().regex._root))
+    self.init(_RegexFactory.capture(component().regex._root))
   }
 
   @_alwaysEmitIntoClient
@@ -3917,7 +3917,7 @@ extension Capture {
   public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, C7, C8>(
     @RegexComponentBuilder _ component: () -> R
   ) where RegexOutput == (Substring, W, C1, C2, C3, C4, C5, C6, C7, C8), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8) {
-    self.init(_RegexFactory.node(component().regex._root))
+    self.init(_RegexFactory.capture(component().regex._root))
   }
 
   @_alwaysEmitIntoClient
@@ -4030,7 +4030,7 @@ extension Capture {
   public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, C7, C8, C9>(
     @RegexComponentBuilder _ component: () -> R
   ) where RegexOutput == (Substring, W, C1, C2, C3, C4, C5, C6, C7, C8, C9), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
-    self.init(_RegexFactory.node(component().regex._root))
+    self.init(_RegexFactory.capture(component().regex._root))
   }
 
   @_alwaysEmitIntoClient
@@ -4143,7 +4143,7 @@ extension Capture {
   public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10>(
     @RegexComponentBuilder _ component: () -> R
   ) where RegexOutput == (Substring, W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10) {
-    self.init(_RegexFactory.node(component().regex._root))
+    self.init(_RegexFactory.capture(component().regex._root))
   }
 
   @_alwaysEmitIntoClient

--- a/Sources/VariadicsGenerator/VariadicsGenerator.swift
+++ b/Sources/VariadicsGenerator/VariadicsGenerator.swift
@@ -709,7 +709,7 @@ struct VariadicsGenerator: ParsableCommand {
         public init<\(genericParams)>(
           @\(concatBuilderName) _ component: () -> R
         ) \(whereClauseRaw) {
-          self.init(_RegexFactory.node(component().regex._root))
+          self.init(_RegexFactory.capture(component().regex._root))
         }
 
       \(disfavored)\

--- a/Sources/VariadicsGenerator/VariadicsGenerator.swift
+++ b/Sources/VariadicsGenerator/VariadicsGenerator.swift
@@ -257,10 +257,13 @@ struct VariadicsGenerator: ParsableCommand {
     output("""
       \(defaultAvailableAttr)
       extension \(concatBuilderName) {
+        @_alwaysEmitIntoClient
         public static func buildPartialBlock<\(genericParams)>(
           accumulated: R0, next: R1
         ) -> \(regexTypeName)<\(matchType)> \(whereClause) {
-          .init(node: accumulated.regex.root.appending(next.regex.root))
+          _RegexFactory.node(
+            accumulated.regex._root.appending(next.regex._root)
+          )
         }
       }
 
@@ -273,6 +276,7 @@ struct VariadicsGenerator: ParsableCommand {
       \(defaultAvailableAttr)
       extension \(concatBuilderName) {
         \(defaultAvailableAttr)
+        @_alwaysEmitIntoClient
         public static func buildPartialBlock<W0
       """)
     outputForEach(0..<leftArity) {
@@ -304,7 +308,9 @@ struct VariadicsGenerator: ParsableCommand {
     }
     output("""
         {
-          .init(node: accumulated.regex.root.appending(next.regex.root))
+          _RegexFactory.node(
+            accumulated.regex._root.appending(next.regex._root)
+          )
         }
       }
 
@@ -386,24 +392,24 @@ struct VariadicsGenerator: ParsableCommand {
       \(defaultAvailableAttr)
       extension \(kind.rawValue) {
       \(params.disfavored)\
+        @_alwaysEmitIntoClient
         public init<\(params.genericParams)>(
           _ component: Component,
           _ behavior: RegexRepetitionBehavior? = nil
         ) \(params.whereClauseForInit) {
-          let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
-          self.init(node: .quantification(.\(kind.astQuantifierAmount), kind, component.regex.root))
+          self.init(_RegexFactory.\(kind.astQuantifierAmount)(behavior, component.regex._root))
         }
       }
 
       \(defaultAvailableAttr)
       extension \(kind.rawValue) {
       \(params.disfavored)\
+        @_alwaysEmitIntoClient
         public init<\(params.genericParams)>(
           _ behavior: RegexRepetitionBehavior? = nil,
           @\(concatBuilderName) _ component: () -> Component
         ) \(params.whereClauseForInit) {
-          let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
-          self.init(node: .quantification(.\(kind.astQuantifierAmount), kind, component().regex.root))
+          self.init(_RegexFactory.\(kind.astQuantifierAmount)(behavior, component().regex._root))
         }
       }
 
@@ -411,10 +417,11 @@ struct VariadicsGenerator: ParsableCommand {
         """
         \(defaultAvailableAttr)
         extension \(concatBuilderName) {
+          @_alwaysEmitIntoClient
           public static func buildLimitedAvailability<\(params.genericParams)>(
             _ component: Component
           ) -> \(regexTypeName)<\(params.matchType)> \(params.whereClause) {
-            .init(node: .quantification(.\(kind.astQuantifierAmount), .default, component.regex.root))
+            _RegexFactory.\(kind.astQuantifierAmount)(nil, component.regex._root)
           }
         }
         """ : "")
@@ -428,9 +435,7 @@ struct VariadicsGenerator: ParsableCommand {
     let groupName = "Local"
     func node(builder: Bool) -> String {
       """
-      .nonCapturingGroup(.atomicNonCapturing, component\(
-        builder ? "()" : ""
-      ).regex.root)
+      component\(builder ? "()" : "").regex._root
       """
     }
 
@@ -457,10 +462,11 @@ struct VariadicsGenerator: ParsableCommand {
       extension \(groupName) {
         \(defaultAvailableAttr)
       \(disfavored)\
+        @_alwaysEmitIntoClient
         public init<\(genericParams)>(
           _ component: Component
         ) \(whereClauseForInit) {
-          self.init(node: \(node(builder: false)))
+          self.init(_RegexFactory.atomicNonCapturing(\(node(builder: false))))
         }
       }
 
@@ -468,10 +474,11 @@ struct VariadicsGenerator: ParsableCommand {
       extension \(groupName) {
         \(defaultAvailableAttr)
       \(disfavored)\
+        @_alwaysEmitIntoClient
         public init<\(genericParams)>(
           @\(concatBuilderName) _ component: () -> Component
         ) \(whereClauseForInit) {
-          self.init(node: \(node(builder: true)))
+          self.init(_RegexFactory.atomicNonCapturing(\(node(builder: true))))
         }
       }
 
@@ -490,41 +497,45 @@ struct VariadicsGenerator: ParsableCommand {
       \(defaultAvailableAttr)
       extension Repeat {
       \(params.disfavored)\
+        @_alwaysEmitIntoClient
         public init<\(params.genericParams)>(
           _ component: Component,
           count: Int
         ) \(params.whereClauseForInit) {
           assert(count > 0, "Must specify a positive count")
           // TODO: Emit a warning about `repeatMatch(count: 0)` or `repeatMatch(count: 1)`
-          self.init(node: .quantification(.exactly(count), .default, component.regex.root))
+          self.init(_RegexFactory.exactly(count, component.regex._root))
         }
 
       \(params.disfavored)\
+        @_alwaysEmitIntoClient
         public init<\(params.genericParams)>(
           count: Int,
           @\(concatBuilderName) _ component: () -> Component
         ) \(params.whereClauseForInit) {
           assert(count > 0, "Must specify a positive count")
           // TODO: Emit a warning about `repeatMatch(count: 0)` or `repeatMatch(count: 1)`
-          self.init(node: .quantification(.exactly(count), .default, component().regex.root))
+          self.init(_RegexFactory.exactly(count, component().regex._root))
         }
 
       \(params.disfavored)\
+        @_alwaysEmitIntoClient
         public init<\(params.genericParams), R: RangeExpression>(
           _ component: Component,
           _ expression: R,
           _ behavior: RegexRepetitionBehavior? = nil
         ) \(params.repeatingWhereClause) {
-          self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component.regex.root))
+          self.init(_RegexFactory.repeating(expression.relative(to: 0..<Int.max), behavior, component.regex._root))
         }
 
       \(params.disfavored)\
+        @_alwaysEmitIntoClient
         public init<\(params.genericParams), R: RangeExpression>(
           _ expression: R,
           _ behavior: RegexRepetitionBehavior? = nil,
           @\(concatBuilderName) _ component: () -> Component
         ) \(params.repeatingWhereClause) {
-          self.init(node: .repeating(expression.relative(to: 0..<Int.max), behavior, component().regex.root))
+          self.init(_RegexFactory.repeating(expression.relative(to: 0..<Int.max), behavior, component().regex._root))
         }
       }
       
@@ -572,10 +583,11 @@ struct VariadicsGenerator: ParsableCommand {
     output("""
       \(defaultAvailableAttr)
       extension \(altBuilderName) {
+        @_alwaysEmitIntoClient
         public static func buildPartialBlock<\(genericParams)>(
           accumulated: R0, next: R1
         ) -> ChoiceOf<\(matchType)> \(whereClause) {
-          .init(node: accumulated.regex.root.appendingAlternationCase(next.regex.root))
+          .init(_RegexFactory.node(accumulated.regex._root.appendingAlternationCase(next.regex._root)))
         }
       }
 
@@ -599,8 +611,9 @@ struct VariadicsGenerator: ParsableCommand {
     output("""
       \(defaultAvailableAttr)
       extension \(altBuilderName) {
+        @_alwaysEmitIntoClient
         public static func buildPartialBlock<\(genericParams)>(first regex: R) -> ChoiceOf<(W, \(resultCaptures))> \(whereClause) {
-          .init(node: .orderedChoice([regex.regex.root]))
+          .init(_RegexFactory.orderedChoice(regex.regex._root))
         }
       }
       
@@ -630,64 +643,60 @@ struct VariadicsGenerator: ParsableCommand {
       \(defaultAvailableAttr)
       extension Capture {
       \(disfavored)\
+        @_alwaysEmitIntoClient
         public init<\(genericParams)>(
           _ component: R
         ) \(whereClauseRaw) {
-          self.init(node: .capture(component.regex.root))
+          self.init(_RegexFactory.capture(component.regex._root))
         }
 
       \(disfavored)\
+        @_alwaysEmitIntoClient
         public init<\(genericParams)>(
           _ component: R, as reference: Reference<W>
         ) \(whereClauseRaw) {
-          self.init(node: .capture(reference: reference.id, component.regex.root))
+          self.init(_RegexFactory.capture(component.regex._root, reference))
         }
 
       \(disfavored)\
+        @_alwaysEmitIntoClient
         public init<\(genericParams), NewCapture>(
           _ component: R,
           transform: @escaping (W) throws -> NewCapture
         ) \(whereClauseTransformed) {
-          self.init(node: .capture(
-            component.regex.root,
-            CaptureTransform(transform)))
+          self.init(_RegexFactory.capture(component.regex._root, nil, transform))
         }
 
       \(disfavored)\
+        @_alwaysEmitIntoClient
         public init<\(genericParams), NewCapture>(
           _ component: R,
           as reference: Reference<NewCapture>,
           transform: @escaping (W) throws -> NewCapture
         ) \(whereClauseTransformed) {
-          self.init(node: .capture(
-            reference: reference.id,
-            component.regex.root,
-            CaptureTransform(transform)))
+          self.init(_RegexFactory.capture(component.regex._root, reference, transform))
         }
       }
 
       \(defaultAvailableAttr)
       extension TryCapture {
       \(disfavored)\
+        @_alwaysEmitIntoClient
         public init<\(genericParams), NewCapture>(
           _ component: R,
           transform: @escaping (W) throws -> NewCapture?
         ) \(whereClauseTransformed) {
-          self.init(node: .capture(
-          component.regex.root,
-          CaptureTransform(transform)))
+          self.init(_RegexFactory.captureOptional(component.regex._root, nil, transform))
         }
 
       \(disfavored)\
+        @_alwaysEmitIntoClient
         public init<\(genericParams), NewCapture>(
           _ component: R,
           as reference: Reference<NewCapture>,
           transform: @escaping (W) throws -> NewCapture?
         ) \(whereClauseTransformed) {
-          self.init(node: .capture(
-            reference: reference.id,
-            component.regex.root,
-            CaptureTransform(transform)))
+          self.init(_RegexFactory.captureOptional(component.regex._root, reference, transform))
         }
       }
 
@@ -696,67 +705,61 @@ struct VariadicsGenerator: ParsableCommand {
       \(defaultAvailableAttr)
       extension Capture {
       \(disfavored)\
+        @_alwaysEmitIntoClient
         public init<\(genericParams)>(
           @\(concatBuilderName) _ component: () -> R
         ) \(whereClauseRaw) {
-          self.init(node: .capture(component().regex.root))
+          self.init(_RegexFactory.node(component().regex._root))
         }
 
       \(disfavored)\
+        @_alwaysEmitIntoClient
         public init<\(genericParams)>(
           as reference: Reference<W>,
           @\(concatBuilderName) _ component: () -> R
         ) \(whereClauseRaw) {
-          self.init(node: .capture(
-            reference: reference.id,
-            component().regex.root))
+          self.init(_RegexFactory.capture(component().regex._root, reference))
         }
 
       \(disfavored)\
+        @_alwaysEmitIntoClient
         public init<\(genericParams), NewCapture>(
           @\(concatBuilderName) _ component: () -> R,
           transform: @escaping (W) throws -> NewCapture
         ) \(whereClauseTransformed) {
-          self.init(node: .capture(
-            component().regex.root,
-            CaptureTransform(transform)))
+          self.init(_RegexFactory.capture(component().regex._root, nil, transform))
         }
 
-      \(disfavored)\
+        \(disfavored)\
+        @_alwaysEmitIntoClient
         public init<\(genericParams), NewCapture>(
           as reference: Reference<NewCapture>,
           @\(concatBuilderName) _ component: () -> R,
           transform: @escaping (W) throws -> NewCapture
         ) \(whereClauseTransformed) {
-          self.init(node: .capture(
-            reference: reference.id,
-            component().regex.root,
-            CaptureTransform(transform)))
+          self.init(_RegexFactory.capture(component().regex._root, reference, transform))
         }
       }
 
       \(defaultAvailableAttr)
       extension TryCapture {
       \(disfavored)\
+        @_alwaysEmitIntoClient
         public init<\(genericParams), NewCapture>(
           @\(concatBuilderName) _ component: () -> R,
           transform: @escaping (W) throws -> NewCapture?
         ) \(whereClauseTransformed) {
-          self.init(node: .capture(
-            component().regex.root,
-            CaptureTransform(transform)))
+          self.init(_RegexFactory.captureOptional(component().regex._root, nil, transform))
         }
 
       \(disfavored)\
+        @_alwaysEmitIntoClient
         public init<\(genericParams), NewCapture>(
           as reference: Reference<NewCapture>,
           @\(concatBuilderName) _ component: () -> R,
           transform: @escaping (W) throws -> NewCapture?
         ) \(whereClauseTransformed) {
-          self.init(node: .capture(
-            reference: reference.id,
-            component().regex.root,
-            CaptureTransform(transform)))
+          self.init(_RegexFactory.captureOptional(component().regex._root, reference, transform))
         }
       }
 


### PR DESCRIPTION
This marks all of the variadic builder overloads as @_alwaysEmitIntoClient so that these aren't permanently part of our ABI.