### PR TITLE
[main] Fix duplicate symbols static-linking failure by renaming symbols

### DIFF
--- a/Sources/_CUnicode/UnicodeData.c
+++ b/Sources/_CUnicode/UnicodeData.c
@@ -46,10 +46,10 @@ static uint32_t hash(uint32_t scalar, uint32_t level, uint32_t seed) {
 
 // This implementation is based on the minimal perfect hashing strategy found
 // here: https://arxiv.org/pdf/1702.03154.pdf
-intptr_t _swift_stdlib_getMphIdx(uint32_t scalar, intptr_t levels,
-                                 const uint64_t * const *keys,
-                                 const uint16_t * const *ranks,
-                                 const uint16_t * const sizes) {
+intptr_t _swift_string_processing_getMphIdx(uint32_t scalar, intptr_t levels,
+                                            const uint64_t * const *keys,
+                                            const uint16_t * const *ranks,
+                                            const uint16_t * const sizes) {
   intptr_t resultIdx = 0;
 
   // Here, levels represent the numbers of bit arrays used for this hash table.
@@ -100,9 +100,9 @@ intptr_t _swift_stdlib_getMphIdx(uint32_t scalar, intptr_t levels,
   return resultIdx;
 }
 
-intptr_t _swift_stdlib_getScalarBitArrayIdx(uint32_t scalar,
-                                              const uint64_t *bitArrays,
-                                              const uint16_t *ranks) {
+intptr_t _swift_string_processing_getScalarBitArrayIdx(uint32_t scalar,
+                                                       const uint64_t *bitArrays,
+                                                       const uint16_t *ranks) {
   uint64_t chunkSize = 0x110000 / 64 / 64;
   uint64_t base = scalar / chunkSize;
   uint64_t idx = base / 64;

--- a/Sources/_CUnicode/UnicodeScalarProps.c
+++ b/Sources/_CUnicode/UnicodeScalarProps.c
@@ -14,7 +14,7 @@
 #include "include/UnicodeData.h"
 
 SWIFT_CC
-uint8_t _swift_stdlib_getScript(uint32_t scalar) {
+uint8_t _swift_string_processing_getScript(uint32_t scalar) {
   int lowerBoundIndex = 0;
   int endIndex = SCRIPTS_COUNT;
   int upperBoundIndex = endIndex - 1;
@@ -68,9 +68,9 @@ uint8_t _swift_stdlib_getScript(uint32_t scalar) {
 }
 
 SWIFT_CC
-const uint8_t *_swift_stdlib_getScriptExtensions(uint32_t scalar,
-                                                 uint8_t *count) {
-  intptr_t dataIdx = _swift_stdlib_getScalarBitArrayIdx(scalar,
+const uint8_t *_swift_string_processing_getScriptExtensions(uint32_t scalar,
+                                                            uint8_t *count) {
+  intptr_t dataIdx = _swift_string_processing_getScalarBitArrayIdx(scalar,
                                                 _swift_stdlib_script_extensions,
                                          _swift_stdlib_script_extensions_ranks);
   

--- a/Sources/_CUnicode/include/UnicodeData.h
+++ b/Sources/_CUnicode/include/UnicodeData.h
@@ -23,24 +23,24 @@
 // Utilities
 //===----------------------------------------------------------------------===//
 
-intptr_t _swift_stdlib_getMphIdx(uint32_t scalar, intptr_t levels,
-                                 const uint64_t * const *keys,
-                                 const uint16_t * const *ranks,
-                                 const uint16_t * const sizes);
+intptr_t _swift_string_processing_getMphIdx(uint32_t scalar, intptr_t levels,
+                                            const uint64_t * const *keys,
+                                            const uint16_t * const *ranks,
+                                            const uint16_t * const sizes);
 
-intptr_t _swift_stdlib_getScalarBitArrayIdx(uint32_t scalar,
-                                            const uint64_t *bitArrays,
-                                            const uint16_t *ranks);
+intptr_t _swift_string_processing_getScalarBitArrayIdx(uint32_t scalar,
+                                                       const uint64_t *bitArrays,
+                                                       const uint16_t *ranks);
 
 //===----------------------------------------------------------------------===//
 // Scalar Props
 //===----------------------------------------------------------------------===//
 
 SWIFT_CC
-uint8_t _swift_stdlib_getScript(uint32_t scalar);
+uint8_t _swift_string_processing_getScript(uint32_t scalar);
 
 SWIFT_CC
-const uint8_t *_swift_stdlib_getScriptExtensions(uint32_t scalar,
-                                                 uint8_t *count);
+const uint8_t *_swift_string_processing_getScriptExtensions(uint32_t scalar,
+                                                            uint8_t *count);
 
 #endif // SWIFT_STDLIB_SHIMS_UNICODEDATA_H

--- a/Sources/_StringProcessing/Unicode/ScalarProps.swift
+++ b/Sources/_StringProcessing/Unicode/ScalarProps.swift
@@ -9,18 +9,18 @@
 //
 //===----------------------------------------------------------------------===//
 
-@_silgen_name("_swift_stdlib_getScript")
-func _swift_stdlib_getScript(_: UInt32) -> UInt8
+@_silgen_name("_swift_string_processing_getScript")
+func _swift_string_processing_getScript(_: UInt32) -> UInt8
 
-@_silgen_name("_swift_stdlib_getScriptExtensions")
-func _swift_stdlib_getScriptExtensions(
+@_silgen_name("_swift_string_processing_getScriptExtensions")
+func _swift_string_processing_getScriptExtensions(
   _: UInt32,
   _: UnsafeMutablePointer<UInt8>
 ) -> UnsafePointer<UInt8>?
 
 extension Unicode.Script {
   init(_ scalar: Unicode.Scalar) {
-    let rawValue = _swift_stdlib_getScript(scalar.value)
+    let rawValue = _swift_string_processing_getScript(scalar.value)
     
     _internalInvariant(rawValue != .max, "Unknown script rawValue: \(rawValue)")
     
@@ -29,7 +29,7 @@ extension Unicode.Script {
   
   static func extensions(for scalar: Unicode.Scalar) -> [Unicode.Script] {
     var count: UInt8 = 0
-    let pointer = _swift_stdlib_getScriptExtensions(scalar.value, &count)
+    let pointer = _swift_string_processing_getScriptExtensions(scalar.value, &count)
     
     guard let pointer = pointer else {
       return [Unicode.Script(scalar)]


### PR DESCRIPTION
Upstream https://github.com/apple/swift-experimental-string-processing/pull/500 into main.