### PR TITLE
Reject .NET subtraction and quote range operands

### DIFF
--- a/Sources/_RegexParser/Regex/AST/CustomCharClass.swift
+++ b/Sources/_RegexParser/Regex/AST/CustomCharClass.swift
@@ -62,6 +62,10 @@ extension AST {
         self.rhs = rhs
         self.trivia = trivia
       }
+
+      public var location: SourceLocation {
+        lhs.location.union(with: rhs.location)
+      }
     }
     public enum SetOp: String, Hashable {
       case subtraction = "--"
@@ -107,6 +111,25 @@ extension CustomCC.Member {
 
   public var isSemantic: Bool {
     !isTrivia
+  }
+
+  public var location: SourceLocation {
+    switch self {
+    case let .custom(c): return c.location
+    case let .range(r):  return r.location
+    case let .atom(a):   return a.location
+    case let .quote(q):  return q.location
+    case let .trivia(t): return t.location
+    case let .setOperation(lhs, dash, rhs):
+      var loc = dash.location
+      if let lhs = lhs.first {
+        loc = loc.union(with: lhs.location)
+      }
+      if let rhs = rhs.last {
+        loc = loc.union(with: rhs.location)
+      }
+      return loc
+    }
   }
 }
 

--- a/Sources/_RegexParser/Regex/Parse/Diagnostics.swift
+++ b/Sources/_RegexParser/Regex/Parse/Diagnostics.swift
@@ -94,6 +94,7 @@ enum ParseError: Error, Hashable {
   case invalidNamedReference(String)
   case duplicateNamedCapture(String)
   case invalidCharacterClassRangeOperand
+  case unsupportedDotNetSubtraction
   case invalidQuantifierRange(Int, Int)
   case invalidCharacterRange(from: Character, to: Character)
   case notQuantifiable
@@ -174,7 +175,9 @@ extension ParseError: CustomStringConvertible {
     case .expectedCustomCharacterClassMembers:
       return "expected custom character class members"
     case .invalidCharacterClassRangeOperand:
-      return "invalid character class range"
+      return "invalid bound for character class range"
+    case .unsupportedDotNetSubtraction:
+      return "subtraction with '-' is unsupported; use '--' instead"
     case .emptyProperty:
       return "empty property"
     case .unknownProperty(let key, let value):

--- a/Sources/_RegexParser/Regex/Parse/LexicalAnalysis.swift
+++ b/Sources/_RegexParser/Regex/Parse/LexicalAnalysis.swift
@@ -1245,6 +1245,25 @@ extension Source {
     return nil
   }
 
+  /// Check to see if we can lex a .NET subtraction. Returns the
+  /// location of the `-`.
+  ///
+  ///     DotNetSubtraction -> Trivia* '-' Trivia* CustomCharClass
+  ///
+  func canLexDotNetCharClassSubtraction(
+    context: ParsingContext
+  ) -> SourceLocation? {
+    lookahead { src in
+      // We can lex '-' as a .NET subtraction if it precedes a custom character
+      // class.
+      while (try? src.lexTrivia(context: context)) != nil {}
+      guard let dashLoc = src.tryEatWithLoc("-") else { return nil }
+      while (try? src.lexTrivia(context: context)) != nil {}
+      guard src.lexCustomCCStart() != nil else { return nil }
+      return dashLoc
+    }
+  }
+
   private mutating func lexPOSIXCharacterProperty(
   ) throws -> Located<AST.Atom.CharacterProperty>? {
     try recordLoc { src in

--- a/Tests/RegexTests/ParseTests.swift
+++ b/Tests/RegexTests/ParseTests.swift
@@ -517,10 +517,36 @@ extension RegexTests {
 
     parseTest(
       "[a-b-c]", charClass(range_m("a", "b"), "-", "c"))
+    parseTest(
+      "[a-b-c-d]", charClass(range_m("a", "b"), "-", range_m("c", "d")))
+
+    parseTest("[a-c---]", charClass(
+      setOp(range_m("a", "c"), op: .subtraction, "-")
+    ))
+
+    parseTest("(?x)[a-c -- -]", concat(
+      changeMatchingOptions(matchingOptions(adding: .extended)),
+      charClass(setOp(range_m("a", "c"), op: .subtraction, "-"))
+    ))
+
+    parseTest("(?x)[a-c - - -]", concat(
+      changeMatchingOptions(matchingOptions(adding: .extended)),
+      charClass(range_m("a", "c"), range_m("-", "-"))
+    ))
 
     parseTest("[-a-]", charClass("-", "a", "-"))
     parseTest("[[a]-]", charClass(charClass("a"), "-"))
-    parseTest("[[a]-b]", charClass(charClass("a"), "-", "b"))
+    parseTest("[-[a]]", charClass("-", charClass("a")))
+
+    parseTest(#"(?x)[ -[b]]"#, concat(
+      changeMatchingOptions(matchingOptions(adding: .extended)),
+      charClass("-", charClass("b"))
+    ))
+
+    parseTest(#"[ - [ ]]"#, charClass(range_m(" ", " "), charClass(" ")))
+    parseTest(#"[ - [ ] ]"#, charClass(range_m(" ", " "), charClass(" "), " "))
+
+    parseTest(#"[a-c-\Qd\E]"#, charClass(range_m("a", "c"), "-", quote_m("d")))
 
     parseTest("[a-z]", charClass(range_m("a", "z")))
     parseTest("[a-a]", charClass(range_m("a", "a")))
@@ -2692,6 +2718,32 @@ extension RegexTests {
     diagnosticTest("[[:=:]]", .emptyProperty)
 
     diagnosticTest(#"|([\d-c])?"#, .invalidCharacterClassRangeOperand)
+    diagnosticTest("[[a]-b]", .invalidCharacterClassRangeOperand)
+
+    // .NET subtraction is banned, we require explicit '--'.
+    diagnosticTest("[a-[b]]", .unsupportedDotNetSubtraction)
+    diagnosticTest(#"[abc-[def]]"#, .unsupportedDotNetSubtraction)
+    diagnosticTest(#"[abc-[^def]]"#, .unsupportedDotNetSubtraction)
+    diagnosticTest(#"[\d\u{0}[a]-[b-[c]]]"#, .unsupportedDotNetSubtraction)
+    diagnosticTest("[a-z-[d-w-[m-o]]]", .unsupportedDotNetSubtraction)
+    diagnosticTest(#"[a-[:b]]"#, .unsupportedDotNetSubtraction)
+    diagnosticTest(#"[[a]-[b]]"#, .invalidCharacterClassRangeOperand)
+    diagnosticTest(#"[ -[ ]]"#, .unsupportedDotNetSubtraction)
+    diagnosticTest(#"(?x)[a  -  [b]  ]"#, .unsupportedDotNetSubtraction)
+
+    diagnosticTest(#"[a-[]]"#, .expectedCustomCharacterClassMembers)
+    diagnosticTest(#"[-[]]"#, .expectedCustomCharacterClassMembers)
+    diagnosticTest(#"(?x)[ - [ ] ]"#, .expectedCustomCharacterClassMembers)
+    diagnosticTest(#"(?x)[a-[ ] ]"#, .expectedCustomCharacterClassMembers)
+    diagnosticTest(#"[a-[:digit:]]"#, .invalidCharacterClassRangeOperand)
+
+    diagnosticTest("[--]", .expectedCustomCharacterClassMembers)
+    diagnosticTest("[---]", .expectedCustomCharacterClassMembers)
+    diagnosticTest("[----]", .expectedCustomCharacterClassMembers)
+
+    // Quoted sequences aren't currently supported as range operands.
+    diagnosticTest(#"[a-\Qbc\E]"#, .unsupported("range with quoted sequence"))
+    diagnosticTest(#"[\Qbc\E-de]"#, .unsupported("range with quoted sequence"))
 
     diagnosticTest(#"[_-A]"#, .invalidCharacterRange(from: "_", to: "A"))
     diagnosticTest(#"(?i)[_-A]"#, .invalidCharacterRange(from: "_", to: "A"))
@@ -2877,6 +2929,17 @@ extension RegexTests {
         \Q
       /#
       """#, .quoteMayNotSpanMultipleLines)
+
+    // .NET subtraction
+    diagnosticWithDelimitersTest(#"""
+      #/
+      [
+        a # interesting
+        -   #a
+         [ b] # comment
+        ]
+      /#
+      """#, .unsupportedDotNetSubtraction)
 
     // MARK: Group specifiers
 


### PR DESCRIPTION
Tighten up validation of character class range operands such that we reject quotes and custom character classes. This includes rejecting syntax that would be a subtraction in .NET. We throw a custom error that suggests using `--` instead.