### PR TITLE
Revert "Fix _RegexParser build when using 5.6 host tools"

### DIFF
--- a/Sources/_RegexParser/Utility/TypeConstruction.swift
+++ b/Sources/_RegexParser/Utility/TypeConstruction.swift
@@ -60,7 +60,7 @@ public enum TypeConstruction {
       flags |= 0x10000
     }
     
-    let result = elementTypes.withContiguousStorageIfAvailable { elementTypesBuffer -> (value: Any.Type, state: Int) in
+    let result = elementTypes.withContiguousStorageIfAvailable { elementTypesBuffer in
       if let labels = labels {
         return labels.withCString { labelsPtr in
           swift_getTupleTypeMetadata(


### PR DESCRIPTION
Reverts https://github.com/apple/swift-experimental-string-processing/pull/452. We now require a newer toolchain to do host tools builds anyways, so this isn't needed anymore.