### PR TITLE
Fix a few DSL APIs

### DIFF
--- a/Sources/RegexBuilder/Anchor.swift
+++ b/Sources/RegexBuilder/Anchor.swift
@@ -37,16 +37,30 @@ public struct Anchor {
 
 @available(SwiftStdlib 5.7, *)
 extension Anchor: RegexComponent {
-  var baseAssertion: DSLTree._AST.AssertionKind {
+  var baseAssertion: DSLTree.Atom.Assertion {
     switch kind {
-    case .startOfSubject: return .startOfSubject(isInverted)
-    case .endOfSubjectBeforeNewline: return .endOfSubjectBeforeNewline(isInverted)
-    case .endOfSubject: return .endOfSubject(isInverted)
-    case .firstMatchingPositionInSubject: return .firstMatchingPositionInSubject(isInverted)
-    case .textSegmentBoundary: return .textSegmentBoundary(isInverted)
-    case .startOfLine: return .startOfLine(isInverted)
-    case .endOfLine: return .endOfLine(isInverted)
-    case .wordBoundary: return .wordBoundary(isInverted)
+    case .startOfSubject:
+      // FIXME: Inverted?
+      return .startOfSubject
+    case .endOfSubjectBeforeNewline:
+      // FIXME: Inverted?
+      return .endOfSubjectBeforeNewline
+    case .endOfSubject:
+      // FIXME: Inverted?
+      return .endOfSubject
+    case .firstMatchingPositionInSubject:
+      // FIXME: Inverted?
+      return .firstMatchingPositionInSubject
+    case .textSegmentBoundary:
+      return isInverted ? .notTextSegment : .textSegment
+    case .startOfLine:
+      // FIXME: Inverted?
+      return .caretAnchor
+    case .endOfLine:
+      // FIXME: Inverted?
+      return .dollarAnchor
+    case .wordBoundary:
+      return isInverted ? .notWordBoundary : .wordBoundary
     }
   }
   

--- a/Sources/RegexBuilder/Anchor.swift
+++ b/Sources/RegexBuilder/Anchor.swift
@@ -55,10 +55,10 @@ extension Anchor: RegexComponent {
       return isInverted ? .notTextSegment : .textSegment
     case .startOfLine:
       // FIXME: Inverted?
-      return .caretAnchor
+      return .startOfLine
     case .endOfLine:
       // FIXME: Inverted?
-      return .dollarAnchor
+      return .endOfLine
     case .wordBoundary:
       return isInverted ? .notWordBoundary : .wordBoundary
     }

--- a/Sources/RegexBuilder/CharacterClass.swift
+++ b/Sources/RegexBuilder/CharacterClass.swift
@@ -42,7 +42,7 @@ extension CharacterClass {
 @available(SwiftStdlib 5.7, *)
 extension RegexComponent where Self == CharacterClass {
   public static var any: CharacterClass {
-    .init(DSLTree.CustomCharacterClass(members: [.atom(.any)]))
+    .init(DSLTree.CustomCharacterClass(members: [.atom(.dot)]))
   }
 
   public static var anyGraphemeCluster: CharacterClass {

--- a/Sources/RegexBuilder/CharacterClass.swift
+++ b/Sources/RegexBuilder/CharacterClass.swift
@@ -42,7 +42,7 @@ extension CharacterClass {
 @available(SwiftStdlib 5.7, *)
 extension RegexComponent where Self == CharacterClass {
   public static var any: CharacterClass {
-    .init(DSLTree.CustomCharacterClass(members: [.atom(.dot)]))
+    .init(DSLTree.CustomCharacterClass(members: [.atom(.any)]))
   }
 
   public static var anyGraphemeCluster: CharacterClass {

--- a/Sources/RegexBuilder/CharacterClass.swift
+++ b/Sources/RegexBuilder/CharacterClass.swift
@@ -45,6 +45,10 @@ extension RegexComponent where Self == CharacterClass {
     .init(DSLTree.CustomCharacterClass(members: [.atom(.any)]))
   }
 
+  public static var anyNonNewline: CharacterClass {
+    .init(DSLTree.CustomCharacterClass(members: [.atom(.anyNonNewline)]))
+  }
+
   public static var anyGraphemeCluster: CharacterClass {
     .init(unconverted: ._anyGrapheme)
   }

--- a/Sources/_RegexParser/Regex/AST/Atom.swift
+++ b/Sources/_RegexParser/Regex/AST/Atom.swift
@@ -63,10 +63,10 @@ extension AST {
       case dot
 
       /// ^
-      case startOfLine
+      case caretAnchor
 
       /// $
-      case endOfLine
+      case dollarAnchor
 
       // References
       case backreference(Reference)
@@ -105,8 +105,8 @@ extension AST.Atom {
     case .backtrackingDirective(let v): return v
     case .changeMatchingOptions(let v): return v
     case .dot:                          return nil
-    case .startOfLine:                  return nil
-    case .endOfLine:                    return nil
+    case .caretAnchor:                  return nil
+    case .dollarAnchor:                 return nil
     case .invalid:                      return nil
     }
   }
@@ -536,10 +536,10 @@ extension AST.Atom {
     case notTextSegment = #"\Y"#
 
     /// ^
-    case startOfLine = #"^"#
+    case caretAnchor = #"^"#
 
     /// $
-    case endOfLine = #"$"#
+    case dollarAnchor = #"$"#
 
     /// \b (from outside a custom character class)
     case wordBoundary = #"\b"#
@@ -551,8 +551,8 @@ extension AST.Atom {
 
   public var assertionKind: AssertionKind? {
     switch kind {
-    case .startOfLine:     return .startOfLine
-    case .endOfLine:       return .endOfLine
+    case .caretAnchor:  return .caretAnchor
+    case .dollarAnchor: return .dollarAnchor
 
     case .escaped(.wordBoundary):    return .wordBoundary
     case .escaped(.notWordBoundary): return .notWordBoundary
@@ -806,9 +806,9 @@ extension AST.Atom {
       // the AST? Or defer for the matching engine?
       return nil
 
-    case .scalarSequence, .property, .dot, .startOfLine, .endOfLine,
-        .backreference, .subpattern, .callout, .backtrackingDirective,
-        .changeMatchingOptions, .invalid:
+    case .scalarSequence, .property, .dot, .caretAnchor,
+        .dollarAnchor, .backreference, .subpattern, .callout,
+        .backtrackingDirective, .changeMatchingOptions, .invalid:
       return nil
     }
   }
@@ -858,7 +858,7 @@ extension AST.Atom {
     case .keyboardMetaControl(let x):
       return "\\M-\\C-\(x)"
 
-    case .property, .escaped, .dot, .startOfLine, .endOfLine,
+    case .property, .escaped, .dot, .caretAnchor, .dollarAnchor,
         .backreference, .subpattern, .namedCharacter, .callout,
         .backtrackingDirective, .changeMatchingOptions, .invalid:
       return nil
@@ -874,7 +874,7 @@ extension AST.Atom {
     // TODO: Are callouts quantifiable?
     case .escaped(let esc):
       return esc.isQuantifiable
-    case .startOfLine, .endOfLine:
+    case .caretAnchor, .dollarAnchor:
       return false
     default:
       return true

--- a/Sources/_RegexParser/Regex/AST/Atom.swift
+++ b/Sources/_RegexParser/Regex/AST/Atom.swift
@@ -512,67 +512,6 @@ extension AST.Atom.CharacterProperty {
 }
 
 extension AST.Atom {
-  /// Anchors and other built-in zero-width assertions.
-  public enum AssertionKind: String, Hashable {
-    /// \A
-    case startOfSubject = #"\A"#
-
-    /// \Z
-    case endOfSubjectBeforeNewline = #"\Z"#
-
-    /// \z
-    case endOfSubject = #"\z"#
-
-    /// \K
-    case resetStartOfMatch = #"\K"#
-
-    /// \G
-    case firstMatchingPositionInSubject = #"\G"#
-
-    /// \y
-    case textSegment = #"\y"#
-
-    /// \Y
-    case notTextSegment = #"\Y"#
-
-    /// ^
-    case caretAnchor = #"^"#
-
-    /// $
-    case dollarAnchor = #"$"#
-
-    /// \b (from outside a custom character class)
-    case wordBoundary = #"\b"#
-
-    /// \B
-    case notWordBoundary = #"\B"#
-
-  }
-
-  public var assertionKind: AssertionKind? {
-    switch kind {
-    case .caretAnchor:  return .caretAnchor
-    case .dollarAnchor: return .dollarAnchor
-
-    case .escaped(.wordBoundary):    return .wordBoundary
-    case .escaped(.notWordBoundary): return .notWordBoundary
-    case .escaped(.startOfSubject):  return .startOfSubject
-    case .escaped(.endOfSubject):    return .endOfSubject
-    case .escaped(.textSegment):     return .textSegment
-    case .escaped(.notTextSegment):  return .notTextSegment
-    case .escaped(.endOfSubjectBeforeNewline):
-      return .endOfSubjectBeforeNewline
-    case .escaped(.firstMatchingPositionInSubject):
-      return .firstMatchingPositionInSubject
-
-    case .escaped(.resetStartOfMatch): return .resetStartOfMatch
-
-    default: return nil
-    }
-  }
-}
-
-extension AST.Atom {
   public enum Callout: Hashable {
     /// A PCRE callout written `(?C...)`
     public struct PCRE: Hashable {

--- a/Sources/_RegexParser/Regex/AST/Atom.swift
+++ b/Sources/_RegexParser/Regex/AST/Atom.swift
@@ -60,7 +60,7 @@ extension AST {
       case namedCharacter(String)
 
       /// .
-      case any
+      case dot
 
       /// ^
       case startOfLine
@@ -104,7 +104,7 @@ extension AST.Atom {
     case .callout(let v):               return v
     case .backtrackingDirective(let v): return v
     case .changeMatchingOptions(let v): return v
-    case .any:                          return nil
+    case .dot:                          return nil
     case .startOfLine:                  return nil
     case .endOfLine:                    return nil
     case .invalid:                      return nil
@@ -806,7 +806,7 @@ extension AST.Atom {
       // the AST? Or defer for the matching engine?
       return nil
 
-    case .scalarSequence, .property, .any, .startOfLine, .endOfLine,
+    case .scalarSequence, .property, .dot, .startOfLine, .endOfLine,
         .backreference, .subpattern, .callout, .backtrackingDirective,
         .changeMatchingOptions, .invalid:
       return nil
@@ -858,7 +858,7 @@ extension AST.Atom {
     case .keyboardMetaControl(let x):
       return "\\M-\\C-\(x)"
 
-    case .property, .escaped, .any, .startOfLine, .endOfLine,
+    case .property, .escaped, .dot, .startOfLine, .endOfLine,
         .backreference, .subpattern, .namedCharacter, .callout,
         .backtrackingDirective, .changeMatchingOptions, .invalid:
       return nil

--- a/Sources/_RegexParser/Regex/Parse/LexicalAnalysis.swift
+++ b/Sources/_RegexParser/Regex/Parse/LexicalAnalysis.swift
@@ -2073,7 +2073,7 @@ extension Parser {
         p.unreachable("Should have lexed a group or group-like atom")
 
       // (sometimes) special metacharacters
-      case ".": return customCC ? .char(".") : .any
+      case ".": return customCC ? .char(".") : .dot
       case "^": return customCC ? .char("^") : .startOfLine
       case "$": return customCC ? .char("$") : .endOfLine
 

--- a/Sources/_RegexParser/Regex/Parse/LexicalAnalysis.swift
+++ b/Sources/_RegexParser/Regex/Parse/LexicalAnalysis.swift
@@ -2074,8 +2074,8 @@ extension Parser {
 
       // (sometimes) special metacharacters
       case ".": return customCC ? .char(".") : .dot
-      case "^": return customCC ? .char("^") : .startOfLine
-      case "$": return customCC ? .char("$") : .endOfLine
+      case "^": return customCC ? .char("^") : .caretAnchor
+      case "$": return customCC ? .char("$") : .dollarAnchor
 
       // Escaped
       case "\\": return p.expectEscaped().value

--- a/Sources/_RegexParser/Regex/Parse/Sema.swift
+++ b/Sources/_RegexParser/Regex/Parse/Sema.swift
@@ -288,7 +288,7 @@ extension RegexValidator {
               at: atom.location)
       }
 
-    case .char, .scalar, .startOfLine, .endOfLine, .dot:
+    case .char, .scalar, .caretAnchor, .dollarAnchor, .dot:
       break
 
     case .invalid:

--- a/Sources/_RegexParser/Regex/Parse/Sema.swift
+++ b/Sources/_RegexParser/Regex/Parse/Sema.swift
@@ -221,7 +221,7 @@ extension RegexValidator {
   ) {
     switch esc {
     case .resetStartOfMatch, .singleDataUnit, .trueAnychar,
-        // '\N' needs to be emitted using 'emitAny'.
+        // '\N' needs to be emitted using 'emitDot'.
         .notNewline:
       error(.unsupported("'\\\(esc.character)'"), at: loc)
 
@@ -288,7 +288,7 @@ extension RegexValidator {
               at: atom.location)
       }
 
-    case .char, .scalar, .startOfLine, .endOfLine, .any:
+    case .char, .scalar, .startOfLine, .endOfLine, .dot:
       break
 
     case .invalid:

--- a/Sources/_RegexParser/Regex/Printing/DumpAST.swift
+++ b/Sources/_RegexParser/Regex/Printing/DumpAST.swift
@@ -153,9 +153,9 @@ extension AST.Atom {
     case .keyboardControl, .keyboardMeta, .keyboardMetaControl:
       fatalError("TODO")
 
-    case .dot:         return "."
-    case .startOfLine: return "^"
-    case .endOfLine:   return "$"
+    case .dot:          return "."
+    case .caretAnchor:  return "^"
+    case .dollarAnchor: return "$"
 
     case .backreference(let r), .subpattern(let r):
       return "\(r._dumpBase)"

--- a/Sources/_RegexParser/Regex/Printing/DumpAST.swift
+++ b/Sources/_RegexParser/Regex/Printing/DumpAST.swift
@@ -153,7 +153,7 @@ extension AST.Atom {
     case .keyboardControl, .keyboardMeta, .keyboardMetaControl:
       fatalError("TODO")
 
-    case .any:         return "."
+    case .dot:         return "."
     case .startOfLine: return "^"
     case .endOfLine:   return "$"
 

--- a/Sources/_RegexParser/Regex/Printing/PrintAsCanonical.swift
+++ b/Sources/_RegexParser/Regex/Printing/PrintAsCanonical.swift
@@ -237,9 +237,6 @@ extension AST.Atom.Number {
 
 extension AST.Atom {
   var _canonicalBase: String {
-    if let anchor = self.assertionKind {
-      return anchor.rawValue
-    }
     if let lit = self.literalStringValue {
       // FIXME: We may have to re-introduce escapes
       // For example, `\.` will come back as "." instead
@@ -248,6 +245,10 @@ extension AST.Atom {
       return lit
     }
     switch self.kind {
+    case .caretAnchor:
+      return "^"
+    case .dollarAnchor:
+      return "$"
     case .escaped(let e):
       return "\\\(e.character)"
     case .backreference(let br):

--- a/Sources/_StringProcessing/ByteCodeGen.swift
+++ b/Sources/_StringProcessing/ByteCodeGen.swift
@@ -72,7 +72,7 @@ fileprivate extension Compiler.ByteCodeGen {
       }
 
     case let .assertion(kind):
-      try emitAssertion(kind.ast)
+      try emitAssertion(kind)
 
     case let .backreference(ref):
       try emitBackreference(ref.ast)
@@ -146,7 +146,7 @@ fileprivate extension Compiler.ByteCodeGen {
   }
 
   mutating func emitAssertion(
-    _ kind: AST.Atom.AssertionKind
+    _ kind: DSLTree.Atom.Assertion
   ) throws {
     // FIXME: Depends on API model we have... We may want to
     // think through some of these with API interactions in mind

--- a/Sources/_StringProcessing/ByteCodeGen.swift
+++ b/Sources/_StringProcessing/ByteCodeGen.swift
@@ -202,7 +202,7 @@ fileprivate extension Compiler.ByteCodeGen {
         !input.isOnGraphemeClusterBoundary(pos)
       }
 
-    case .startOfLine:
+    case .caretAnchor:
       // FIXME: Anchor.startOfLine must always use this first branch
       // The behavior of `^` should depend on `anchorsMatchNewlines`, but
       // the DSL-based `.startOfLine` anchor should always match the start
@@ -224,7 +224,7 @@ fileprivate extension Compiler.ByteCodeGen {
         }
       }
       
-    case .endOfLine:
+    case .dollarAnchor:
       // FIXME: Anchor.endOfLine must always use this first branch
       // The behavior of `$` should depend on `anchorsMatchNewlines`, but
       // the DSL-based `.endOfLine` anchor should always match the end

--- a/Sources/_StringProcessing/ByteCodeGen.swift
+++ b/Sources/_StringProcessing/ByteCodeGen.swift
@@ -145,6 +145,32 @@ fileprivate extension Compiler.ByteCodeGen {
     }
   }
 
+  mutating func emitStartOfLine() {
+    builder.buildAssert { [semanticLevel = options.semanticLevel]
+        (_, _, input, pos, subjectBounds) in
+      if pos == subjectBounds.lowerBound { return true }
+      switch semanticLevel {
+      case .graphemeCluster:
+        return input[input.index(before: pos)].isNewline
+      case .unicodeScalar:
+        return input.unicodeScalars[input.unicodeScalars.index(before: pos)].isNewline
+      }
+    }
+  }
+
+  mutating func emitEndOfLine() {
+    builder.buildAssert { [semanticLevel = options.semanticLevel]
+      (_, _, input, pos, subjectBounds) in
+      if pos == subjectBounds.upperBound { return true }
+      switch semanticLevel {
+      case .graphemeCluster:
+        return input[pos].isNewline
+      case .unicodeScalar:
+        return input.unicodeScalars[pos].isNewline
+      }
+    }
+  }
+
   mutating func emitAssertion(
     _ kind: DSLTree.Atom.Assertion
   ) throws {
@@ -202,44 +228,24 @@ fileprivate extension Compiler.ByteCodeGen {
         !input.isOnGraphemeClusterBoundary(pos)
       }
 
+    case .startOfLine:
+      emitStartOfLine()
+
+    case .endOfLine:
+      emitEndOfLine()
+
     case .caretAnchor:
-      // FIXME: Anchor.startOfLine must always use this first branch
-      // The behavior of `^` should depend on `anchorsMatchNewlines`, but
-      // the DSL-based `.startOfLine` anchor should always match the start
-      // of a line. Right now we don't distinguish between those anchors.
       if options.anchorsMatchNewlines {
-        builder.buildAssert { [semanticLevel = options.semanticLevel]
-            (_, _, input, pos, subjectBounds) in
-          if pos == subjectBounds.lowerBound { return true }
-          switch semanticLevel {
-          case .graphemeCluster:
-            return input[input.index(before: pos)].isNewline
-          case .unicodeScalar:
-            return input.unicodeScalars[input.unicodeScalars.index(before: pos)].isNewline
-          }
-        }
+        emitStartOfLine()
       } else {
         builder.buildAssert { (_, _, input, pos, subjectBounds) in
           pos == subjectBounds.lowerBound
         }
       }
-      
+
     case .dollarAnchor:
-      // FIXME: Anchor.endOfLine must always use this first branch
-      // The behavior of `$` should depend on `anchorsMatchNewlines`, but
-      // the DSL-based `.endOfLine` anchor should always match the end
-      // of a line. Right now we don't distinguish between those anchors.
       if options.anchorsMatchNewlines {
-        builder.buildAssert { [semanticLevel = options.semanticLevel]
-            (_, _, input, pos, subjectBounds) in
-          if pos == subjectBounds.upperBound { return true }
-          switch semanticLevel {
-          case .graphemeCluster:
-            return input[pos].isNewline
-          case .unicodeScalar:
-            return input.unicodeScalars[pos].isNewline
-          }
-        }
+        emitEndOfLine()
       } else {
         builder.buildAssert { (_, _, input, pos, subjectBounds) in
           pos == subjectBounds.upperBound

--- a/Sources/_StringProcessing/ByteCodeGen.swift
+++ b/Sources/_StringProcessing/ByteCodeGen.swift
@@ -58,6 +58,9 @@ fileprivate extension Compiler.ByteCodeGen {
     case .any:
       emitAny()
 
+    case .anyNonNewline:
+      emitAnyNonNewline()
+
     case .dot:
       emitDot()
 
@@ -341,11 +344,7 @@ fileprivate extension Compiler.ByteCodeGen {
     }
   }
 
-  mutating func emitDot() {
-    if options.dotMatchesNewline {
-      emitAny()
-      return
-    }
+  mutating func emitAnyNonNewline() {
     switch options.semanticLevel {
     case .graphemeCluster:
       builder.buildConsume { input, bounds in
@@ -359,6 +358,14 @@ fileprivate extension Compiler.ByteCodeGen {
         ? nil
         : input.unicodeScalars.index(after: bounds.lowerBound)
       }
+    }
+  }
+
+  mutating func emitDot() {
+    if options.dotMatchesNewline {
+      emitAny()
+    } else {
+      emitAnyNonNewline()
     }
   }
 

--- a/Sources/_StringProcessing/ByteCodeGen.swift
+++ b/Sources/_StringProcessing/ByteCodeGen.swift
@@ -55,6 +55,9 @@ fileprivate extension Compiler.ByteCodeGen {
       }
     }
     switch a {
+    case .any:
+      emitAny()
+
     case .dot:
       emitDot()
 
@@ -320,23 +323,31 @@ fileprivate extension Compiler.ByteCodeGen {
     builder.buildMatch(c, isCaseInsensitive: false)
   }
 
-  mutating func emitDot() {
-    switch (options.semanticLevel, options.dotMatchesNewline) {
-    case (.graphemeCluster, true):
+  mutating func emitAny() {
+    switch options.semanticLevel {
+    case .graphemeCluster:
       builder.buildAdvance(1)
-    case (.graphemeCluster, false):
+    case .unicodeScalar:
+      // TODO: builder.buildAdvanceUnicodeScalar(1)
+      builder.buildConsume { input, bounds in
+        input.unicodeScalars.index(after: bounds.lowerBound)
+      }
+    }
+  }
+
+  mutating func emitDot() {
+    if options.dotMatchesNewline {
+      emitAny()
+      return
+    }
+    switch options.semanticLevel {
+    case .graphemeCluster:
       builder.buildConsume { input, bounds in
         input[bounds.lowerBound].isNewline
         ? nil
         : input.index(after: bounds.lowerBound)
       }
-
-    case (.unicodeScalar, true):
-      // TODO: builder.buildAdvanceUnicodeScalar(1)
-      builder.buildConsume { input, bounds in
-        input.unicodeScalars.index(after: bounds.lowerBound)
-      }
-    case (.unicodeScalar, false):
+    case .unicodeScalar:
       builder.buildConsume { input, bounds in
         input[bounds.lowerBound].isNewline
         ? nil

--- a/Sources/_StringProcessing/ByteCodeGen.swift
+++ b/Sources/_StringProcessing/ByteCodeGen.swift
@@ -55,8 +55,8 @@ fileprivate extension Compiler.ByteCodeGen {
       }
     }
     switch a {
-    case .any:
-      emitAny()
+    case .dot:
+      emitDot()
 
     case let .char(c):
       emitCharacter(c)
@@ -320,7 +320,7 @@ fileprivate extension Compiler.ByteCodeGen {
     builder.buildMatch(c, isCaseInsensitive: false)
   }
 
-  mutating func emitAny() {
+  mutating func emitDot() {
     switch (options.semanticLevel, options.dotMatchesNewline) {
     case (.graphemeCluster, true):
       builder.buildAdvance(1)
@@ -823,9 +823,9 @@ fileprivate extension Compiler.ByteCodeGen {
       try emitQuantification(amt.ast, kind, child)
 
     case let .customCharacterClass(ccc):
-      if ccc.containsAny {
+      if ccc.containsDot {
         if !ccc.isInverted {
-          emitAny()
+          emitDot()
         } else {
           throw Unsupported("Inverted any")
         }

--- a/Sources/_StringProcessing/ConsumerInterface.swift
+++ b/Sources/_StringProcessing/ConsumerInterface.swift
@@ -293,7 +293,7 @@ extension AST.Atom {
         "Should have been handled by tree conversion")
       fatalError(".atom(.dot) is handled in emitDot")
 
-    case .startOfLine, .endOfLine:
+    case .caretAnchor, .dollarAnchor:
       // handled in emitAssertion
       return nil
 

--- a/Sources/_StringProcessing/ConsumerInterface.swift
+++ b/Sources/_StringProcessing/ConsumerInterface.swift
@@ -128,7 +128,7 @@ extension DSLTree.Atom {
       // can match a single scalar in scalar semantic mode.
       return try Character(s).generateConsumer(opts)
 
-    case .dot:
+    case .any, .dot:
       // FIXME: Should this be a total ordering?
       if opts.semanticLevel == .graphemeCluster {
         return { input, bounds in

--- a/Sources/_StringProcessing/ConsumerInterface.swift
+++ b/Sources/_StringProcessing/ConsumerInterface.swift
@@ -128,7 +128,7 @@ extension DSLTree.Atom {
       // can match a single scalar in scalar semantic mode.
       return try Character(s).generateConsumer(opts)
 
-    case .any, .dot:
+    case .any:
       // FIXME: Should this be a total ordering?
       if opts.semanticLevel == .graphemeCluster {
         return { input, bounds in
@@ -139,6 +139,9 @@ extension DSLTree.Atom {
           true
         }
       }
+
+    case .dot:
+      throw Unreachable(".atom(.dot) should be handled by emitDot")
 
     case .assertion:
       // TODO: We could handle, should this be total?

--- a/Sources/_StringProcessing/ConsumerInterface.swift
+++ b/Sources/_StringProcessing/ConsumerInterface.swift
@@ -140,6 +140,22 @@ extension DSLTree.Atom {
         }
       }
 
+    case .anyNonNewline:
+      switch opts.semanticLevel {
+      case .graphemeCluster:
+        return { input, bounds in
+          input[bounds.lowerBound].isNewline
+            ? nil
+            : input.index(after: bounds.lowerBound)
+        }
+      case .unicodeScalar:
+        return { input, bounds in
+          input[bounds.lowerBound].isNewline
+            ? nil
+            : input.unicodeScalars.index(after: bounds.lowerBound)
+        }
+      }
+
     case .dot:
       throw Unreachable(".atom(.dot) should be handled by emitDot")
 

--- a/Sources/_StringProcessing/ConsumerInterface.swift
+++ b/Sources/_StringProcessing/ConsumerInterface.swift
@@ -128,7 +128,7 @@ extension DSLTree.Atom {
       // can match a single scalar in scalar semantic mode.
       return try Character(s).generateConsumer(opts)
 
-    case .any:
+    case .dot:
       // FIXME: Should this be a total ordering?
       if opts.semanticLevel == .graphemeCluster {
         return { input, bounds in
@@ -285,10 +285,10 @@ extension AST.Atom {
     case let .namedCharacter(name):
       return consumeName(name, opts: opts)
       
-    case .any:
+    case .dot:
       assertionFailure(
         "Should have been handled by tree conversion")
-      fatalError(".atom(.any) is handled in emitAny")
+      fatalError(".atom(.dot) is handled in emitDot")
 
     case .startOfLine, .endOfLine:
       // handled in emitAssertion

--- a/Sources/_StringProcessing/PrintAsPattern.swift
+++ b/Sources/_StringProcessing/PrintAsPattern.swift
@@ -919,7 +919,8 @@ extension AST.Atom {
     case .namedCharacter:
       return (" /* TODO: named character */", false)
 
-    case .any:
+    case .dot:
+      // FIXME: This is wrong, the DSL doesn't have an equivalent to .dot.
       return (".any", true)
 
     case .startOfLine, .endOfLine:
@@ -974,7 +975,7 @@ extension AST.Atom {
     case .namedCharacter(let n):
       return "\\N{\(n)}"
       
-    case .any:
+    case .dot:
       return "."
       
     case .startOfLine, .endOfLine:
@@ -1123,7 +1124,8 @@ extension DSLTree.Atom {
     _ printer: inout PrettyPrinter
   ) -> (String, canBeWrapped: Bool)? {
     switch self {
-    case .any:
+    case .dot:
+      // FIXME: This is wrong, the DSL doesn't have an equivalent to .dot.
       return (".any", true)
       
     case let .char(c):
@@ -1165,7 +1167,7 @@ extension DSLTree.Atom {
   
   var _regexBase: String {
     switch self {
-    case .any:
+    case .dot:
       return "."
       
     case let .char(c):

--- a/Sources/_StringProcessing/PrintAsPattern.swift
+++ b/Sources/_StringProcessing/PrintAsPattern.swift
@@ -651,12 +651,16 @@ extension DSLTree.Atom.Assertion {
   // TODO: Some way to integrate this with conversion...
   var _patternBase: String {
     switch self {
-    case .caretAnchor:
-      // FIXME: The DSL doesn't have a way of representing this.
+    case .startOfLine:
       return "Anchor.startOfLine"
-    case .dollarAnchor:
-      // FIXME: The DSL doesn't have a way of representing this.
+    case .endOfLine:
       return "Anchor.endOfLine"
+    case .caretAnchor:
+      // The DSL doesn't have an equivalent to this, so print as regex.
+      return "/^/"
+    case .dollarAnchor:
+      // The DSL doesn't have an equivalent to this, so print as regex.
+      return "/$/"
     case .wordBoundary:
       return "Anchor.wordBoundary"
     case .notWordBoundary:

--- a/Sources/_StringProcessing/PrintAsPattern.swift
+++ b/Sources/_StringProcessing/PrintAsPattern.swift
@@ -1133,6 +1133,9 @@ extension DSLTree.Atom {
     case .any:
       return (".any", true)
 
+    case .anyNonNewline:
+      return (".anyNonNewline", true)
+
     case .dot:
       // The DSL does not have an equivalent to '.', print as a regex.
       return ("/./", false)
@@ -1178,6 +1181,9 @@ extension DSLTree.Atom {
     switch self {
     case .any:
       return "(?s:.)"
+
+    case .anyNonNewline:
+      return "(?-s:.)"
 
     case .dot:
       return "."

--- a/Sources/_StringProcessing/PrintAsPattern.swift
+++ b/Sources/_StringProcessing/PrintAsPattern.swift
@@ -920,8 +920,8 @@ extension AST.Atom {
       return (" /* TODO: named character */", false)
 
     case .dot:
-      // FIXME: This is wrong, the DSL doesn't have an equivalent to .dot.
-      return (".any", true)
+      // The DSL does not have an equivalent to '.', print as a regex.
+      return ("/./", false)
 
     case .startOfLine, .endOfLine:
       fatalError("unreachable")
@@ -1128,8 +1128,8 @@ extension DSLTree.Atom {
       return (".any", true)
 
     case .dot:
-      // FIXME: This is wrong, the DSL doesn't have an equivalent to .dot.
-      return (".any", true)
+      // The DSL does not have an equivalent to '.', print as a regex.
+      return ("/./", false)
       
     case let .char(c):
       return (String(c)._quoted, false)

--- a/Sources/_StringProcessing/PrintAsPattern.swift
+++ b/Sources/_StringProcessing/PrintAsPattern.swift
@@ -651,9 +651,11 @@ extension AST.Atom.AssertionKind {
   // TODO: Some way to integrate this with conversion...
   var _patternBase: String {
     switch self {
-    case .startOfLine:
+    case .caretAnchor:
+      // FIXME: The DSL doesn't have a way of representing this.
       return "Anchor.startOfLine"
-    case .endOfLine:
+    case .dollarAnchor:
+      // FIXME: The DSL doesn't have a way of representing this.
       return "Anchor.endOfLine"
     case .wordBoundary:
       return "Anchor.wordBoundary"
@@ -923,7 +925,7 @@ extension AST.Atom {
       // The DSL does not have an equivalent to '.', print as a regex.
       return ("/./", false)
 
-    case .startOfLine, .endOfLine:
+    case .caretAnchor, .dollarAnchor:
       fatalError("unreachable")
 
     case .backreference:
@@ -978,7 +980,7 @@ extension AST.Atom {
     case .dot:
       return "."
       
-    case .startOfLine, .endOfLine:
+    case .caretAnchor, .dollarAnchor:
       fatalError("unreachable")
       
     case .backreference:

--- a/Sources/_StringProcessing/PrintAsPattern.swift
+++ b/Sources/_StringProcessing/PrintAsPattern.swift
@@ -647,7 +647,7 @@ extension StringLiteralBuilder: CustomStringConvertible {
   var description: String { result }
 }
 
-extension AST.Atom.AssertionKind {
+extension DSLTree.Atom.Assertion {
   // TODO: Some way to integrate this with conversion...
   var _patternBase: String {
     switch self {
@@ -835,7 +835,7 @@ extension AST.Atom {
   ///
   /// TODO: Some way to integrate this with conversion...
   var _patternBase: (String, canBeWrapped: Bool) {
-    if let anchor = self.assertionKind {
+    if let anchor = self.dslAssertionKind {
       return (anchor._patternBase, false)
     }
 
@@ -1148,7 +1148,7 @@ extension DSLTree.Atom {
       }
       
     case .assertion(let a):
-      return (a.ast._patternBase, false)
+      return (a._patternBase, false)
       
     case .backreference(_):
       return ("/* TOOD: backreferences */", false)

--- a/Sources/_StringProcessing/PrintAsPattern.swift
+++ b/Sources/_StringProcessing/PrintAsPattern.swift
@@ -1124,6 +1124,9 @@ extension DSLTree.Atom {
     _ printer: inout PrettyPrinter
   ) -> (String, canBeWrapped: Bool)? {
     switch self {
+    case .any:
+      return (".any", true)
+
     case .dot:
       // FIXME: This is wrong, the DSL doesn't have an equivalent to .dot.
       return (".any", true)
@@ -1167,6 +1170,9 @@ extension DSLTree.Atom {
   
   var _regexBase: String {
     switch self {
+    case .any:
+      return "(?s:.)"
+
     case .dot:
       return "."
       

--- a/Sources/_StringProcessing/Regex/ASTConversion.swift
+++ b/Sources/_StringProcessing/Regex/ASTConversion.swift
@@ -208,10 +208,38 @@ extension AST.CustomCharacterClass {
   }
 }
 
+extension AST.Atom.EscapedBuiltin {
+  var dslAssertionKind: DSLTree.Atom.Assertion? {
+    switch self {
+    case .wordBoundary:                   return .wordBoundary
+    case .notWordBoundary:                return .notWordBoundary
+    case .startOfSubject:                 return .startOfSubject
+    case .endOfSubject:                   return .endOfSubject
+    case .textSegment:                    return .textSegment
+    case .notTextSegment:                 return .notTextSegment
+    case .endOfSubjectBeforeNewline:      return .endOfSubjectBeforeNewline
+    case .firstMatchingPositionInSubject: return .firstMatchingPositionInSubject
+    case .resetStartOfMatch:              return .resetStartOfMatch
+    default: return nil
+    }
+  }
+}
+
+extension AST.Atom {
+  var dslAssertionKind: DSLTree.Atom.Assertion? {
+    switch kind {
+    case .caretAnchor:    return .caretAnchor
+    case .dollarAnchor:   return .dollarAnchor
+    case .escaped(let b): return b.dslAssertionKind
+    default: return nil
+    }
+  }
+}
+
 extension AST.Atom {
   var dslTreeAtom: DSLTree.Atom {
-    if let kind = assertionKind {
-      return .assertion(.init(ast: kind))
+    if let kind = dslAssertionKind {
+      return .assertion(kind)
     }
 
     switch self.kind {

--- a/Sources/_StringProcessing/Regex/ASTConversion.swift
+++ b/Sources/_StringProcessing/Regex/ASTConversion.swift
@@ -217,7 +217,7 @@ extension AST.Atom {
     switch self.kind {
     case let .char(c):                    return .char(c)
     case let .scalar(s):                  return .scalar(s.value)
-    case .any:                            return .any
+    case .dot:                            return .dot
     case let .backreference(r):           return .backreference(.init(ast: r))
     case let .changeMatchingOptions(seq): return .changeMatchingOptions(.init(ast: seq))
 

--- a/Sources/_StringProcessing/Regex/DSLTree.swift
+++ b/Sources/_StringProcessing/Regex/DSLTree.swift
@@ -721,10 +721,10 @@ extension DSLTree {
           : .init(ast: .textSegment)
       }
       public static func startOfLine(_ inverted: Bool = false) -> Self {
-        .init(ast: .startOfLine)
+        .init(ast: .caretAnchor)
       }
       public static func endOfLine(_ inverted: Bool = false) -> Self {
-        .init(ast: .endOfLine)
+        .init(ast: .dollarAnchor)
       }
       public static func wordBoundary(_ inverted: Bool = false) -> Self {
         inverted

--- a/Sources/_StringProcessing/Regex/DSLTree.swift
+++ b/Sources/_StringProcessing/Regex/DSLTree.swift
@@ -173,13 +173,51 @@ extension DSLTree {
     /// newlines unless single line mode is enabled.
     case dot
 
-    case assertion(_AST.AssertionKind)
+    case assertion(Assertion)
     case backreference(_AST.Reference)
     case symbolicReference(ReferenceID)
 
     case changeMatchingOptions(_AST.MatchingOptionSequence)
 
     case unconverted(_AST.Atom)
+  }
+}
+
+extension DSLTree.Atom {
+  @_spi(RegexBuilder)
+  public enum Assertion: Hashable {
+    /// \A
+    case startOfSubject
+
+    /// \Z
+    case endOfSubjectBeforeNewline
+
+    /// \z
+    case endOfSubject
+
+    /// \K
+    case resetStartOfMatch
+
+    /// \G
+    case firstMatchingPositionInSubject
+
+    /// \y
+    case textSegment
+
+    /// \Y
+    case notTextSegment
+
+    /// ^
+    case caretAnchor
+
+    /// $
+    case dollarAnchor
+
+    /// \b (from outside a custom character class)
+    case wordBoundary
+
+    /// \B
+    case notWordBoundary
   }
 }
 
@@ -697,40 +735,6 @@ extension DSLTree {
     @_spi(RegexBuilder)
     public struct AbsentFunction {
       internal var ast: AST.AbsentFunction
-    }
-    
-    @_spi(RegexBuilder)
-    public struct AssertionKind {
-      internal var ast: AST.Atom.AssertionKind
-      
-      public static func startOfSubject(_ inverted: Bool = false) -> Self {
-        .init(ast: .startOfSubject)
-      }
-      public static func endOfSubjectBeforeNewline(_ inverted: Bool = false) -> Self {
-        .init(ast: .endOfSubjectBeforeNewline)
-      }
-      public static func endOfSubject(_ inverted: Bool = false) -> Self {
-        .init(ast: .endOfSubject)
-      }
-      public static func firstMatchingPositionInSubject(_ inverted: Bool = false) -> Self {
-        .init(ast: .firstMatchingPositionInSubject)
-      }
-      public static func textSegmentBoundary(_ inverted: Bool = false) -> Self {
-        inverted
-          ? .init(ast: .notTextSegment)
-          : .init(ast: .textSegment)
-      }
-      public static func startOfLine(_ inverted: Bool = false) -> Self {
-        .init(ast: .caretAnchor)
-      }
-      public static func endOfLine(_ inverted: Bool = false) -> Self {
-        .init(ast: .dollarAnchor)
-      }
-      public static func wordBoundary(_ inverted: Bool = false) -> Self {
-        inverted
-          ? .init(ast: .notWordBoundary)
-          : .init(ast: .wordBoundary)
-      }
     }
     
     @_spi(RegexBuilder)

--- a/Sources/_StringProcessing/Regex/DSLTree.swift
+++ b/Sources/_StringProcessing/Regex/DSLTree.swift
@@ -169,6 +169,10 @@ extension DSLTree {
     /// Any character, including newlines.
     case any
 
+    /// Any character, excluding newlines. This differs from '.', as it is not
+    /// affected by single line mode.
+    case anyNonNewline
+
     /// The DSL representation of '.' in a regex literal. This does not match
     /// newlines unless single line mode is enabled.
     case dot
@@ -795,8 +799,8 @@ extension DSLTree.Atom {
     switch self {
     case .changeMatchingOptions, .assertion:
       return false
-    case .char, .scalar, .any, .dot, .backreference, .symbolicReference,
-        .unconverted:
+    case .char, .scalar, .any, .anyNonNewline, .dot, .backreference,
+        .symbolicReference, .unconverted:
       return true
     }
   }

--- a/Sources/_StringProcessing/Regex/DSLTree.swift
+++ b/Sources/_StringProcessing/Regex/DSLTree.swift
@@ -207,6 +207,14 @@ extension DSLTree.Atom {
     /// \Y
     case notTextSegment
 
+    /// The DSL's Anchor.startOfLine, which matches the start of a line
+    /// even if `anchorsMatchNewlines` is false.
+    case startOfLine
+
+    /// The DSL's Anchor.endOfLine, which matches the end of a line
+    /// even if `anchorsMatchNewlines` is false.
+    case endOfLine
+
     /// ^
     case caretAnchor
 

--- a/Sources/_StringProcessing/Regex/DSLTree.swift
+++ b/Sources/_StringProcessing/Regex/DSLTree.swift
@@ -757,8 +757,7 @@ extension DSLTree {
         .init(ast: .init(.escaped(.horizontalWhitespace), .fake))
       }
       public static var _newlineSequence: Self {
-        // FIXME: newline sequence is not same as \n
-        .init(ast: .init(.escaped(.newline), .fake))
+        .init(ast: .init(.escaped(.newlineSequence), .fake))
       }
       public static var _verticalWhitespace: Self {
         .init(ast: .init(.escaped(.verticalTab), .fake))

--- a/Sources/_StringProcessing/Regex/DSLTree.swift
+++ b/Sources/_StringProcessing/Regex/DSLTree.swift
@@ -117,11 +117,11 @@ extension DSLTree {
     var members: [Member]
     var isInverted: Bool
     
-    var containsAny: Bool {
+    var containsDot: Bool {
       members.contains { member in
         switch member {
-        case .atom(.any): return true
-        case .custom(let ccc): return ccc.containsAny
+        case .atom(.dot): return true
+        case .custom(let ccc): return ccc.containsDot
         default:
           return false
         }
@@ -165,7 +165,10 @@ extension DSLTree {
   public enum Atom {
     case char(Character)
     case scalar(Unicode.Scalar)
-    case any
+
+    /// The DSL representation of '.' in a regex literal. This does not match
+    /// newlines unless single line mode is enabled.
+    case dot
 
     case assertion(_AST.AssertionKind)
     case backreference(_AST.Reference)
@@ -777,7 +780,7 @@ extension DSLTree.Atom {
     switch self {
     case .changeMatchingOptions, .assertion:
       return false
-    case .char, .scalar, .any, .backreference, .symbolicReference, .unconverted:
+    case .char, .scalar, .dot, .backreference, .symbolicReference, .unconverted:
       return true
     }
   }

--- a/Sources/_StringProcessing/Regex/DSLTree.swift
+++ b/Sources/_StringProcessing/Regex/DSLTree.swift
@@ -166,6 +166,9 @@ extension DSLTree {
     case char(Character)
     case scalar(Unicode.Scalar)
 
+    /// Any character, including newlines.
+    case any
+
     /// The DSL representation of '.' in a regex literal. This does not match
     /// newlines unless single line mode is enabled.
     case dot
@@ -780,7 +783,8 @@ extension DSLTree.Atom {
     switch self {
     case .changeMatchingOptions, .assertion:
       return false
-    case .char, .scalar, .dot, .backreference, .symbolicReference, .unconverted:
+    case .char, .scalar, .any, .dot, .backreference, .symbolicReference,
+        .unconverted:
       return true
     }
   }

--- a/Sources/_StringProcessing/Utility/RegexFactory.swift
+++ b/Sources/_StringProcessing/Utility/RegexFactory.swift
@@ -40,7 +40,7 @@ public struct _RegexFactory {
   @_spi(RegexBuilder)
   @available(SwiftStdlib 5.7, *)
   public func assertion<Output>(
-    _ kind: DSLTree._AST.AssertionKind
+    _ kind: DSLTree.Atom.Assertion
   ) -> Regex<Output> {
     .init(node: .atom(.assertion(kind)))
   }

--- a/Sources/_StringProcessing/_CharacterClassModel.swift
+++ b/Sources/_StringProcessing/_CharacterClassModel.swift
@@ -245,8 +245,8 @@ extension AST.Atom {
       // this? Or does grapheme-semantic mode complicate that?
       return nil
       
-    case .any:
-      // `.any` is handled in the matching engine by Compiler.emitAny() and in
+    case .dot:
+      // `.dot` is handled in the matching engine by Compiler.emitDot() and in
       // the legacy compiler by the `.any` instruction, which can provide lower
       // level instructions than the CharacterClass-generated consumer closure
       //
@@ -275,7 +275,7 @@ extension AST.Atom.EscapedBuiltin {
 
     // FIXME: This is more like '.' than inverted '\R', as it is affected
     // by e.g (*CR). We should therefore really be emitting it through
-    // emitAny(). For now we treat it as semantically invalid.
+    // emitDot(). For now we treat it as semantically invalid.
     case .notNewline: return .newlineSequence.inverted
 
     case .whitespace:    return .whitespace

--- a/Tests/RegexBuilderTests/RegexDSLTests.swift
+++ b/Tests/RegexBuilderTests/RegexDSLTests.swift
@@ -224,6 +224,30 @@ class RegexDSLTests: XCTestCase {
         }.matchingSemantics(.unicodeScalar).asciiOnlyWhitespace(asciiOnly)
       }
     }
+
+    // Make sure horizontal whitespace does not match newlines or other
+    // vertical whitespace.
+    try _testDSLCaptures(
+      ("  \u{A0} \u{9}  \t ", "  \u{A0} \u{9}  \t "),
+      (" \n", nil),
+      (" \r", nil),
+      (" \r\n", nil),
+      (" \u{2028}", nil),
+      matchType: Substring.self, ==)
+    {
+      OneOrMore(.horizontalWhitespace)
+    }
+
+    // Horizontal whitespace in ASCII mode.
+    try _testDSLCaptures(
+      ("   \u{9}  \t ", "   \u{9}  \t "),
+      ("\u{A0}", nil),
+      matchType: Substring.self, ==)
+    {
+      Regex {
+        OneOrMore(.horizontalWhitespace)
+      }.asciiOnlyWhitespace()
+    }
   }
 
   func testCharacterClassOperations() throws {

--- a/Tests/RegexBuilderTests/RegexDSLTests.swift
+++ b/Tests/RegexBuilderTests/RegexDSLTests.swift
@@ -259,6 +259,34 @@ class RegexDSLTests: XCTestCase {
         }.dotMatchesNewlines(dotMatchesNewline)
       }
     }
+
+    // `.anyGraphemeCluster` is the same as `.any` in grapheme mode.
+    for mode in [RegexSemanticLevel.graphemeCluster, .unicodeScalar] {
+      try _testDSLCaptures(
+        ("a", "a"),
+        ("\r\n", "\r\n"),
+        ("e\u{301}", "e\u{301}"),
+        ("e\u{301}f", nil),
+        ("e\u{303}\u{301}\u{302}", "e\u{303}\u{301}\u{302}"),
+        matchType: Substring.self, ==)
+      {
+        Regex {
+          One(.anyGraphemeCluster)
+        }.matchingSemantics(mode)
+      }
+
+      // Like `.any` it also always matches newlines.
+      for dotMatchesNewline in [true, false] {
+        try _testDSLCaptures(
+          ("abc\(allNewlines)def", "abc\(allNewlines)def"),
+          matchType: Substring.self, ==)
+        {
+          Regex {
+            OneOrMore(.anyGraphemeCluster)
+          }.matchingSemantics(mode).dotMatchesNewlines(dotMatchesNewline)
+        }
+      }
+    }
   }
 
   func testMatchResultDotZeroWithoutCapture() throws {

--- a/Tests/RegexBuilderTests/RegexDSLTests.swift
+++ b/Tests/RegexBuilderTests/RegexDSLTests.swift
@@ -114,6 +114,116 @@ class RegexDSLTests: XCTestCase {
         CharacterClass.whitespace.inverted
       }
     }
+
+    let allNewlines = "\u{A}\u{B}\u{C}\u{D}\r\n\u{85}\u{2028}\u{2029}"
+    let asciiNewlines = "\u{A}\u{B}\u{C}\u{D}\r\n"
+
+    // `.newlineSequence` and `.verticalWhitespace` match the same set of
+    // newlines in grapheme semantic mode, and scalar mode when applied with
+    // OneOrMore.
+    for cc in [CharacterClass.newlineSequence, .verticalWhitespace] {
+      for mode in [RegexSemanticLevel.unicodeScalar, .graphemeCluster] {
+        try _testDSLCaptures(
+          ("\n", ("\n", "\n")),
+          ("\r", ("\r", "\r")),
+          ("\r\n", ("\r\n", "\r\n")),
+          (allNewlines, (allNewlines[...], allNewlines[...])),
+          ("abc\ndef", ("abc\ndef", "\n")),
+          ("abc\n\r\ndef", ("abc\n\r\ndef", "\n\r\n")),
+          ("abc\(allNewlines)def", ("abc\(allNewlines)def", allNewlines[...])),
+          ("abc", nil),
+          matchType: (Substring, Substring).self, ==)
+        {
+          Regex {
+            ZeroOrMore {
+              cc.inverted
+            }
+            Capture {
+              OneOrMore(cc)
+            }
+            ZeroOrMore {
+              cc.inverted
+            }
+          }.matchingSemantics(mode)
+        }
+
+        // Try with ASCII-only whitespace.
+        try _testDSLCaptures(
+          ("\n", ("\n", "\n")),
+          ("\r", ("\r", "\r")),
+          ("\r\n", ("\r\n", "\r\n")),
+          (allNewlines, (allNewlines[...], asciiNewlines[...])),
+          ("abc\ndef", ("abc\ndef", "\n")),
+          ("abc\n\r\ndef", ("abc\n\r\ndef", "\n\r\n")),
+          ("abc\(allNewlines)def", ("abc\(allNewlines)def", asciiNewlines[...])),
+          ("abc", nil),
+          matchType: (Substring, Substring).self, ==)
+        {
+          Regex {
+            ZeroOrMore {
+              cc.inverted
+            }
+            Capture {
+              OneOrMore(cc)
+            }
+            ZeroOrMore {
+              cc.inverted
+            }
+          }.matchingSemantics(mode).asciiOnlyWhitespace()
+        }
+      }
+    }
+
+    // `.newlineSequence` in scalar mode may match a single `\r\n`.
+    // `.verticalWhitespace` may not.
+    for asciiOnly in [true, false] {
+      try _testDSLCaptures(
+        ("\r", "\r"),
+        ("\r\n", "\r\n"),
+        matchType: Substring.self, ==)
+      {
+        Regex {
+          CharacterClass.newlineSequence
+        }.matchingSemantics(.unicodeScalar).asciiOnlyWhitespace(asciiOnly)
+      }
+      try _testDSLCaptures(
+        ("\r", nil),
+        ("\r\n", nil),
+        matchType: Substring.self, ==)
+      {
+        Regex {
+          CharacterClass.newlineSequence.inverted
+        }.matchingSemantics(.unicodeScalar).asciiOnlyWhitespace(asciiOnly)
+      }
+      try _testDSLCaptures(
+        ("\r", "\r"),
+        ("\r\n", nil),
+        matchType: Substring.self, ==)
+      {
+        Regex {
+          CharacterClass.verticalWhitespace
+        }.matchingSemantics(.unicodeScalar).asciiOnlyWhitespace(asciiOnly)
+      }
+      try _testDSLCaptures(
+        ("\r", nil),
+        ("\r\n", nil),
+        matchType: Substring.self, ==)
+      {
+        Regex {
+          CharacterClass.verticalWhitespace.inverted
+        }.matchingSemantics(.unicodeScalar).asciiOnlyWhitespace(asciiOnly)
+      }
+      try _testDSLCaptures(
+        ("\r", nil),
+        ("\r\n", nil),
+        matchType: Substring.self, ==)
+      {
+        Regex {
+          CharacterClass.verticalWhitespace.inverted
+          "\n"
+        }.matchingSemantics(.unicodeScalar).asciiOnlyWhitespace(asciiOnly)
+      }
+    }
   }
 
   func testCharacterClassOperations() throws {

--- a/Tests/RegexBuilderTests/RegexDSLTests.swift
+++ b/Tests/RegexBuilderTests/RegexDSLTests.swift
@@ -73,6 +73,9 @@ class RegexDSLTests: XCTestCase {
     XCTAssertTrue(match.output == substringMatch.output)
   }
 
+  let allNewlines = "\u{A}\u{B}\u{C}\u{D}\r\n\u{85}\u{2028}\u{2029}"
+  let asciiNewlines = "\u{A}\u{B}\u{C}\u{D}\r\n"
+
   func testCharacterClasses() throws {
     try _testDSLCaptures(
       ("a c", ("a c", " ", "c")),
@@ -114,9 +117,6 @@ class RegexDSLTests: XCTestCase {
         CharacterClass.whitespace.inverted
       }
     }
-
-    let allNewlines = "\u{A}\u{B}\u{C}\u{D}\r\n\u{85}\u{2028}\u{2029}"
-    let asciiNewlines = "\u{A}\u{B}\u{C}\u{D}\r\n"
 
     // `.newlineSequence` and `.verticalWhitespace` match the same set of
     // newlines in grapheme semantic mode, and scalar mode when applied with
@@ -244,6 +244,20 @@ class RegexDSLTests: XCTestCase {
       CharacterClass.digit.subtracting("3"..."9")     // 1, 2, non-ascii digits
 
       CharacterClass.hexDigit.intersection("a"..."z") // a-f
+    }
+  }
+
+  func testAny() throws {
+    // .any matches newlines regardless of matching options.
+    for dotMatchesNewline in [true, false] {
+      try _testDSLCaptures(
+        ("abc\(allNewlines)def", "abc\(allNewlines)def"),
+        matchType: Substring.self, ==)
+      {
+        Regex {
+          OneOrMore(.any)
+        }.dotMatchesNewlines(dotMatchesNewline)
+      }
     }
   }
 

--- a/Tests/RegexBuilderTests/RegexDSLTests.swift
+++ b/Tests/RegexBuilderTests/RegexDSLTests.swift
@@ -313,6 +313,63 @@ class RegexDSLTests: XCTestCase {
     }
   }
 
+  func testAnyNonNewline() throws {
+    // `.anyNonNewline` is `.` without single-line mode.
+    for mode in [RegexSemanticLevel.graphemeCluster, .unicodeScalar] {
+      for dotMatchesNewline in [true, false] {
+        try _testDSLCaptures(
+          ("abcdef", "abcdef"),
+          ("abcdef\n", nil),
+          ("\r\n", nil),
+          ("\r", nil),
+          ("\n", nil),
+          matchType: Substring.self, ==)
+        {
+          Regex {
+            OneOrMore(.anyNonNewline)
+          }.matchingSemantics(mode).dotMatchesNewlines(dotMatchesNewline)
+        }
+
+        try _testDSLCaptures(
+          ("abcdef", nil),
+          ("abcdef\n", nil),
+          ("\r\n", "\r\n"),
+          ("\r", "\r"),
+          ("\n", "\n"),
+          matchType: Substring.self, ==)
+        {
+          Regex {
+            OneOrMore(.anyNonNewline.inverted)
+          }.matchingSemantics(mode).dotMatchesNewlines(dotMatchesNewline)
+        }
+
+        try _testDSLCaptures(
+          ("abc", "abc"),
+          ("abcd", nil),
+          ("\r\n", nil),
+          ("\r", nil),
+          ("\n", nil),
+          matchType: Substring.self, ==)
+        {
+          Regex {
+            OneOrMore(CharacterClass.anyNonNewline.intersection(.anyOf("\n\rabc")))
+          }.matchingSemantics(mode).dotMatchesNewlines(dotMatchesNewline)
+        }
+      }
+    }
+
+    try _testDSLCaptures(
+      ("\r\n", "\r\n"), matchType: Substring.self, ==) {
+        CharacterClass.anyNonNewline.inverted
+      }
+    try _testDSLCaptures(
+      ("\r\n", nil), matchType: Substring.self, ==) {
+        Regex {
+          CharacterClass.anyNonNewline.inverted
+        }.matchingSemantics(.unicodeScalar)
+      }
+  }
+
   func testMatchResultDotZeroWithoutCapture() throws {
     let match = try XCTUnwrap("aaa".wholeMatch { OneOrMore { "a" } })
     XCTAssertEqual(match.0, "aaa")

--- a/Tests/RegexBuilderTests/RegexDSLTests.swift
+++ b/Tests/RegexBuilderTests/RegexDSLTests.swift
@@ -802,19 +802,40 @@ class RegexDSLTests: XCTestCase {
         Anchor.endOfSubject
       }.anchorsMatchLineEndings()
     }
-    
-    // FIXME: Anchor.start/endOfLine needs to always match line endings,
-    // even when the `anchorsMatchLineEndings()` option is turned off.
+
     try _testDSLCaptures(
-      ("\naaa", "aaa"),
-      ("aaa\n", "aaa"),
-      ("\naaa\n", "aaa"),
-      matchType: Substring.self, ==, xfail: true)
+      ("\naaa", "\naaa"),
+      ("aaa\n", "aaa\n"),
+      ("\naaa\n", "\naaa\n"),
+      matchType: Substring.self, ==)
     {
       Regex {
+        Optionally { "\n" }
         Anchor.startOfLine
         Repeat("a", count: 3)
         Anchor.endOfLine
+        Optionally { "\n" }
+      }
+    }
+
+    // startOfLine/endOfLine apply regardless of mode.
+    for matchLineEndings in [true, false] {
+      for mode in [RegexSemanticLevel.graphemeCluster, .unicodeScalar] {
+        let r = Regex {
+          Anchor.startOfLine
+          Repeat("a", count: 3)
+          Anchor.endOfLine
+        }.anchorsMatchLineEndings(matchLineEndings).matchingSemantics(mode)
+
+        XCTAssertNotNil(try r.firstMatch(in: "\naaa"))
+        XCTAssertNotNil(try r.firstMatch(in: "aaa\n"))
+        XCTAssertNotNil(try r.firstMatch(in: "\naaa\n"))
+        XCTAssertNotNil(try r.firstMatch(in: "\naaa\r\n"))
+        XCTAssertNotNil(try r.firstMatch(in: "\r\naaa\n"))
+        XCTAssertNotNil(try r.firstMatch(in: "\r\naaa\r\n"))
+
+        XCTAssertNil(try r.firstMatch(in: "\nbaaa\n"))
+        XCTAssertNil(try r.firstMatch(in: "\naaab\n"))
       }
     }
   }

--- a/Tests/RegexTests/ParseTests.swift
+++ b/Tests/RegexTests/ParseTests.swift
@@ -359,14 +359,14 @@ extension RegexTests {
     parseTest(
       "(.)*(.*)",
       concat(
-        zeroOrMore(of: capture(atom(.any))),
-        capture(zeroOrMore(of: atom(.any)))),
+        zeroOrMore(of: capture(atom(.dot))),
+        capture(zeroOrMore(of: atom(.dot)))),
       captures: [.opt, .cap])
     parseTest(
       "((.))*((.)?)",
       concat(
-        zeroOrMore(of: capture(capture(atom(.any)))),
-        capture(zeroOrOne(of: capture(atom(.any))))),
+        zeroOrMore(of: capture(capture(atom(.dot)))),
+        capture(zeroOrOne(of: capture(atom(.dot))))),
       captures: [.opt, .opt, .cap, .opt])
     parseTest(
       #"abc\d"#,
@@ -479,7 +479,7 @@ extension RegexTests {
 
     parseTest(#"abc\d"#, concat("a", "b", "c", escaped(.decimalDigit)))
 
-    // FIXME: '\N' should be emitted through 'emitAny', not through the
+    // FIXME: '\N' should be emitted through 'emitDot', not through the
     // _CharacterClassModel model.
     parseTest(#"\N"#, escaped(.notNewline), unsupported: true)
 

--- a/Tests/RegexTests/RenderDSLTests.swift
+++ b/Tests/RegexTests/RenderDSLTests.swift
@@ -68,6 +68,23 @@ extension RenderDSLTests {
       }
       """)
   }
+
+  func testDot() throws {
+    try testConversion(#".+"#, #"""
+      Regex {
+        OneOrMore {
+          /./
+        }
+      }
+      """#)
+    try testConversion(#"a.c"#, #"""
+      Regex {
+        "a"
+        /./
+        "c"
+      }
+      """#)
+  }
   
   func testOptions() throws {
     try XCTExpectFailure("Options like '(?i)' aren't converted") {

--- a/Tests/RegexTests/RenderDSLTests.swift
+++ b/Tests/RegexTests/RenderDSLTests.swift
@@ -85,7 +85,21 @@ extension RenderDSLTests {
       }
       """#)
   }
-  
+
+  func testAnchor() throws {
+    try testConversion(#"^(?:a|b|c)$"#, #"""
+      Regex {
+        /^/
+        ChoiceOf {
+          "a"
+          "b"
+          "c"
+        }
+        /$/
+      }
+      """#)
+  }
+
   func testOptions() throws {
     try XCTExpectFailure("Options like '(?i)' aren't converted") {
       try testConversion(#"(?i)abc"#, """


### PR DESCRIPTION
Fix `CharacterClass.newlineSequence` such that it doesn't crash, `CharacterClass.any` such that it matches newlines, and implement `CharacterClass.anyNonNewline`.

Also fix `Anchor.startOfLine` and `Anchor.endOfLine` such that they always match newlines.

Resolves #537 (rdar://96330096)
Resolves #553 (rdar://96509234)
Resolves #571 (rdar://97029630)
Resolves #539 (rdar://97029702)