### PR TITLE
[5.7] Deprecate `Regex.init(quoting:)`

### DIFF
--- a/Sources/_StringProcessing/Regex/Core.swift
+++ b/Sources/_StringProcessing/Regex/Core.swift
@@ -63,6 +63,7 @@ public struct Regex<Output>: RegexComponent {
 
 @available(SwiftStdlib 5.7, *)
 extension Regex {
+  @available(*, deprecated, renamed: "init(verbatim:)")
   public init(quoting string: String) {
     self.init(node: .quotedLiteral(string))
   }


### PR DESCRIPTION
*5.7 cherry-pick of https://github.com/apple/swift-experimental-string-processing/pull/602*

This was renamed to `init(verbatim:)`, but we never removed the old overload. Deprecate it, and suggest using `init(verbatim:)` instead.

rdar://98737122