### PR TITLE
[Do not merge] Reduced test case for strange test crashes

### DIFF
--- a/Tests/RegexBuilderTests/GoodBadFunctionTests.swift
+++ b/Tests/RegexBuilderTests/GoodBadFunctionTests.swift
@@ -1,0 +1,18 @@
+import XCTest
+import _StringProcessing
+@testable import RegexBuilder
+
+func goodFunction<T>(_ r: some RegexComponent<T>) {
+  _ = try? r.regex.firstMatch(in: "...")
+}
+
+fileprivate func badFunction<T>(_ r: Regex<T>) {
+  _ = try? r.firstMatch(in: "...")
+}
+
+class GoodBadFunctionTests: XCTestCase {
+  func testGoodBadFunctions() {
+    goodFunction(Regex { "asdf" })
+    badFunction(Regex { "asdf" })
+  }
+}


### PR DESCRIPTION
This is a very odd bug that is showing up in CI and on the command line, but not in Xcode with a similar toolchain selected. The `GoodBadFunctionTests.swift` file has a reduced test case that demonstrates the problem: With this code included, I see several _other_ tests that crash, even in different test modules.

The problem disappears if you comment out the call to `badFunction`, but then re-appears if you make `badFunction` internal instead of fileprivate. I've been testing this with
`swift-DEVELOPMENT-SNAPSHOT-2023-01-30-a.xctoolchain`.