### PR TITLE
Fix crash when emitting an atom of any

### DIFF
--- a/Sources/_StringProcessing/ConsumerInterface.swift
+++ b/Sources/_StringProcessing/ConsumerInterface.swift
@@ -117,8 +117,15 @@ extension DSLTree.Atom {
 
     case .any:
       // FIXME: Should this be a total ordering?
-      fatalError(
-        "unreachable: emitAny() should be called isntead")
+      if opts.semanticLevel == .graphemeCluster {
+        return { input, bounds in
+          input.index(after: bounds.lowerBound)
+        }
+      } else {
+        return consumeScalar { _ in
+          true
+        }
+      }
 
     case .assertion:
       // TODO: We could handle, should this be total?

--- a/Tests/RegexBuilderTests/RegexDSLTests.swift
+++ b/Tests/RegexBuilderTests/RegexDSLTests.swift
@@ -1216,6 +1216,29 @@ class RegexDSLTests: XCTestCase {
       }
     }
   }
+  
+  // rdar://96280236
+  func testCharacterClassAnyCrash() {
+    let regex = Regex {
+      "{"
+      Capture {
+        OneOrMore {
+          CharacterClass.any.subtracting(.anyOf("}"))
+        }
+      }
+      "}"
+    }
+    
+    func replace(_ template: String) throws -> String {
+      var b = template
+      while let result = try regex.firstMatch(in: b) {
+        b.replaceSubrange(result.range, with: "foo")
+      }
+      return b
+    }
+    
+    XCTAssertEqual(try replace("{bar}"), "foo")
+  }
 }
 
 extension Unicode.Scalar {


### PR DESCRIPTION
When emitting an atom of any, we were unconditionally failing and crashing the process. I think this is an oversight because this case can occur pretty often with `CharacterClass.any` who creates one of these.

Resolves: rdar://96280236