### PR TITLE
[5.7] Backreferences do not guarantee forward progress

### DIFF
--- a/Sources/_StringProcessing/ByteCodeGen.swift
+++ b/Sources/_StringProcessing/ByteCodeGen.swift
@@ -1061,6 +1061,8 @@ extension DSLTree.Node {
     case .atom(let atom):
       switch atom {
       case .changeMatchingOptions, .assertion: return false
+      // Captures may be nil so backreferences may be zero length matches
+      case .backreference: return false
       default: return true
       }
     case .trivia, .empty:

--- a/Tests/RegexTests/MatchTests.swift
+++ b/Tests/RegexTests/MatchTests.swift
@@ -2534,4 +2534,8 @@ extension RegexTests {
     expectCompletion(regex: #"(a{,4})*"#, in: "aa")
     expectCompletion(regex: #"((|)+)*"#, in: "aa")
   }
+  
+  func testFuzzerArtifacts() throws {
+    expectCompletion(regex: #"(b?)\1*"#, in: "a")
+  }
 }


### PR DESCRIPTION
Cherry pick of #598 
rdar://98517792

Makes regexes with quantified nil back references not spin forever