### PR TITLE
Fix Repeat off-by-one error

### DIFF
--- a/Sources/RegexBuilder/Variadics.swift
+++ b/Sources/RegexBuilder/Variadics.swift
@@ -784,7 +784,7 @@ extension Repeat {
     _ component: Component,
     count: Int
   ) where RegexOutput == Substring {
-    assert(count > 0, "Must specify a positive count")
+    precondition(count >= 0, "Must specify a positive count")
     let factory = makeFactory()
     self.init(factory.exactly(count, component))
   }
@@ -795,7 +795,7 @@ extension Repeat {
     count: Int,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == Substring {
-    assert(count > 0, "Must specify a positive count")
+    precondition(count >= 0, "Must specify a positive count")
     let factory = makeFactory()
     self.init(factory.exactly(count, component()))
   }
@@ -913,7 +913,7 @@ extension Repeat {
     _ component: Component,
     count: Int
   ) where RegexOutput == (Substring, C1?), Component.RegexOutput == (W, C1) {
-    assert(count > 0, "Must specify a positive count")
+    precondition(count >= 0, "Must specify a positive count")
     let factory = makeFactory()
     self.init(factory.exactly(count, component))
   }
@@ -923,7 +923,7 @@ extension Repeat {
     count: Int,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C1?), Component.RegexOutput == (W, C1) {
-    assert(count > 0, "Must specify a positive count")
+    precondition(count >= 0, "Must specify a positive count")
     let factory = makeFactory()
     self.init(factory.exactly(count, component()))
   }
@@ -1039,7 +1039,7 @@ extension Repeat {
     _ component: Component,
     count: Int
   ) where RegexOutput == (Substring, C1?, C2?), Component.RegexOutput == (W, C1, C2) {
-    assert(count > 0, "Must specify a positive count")
+    precondition(count >= 0, "Must specify a positive count")
     let factory = makeFactory()
     self.init(factory.exactly(count, component))
   }
@@ -1049,7 +1049,7 @@ extension Repeat {
     count: Int,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C1?, C2?), Component.RegexOutput == (W, C1, C2) {
-    assert(count > 0, "Must specify a positive count")
+    precondition(count >= 0, "Must specify a positive count")
     let factory = makeFactory()
     self.init(factory.exactly(count, component()))
   }
@@ -1165,7 +1165,7 @@ extension Repeat {
     _ component: Component,
     count: Int
   ) where RegexOutput == (Substring, C1?, C2?, C3?), Component.RegexOutput == (W, C1, C2, C3) {
-    assert(count > 0, "Must specify a positive count")
+    precondition(count >= 0, "Must specify a positive count")
     let factory = makeFactory()
     self.init(factory.exactly(count, component))
   }
@@ -1175,7 +1175,7 @@ extension Repeat {
     count: Int,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C1?, C2?, C3?), Component.RegexOutput == (W, C1, C2, C3) {
-    assert(count > 0, "Must specify a positive count")
+    precondition(count >= 0, "Must specify a positive count")
     let factory = makeFactory()
     self.init(factory.exactly(count, component()))
   }
@@ -1291,7 +1291,7 @@ extension Repeat {
     _ component: Component,
     count: Int
   ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?), Component.RegexOutput == (W, C1, C2, C3, C4) {
-    assert(count > 0, "Must specify a positive count")
+    precondition(count >= 0, "Must specify a positive count")
     let factory = makeFactory()
     self.init(factory.exactly(count, component))
   }
@@ -1301,7 +1301,7 @@ extension Repeat {
     count: Int,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?), Component.RegexOutput == (W, C1, C2, C3, C4) {
-    assert(count > 0, "Must specify a positive count")
+    precondition(count >= 0, "Must specify a positive count")
     let factory = makeFactory()
     self.init(factory.exactly(count, component()))
   }
@@ -1417,7 +1417,7 @@ extension Repeat {
     _ component: Component,
     count: Int
   ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?), Component.RegexOutput == (W, C1, C2, C3, C4, C5) {
-    assert(count > 0, "Must specify a positive count")
+    precondition(count >= 0, "Must specify a positive count")
     let factory = makeFactory()
     self.init(factory.exactly(count, component))
   }
@@ -1427,7 +1427,7 @@ extension Repeat {
     count: Int,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?), Component.RegexOutput == (W, C1, C2, C3, C4, C5) {
-    assert(count > 0, "Must specify a positive count")
+    precondition(count >= 0, "Must specify a positive count")
     let factory = makeFactory()
     self.init(factory.exactly(count, component()))
   }
@@ -1543,7 +1543,7 @@ extension Repeat {
     _ component: Component,
     count: Int
   ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?, C6?), Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6) {
-    assert(count > 0, "Must specify a positive count")
+    precondition(count >= 0, "Must specify a positive count")
     let factory = makeFactory()
     self.init(factory.exactly(count, component))
   }
