### PR TITLE
Fix matching of backreferences in scalar mode

### DIFF
--- a/Sources/_StringProcessing/ByteCodeGen.swift
+++ b/Sources/_StringProcessing/ByteCodeGen.swift
@@ -84,7 +84,8 @@ fileprivate extension Compiler.ByteCodeGen {
       try emitBackreference(ref.ast)
 
     case let .symbolicReference(id):
-      builder.buildUnresolvedReference(id: id)
+      builder.buildUnresolvedReference(
+        id: id, isScalarMode: options.semanticLevel == .unicodeScalar)
 
     case let .changeMatchingOptions(optionSequence):
       if !hasEmittedFirstMatchableAtom {
@@ -143,9 +144,11 @@ fileprivate extension Compiler.ByteCodeGen {
       guard let i = n.value else {
         throw Unreachable("Expected a value")
       }
-      builder.buildBackreference(.init(i))
+      builder.buildBackreference(
+        .init(i), isScalarMode: options.semanticLevel == .unicodeScalar)
     case .named(let name):
-      try builder.buildNamedReference(name)
+      try builder.buildNamedReference(
+        name, isScalarMode: options.semanticLevel == .unicodeScalar)
     case .relative:
       throw Unsupported("Backreference kind: \(ref)")
     }

--- a/Sources/_StringProcessing/Engine/InstPayload.swift
+++ b/Sources/_StringProcessing/Engine/InstPayload.swift
@@ -240,13 +240,19 @@ extension Instruction.Payload {
     interpret()
   }
 
+  init(capture: CaptureRegister, isScalarMode: Bool) {
+    self.init(isScalarMode ? 1 : 0, capture)
+  }
+  var captureAndMode: (isScalarMode: Bool, CaptureRegister) {
+    let pair: (UInt64, CaptureRegister) = interpretPair()
+    return (pair.0 == 1, pair.1)
+  }
   init(capture: CaptureRegister) {
     self.init(capture)
   }
   var capture: CaptureRegister {
     interpret()
   }
-
 
   // MARK: Packed operand payloads
 

--- a/Tests/RegexTests/MatchTests.swift
+++ b/Tests/RegexTests/MatchTests.swift
@@ -1643,6 +1643,11 @@ extension RegexTests {
       (input: "123x23", match: "23x23"),
       xfail: true)
     
+    // Backreferences in scalar mode
+    // In scalar mode the backreference should not match
+    firstMatchTest(#"(.+)\1"#, input: "ée\u{301}", match: "ée\u{301}")
+    firstMatchTest(#"(.+)\1"#, input: "ée\u{301}", match: nil, semanticLevel: .unicodeScalar)
+
     // Backreferences in lookaheads
     firstMatchTests(
       #"^(?=.*(.)(.)\2\1).+$"#,


### PR DESCRIPTION
`.backreference` always matched in grapheme semantic mode (using `matchSeq()` which calls `match`), making this test fail

```
    // Backreferences in scalar mode
    // In scalar mode the backreference should not match
    firstMatchTest(#"(.+)\1"#, input: "ée\u{301}", match: "ée\u{301}")
    firstMatchTest(#"(.+)\1"#, input: "ée\u{301}", match: nil, semanticLevel: .unicodeScalar)
```

Fixed this by adding a bit to the payload for back references to check if it was emitted in unicode scalar mode