### PR TITLE
Set availability for inverted character class test

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -93,7 +93,7 @@ let package = Package(
             name: "DocumentationTests",
             dependencies: ["_StringProcessing", "RegexBuilder"],
             swiftSettings: [
-                .unsafeFlags(["-Xfrontend", "-disable-availability-checking"]),
+                availabilityDefinition,
                 .unsafeFlags(["-enable-bare-slash-regex"]),
             ]),
         

--- a/Tests/DocumentationTests/RegexBuilderTests.swift
+++ b/Tests/DocumentationTests/RegexBuilderTests.swift
@@ -19,8 +19,13 @@ import RegexBuilder
 
 class RegexBuilderTests: XCTestCase {}
 
+@available(SwiftStdlib 5.7, *)
 extension RegexBuilderTests {
   func testCharacterClass_inverted() throws {
+    // `CharacterClass` depends on some standard library SPI that is only
+    // available in >= macOS 13. The warning for the next line is spurious.
+    guard #available(macOS 13, *) else { return }
+    
     let validCharacters = CharacterClass("a"..."z", .anyOf("-_"))
     let invalidCharacters = validCharacters.inverted
     

--- a/Tests/DocumentationTests/RegexTests.swift
+++ b/Tests/DocumentationTests/RegexTests.swift
@@ -18,6 +18,7 @@ import _StringProcessing
 
 class RegexTests: XCTestCase {}
 
+@available(SwiftStdlib 5.7, *)
 extension RegexTests {
   func testRegex() throws {
     // 'keyAndValue' is created using a regex literal
@@ -91,6 +92,7 @@ extension RegexTests {
   }
 }
 
+@available(SwiftStdlib 5.7, *)
 extension RegexTests {
   func testRegex_wholeMatchIn() throws {
     let digits = /[0-9]+/


### PR DESCRIPTION
This feature depends on running with a Swift 5.7 stdlib, and fails when that isn't available.