@@ -1553,7 +1553,7 @@ extension Repeat {
     count: Int,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?, C6?), Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6) {
-    assert(count > 0, "Must specify a positive count")
+    precondition(count >= 0, "Must specify a positive count")
     let factory = makeFactory()
     self.init(factory.exactly(count, component()))
   }
@@ -1669,7 +1669,7 @@ extension Repeat {
     _ component: Component,
     count: Int
   ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?, C6?, C7?), Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7) {
-    assert(count > 0, "Must specify a positive count")
+    precondition(count >= 0, "Must specify a positive count")
     let factory = makeFactory()
     self.init(factory.exactly(count, component))
   }
@@ -1679,7 +1679,7 @@ extension Repeat {
     count: Int,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?, C6?, C7?), Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7) {
-    assert(count > 0, "Must specify a positive count")
+    precondition(count >= 0, "Must specify a positive count")
     let factory = makeFactory()
     self.init(factory.exactly(count, component()))
   }
@@ -1795,7 +1795,7 @@ extension Repeat {
     _ component: Component,
     count: Int
   ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?), Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8) {
-    assert(count > 0, "Must specify a positive count")
+    precondition(count >= 0, "Must specify a positive count")
     let factory = makeFactory()
     self.init(factory.exactly(count, component))
   }
@@ -1805,7 +1805,7 @@ extension Repeat {
     count: Int,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?), Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8) {
-    assert(count > 0, "Must specify a positive count")
+    precondition(count >= 0, "Must specify a positive count")
     let factory = makeFactory()
     self.init(factory.exactly(count, component()))
   }
@@ -1921,7 +1921,7 @@ extension Repeat {
     _ component: Component,
     count: Int
   ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?), Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
-    assert(count > 0, "Must specify a positive count")
+    precondition(count >= 0, "Must specify a positive count")
     let factory = makeFactory()
     self.init(factory.exactly(count, component))
   }
@@ -1931,7 +1931,7 @@ extension Repeat {
     count: Int,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?), Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
-    assert(count > 0, "Must specify a positive count")
+    precondition(count >= 0, "Must specify a positive count")
     let factory = makeFactory()
     self.init(factory.exactly(count, component()))
   }
@@ -2047,7 +2047,7 @@ extension Repeat {
     _ component: Component,
     count: Int
   ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?, C10?), Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10) {
-    assert(count > 0, "Must specify a positive count")
+    precondition(count >= 0, "Must specify a positive count")
     let factory = makeFactory()
     self.init(factory.exactly(count, component))
   }
@@ -2057,7 +2057,7 @@ extension Repeat {
     count: Int,
     @RegexComponentBuilder _ component: () -> Component
   ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?, C10?), Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10) {
-    assert(count > 0, "Must specify a positive count")
+    precondition(count >= 0, "Must specify a positive count")
     let factory = makeFactory()
     self.init(factory.exactly(count, component()))
   }

--- a/Sources/VariadicsGenerator/VariadicsGenerator.swift
+++ b/Sources/VariadicsGenerator/VariadicsGenerator.swift
@@ -505,7 +505,7 @@ struct VariadicsGenerator: ParsableCommand {
           _ component: Component,
           count: Int
         ) \(params.whereClauseForInit) {
-          assert(count > 0, "Must specify a positive count")
+          precondition(count >= 0, "Must specify a positive count")
           let factory = makeFactory()
           self.init(factory.exactly(count, component))
         }
