### PR TITLE
Rename various APIs

### DIFF
--- a/Sources/RegexBuilder/Anchor.swift
+++ b/Sources/RegexBuilder/Anchor.swift
@@ -104,6 +104,12 @@ extension Anchor {
   ///
   /// This anchor is equivalent to `^` in regex syntax when the `m` option
   /// has been enabled or `anchorsMatchLineEndings(true)` has been called.
+  ///
+  /// For example, the following regexes are all equivalent:
+  ///
+  /// - `Regex { Anchor.startOfLine }`
+  /// - `/(?m)^/` or `/(?m:^)/`
+  /// - `/^/.anchorsMatchLineEndings(true)`
   public static var startOfLine: Anchor {
     Anchor(kind: .startOfLine)
   }
@@ -113,6 +119,12 @@ extension Anchor {
   ///
   /// This anchor is equivalent to `$` in regex syntax when the `m` option
   /// has been enabled or `anchorsMatchLineEndings(true)` has been called.
+  ///
+  /// For example, the following regexes are all equivalent:
+  ///
+  /// - `Regex { Anchor.endOfLine }`
+  /// - `/(?m)$/` or `/(?m:$)/`
+  /// - `/$/.anchorsMatchLineEndings(true)`
   public static var endOfLine: Anchor {
     Anchor(kind: .endOfLine)
   }

--- a/Sources/_StringProcessing/Regex/Options.swift
+++ b/Sources/_StringProcessing/Regex/Options.swift
@@ -65,7 +65,7 @@ extension RegexComponent {
   /// - Parameter wordBoundaryKind: The algorithm to use for determining word boundaries.
   /// - Returns: The modified regular expression.
   public func wordBoundaryKind(_ wordBoundaryKind: RegexWordBoundaryKind) -> Regex<RegexOutput> {
-    wrapInOption(.unicodeWordBoundaries, addingIf: wordBoundaryKind == .unicodeLevel2)
+    wrapInOption(.unicodeWordBoundaries, addingIf: wordBoundaryKind == .default)
   }
   
   /// Returns a regular expression where the start and end of input
@@ -83,8 +83,8 @@ extension RegexComponent {
   ///
   /// This method corresponds to applying the `m` option in regex syntax. For
   /// this behavior in the `RegexBuilder` syntax, see
-  /// ``Anchor.startOfLine``, ``Anchor.endOfLine``, ``Anchor.startOfInput``,
-  /// and ``Anchor.endOfInput``.
+  /// ``Anchor.startOfLine``, ``Anchor.endOfLine``, ``Anchor.startOfSubject``,
+  /// and ``Anchor.endOfSubject``.
   ///
   /// - Parameter matchLineEndings: A Boolean value indicating whether `^` and
   ///   `$` should match the start and end of lines, respectively.
@@ -205,7 +205,7 @@ public struct RegexWordBoundaryKind: Hashable {
   /// that match `/\w\W/` or `/\W\w/`, or between the start or end of the input
   /// and a `\w` character. Word boundaries therefore depend on the option-
   /// defined behavior of `\w`.
-  public static var unicodeLevel1: Self {
+  public static var simple: Self {
     .init(base: .unicodeLevel1)
   }
 
@@ -215,7 +215,7 @@ public struct RegexWordBoundaryKind: Hashable {
   /// Default word boundaries use a Unicode algorithm that handles some cases
   /// better than simple word boundaries, such as words with internal
   /// punctuation, changes in script, and Emoji.
-  public static var unicodeLevel2: Self {
+  public static var `default`: Self {
     .init(base: .unicodeLevel2)
   }
 }

--- a/Tests/RegexBuilderTests/RegexDSLTests.swift
+++ b/Tests/RegexBuilderTests/RegexDSLTests.swift
@@ -311,7 +311,7 @@ class RegexDSLTests: XCTestCase {
           OneOrMore(.word)
           Anchor.wordBoundary
         }
-        .wordBoundaryKind(.unicodeLevel1)
+        .wordBoundaryKind(.simple)
         OneOrMore(.any, .reluctant)
         "stop"
       }

--- a/Tests/RegexTests/UTS18Tests.swift
+++ b/Tests/RegexTests/UTS18Tests.swift
@@ -222,7 +222,7 @@ extension UTS18Tests {
   // - Nonspacing marks are never divided from their base characters, and
   //   otherwise ignored in locating boundaries.
   func testSimpleWordBoundaries() {
-    let simpleWordRegex = regex(#".+?\b"#).wordBoundaryKind(.unicodeLevel1)
+    let simpleWordRegex = regex(#".+?\b"#).wordBoundaryKind(.simple)
     expectFirstMatch(input, simpleWordRegex, input[pos: ..<11])
     expectFirstMatch("don't", simpleWordRegex, "don")
     expectFirstMatch("Cafe\u{301}", simpleWordRegex, "Café")


### PR DESCRIPTION
These APIs did not match the proposed spelling, so this changes their names to match what is currently being proposed.