### PR TITLE
Store source locations of builder expressions for regex compilation errors

### DIFF
--- a/Sources/RegexBuilder/Builder.swift
+++ b/Sources/RegexBuilder/Builder.swift
@@ -14,17 +14,49 @@
 @available(SwiftStdlib 5.7, *)
 @resultBuilder
 public enum RegexComponentBuilder {
+  /// A builder component that stores a regex component and its source location
+   /// for debugging purposes.
+  public struct Component<Value: RegexComponent>: RegexComponent {
+     public let value: Value
+     public let file: String
+     public let function: String
+     public let line: Int
+     public let column: Int
+
+    @usableFromInline
+    internal init(value: Value, file: String, function: String, line: Int, column: Int) {
+      self.value = value
+      self.file = file
+      self.function = function
+      self.line = line
+      self.column = column
+    }
+
+     public var regex: Regex<Value.RegexOutput> {
+       _RegexFactory().located(value, file, function, line, column)
+     }
+   }
+
   public static func buildBlock() -> Regex<Substring> {
     _RegexFactory().empty()
   }
 
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<R: RegexComponent>(
-    first component: R
+    first component: Component<R>
   ) -> Regex<R.RegexOutput> {
     component.regex
   }
 
-  public static func buildExpression<R: RegexComponent>(_ regex: R) -> R {
-    regex
+  @_alwaysEmitIntoClient
+  public static func buildExpression<R: RegexComponent>(
+    _ regex: R,
+     file: String = #file,
+     function: String = #function,
+     line: Int = #line,
+     column: Int = #column
+  ) -> Component<R> {
+    .init(
+      value: regex, file: file, function: function, line: line, column: column)
   }
 }

--- a/Sources/RegexBuilder/DSL.swift
+++ b/Sources/RegexBuilder/DSL.swift
@@ -165,15 +165,26 @@ public struct Repeat<Output>: _BuiltinRegexComponent {
 @available(SwiftStdlib 5.7, *)
 @resultBuilder
 public struct AlternationBuilder {
+  public typealias Component<R: RegexComponent> = RegexComponentBuilder.Component<R>
+
   @_disfavoredOverload
+  @_alwaysEmitIntoClient
   public static func buildPartialBlock<R: RegexComponent>(
     first component: R
   ) -> ChoiceOf<R.RegexOutput> {
     .init(component.regex)
   }
 
-  public static func buildExpression<R: RegexComponent>(_ regex: R) -> R {
-    regex
+  @_alwaysEmitIntoClient
+  public static func buildExpression<R: RegexComponent>(
+    _ regex: R,
+     file: String = #file,
+     function: String = #function,
+     line: Int = #line,
+     column: Int = #column
+  ) -> Component<R> {
+    .init(
+      value: regex, file: file, function: function, line: line, column: column)
   }
 }
 

--- a/Sources/_StringProcessing/ByteCodeGen.swift
+++ b/Sources/_StringProcessing/ByteCodeGen.swift
@@ -826,6 +826,12 @@ fileprivate extension Compiler.ByteCodeGen {
     case .characterPredicate:
       throw Unsupported("character predicates")
 
+    case let .located(n, loc):
+      builder.pushLocation(loc)
+      let result = try emitNode(n)
+      builder.popLocation()
+      return result
+
     case .trivia, .empty:
       return nil
     }

--- a/Sources/_StringProcessing/Compiler.swift
+++ b/Sources/_StringProcessing/Compiler.swift
@@ -44,15 +44,21 @@ class Compiler {
 
 // An error produced when compiling a regular expression.
 enum RegexCompilationError: Error, CustomStringConvertible {
-  // TODO: Source location?
-  case uncapturedReference
+  case uncapturedReference([DSLSourceLocation] = [])
 
   case incorrectOutputType(incorrect: Any.Type, correct: Any.Type)
   
   var description: String {
     switch self {
-    case .uncapturedReference:
-      return "Found a reference used before it captured any match."
+    case .uncapturedReference(let locs):
+      var message = "Found a reference used before it captured any match."
+      if !locs.isEmpty {
+        message += " Used at:\n"
+        for loc in locs {
+          message += "- \(loc)\n"
+        }
+      }
+      return message
     case .incorrectOutputType(let incorrect, let correct):
       return "Cast to incorrect type 'Regex<\(incorrect)>', expected 'Regex<\(correct)>'"
     }

--- a/Sources/_StringProcessing/ConsumerInterface.swift
+++ b/Sources/_StringProcessing/ConsumerInterface.swift
@@ -29,7 +29,7 @@ extension DSLTree.Node {
       // TODO: Should we handle this here?
       return nil
 
-    case let .convertedRegexLiteral(n, _):
+    case let .convertedRegexLiteral(n, _), let .located(n, _):
       return try n.generateConsumer(opts)
 
     case .orderedChoice, .conditional, .concatenation,

--- a/Sources/_StringProcessing/PrintAsPattern.swift
+++ b/Sources/_StringProcessing/PrintAsPattern.swift
@@ -277,6 +277,9 @@ extension PrettyPrinter {
 
     case .absentFunction:
       print("/* TODO: absent function */")
+
+    case let .located(n, _):
+      printAsPattern(convertedFromAST: n)
     }
   }
   

--- a/Sources/_StringProcessing/Regex/DSLSourceLocation.swift
+++ b/Sources/_StringProcessing/Regex/DSLSourceLocation.swift
@@ -1,0 +1,28 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2021-2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+struct DSLSourceLocation {
+  var file: String
+  var function: String
+  var line: Int
+  var column: Int
+}
+
+extension DSLSourceLocation: CustomStringConvertible {
+  var description: String {
+    "\(file)@\(function):\(line):\(column)"
+  }
+}
+
+struct DSLLocated<Value> {
+  var value: Value
+  var location: DSLSourceLocation?
+}

--- a/Sources/_StringProcessing/Regex/DSLTree.swift
+++ b/Sources/_StringProcessing/Regex/DSLTree.swift
@@ -91,6 +91,8 @@ extension DSLTree {
 
     // TODO: Would this just boil down to a consumer?
     case characterPredicate(_CharacterPredicateInterface)
+
+    case located(Node, DSLSourceLocation)
   }
 }
 
@@ -337,6 +339,7 @@ extension DSLTree.Node {
     case let .capture(_, _, n, _):        return [n]
     case let .nonCapturingGroup(_, n):    return [n]
     case let .quantification(_, _, n):    return [n]
+    case let .located(n, _):              return [n]
 
     case let .conditional(_, t, f): return [t,f]
 
@@ -605,6 +608,9 @@ extension CaptureList.Builder {
     case .matcher:
       break
 
+    case .located(let child, _):
+      addCaptures(of: child, optionalNesting: nesting)
+
     case .customCharacterClass, .atom, .trivia, .empty,
         .quotedLiteral, .consumer, .characterPredicate:
       break
@@ -625,7 +631,7 @@ extension DSLTree.Node {
   /// output but forwarding its only child's output.
   var isOutputForwarding: Bool {
     switch self {
-    case .nonCapturingGroup:
+    case .nonCapturingGroup, .located:
       return true
     case .orderedChoice, .concatenation, .capture,
          .conditional, .quantification, .customCharacterClass, .atom,
@@ -685,6 +691,7 @@ extension DSLTree {
       case let .capture(_, _, n, _):        return [_Tree(n)]
       case let .nonCapturingGroup(_, n):    return [_Tree(n)]
       case let .quantification(_, _, n):    return [_Tree(n)]
+      case let .located(n, _):              return [_Tree(n)]
 
       case let .conditional(_, t, f): return [_Tree(t), _Tree(f)]
 

--- a/Sources/_StringProcessing/Utility/RegexFactory.swift
+++ b/Sources/_StringProcessing/Utility/RegexFactory.swift
@@ -200,4 +200,22 @@ public struct _RegexFactory {
       CaptureTransform(transform)
     ))
   }
+
+  @_spi(RegexBuilder)
+  @available(SwiftStdlib 5.7, *)
+  public func located<Output>(
+    _ component: some RegexComponent<Output>,
+    _ file: String,
+    _ function: String,
+    _ line: Int,
+    _ column: Int
+  ) -> Regex<Output> {
+    .init(node: .located(
+      component.regex.root,
+      DSLSourceLocation(
+        file: file,
+        function: function,
+        line: line,
+        column: column)))
+  }
 }

--- a/Tests/RegexBuilderTests/RegexDSLTests.swift
+++ b/Tests/RegexBuilderTests/RegexDSLTests.swift
@@ -1118,6 +1118,22 @@ class RegexDSLTests: XCTestCase {
         }
       }
     }
+
+    do {
+       let a = Reference(Substring.self)
+       let _ = Regex {
+         "abc"
+         a
+         OneOrMore(a)
+       }
+       // Run the following line to trigger the runtime compilation error:
+       // _ = "abc".firstMatch(of: regex)
+       //
+       // Fatal error: ... Found a reference used before
+       // it captured any match. Used at:
+       // - .../Tests/RegexBuilderTests/RegexDSLTests.swift@testBackreference():1126:10
+       // - .../Tests/RegexBuilderTests/RegexDSLTests.swift@testBackreference():1127:10
+     }
   }
 
   struct SemanticVersion: Equatable {


### PR DESCRIPTION
Store source locations using `buildExpression(_:)` and print locations upon regex compilation errors. The regex builder DSL proposal already includes a `buildExpression(_:)` that stores source locations in a `RegexComponentBuilder.Component<R>` type.

Resolves rdar://96119443.

----

Example:

```swift
let a = Reference(Substring.self)
let regex = Regex {
  "abc"
  a
  OneOrMore(a)
}
_ = "abc".firstMatch(of: regex)
```

```console
// Fatal error: ... Found a reference used before it captured any match. Used at:
// - .../Tests/RegexBuilderTests/RegexDSLTests.swift@testBackreference():1126:10
// - .../Tests/RegexBuilderTests/RegexDSLTests.swift@testBackreference():1127:10
```