@@ -516,7 +516,7 @@ struct VariadicsGenerator: ParsableCommand {
           count: Int,
           @\(concatBuilderName) _ component: () -> Component
         ) \(params.whereClauseForInit) {
-          assert(count > 0, "Must specify a positive count")
+          precondition(count >= 0, "Must specify a positive count")
           let factory = makeFactory()
           self.init(factory.exactly(count, component()))
         }

--- a/Sources/_StringProcessing/Regex/DSLTree.swift
+++ b/Sources/_StringProcessing/Regex/DSLTree.swift
@@ -853,9 +853,9 @@ extension DSLTree.Node {
     _ node: DSLTree.Node
   ) -> DSLTree.Node {
     // TODO: Throw these as errors
-    assert(range.lowerBound >= 0, "Cannot specify a negative lower bound")
-    assert(!range.isEmpty, "Cannot specify an empty range")
-    
+    precondition(range.lowerBound >= 0, "Cannot specify a negative lower bound")
+    precondition(!range.isEmpty, "Cannot specify an empty range")
+
     let kind: DSLTree.QuantificationKind = behavior
       .map { .explicit($0.dslTreeKind) } ?? .default
 

--- a/Sources/_StringProcessing/Regex/DSLTree.swift
+++ b/Sources/_StringProcessing/Regex/DSLTree.swift
@@ -856,22 +856,35 @@ extension DSLTree.Node {
     assert(range.lowerBound >= 0, "Cannot specify a negative lower bound")
     assert(!range.isEmpty, "Cannot specify an empty range")
     
-    let kind: DSLTree.QuantificationKind = behavior.map { .explicit($0.dslTreeKind) } ?? .default
-    
-    switch (range.lowerBound, range.upperBound) {
-    case (0, Int.max): // 0...
-      return .quantification(.zeroOrMore, kind, node)
-    case (1, Int.max): // 1...
-      return .quantification(.oneOrMore, kind, node)
-    case _ where range.count == 1: // ..<1 or ...0 or any range with count == 1
+    let kind: DSLTree.QuantificationKind = behavior
+      .map { .explicit($0.dslTreeKind) } ?? .default
+
+    // The upper bound needs adjusting down as
+    // `.quantification` expects a closed range.
+    let lower = range.lowerBound
+    let upperInclusive = range.upperBound - 1
+
+    // Unbounded cases
+    if range.upperBound == Int.max {
+      switch lower {
+      case 0: // 0...
+        return .quantification(.zeroOrMore, kind, node)
+      case 1: // 1...
+        return .quantification(.oneOrMore, kind, node)
+      default: // n...
+        return .quantification(.nOrMore(lower), kind, node)
+      }
+    }
+    if range.count == 1 {
+      // ..<1 or ...0 or any range with count == 1
       // Note: `behavior` is ignored in this case
-      return .quantification(.exactly(range.lowerBound), .default, node)
-    case (0, _): // 0..<n or 0...n or ..<n or ...n
-      return .quantification(.upToN(range.upperBound), kind, node)
-    case (_, Int.max): // n...
-      return .quantification(.nOrMore(range.lowerBound), kind, node)
-    default: // any other range
-      return .quantification(.range(range.lowerBound, range.upperBound), kind, node)
+      return .quantification(.exactly(lower), .default, node)
+    }
+    switch lower {
+    case 0: // 0..<n or 0...n or ..<n or ...n
+      return .quantification(.upToN(upperInclusive), kind, node)
+    default:
+      return .quantification(.range(lower, upperInclusive), kind, node)
     }
   }
 }

--- a/Tests/RegexBuilderTests/RegexDSLTests.swift
+++ b/Tests/RegexBuilderTests/RegexDSLTests.swift
@@ -450,9 +450,13 @@ class RegexDSLTests: XCTestCase {
 
     try _testDSLCaptures(
       ("aaabbbcccdddeeefff", "aaabbbcccdddeeefff"),
+      ("aaabbbcccccdddeeefff", "aaabbbcccccdddeeefff"),
+      ("aaabbbcccddddeeefff", "aaabbbcccddddeeefff"),
+      ("aaabbbccccccdddeeefff", nil),
       ("aaaabbbcccdddeeefff", nil),
       ("aaacccdddeeefff", nil),
       ("aaabbbcccccccdddeeefff", nil),
+      ("aaabbbcccdddddeeefff", nil),
       ("aaabbbcccddddddeeefff", nil),
       ("aaabbbcccdddefff", nil),
       ("aaabbbcccdddeee", "aaabbbcccdddeee"),
@@ -465,7 +469,102 @@ class RegexDSLTests: XCTestCase {
       Repeat(2...) { "e" }
       Repeat(0...) { "f" }
     }
-    
+
+    try _testDSLCaptures(
+      ("", nil),
+      ("a", nil),
+      ("aa", "aa"),
+      ("aaa", "aaa"),
+      matchType: Substring.self, ==)
+    {
+      Repeat(2...) { "a" }
+    }
+
+    try _testDSLCaptures(
+      ("", ""),
+      ("a", "a"),
+      ("aa", "aa"),
+      ("aaa", nil),
+      matchType: Substring.self, ==)
+    {
+      Repeat(...2) { "a" }
+    }
+
+    try _testDSLCaptures(
+      ("", ""),
+      ("a", "a"),
+      ("aa", nil),
+      ("aaa", nil),
+      matchType: Substring.self, ==)
+    {
+      Repeat(..<2) { "a" }
+    }
+
+    try _testDSLCaptures(
+      ("", ""),
+      ("a", nil),
+      ("aa", nil),
+      matchType: Substring.self, ==)
+    {
+      Repeat(...0) { "a" }
+    }
+
+    try _testDSLCaptures(
+      ("", ""),
+      ("a", nil),
+      ("aa", nil),
+      matchType: Substring.self, ==)
+    {
+      Repeat(0 ... 0) { "a" }
+    }
+
+    try _testDSLCaptures(
+      ("", ""),
+      ("a", "a"),
+      ("aa", nil),
+      matchType: Substring.self, ==)
+    {
+      Repeat(0 ... 1) { "a" }
+    }
+
+    try _testDSLCaptures(
+      ("", nil),
+      ("a", "a"),
+      ("aa", "aa"),
+      ("aaa", nil),
+      matchType: Substring.self, ==)
+    {
+      Repeat(1 ... 2) { "a" }
+    }
+
+    try _testDSLCaptures(
+      ("", ""),
+      ("a", nil),
+      ("aa", nil),
+      matchType: Substring.self, ==)
+    {
+      Repeat(0 ..< 1) { "a" }
+    }
+
+    try _testDSLCaptures(
+      ("", ""),
+      ("a", "a"),
+      ("aa", nil),
+      matchType: Substring.self, ==)
+    {
+      Repeat(0 ..< 2) { "a" }
+    }
+
+    try _testDSLCaptures(
+      ("", nil),
+      ("a", "a"),
+      ("aa", "aa"),
+      ("aaa", nil),
+      matchType: Substring.self, ==)
+    {
+      Repeat(1 ..< 3) { "a" }
+    }
+
     let octoDecimalRegex: Regex<(Substring, Int?)> = Regex {
       let charClass = CharacterClass(.digit, "a"..."h")//.ignoringCase()
       Capture {

--- a/Tests/RegexBuilderTests/RegexDSLTests.swift
+++ b/Tests/RegexBuilderTests/RegexDSLTests.swift
@@ -520,6 +520,15 @@ class RegexDSLTests: XCTestCase {
 
     try _testDSLCaptures(
       ("", ""),
+      ("a", nil),
+      ("aa", nil),
+      matchType: Substring.self, ==)
+    {
+      Repeat(count: 0) { "a" }
+    }
+
+    try _testDSLCaptures(
+      ("", ""),
       ("a", "a"),
       ("aa", nil),
       matchType: Substring.self, ==)


### PR DESCRIPTION
Adjust the upper bound of the Range down when forming the quantification, as it expects an inclusive upper bound. Additionally, upgrade a couple of assertions to preconditions to ensure we don't silently fail byte code emission.

Resolves #478