### PR TITLE
Retract ~= for Regex.

### DIFF
--- a/Sources/_StringProcessing/Regex/Match.swift
+++ b/Sources/_StringProcessing/Regex/Match.swift
@@ -177,14 +177,3 @@ extension BidirectionalCollection where SubSequence == Substring {
     try? r.regex.prefixMatch(in: self[...])
   }
 }
-
-@available(SwiftStdlib 5.7, *)
-extension RegexComponent {
-  public static func ~=(regex: Self, input: String) -> Bool {
-    input.wholeMatch(of: regex) != nil
-  }
-
-  public static func ~=(regex: Self, input: Substring) -> Bool {
-    input.wholeMatch(of: regex) != nil
-  }
-}


### PR DESCRIPTION
We'd like to provide this, but we haven't been able to reach agreement on what the semantics actually ought to be. The original version used wholeMatch; contains is arguably more flexible, but feels less natural when compared to how ~= is used for other types in the language.

Additionally, we'd like to investigate the possibility of using named captures to effect bindings in case statements in the future, and we don't want to wall ourselves off from that until we've had time to think about it some more.