### PR TITLE
[5.7] Don't assume quoted literals are non-empty during bytecodegen

### DIFF
--- a/Sources/_StringProcessing/ByteCodeGen.swift
+++ b/Sources/_StringProcessing/ByteCodeGen.swift
@@ -109,7 +109,7 @@ fileprivate extension Compiler.ByteCodeGen {
     }
 
     // Fast path for eliding boundary checks for an all ascii quoted literal
-    if optimizationsEnabled && s.allSatisfy(\.isASCII) {
+    if optimizationsEnabled && s.allSatisfy(\.isASCII) && !s.isEmpty {
       let lastIdx = s.unicodeScalars.indices.last!
       for idx in s.unicodeScalars.indices {
         let boundaryCheck = idx == lastIdx

--- a/Tests/RegexTests/MatchTests.swift
+++ b/Tests/RegexTests/MatchTests.swift
@@ -2465,6 +2465,9 @@ extension RegexTests {
 
     // case insensitive tests
     firstMatchTest(#"(?i)abc\u{301}d"#, input: "AbC\u{301}d", match: "AbC\u{301}d", semanticLevel: .unicodeScalar)
+
+    // check that we don't crash on empty strings
+    firstMatchTest(#"\Q\E"#, input: "", match: "")
   }
   
   func testCase() {


### PR DESCRIPTION
When given an empty quoted literal (ie `\Q\E`) the regex engine crashes while attempting an optimization which assumes that the input is non-empty

Cherry pick of #600
rdar://98691039

