### PR TITLE
Correct misspelling in DSL renderer

### DIFF
--- a/Sources/_StringProcessing/PrintAsPattern.swift
+++ b/Sources/_StringProcessing/PrintAsPattern.swift
@@ -770,7 +770,7 @@ extension DSLTree.Atom.CharacterClass {
     case .verticalWhitespace:
       return ".verticalWhitespace"
     case .notVerticalWhitespace:
-      return ".vertialWhitespace.inverted"
+      return ".verticalWhitespace.inverted"
     case .whitespace:
       return ".whitespace"
     case .notWhitespace:

--- a/Tests/RegexTests/RenderDSLTests.swift
+++ b/Tests/RegexTests/RenderDSLTests.swift
@@ -135,6 +135,32 @@ extension RenderDSLTests {
         }
       }
       """#)
+    
+    try testConversion(#"a(?:\w|\W)b(?:\d|\D)c(?:\v|\V)d(?:\h|\H)e"#, #"""
+      Regex {
+        "a"
+        ChoiceOf {
+          One(.word)
+          One(.word.inverted)
+        }
+        "b"
+        ChoiceOf {
+          One(.digit)
+          One(.digit.inverted)
+        }
+        "c"
+        ChoiceOf {
+          One(.verticalWhitespace)
+          One(.verticalWhitespace.inverted)
+        }
+        "d"
+        ChoiceOf {
+          One(.horizontalWhitespace)
+          One(.horizontalWhitespace.inverted)
+        }
+        "e"
+      }
+      """#)
   }
 
   func testOptions() throws {


### PR DESCRIPTION
vertial -> vertical

rdar://104602317