### PR TITLE
[5.7] Update to match Unicode proposal

### DIFF
--- a/Sources/RegexBuilder/CharacterClass.swift
+++ b/Sources/RegexBuilder/CharacterClass.swift
@@ -52,10 +52,6 @@ extension RegexComponent where Self == CharacterClass {
     .init(unconverted: .anyGrapheme)
   }
   
-  public static var anyUnicodeScalar: CharacterClass {
-    .init(unconverted: .anyUnicodeScalar)
-  }
-
   public static var whitespace: CharacterClass {
     .init(unconverted: .whitespace)
   }

--- a/Sources/RegexBuilder/CharacterClass.swift
+++ b/Sources/RegexBuilder/CharacterClass.swift
@@ -48,7 +48,7 @@ extension RegexComponent where Self == CharacterClass {
     .init(DSLTree.CustomCharacterClass(members: [.atom(.any)]))
   }
 
-  public static var anyGrapheme: CharacterClass {
+  public static var anyGraphemeCluster: CharacterClass {
     .init(unconverted: .anyGrapheme)
   }
   

--- a/Sources/_RegexParser/Regex/Parse/Sema.swift
+++ b/Sources/_RegexParser/Regex/Parse/Sema.swift
@@ -220,14 +220,14 @@ extension RegexValidator {
     _ esc: AST.Atom.EscapedBuiltin, at loc: SourceLocation
   ) {
     switch esc {
-    case .resetStartOfMatch, .singleDataUnit,
+    case .resetStartOfMatch, .singleDataUnit, .trueAnychar,
         // '\N' needs to be emitted using 'emitAny'.
         .notNewline:
       error(.unsupported("'\\\(esc.character)'"), at: loc)
 
     // Character classes.
     case .decimalDigit, .notDecimalDigit, .whitespace, .notWhitespace,
-        .wordCharacter, .notWordCharacter, .graphemeCluster, .trueAnychar,
+        .wordCharacter, .notWordCharacter, .graphemeCluster,
         .horizontalWhitespace, .notHorizontalWhitespace,
         .verticalTab, .notVerticalTab:
       break

--- a/Tests/RegexBuilderTests/AlgorithmsTests.swift
+++ b/Tests/RegexBuilderTests/AlgorithmsTests.swift
@@ -260,7 +260,7 @@ class AlgorithmsResultBuilderTests: XCTestCase {
   func testStartsAndContains() throws {
     let fam = "👨‍👩‍👧‍👦👨‍👨‍👧‍👧  we Ⓡ family"
     let startsWithGrapheme = fam.starts {
-      OneOrMore(.anyGrapheme)
+      OneOrMore(.anyGraphemeCluster)
       OneOrMore(.whitespace)
     }
     XCTAssertEqual(startsWithGrapheme, true)
@@ -272,7 +272,7 @@ class AlgorithmsResultBuilderTests: XCTestCase {
 
     let content = {
       Regex {
-        OneOrMore(.anyGrapheme)
+        OneOrMore(.anyGraphemeCluster)
         OneOrMore(.whitespace)
       }
     }
@@ -321,7 +321,7 @@ class AlgorithmsResultBuilderTests: XCTestCase {
 
     var mutable = "👨‍👩‍👧‍👦  we Ⓡ family"
     mutable.trimPrefix {
-      .anyGrapheme
+      .anyGraphemeCluster
       ZeroOrMore(.whitespace)
     }
     XCTAssertEqual(mutable, "we Ⓡ family")

--- a/Tests/RegexTests/MatchTests.swift
+++ b/Tests/RegexTests/MatchTests.swift
@@ -1786,7 +1786,7 @@ extension RegexTests {
       match: eDecomposed,
       xfail: true
     )
-    firstMatchTest(#"\O"#, input: eComposed, match: eComposed)
+    firstMatchTest(#"\O"#, input: eComposed, match: eComposed, xfail: true)
     firstMatchTest(#"\O"#, input: eDecomposed, match: nil,
               xfail: true)
 

--- a/Tests/RegexTests/ParseTests.swift
+++ b/Tests/RegexTests/ParseTests.swift
@@ -806,6 +806,8 @@ extension RegexTests {
     parseTest(#"\M-\C--"#, atom(.keyboardMetaControl("-")), unsupported: true)
     parseTest(#"\M-a"#, atom(.keyboardMeta("a")), unsupported: true)
 
+    parseTest(#"\O"#, escaped(.trueAnychar), unsupported: true)
+
     // MARK: Comments
 
     parseTest(


### PR DESCRIPTION
*5.7 cherry-pick of https://github.com/apple/swift-experimental-string-processing/pull/540*

Mark `\O` unsupported and remove `CharacterClass.anyUnicodeScalar`, as per [the Unicode proposal](https://github.com/apple/swift-evolution/blob/main/proposals/0363-unicode-for-string-processing.md#include-o-and-characterclassanyunicodescalar), we have decided not to support these for now. Additionally rename `anyGrapheme` to `anyGraphemeCluster` to match the proposal.

Resolves #538
rdar://96505816