### PR TITLE
[swift 5.8] Fix output type mismatch

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -8,6 +8,10 @@ let availabilityDefinition = PackageDescription.SwiftSetting.unsafeFlags([
     "-define-availability",
     "-Xfrontend",
     "SwiftStdlib 5.7:macOS 9999, iOS 9999, watchOS 9999, tvOS 9999",
+    "-Xfrontend",
+    "-define-availability",
+    "-Xfrontend",
+    "SwiftStdlib 5.8:macOS 9999, iOS 9999, watchOS 9999, tvOS 9999",
 ])
 
 /// Swift settings for building a private stdlib-like module that is to be used
@@ -87,7 +91,7 @@ let package = Package(
             name: "RegexBuilderTests",
             dependencies: ["_StringProcessing", "RegexBuilder", "TestSupport"],
             swiftSettings: [
-                .unsafeFlags(["-Xfrontend", "-disable-availability-checking"])
+                availabilityDefinition
             ]),
         .testTarget(
             name: "DocumentationTests",

--- a/Sources/RegexBuilder/Variadics.swift
+++ b/Sources/RegexBuilder/Variadics.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2021-2022 Apple Inc. and the Swift project authors
+// Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -20,7 +20,7 @@ extension RegexComponentBuilder {
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C1)>  where R0.RegexOutput == W0, R1.RegexOutput == (W1, C1) {
     let factory = makeFactory()
-    return factory.accumulate(accumulated, next)
+    return factory.accumulate(ignoringOutputTypeOf: accumulated, next)
   }
 }
 @available(SwiftStdlib 5.7, *)
@@ -30,7 +30,7 @@ extension RegexComponentBuilder {
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C1, C2)>  where R0.RegexOutput == W0, R1.RegexOutput == (W1, C1, C2) {
     let factory = makeFactory()
-    return factory.accumulate(accumulated, next)
+    return factory.accumulate(ignoringOutputTypeOf: accumulated, next)
   }
 }
 @available(SwiftStdlib 5.7, *)
@@ -40,7 +40,7 @@ extension RegexComponentBuilder {
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C1, C2, C3)>  where R0.RegexOutput == W0, R1.RegexOutput == (W1, C1, C2, C3) {
     let factory = makeFactory()
-    return factory.accumulate(accumulated, next)
+    return factory.accumulate(ignoringOutputTypeOf: accumulated, next)
   }
 }
 @available(SwiftStdlib 5.7, *)
@@ -50,7 +50,7 @@ extension RegexComponentBuilder {
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C1, C2, C3, C4)>  where R0.RegexOutput == W0, R1.RegexOutput == (W1, C1, C2, C3, C4) {
     let factory = makeFactory()
-    return factory.accumulate(accumulated, next)
+    return factory.accumulate(ignoringOutputTypeOf: accumulated, next)
   }
 }
 @available(SwiftStdlib 5.7, *)
@@ -60,7 +60,7 @@ extension RegexComponentBuilder {
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C1, C2, C3, C4, C5)>  where R0.RegexOutput == W0, R1.RegexOutput == (W1, C1, C2, C3, C4, C5) {
     let factory = makeFactory()
-    return factory.accumulate(accumulated, next)
+    return factory.accumulate(ignoringOutputTypeOf: accumulated, next)
   }
 }
 @available(SwiftStdlib 5.7, *)
@@ -70,7 +70,7 @@ extension RegexComponentBuilder {
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C1, C2, C3, C4, C5, C6)>  where R0.RegexOutput == W0, R1.RegexOutput == (W1, C1, C2, C3, C4, C5, C6) {
     let factory = makeFactory()
-    return factory.accumulate(accumulated, next)
+    return factory.accumulate(ignoringOutputTypeOf: accumulated, next)
   }
 }
 @available(SwiftStdlib 5.7, *)
@@ -80,7 +80,7 @@ extension RegexComponentBuilder {
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C1, C2, C3, C4, C5, C6, C7)>  where R0.RegexOutput == W0, R1.RegexOutput == (W1, C1, C2, C3, C4, C5, C6, C7) {
     let factory = makeFactory()
-    return factory.accumulate(accumulated, next)
+    return factory.accumulate(ignoringOutputTypeOf: accumulated, next)
   }
 }
 @available(SwiftStdlib 5.7, *)
