### PR TITLE
Fixes for possessive quantification, atomic groups, and lookarounds

### DIFF
--- a/Sources/_StringProcessing/ByteCodeGen.swift
+++ b/Sources/_StringProcessing/ByteCodeGen.swift
@@ -620,10 +620,10 @@ fileprivate extension Compiler.ByteCodeGen {
     }
 
     // exit-policy:
+    //   <possessive: clearSavePoint>
     //   condBranch(to: exit, ifZeroElseDecrement: %extraTrips)
     //   <eager: split(to: loop, saving: exit)>
     //   <possesive:
-    //     clearSavePoint
     //     split(to: loop, saving: exit)>
     //   <reluctant: save(restoringAt: loop)
     builder.label(exitPolicy)

--- a/Sources/_StringProcessing/ByteCodeGen.swift
+++ b/Sources/_StringProcessing/ByteCodeGen.swift
@@ -310,8 +310,11 @@ fileprivate extension Compiler.ByteCodeGen {
     let intercept = builder.makeAddress()
     let success = builder.makeAddress()
 
-    builder.buildSave(success)
-    let id = builder.buildSaveWithID(intercept)
+    // Positive lookaheads propagate captures through the success SP
+    builder.buildSave(success, keepsCaptures: true)
+    // Negative lookaheads should not propagate captures, so the intercept SP
+    // does not keep captures
+    let id = builder.buildSaveWithID(intercept, keepsCaptures: false)
     try emitNode(child)
     builder.buildClearThrough(id)
     if !positive {
@@ -347,7 +350,7 @@ fileprivate extension Compiler.ByteCodeGen {
     let intercept = builder.makeAddress()
     let success = builder.makeAddress()
 
-    builder.buildSaveAddress(success)
+    builder.buildSaveAddress(success, keepsCaptures: true)
     let id = builder.buildSaveWithID(intercept)
     try emitNode(child)
     builder.buildClearThrough(id)

--- a/Sources/_StringProcessing/ByteCodeGen.swift
+++ b/Sources/_StringProcessing/ByteCodeGen.swift
@@ -627,6 +627,9 @@ fileprivate extension Compiler.ByteCodeGen {
     //     split(to: loop, saving: exit)>
     //   <reluctant: save(restoringAt: loop)
     builder.label(exitPolicy)
+    if updatedKind == .possessive {
+      builder.buildClear()
+    }
     switch extraTrips {
     case nil: break
     case 0:   builder.buildBranch(to: exit)
@@ -640,7 +643,6 @@ fileprivate extension Compiler.ByteCodeGen {
     case .eager:
       builder.buildSplit(to: loopBody, saving: exit)
     case .possessive:
-      builder.buildClear()
       builder.buildSplit(to: loopBody, saving: exit)
     case .reluctant:
       builder.buildSave(loopBody)

--- a/Sources/_StringProcessing/Engine/Backtracking.swift
+++ b/Sources/_StringProcessing/Engine/Backtracking.swift
@@ -11,6 +11,7 @@
 
 extension Processor {
   struct SavePoint {
+    var id: SavePointID?
     var pc: InstructionAddress
     var pos: Position?
     // Quantifiers may store a range of positions to restore to
@@ -75,9 +76,11 @@ extension Processor {
 
   func makeSavePoint(
     _ pc: InstructionAddress,
-    addressOnly: Bool = false
+    addressOnly: Bool = false,
+    withID id: SavePointID? = nil
   ) -> SavePoint {
     SavePoint(
+      id: id,
       pc: pc,
       pos: addressOnly ? nil : currentPosition,
       rangeStart: nil,
@@ -91,6 +94,7 @@ extension Processor {
   func startQuantifierSavePoint() -> SavePoint {
     // Restores to the instruction AFTER the current quantifier instruction
     SavePoint(
+      id: nil,
       pc: controller.pc + 1,
       pos: nil,
       rangeStart: nil,

--- a/Sources/_StringProcessing/Engine/Backtracking.swift
+++ b/Sources/_StringProcessing/Engine/Backtracking.swift
@@ -26,7 +26,7 @@ extension Processor {
 
     // FIXME: Save minimal info (e.g. stack position and
     // perhaps current start)
-    var captureEnds: [_StoredCapture]
+    var captureEnds: [_StoredCapture]?
 
     // The int registers store values that can be relevant to
     // backtracking, such as the number of trips in a quantification.
@@ -38,7 +38,7 @@ extension Processor {
       pc: InstructionAddress,
       pos: Position?,
       stackEnd: CallStackAddress,
-      captureEnds: [_StoredCapture],
+      captureEnds: [_StoredCapture]?,
       intRegisters: [Int],
       PositionRegister: [Input.Index]
     ) {
@@ -77,7 +77,8 @@ extension Processor {
   func makeSavePoint(
     _ pc: InstructionAddress,
     addressOnly: Bool = false,
-    withID id: SavePointID? = nil
+    withID id: SavePointID? = nil,
+    keepCaptures: Bool = false
   ) -> SavePoint {
     SavePoint(
       id: id,
@@ -86,7 +87,7 @@ extension Processor {
       rangeStart: nil,
       rangeEnd: nil,
       stackEnd: .init(callStack.count),
-      captureEnds: storedCaptures,
+      captureEnds: keepCaptures ? nil : storedCaptures,
       intRegisters: registers.ints,
       posRegisters: registers.positions)
   }

--- a/Sources/_StringProcessing/Engine/Instruction.swift
+++ b/Sources/_StringProcessing/Engine/Instruction.swift
@@ -183,6 +183,9 @@ extension Instruction {
     ///
     /// Precondition: There is a save point to remove
     case clear
+    
+    /// Remove the save point with the given id
+    case clearReluctantQuantDummy
 
     /// Remove save points up to and including the operand
     ///

--- a/Sources/_StringProcessing/Engine/MEBuilder.swift
+++ b/Sources/_StringProcessing/Engine/MEBuilder.swift
@@ -51,6 +51,8 @@ extension MEProgram {
       // We currently deduce the capture count from the capture register number.
       nextCaptureRegister.rawValue
     }
+    
+    var nextSavePointID: SavePointID = 0
 
     init() {}
   }
@@ -60,11 +62,16 @@ extension MEProgram.Builder {
   struct AddressFixup {
     var first: AddressToken
     var second: AddressToken? = nil
+    var id: SavePointID?
 
-    init(_ a: AddressToken) { self.first = a }
-    init(_ a: AddressToken, _ b: AddressToken) {
+    init(_ a: AddressToken, id: SavePointID? = nil) {
+      self.first = a
+      self.id = id
+    }
+    init(_ a: AddressToken, _ b: AddressToken, id: SavePointID? = nil) {
       self.first = a
       self.second = b
+      self.id = id
     }
   }
 }
@@ -125,19 +132,34 @@ extension MEProgram.Builder {
     instructions.append(.init(.saveAddress))
     fixup(to: t)
   }
+  
+  mutating func buildSaveWithID(_ t: AddressToken) -> SavePointID {
+    let id = makeSavePointID()
+    instructions.append(.init(.save))
+    fixup(to: t, id: id)
+    return id
+  }
+  mutating func buildSaveAddressWithID(_ t: AddressToken) -> SavePointID {
+    let id = makeSavePointID()
+    instructions.append(.init(.saveAddress))
+    fixup(to: t, id: id)
+    return id
+  }
   mutating func buildSplit(
-    to: AddressToken, saving: AddressToken
+    to: AddressToken, saving: AddressToken, id: SavePointID? = nil
   ) {
     instructions.append(.init(.splitSaving))
-    fixup(to: (to, saving))
+    fixup(to: (to, saving), id: id)
   }
 
   mutating func buildClear() {
     instructions.append(.init(.clear))
   }
-  mutating func buildClearThrough(_ t: AddressToken) {
-    instructions.append(.init(.clearThrough))
-    fixup(to: t)
+  mutating func buildClear(reluctantQuantDummy id: SavePointID) {
+    instructions.append(.init(.clearReluctantQuantDummy, .init(saveID: id)))
+  }
+  mutating func buildClearThrough(_ id: SavePointID) {
+    instructions.append(.init(.clearThrough, .init(saveID: id)))
   }
   mutating func buildFail() {
     instructions.append(.init(.fail))
@@ -357,15 +379,16 @@ extension MEProgram.Builder {
         payload = .init(addr: addr, int: inst.payload.int)
       case .condBranchSamePosition:
         payload = .init(addr: addr, position: inst.payload.position)
-      case .branch, .save, .saveAddress, .clearThrough:
+      case .branch:
         payload = .init(addr: addr)
-
+      case .save, .saveAddress:
+        payload = .init(save: addr, id: tok.id)
       case .splitSaving:
         guard let fix2 = tok.second else {
           throw Unreachable("TODO: reason")
         }
         let saving = addressTokens[fix2.rawValue]!
-        payload = .init(addr: addr, addr2: saving)
+        payload = .init(save: saving, id: tok.id, splitTo: addr)
 
       default: throw Unreachable("TODO: reason")
 
@@ -435,22 +458,23 @@ extension MEProgram.Builder {
   // Associate the most recently added instruction with
   // the provided token, ensuring it is fixed up during
   // assembly
-  mutating func fixup(to t: AddressToken) {
+  mutating func fixup(to t: AddressToken, id: SavePointID? = nil) {
     assert(!instructions.isEmpty)
     addressFixups.append(
-      (InstructionAddress(instructions.endIndex-1), .init(t)))
+      (InstructionAddress(instructions.endIndex-1), .init(t, id: id)))
   }
 
   // Associate the most recently added instruction with
   // the provided tokens, ensuring it is fixed up during
   // assembly
   mutating func fixup(
-    to ts: (AddressToken, AddressToken)
+    to ts: (AddressToken, AddressToken),
+    id: SavePointID? = nil
   ) {
     assert(!instructions.isEmpty)
     addressFixups.append((
       InstructionAddress(instructions.endIndex-1),
-      .init(ts.0, ts.1)))
+      .init(ts.0, ts.1, id: id)))
   }
 
   // Push an "empty" save point which will, upon restore, just restore from
@@ -459,11 +483,11 @@ extension MEProgram.Builder {
   //
   // This is useful for possessive quantification that needs some initial save
   // point to "ratchet" upon a successful match.
-  mutating func pushEmptySavePoint() {
+  mutating func pushEmptySavePoint() -> SavePointID {
     if failAddressToken == nil {
       failAddressToken = makeAddress()
     }
-    buildSaveAddress(failAddressToken!)
+    return buildSaveAddressWithID(failAddressToken!)
   }
 
 }
@@ -527,6 +551,10 @@ extension MEProgram.Builder {
     let r = nextPositionRegister
     defer { nextPositionRegister.rawValue += 1 }
     return r
+  }
+  mutating func makeSavePointID() -> SavePointID {
+    defer { nextSavePointID.rawValue += 1 }
+    return nextSavePointID
   }
 
   // TODO: A register-mapping helper struct, which could release

--- a/Sources/_StringProcessing/Engine/Tracing.swift
+++ b/Sources/_StringProcessing/Engine/Tracing.swift
@@ -93,9 +93,9 @@ extension Instruction: CustomStringConvertible {
       let payload = payload.savePayload
       let resumeAddr = payload.addr
       if payload.hasID {
-        return "\(opcode) \(resumeAddr) id: \(payload.id)"
+        return "\(opcode) \(resumeAddr) keepsCaptures? \(payload.keepsCaptures) id: \(payload.id)"
       }
-      return "\(opcode) \(resumeAddr)"
+      return "\(opcode) \(resumeAddr) keepsCaptures? \(payload.keepsCaptures)"
     case .splitSaving:
       let payload = payload.savePayload
       if payload.hasID {
@@ -134,7 +134,7 @@ extension Processor.SavePoint {
       idStr = ""
     }
     return """
-      pc: \(self.pc), pos: \(posStr), stackEnd: \(stackEnd)\(idStr)
+      pc: \(self.pc), pos: \(posStr), stackEnd: \(stackEnd), keepsCaptures? \(self.captureEnds == nil)\(idStr)
       """
   }
 }

--- a/Sources/_StringProcessing/Utility/TypedInt.swift
+++ b/Sources/_StringProcessing/Utility/TypedInt.swift
@@ -110,6 +110,8 @@ enum _PositionStackAddress {}
 typealias SavePointStackAddress = TypedInt<_SavePointAddress>
 enum _SavePointAddress {}
 
+typealias SavePointID = TypedInt<_SavePointID>
+enum _SavePointID {}
 
 // MARK: - Registers
 

--- a/Tests/RegexTests/CompileTests.swift
+++ b/Tests/RegexTests/CompileTests.swift
@@ -27,6 +27,7 @@ enum DecodedInstr {
   case splitSaving
   case clear
   case clearThrough
+  case clearReluctantQuantDummy
   case accept
   case fail
   case advance
@@ -81,6 +82,8 @@ extension DecodedInstr {
       return .clear
     case .clearThrough:
       return .clearThrough
+    case .clearReluctantQuantDummy:
+      return .clearReluctantQuantDummy
     case .accept:
       return .accept
     case .fail:

--- a/Tests/RegexTests/MatchTests.swift
+++ b/Tests/RegexTests/MatchTests.swift
@@ -589,7 +589,7 @@ extension RegexTests {
     firstMatchTests(
       "(a|a)?+a",
       ("a", nil),
-      xfail: true)
+      xfail: false)
     firstMatchTests(
       "(a|a){2,4}+a",
       ("a", nil),
@@ -598,7 +598,7 @@ extension RegexTests {
       "(a|a){2,4}+a",
       ("aaa", nil),
       ("aaaa", nil),
-      xfail: true)
+      xfail: false)
 
     firstMatchTests(
       "(?:a{2,4}?b)+",

--- a/Tests/RegexTests/MatchTests.swift
+++ b/Tests/RegexTests/MatchTests.swift
@@ -391,7 +391,7 @@ extension RegexTests {
       #"a(?#. comment)b"#, input: "123abcxyz", match: "ab")
   }
 
-  func testMatchQuantification() {
+  func testMatchQuantification() throws {
     // MARK: Quantification
 
     firstMatchTest(
@@ -460,6 +460,11 @@ extension RegexTests {
     firstMatchTests(
       ".*+x",
       ("abc", nil), ("abcx", nil), ("", nil))
+    
+    // Make sure that possessive quant doesn't clear out existing save points
+    let r = try Regex("a?(ab)?+")
+    let match = try r.wholeMatch(in: "ab")
+    XCTAssertEqual(match?.0, "ab")
 
     firstMatchTests(
       "a+b",
@@ -580,7 +585,7 @@ extension RegexTests {
     firstMatchTests(
       "a?+a",
       ("a", nil),
-      xfail: true)
+      xfail: false)
     firstMatchTests(
       "(a|a)?+a",
       ("a", nil),
@@ -1617,7 +1622,7 @@ extension RegexTests {
     firstMatchTests(
       #"^(?:a?+)a$"#,
       (input: "a", match: nil),
-      xfail: true)
+      xfail: false)
     firstMatchTests(
       #"^(?:a?+)a$"#,
       (input: "aa", match: "aa"),

--- a/Tests/RegexTests/MatchTests.swift
+++ b/Tests/RegexTests/MatchTests.swift
@@ -2559,6 +2559,12 @@ extension RegexTests {
   }
   
   func testFuzzerArtifacts() throws {
+    // rdar://98517792
     expectCompletion(regex: #"(b?)\1*"#, in: "a")
+
+    // rdar://98852151
+    firstMatchTest(#"\p{L}?+\p{L}"#, input: "a", match: nil)
+    firstMatchTest(#"🧟‍♀️?+🧟‍♀️"#, input: "🧟‍♀️", match: nil)
+    firstMatchTest(#"🧟‍♀️{,3}+🧟‍♀️"#, input: "🧟‍♀️🧟‍♀️🧟‍♀️", match: nil)
   }
 }


### PR DESCRIPTION
Let capture information escape atomic groups and lookarounds: rdar://98738984
Correctly clear the dummy save point in possessive quantification: rdar://98852151