### PR TITLE
Deprecate `Regex.init(quoting:)`

### DIFF
--- a/Sources/_StringProcessing/Regex/Core.swift
+++ b/Sources/_StringProcessing/Regex/Core.swift
@@ -63,6 +63,7 @@ public struct Regex<Output>: RegexComponent {
 
 @available(SwiftStdlib 5.7, *)
 extension Regex {
+  @available(*, deprecated, renamed: "init(verbatim:)")
   public init(quoting string: String) {
     self.init(node: .quotedLiteral(string))
   }


### PR DESCRIPTION
This was renamed to `init(verbatim:)`, but we never removed the old overload. Deprecate it, and suggest using `init(verbatim:)` instead.

rdar://98737122