@@ -90,7 +90,7 @@ extension RegexComponentBuilder {
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C1, C2, C3, C4, C5, C6, C7, C8)>  where R0.RegexOutput == W0, R1.RegexOutput == (W1, C1, C2, C3, C4, C5, C6, C7, C8) {
     let factory = makeFactory()
-    return factory.accumulate(accumulated, next)
+    return factory.accumulate(ignoringOutputTypeOf: accumulated, next)
   }
 }
 @available(SwiftStdlib 5.7, *)
@@ -100,7 +100,7 @@ extension RegexComponentBuilder {
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C1, C2, C3, C4, C5, C6, C7, C8, C9)>  where R0.RegexOutput == W0, R1.RegexOutput == (W1, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
     let factory = makeFactory()
-    return factory.accumulate(accumulated, next)
+    return factory.accumulate(ignoringOutputTypeOf: accumulated, next)
   }
 }
 @available(SwiftStdlib 5.7, *)
@@ -110,7 +110,7 @@ extension RegexComponentBuilder {
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10)>  where R0.RegexOutput == W0, R1.RegexOutput == (W1, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10) {
     let factory = makeFactory()
-    return factory.accumulate(accumulated, next)
+    return factory.accumulate(ignoringOutputTypeOf: accumulated, next)
   }
 }
 @available(SwiftStdlib 5.7, *)
@@ -565,123 +565,112 @@ extension RegexComponentBuilder {
 }
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
-  @available(SwiftStdlib 5.7, *)
   @_alwaysEmitIntoClient
   public static func buildPartialBlock<W0, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<Substring> where R0.RegexOutput == W0  {
     let factory = makeFactory()
-    return factory.accumulate(accumulated, next)
+    return factory.accumulate(ignoringOutputTypeOf: accumulated, andAlso: next)
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
-  @available(SwiftStdlib 5.7, *)
   @_alwaysEmitIntoClient
   public static func buildPartialBlock<W0, C0, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C0)> where R0.RegexOutput == (W0, C0)  {
     let factory = makeFactory()
-    return factory.accumulate(accumulated, next)
+    return factory.accumulate(accumulated, ignoringOutputTypeOf: next)
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
-  @available(SwiftStdlib 5.7, *)
   @_alwaysEmitIntoClient
   public static func buildPartialBlock<W0, C0, C1, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C0, C1)> where R0.RegexOutput == (W0, C0, C1)  {
     let factory = makeFactory()
-    return factory.accumulate(accumulated, next)
+    return factory.accumulate(accumulated, ignoringOutputTypeOf: next)
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
-  @available(SwiftStdlib 5.7, *)
   @_alwaysEmitIntoClient
   public static func buildPartialBlock<W0, C0, C1, C2, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C0, C1, C2)> where R0.RegexOutput == (W0, C0, C1, C2)  {
     let factory = makeFactory()
-    return factory.accumulate(accumulated, next)
+    return factory.accumulate(accumulated, ignoringOutputTypeOf: next)
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
-  @available(SwiftStdlib 5.7, *)
   @_alwaysEmitIntoClient
   public static func buildPartialBlock<W0, C0, C1, C2, C3, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C0, C1, C2, C3)> where R0.RegexOutput == (W0, C0, C1, C2, C3)  {
     let factory = makeFactory()
-    return factory.accumulate(accumulated, next)
+    return factory.accumulate(accumulated, ignoringOutputTypeOf: next)
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
-  @available(SwiftStdlib 5.7, *)
   @_alwaysEmitIntoClient
   public static func buildPartialBlock<W0, C0, C1, C2, C3, C4, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C0, C1, C2, C3, C4)> where R0.RegexOutput == (W0, C0, C1, C2, C3, C4)  {
     let factory = makeFactory()
-    return factory.accumulate(accumulated, next)
+    return factory.accumulate(accumulated, ignoringOutputTypeOf: next)
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
-  @available(SwiftStdlib 5.7, *)
   @_alwaysEmitIntoClient
   public static func buildPartialBlock<W0, C0, C1, C2, C3, C4, C5, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5)> where R0.RegexOutput == (W0, C0, C1, C2, C3, C4, C5)  {
     let factory = makeFactory()
-    return factory.accumulate(accumulated, next)
+    return factory.accumulate(accumulated, ignoringOutputTypeOf: next)
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
-  @available(SwiftStdlib 5.7, *)
   @_alwaysEmitIntoClient
   public static func buildPartialBlock<W0, C0, C1, C2, C3, C4, C5, C6, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6)> where R0.RegexOutput == (W0, C0, C1, C2, C3, C4, C5, C6)  {
     let factory = makeFactory()
-    return factory.accumulate(accumulated, next)
+    return factory.accumulate(accumulated, ignoringOutputTypeOf: next)
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
-  @available(SwiftStdlib 5.7, *)
   @_alwaysEmitIntoClient
   public static func buildPartialBlock<W0, C0, C1, C2, C3, C4, C5, C6, C7, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7)> where R0.RegexOutput == (W0, C0, C1, C2, C3, C4, C5, C6, C7)  {
     let factory = makeFactory()
-    return factory.accumulate(accumulated, next)
+    return factory.accumulate(accumulated, ignoringOutputTypeOf: next)
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
-  @available(SwiftStdlib 5.7, *)
   @_alwaysEmitIntoClient
   public static func buildPartialBlock<W0, C0, C1, C2, C3, C4, C5, C6, C7, C8, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8)> where R0.RegexOutput == (W0, C0, C1, C2, C3, C4, C5, C6, C7, C8)  {
     let factory = makeFactory()
-    return factory.accumulate(accumulated, next)
+    return factory.accumulate(accumulated, ignoringOutputTypeOf: next)
   }
 }
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
-  @available(SwiftStdlib 5.7, *)
   @_alwaysEmitIntoClient
   public static func buildPartialBlock<W0, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9, R0: RegexComponent, R1: RegexComponent>(
     accumulated: R0, next: R1
   ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9)> where R0.RegexOutput == (W0, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9)  {
     let factory = makeFactory()
-    return factory.accumulate(accumulated, next)
+    return factory.accumulate(accumulated, ignoringOutputTypeOf: next)
   }
 }
 
