### PR TITLE
Remove `re'...'` and `rx'...'` delimiters

### DIFF
--- a/Sources/_RegexParser/Regex/Parse/Parse.swift
+++ b/Sources/_RegexParser/Regex/Parse/Parse.swift
@@ -672,9 +672,7 @@ fileprivate func defaultSyntaxOptions(
       return [.multilineCompilerLiteral, .extendedSyntax]
     }
     return .traditional
-  case .reSingleQuote:
-    return .traditional
-  case .experimental, .rxSingleQuote:
+  case .experimental:
     return .experimental
   }
 }

--- a/Tests/RegexTests/LexTests.swift
+++ b/Tests/RegexTests/LexTests.swift
@@ -96,9 +96,6 @@ extension RegexTests {
       ("#|abc/#def#", nil),
       ("#/abc\n/#", nil),
       ("#/abc\r/#", nil),
-
-      (#"re'abcre\''"#, (#"abcre\'"#, delim(.reSingleQuote))),
-      (#"re'\'"#, nil)
     ]
 
     for (input, expected) in testCases {


### PR DESCRIPTION
We didn't end up choosing these, remove their lexing code. `#|...|#` remains to test the experimental syntax.