### PR TITLE
Backreferences do not guarantee forward progress

### DIFF
--- a/Sources/_StringProcessing/ByteCodeGen.swift
+++ b/Sources/_StringProcessing/ByteCodeGen.swift
@@ -1019,6 +1019,8 @@ extension DSLTree.Node {
     case .atom(let atom):
       switch atom {
       case .changeMatchingOptions, .assertion: return false
+      // Captures may be nil so backreferences may be zero length matches
+      case .backreference: return false
       default: return true
       }
     case .trivia, .empty:

--- a/Tests/RegexTests/MatchTests.swift
+++ b/Tests/RegexTests/MatchTests.swift
@@ -2549,4 +2549,8 @@ extension RegexTests {
     expectProgram(for: "a{\(maxStorable-1),\(maxStorable*2)}", doesNotContain: [.quantify])
     expectProgram(for: "a{\(maxStorable),\(maxStorable*2+1)}", doesNotContain: [.quantify])
   }
+  
+  func testFuzzerArtifacts() throws {
+    expectCompletion(regex: #"(b?)\1*"#, in: "a")
+  }
 }


### PR DESCRIPTION
The regex `(b?)\1*` spins the matching engine forever. This is the same bug as the one in rdar://96461197 but we had missed this case.

rdar://98517792