@@ -6884,7 +6873,3 @@ extension TryCapture {
     self.init(factory.captureOptional(componentBuilder(), reference._raw, transform))
   }
 }
-
-
-
-// END AUTO-GENERATED CONTENT

--- a/Sources/VariadicsGenerator/VariadicsGenerator.swift
+++ b/Sources/VariadicsGenerator/VariadicsGenerator.swift
@@ -132,7 +132,7 @@ struct VariadicsGenerator: ParsableCommand {
       //
       // This source file is part of the Swift.org open source project
       //
-      // Copyright (c) 2021-2022 Apple Inc. and the Swift project authors
+      // Copyright (c) 2021-2023 Apple Inc. and the Swift project authors
       // Licensed under Apache License v2.0 with Runtime Library Exception
       //
       // See https://swift.org/LICENSE.txt for license information
@@ -262,7 +262,20 @@ struct VariadicsGenerator: ParsableCommand {
           accumulated: R0, next: R1
         ) -> \(regexTypeName)<\(matchType)> \(whereClause) {
           let factory = makeFactory()
+      
+      """)
+    if leftArity == 0 {
+      output("""
+          return factory.accumulate(ignoringOutputTypeOf: accumulated, next)
+      
+      """)
+    } else {
+      output("""
           return factory.accumulate(accumulated, next)
+      
+      """)
+    }
+    output("""
         }
       }
 
