### PR TITLE
Add tests for line start/end word boundary diffs

### DIFF
--- a/Tests/RegexTests/MatchTests.swift
+++ b/Tests/RegexTests/MatchTests.swift
@@ -1517,6 +1517,19 @@ extension RegexTests {
       (" 123", "23"),
       ("123 456", "23"))
 
+    let defaultBoundaryRegex = try Regex(#"\b.{3}X.{3}\b"#)
+    // Default word boundaries match at the start/end of a string/line.
+    XCTAssertNotNil(try defaultBoundaryRegex.firstMatch(in: "---X---"))
+    XCTAssertNotNil(try defaultBoundaryRegex.firstMatch(in: "abc\n---X---\ndef"))
+    
+    let simpleBoundaryRegex = defaultBoundaryRegex.wordBoundaryKind(.simple)
+    // Simple word boundaries match only when the adjacent position matches \w.
+    XCTAssertNil(try simpleBoundaryRegex.firstMatch(in: "---X---"))
+    XCTAssertNil(try simpleBoundaryRegex.firstMatch(in: "abc\n---X---\ndef"))
+    
+    XCTAssertNotNil(try simpleBoundaryRegex.firstMatch(in: "x--X--x"))
+    XCTAssertNotNil(try simpleBoundaryRegex.firstMatch(in: "abc\nx--X--x\ndef"))
+    
     // \G and \K
     let regex = try Regex(#"\Gab"#, as: Substring.self)
     XCTAssertEqual("abab".matches(of: regex).map(\.output), ["ab", "ab"])


### PR DESCRIPTION
The `default` and `simple` word boundaries have different behaviors at the start and end of strings/lines. These tests validate that we have the correct behavior implemented. Related to issue #613.