@@ -274,7 +287,6 @@ struct VariadicsGenerator: ParsableCommand {
     output("""
       \(defaultAvailableAttr)
       extension \(concatBuilderName) {
-        \(defaultAvailableAttr)
         @_alwaysEmitIntoClient
         public static func buildPartialBlock<W0
       """)
@@ -308,7 +320,20 @@ struct VariadicsGenerator: ParsableCommand {
     output("""
         {
           let factory = makeFactory()
-          return factory.accumulate(accumulated, next)
+      
+      """)
+    if leftArity == 0 {
+      output("""
+          return factory.accumulate(ignoringOutputTypeOf: accumulated, andAlso: next)
+      
+      """)
+    } else {
+      output("""
+          return factory.accumulate(accumulated, ignoringOutputTypeOf: next)
+      
+      """)
+    }
+    output("""
         }
       }
 

--- a/Sources/_StringProcessing/ByteCodeGen.swift
+++ b/Sources/_StringProcessing/ByteCodeGen.swift
@@ -874,7 +874,7 @@ fileprivate extension Compiler.ByteCodeGen {
       switch node {
       case .concatenation(let ch):
         return ch.flatMap(flatten)
-      case .convertedRegexLiteral(let n, _):
+      case .convertedRegexLiteral(let n, _), .ignoreCapturesInTypedOutput(let n):
         return flatten(n)
       default:
         return [node]
@@ -951,6 +951,9 @@ fileprivate extension Compiler.ByteCodeGen {
     case let .nonCapturingGroup(kind, child):
       try emitNoncapturingGroup(kind.ast, child)
 
+    case let .ignoreCapturesInTypedOutput(child):
+      try emitNode(child)
+      
     case .conditional:
       throw Unsupported("Conditionals")
 

--- a/Sources/_StringProcessing/Capture.swift
+++ b/Sources/_StringProcessing/Capture.swift
@@ -61,7 +61,7 @@ extension Sequence where Element == AnyRegexOutput.Element {
   // and traffic through existentials
   @available(SwiftStdlib 5.7, *)
   func existentialOutput(from input: String) -> Any {
-    let elements = map {
+    let elements = filter(\.representation.visibleInTypedOutput).map {
       $0.existentialOutputComponent(from: input)
     }
     return elements.count == 1

--- a/Sources/_StringProcessing/ConsumerInterface.swift
+++ b/Sources/_StringProcessing/ConsumerInterface.swift
@@ -42,7 +42,7 @@ extension DSLTree.Node {
     case .orderedChoice, .conditional, .concatenation,
         .capture, .nonCapturingGroup,
         .quantification, .trivia, .empty,
-        .absentFunction: return nil
+        .ignoreCapturesInTypedOutput, .absentFunction: return nil
 
     case .consumer:
       fatalError("FIXME: Is this where we handle them?")

--- a/Sources/_StringProcessing/Engine/Structuralize.swift
+++ b/Sources/_StringProcessing/Engine/Structuralize.swift
@@ -14,7 +14,8 @@ extension CaptureList {
         optionalDepth: cap.optionalDepth,
         content: meStored.deconstructed,
         name: cap.name,
-        referenceID: list.referencedCaptureOffsets.first { $1 == i }?.key
+        referenceID: list.referencedCaptureOffsets.first { $1 == i }?.key,
+        visibleInTypedOutput: cap.visibleInTypedOutput
       )
       
       result.append(element)

--- a/Sources/_StringProcessing/PrintAsPattern.swift
+++ b/Sources/_StringProcessing/PrintAsPattern.swift
@@ -131,6 +131,9 @@ extension PrettyPrinter {
         printer.printAsPattern(convertedFromAST: child)
       }
 
+    case let .ignoreCapturesInTypedOutput(child):
+      printAsPattern(convertedFromAST: child, isTopLevel: isTopLevel)
+      
     case .conditional:
       print("/* TODO: conditional */")
 

--- a/Sources/_StringProcessing/Regex/AnyRegexOutput.swift
+++ b/Sources/_StringProcessing/Regex/AnyRegexOutput.swift
@@ -359,6 +359,10 @@ extension AnyRegexOutput {
 
     /// The capture reference this element refers to.
     var referenceID: ReferenceID? = nil
+    
+    /// A Boolean value indicating whether this capture should be included in
+    /// the typed output.
+    var visibleInTypedOutput: Bool
   }
 
   internal init(input: String, elements: [ElementRepresentation]) {

--- a/Sources/_StringProcessing/Utility/RegexFactory.swift
+++ b/Sources/_StringProcessing/Utility/RegexFactory.swift
@@ -20,6 +20,16 @@ public struct _RegexFactory {
   // Hide is behind an SPI that only RegexBuilder can use.
   @_spi(RegexBuilder)
   public init() {}
+
+  @available(SwiftStdlib 5.8, *)
+  public func ignoreCapturesInTypedOutput(
+    _ child: some RegexComponent
+  ) -> Regex<Substring> {
+    // Don't wrap `child` again if it's a leaf node.
+    child.regex.root.hasChildNodes
+      ? .init(node: .ignoreCapturesInTypedOutput(child.regex.root))
+      : .init(node: child.regex.root)
+  }
   
   @available(SwiftStdlib 5.7, *)
   public func accumulate<Output>(

--- a/Tests/RegexBuilderTests/AlgorithmsTests.swift
+++ b/Tests/RegexBuilderTests/AlgorithmsTests.swift
@@ -13,6 +13,7 @@ import XCTest
 import _StringProcessing
 import RegexBuilder
 
+@available(SwiftStdlib 5.7, *)
 class RegexConsumerTests: XCTestCase {
   func testMatches() {
     let regex = Capture(OneOrMore(.digit)) { 2 * Int($0)! }
@@ -105,6 +106,7 @@ class RegexConsumerTests: XCTestCase {
   }
 }
 
+@available(SwiftStdlib 5.7, *)
 class AlgorithmsResultBuilderTests: XCTestCase {
   enum MatchAlgo {
     case whole

--- a/Tests/RegexBuilderTests/AnyRegexOutputTests.swift
+++ b/Tests/RegexBuilderTests/AnyRegexOutputTests.swift
@@ -5,6 +5,7 @@ import RegexBuilder
 
 private let enablePrinting = false
 
+@available(SwiftStdlib 5.7, *)
 extension RegexDSLTests {
 
   func testContrivedAROExample() {

--- a/Tests/RegexBuilderTests/CustomTests.swift
+++ b/Tests/RegexBuilderTests/CustomTests.swift
@@ -14,10 +14,12 @@ import _StringProcessing
 @testable import RegexBuilder
 
 // A nibbler processes a single character from a string
+@available(SwiftStdlib 5.7, *)
 private protocol Nibbler: CustomConsumingRegexComponent {
   func nibble(_: Character) -> RegexOutput?
 }
 
+@available(SwiftStdlib 5.7, *)
 extension Nibbler {
   // Default implementation, just feed the character in
   func consuming(
@@ -34,6 +36,7 @@ extension Nibbler {
 
 
 // A number nibbler
+@available(SwiftStdlib 5.7, *)
 private struct Numbler: Nibbler {
   typealias RegexOutput = Int
   func nibble(_ c: Character) -> Int? {
@@ -42,6 +45,7 @@ private struct Numbler: Nibbler {
 }
 
 // An ASCII value nibbler
+@available(SwiftStdlib 5.7, *)
 private struct Asciibbler: Nibbler {
   typealias RegexOutput = UInt8
   func nibble(_ c: Character) -> UInt8? {
@@ -49,6 +53,7 @@ private struct Asciibbler: Nibbler {
   }
 }
 
+@available(SwiftStdlib 5.7, *)
 private struct IntParser: CustomConsumingRegexComponent {
   struct ParseError: Error, Hashable {}
   typealias RegexOutput = Int
@@ -71,6 +76,7 @@ private struct IntParser: CustomConsumingRegexComponent {
   }
 }
 
+@available(SwiftStdlib 5.7, *)
 private struct CurrencyParser: CustomConsumingRegexComponent {
   enum Currency: String, Hashable {
     case usd = "USD"
@@ -117,9 +123,12 @@ enum MatchCall {
   case firstMatch
 }
 
-func customTest<Match: Equatable>(
+@available(SwiftStdlib 5.7, *)
+fileprivate func customTest<Match: Equatable>(
   _ regex: Regex<Match>,
-  _ tests: (input: String, call: MatchCall, match: Match?)...
+  _ tests: (input: String, call: MatchCall, match: Match?)...,
+  file: StaticString = #file,
+  line: UInt = #line
 ) {
   for (input, call, match) in tests {
     let result: Match?
@@ -129,7 +138,40 @@ func customTest<Match: Equatable>(
     case .firstMatch:
       result = input.firstMatch(of: regex)?.output
     }
-    XCTAssertEqual(result, match)
+    XCTAssertEqual(result, match, file: file, line: line)
+  }
+}
+
+@available(SwiftStdlib 5.7, *)
+fileprivate func customTest<Match>(
+  _ regex: some RegexComponent<Match>,
+  _ isEquivalent: (Match, Match) -> Bool,
+  _ tests: (input: String, call: MatchCall, match: Match?)...,
+  file: StaticString = #file,
+  line: UInt = #line
+) {
+  for (input, call, match) in tests {
+    let result: Match?
+    switch call {
+    case .match:
+      result = input.wholeMatch(of: regex)?.output
+    case .firstMatch:
+      result = input.firstMatch(of: regex)?.output
+    }
+    switch (result, match) {
+    case let (result?, match?):
+      XCTAssert(
+        isEquivalent(result, match),
+        "'\(result)' isn't equal to '\(match)'.",
+        file: file, line: line)
+    case (nil, nil):
+      // Success
+      break
+    case (nil, _):
+      XCTFail("No match when expected", file: file, line: line)
+    case (_, nil):
+      XCTFail("Unexpected match", file: file, line: line)
+    }
   }
 }
 
@@ -178,6 +220,7 @@ extension Concat: BidirectionalCollection {
   }
 }
 
+@available(SwiftStdlib 5.7, *)
 class CustomRegexComponentTests: XCTestCase {
   // TODO: Refactor below into more exhaustive, declarative
   // tests.
@@ -211,39 +254,91 @@ class CustomRegexComponentTests: XCTestCase {
       ("55z", .match, nil),
       ("55z", .firstMatch, 5))
 
-    // TODO: Convert below tests to better infra. Right now
-    // it's hard because `Match` is constrained to be
-    // `Equatable` which tuples cannot be.
+//    customTest(
+//      Regex<Substring> {
+//        #/(?<prefix>\D+)/#
+//        Optionally("~")
+//      },
+//      ("ab123c", .firstMatch, "ab"),
+//      ("abc", .firstMatch, "abc"),
+//      ("123", .firstMatch, nil),
+//      ("a55z", .match, nil),
+//      ("a55z", .firstMatch, "a"))
 
-    let regex3 = Regex {
-      Capture {
-        OneOrMore {
-          Numbler()
+    customTest(
+      Regex<(Substring, Substring, Int)> {
+        #/(\D+)/#
+        Capture(Numbler())
+      },
+      ==,
+      ("ab123c", .firstMatch, ("ab1", "ab", 1)),
+      ("abc", .firstMatch, nil),
+      ("123", .firstMatch, nil),
+      ("a55z", .match, nil),
+      ("a55z", .firstMatch, ("a5", "a", 5)))
+
+    customTest(
+      Regex<(Substring, prefix: Substring)> {
+        #/(?<prefix>\D+)/#
+      },
+      ==,
+      ("ab123c", .firstMatch, ("ab", "ab")),
+      ("abc", .firstMatch, ("abc", "abc")),
+      ("123", .firstMatch, nil),
+      ("a55z", .match, nil),
+      ("a55z", .firstMatch, ("a", "a")))
+
+//    customTest(
+//      Regex<(Substring, Int)> {
+//        #/(?<prefix>\D+)/#
+//        Capture(Numbler())
+//      },
+//      ==,
+//      ("ab123c", .firstMatch, ("ab1", 1)),
+//      ("abc", .firstMatch, nil),
+//      ("123", .firstMatch, nil),
+//      ("a55z", .match, nil),
+//      ("a55z", .firstMatch, ("a5", 5)))
+    
+//    customTest(
+//      Regex<(Substring, Int, Substring)> {
+//        #/(?<prefix>\D+)/#
+//        Regex {
+//          Capture(Numbler())
+//          Capture(OneOrMore(.word))
+//        }
+//      },
+//      ==,
+//      ("ab123c", .firstMatch, ("ab123c", 1, "23c")),
+//      ("abc", .firstMatch, nil),
+//      ("123", .firstMatch, nil),
+//      ("a55z", .match, ("a55z", 5, "5z")),
+//      ("a55z", .firstMatch, ("a55z", 5, "5z")))
+    
+    customTest(
+      Regex<(Substring, Substring)> {
+        Capture {
+          OneOrMore {
+            Numbler()
+          }
         }
-      }
-    }
-
-    let str = "ab123c"
-    let res3 = try XCTUnwrap(str.firstMatch(of: regex3))
-
-    let expectedSubstring = str.dropFirst(2).prefix(3)
-    XCTAssertEqual(res3.range, expectedSubstring.startIndex..<expectedSubstring.endIndex)
-    XCTAssertEqual(res3.output.0, expectedSubstring)
-    XCTAssertEqual(res3.output.1, expectedSubstring)
-
-    let regex4 = Regex {
-      OneOrMore {
-        Capture { Numbler() }
-      }
-    }
-
-    guard let res4 = "ab123c".firstMatch(of: regex4) else {
-      XCTFail()
-      return
-    }
-
-    XCTAssertEqual(res4.output.0, "123")
-    XCTAssertEqual(res4.output.1, 3)
+      },
+      ==,
+      ("abc123", .firstMatch, ("123", "123")),
+      ("abc123", .match, nil),
+      ("abc", .firstMatch, nil))
+    
+    customTest(
+      Regex<(Substring, Int)> {
+        OneOrMore {
+          Capture { Numbler() }
+        }
+      },
+      ==,
+      ("ab123c", .firstMatch, ("123", 3)),
+      ("abc", .firstMatch, nil),
+      ("55z", .match, nil),
+      ("55z", .firstMatch, ("55", 5)))
   }
 
   func testRegexAbort() {

--- a/Tests/RegexBuilderTests/MotivationTests.swift
+++ b/Tests/RegexBuilderTests/MotivationTests.swift
@@ -261,6 +261,7 @@ extension RegexDSLTests {
 
 #endif
 
+@available(SwiftStdlib 5.7, *)
 extension RegexDSLTests {
   func testProposalExample() {
     let statement = """
@@ -309,7 +310,7 @@ extension RegexDSLTests {
           "CREDIT"
           "DEBIT"
         }
-      } transform: { (s: Substring) in
+      } transform: { (s: Substring) -> TransactionKind? in
         TransactionKind(rawValue: String(s))
       }
       
@@ -322,7 +323,7 @@ extension RegexDSLTests {
         Repeat(.digit, count: 2)
         Repeat(.digit, count: 2)
         Repeat(.digit, count: 4)
-      } transform: { (s: Substring) in
+      } transform: { (s: Substring) -> Date? in
         Date(mmddyyyy: String(s))
       }
       
@@ -345,7 +346,7 @@ extension RegexDSLTests {
         OneOrMore(.digit)
         "."
         Repeat(.digit, count: 2)
-      } transform: { (s: Substring) in
+      } transform: { (s: Substring) -> Double? in
         Double(s)
       }
     }

--- a/Tests/RegexTests/CaptureTests.swift
+++ b/Tests/RegexTests/CaptureTests.swift
@@ -16,15 +16,15 @@ import XCTest
 
 extension CaptureList.Capture {
   static var cap: Self {
-    return Self(optionalDepth: 0, .fake)
+    return Self(optionalDepth: 0, visibleInTypedOutput: true, .fake)
   }
 
   static var opt: Self {
-    return Self(optionalDepth: 1, .fake)
+    return Self(optionalDepth: 1, visibleInTypedOutput: true, .fake)
   }
 
   static func named(_ name: String, opt: Int = 0) -> Self {
-    return Self(name: name, optionalDepth: opt, .fake)
+    return Self(name: name, optionalDepth: opt, visibleInTypedOutput: true, .fake)
   }
 }
 extension CaptureList {


### PR DESCRIPTION
Cherry pick of the output type mismatch fix (#626) into the `swift/release/5.8` branch.