### PR TITLE
[5.8] Use `some RegexComponent` in variadic inits

### DIFF
--- a/Sources/RegexBuilder/DSL.swift
+++ b/Sources/RegexBuilder/DSL.swift
@@ -15,9 +15,9 @@
 @available(SwiftStdlib 5.7, *)
 extension Regex {
   /// Creates a regular expression using a RegexBuilder closure.
-  public init<Content: RegexComponent>(
-    @RegexComponentBuilder _ content: () -> Content
-  ) where Content.RegexOutput == Output {
+  public init(
+    @RegexComponentBuilder _ content: () -> some RegexComponent<Output>
+  ) {
     self = content().regex
   }
 }
@@ -91,9 +91,9 @@ public struct One<Output>: RegexComponent {
   public var regex: Regex<Output>
 
   /// Creates a regex component that matches the given component exactly once.
-  public init<Component: RegexComponent>(
-    _ component: Component
-  ) where Component.RegexOutput == Output {
+  public init(
+    _ component: some RegexComponent<Output>
+  ) {
     self.regex = component.regex
   }
 }

--- a/Sources/RegexBuilder/Variadics.swift
+++ b/Sources/RegexBuilder/Variadics.swift
@@ -13,12 +13,15 @@
 
 @_spi(RegexBuilder) import _StringProcessing
 
+// MARK: - Partial block (left arity 0)
+
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
   @_alwaysEmitIntoClient
-  public static func buildPartialBlock<W0, W1, C1, R0: RegexComponent, R1: RegexComponent>(
-    accumulated: R0, next: R1
-  ) -> Regex<(Substring, C1)>  where R0.RegexOutput == W0, R1.RegexOutput == (W1, C1) {
+  public static func buildPartialBlock<W0, W1, C1>(
+    accumulated: some RegexComponent<W0>,
+    next: some RegexComponent<(W1, C1)>
+  ) -> Regex<(Substring, C1)> {
     let factory = makeFactory()
     return factory.accumulate(ignoringOutputTypeOf: accumulated, next)
   }
@@ -26,9 +29,10 @@ extension RegexComponentBuilder {
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
   @_alwaysEmitIntoClient
-  public static func buildPartialBlock<W0, W1, C1, C2, R0: RegexComponent, R1: RegexComponent>(
-    accumulated: R0, next: R1
-  ) -> Regex<(Substring, C1, C2)>  where R0.RegexOutput == W0, R1.RegexOutput == (W1, C1, C2) {
+  public static func buildPartialBlock<W0, W1, C1, C2>(
+    accumulated: some RegexComponent<W0>,
+    next: some RegexComponent<(W1, C1, C2)>
+  ) -> Regex<(Substring, C1, C2)> {
     let factory = makeFactory()
     return factory.accumulate(ignoringOutputTypeOf: accumulated, next)
   }
@@ -36,9 +40,10 @@ extension RegexComponentBuilder {
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
   @_alwaysEmitIntoClient
-  public static func buildPartialBlock<W0, W1, C1, C2, C3, R0: RegexComponent, R1: RegexComponent>(
-    accumulated: R0, next: R1
-  ) -> Regex<(Substring, C1, C2, C3)>  where R0.RegexOutput == W0, R1.RegexOutput == (W1, C1, C2, C3) {
+  public static func buildPartialBlock<W0, W1, C1, C2, C3>(
+    accumulated: some RegexComponent<W0>,
+    next: some RegexComponent<(W1, C1, C2, C3)>
+  ) -> Regex<(Substring, C1, C2, C3)> {
     let factory = makeFactory()
     return factory.accumulate(ignoringOutputTypeOf: accumulated, next)
   }
@@ -46,9 +51,10 @@ extension RegexComponentBuilder {
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
   @_alwaysEmitIntoClient
-  public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, R0: RegexComponent, R1: RegexComponent>(
-    accumulated: R0, next: R1
-  ) -> Regex<(Substring, C1, C2, C3, C4)>  where R0.RegexOutput == W0, R1.RegexOutput == (W1, C1, C2, C3, C4) {
+  public static func buildPartialBlock<W0, W1, C1, C2, C3, C4>(
+    accumulated: some RegexComponent<W0>,
+    next: some RegexComponent<(W1, C1, C2, C3, C4)>
+  ) -> Regex<(Substring, C1, C2, C3, C4)> {
     let factory = makeFactory()
     return factory.accumulate(ignoringOutputTypeOf: accumulated, next)
   }
@@ -56,9 +62,10 @@ extension RegexComponentBuilder {
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
   @_alwaysEmitIntoClient
-  public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, C5, R0: RegexComponent, R1: RegexComponent>(
-    accumulated: R0, next: R1
-  ) -> Regex<(Substring, C1, C2, C3, C4, C5)>  where R0.RegexOutput == W0, R1.RegexOutput == (W1, C1, C2, C3, C4, C5) {
+  public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, C5>(
+    accumulated: some RegexComponent<W0>,
+    next: some RegexComponent<(W1, C1, C2, C3, C4, C5)>
+  ) -> Regex<(Substring, C1, C2, C3, C4, C5)> {
     let factory = makeFactory()
     return factory.accumulate(ignoringOutputTypeOf: accumulated, next)
   }
@@ -66,9 +73,10 @@ extension RegexComponentBuilder {
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
   @_alwaysEmitIntoClient
-  public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, C5, C6, R0: RegexComponent, R1: RegexComponent>(
-    accumulated: R0, next: R1
-  ) -> Regex<(Substring, C1, C2, C3, C4, C5, C6)>  where R0.RegexOutput == W0, R1.RegexOutput == (W1, C1, C2, C3, C4, C5, C6) {
+  public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, C5, C6>(
+    accumulated: some RegexComponent<W0>,
+    next: some RegexComponent<(W1, C1, C2, C3, C4, C5, C6)>
+  ) -> Regex<(Substring, C1, C2, C3, C4, C5, C6)> {
     let factory = makeFactory()
     return factory.accumulate(ignoringOutputTypeOf: accumulated, next)
   }
@@ -76,9 +84,10 @@ extension RegexComponentBuilder {
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
   @_alwaysEmitIntoClient
-  public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, C5, C6, C7, R0: RegexComponent, R1: RegexComponent>(
-    accumulated: R0, next: R1
-  ) -> Regex<(Substring, C1, C2, C3, C4, C5, C6, C7)>  where R0.RegexOutput == W0, R1.RegexOutput == (W1, C1, C2, C3, C4, C5, C6, C7) {
+  public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, C5, C6, C7>(
+    accumulated: some RegexComponent<W0>,
+    next: some RegexComponent<(W1, C1, C2, C3, C4, C5, C6, C7)>
+  ) -> Regex<(Substring, C1, C2, C3, C4, C5, C6, C7)> {
     let factory = makeFactory()
     return factory.accumulate(ignoringOutputTypeOf: accumulated, next)
   }
@@ -86,9 +95,10 @@ extension RegexComponentBuilder {
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
   @_alwaysEmitIntoClient
-  public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, C5, C6, C7, C8, R0: RegexComponent, R1: RegexComponent>(
-    accumulated: R0, next: R1
-  ) -> Regex<(Substring, C1, C2, C3, C4, C5, C6, C7, C8)>  where R0.RegexOutput == W0, R1.RegexOutput == (W1, C1, C2, C3, C4, C5, C6, C7, C8) {
+  public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, C5, C6, C7, C8>(
+    accumulated: some RegexComponent<W0>,
+    next: some RegexComponent<(W1, C1, C2, C3, C4, C5, C6, C7, C8)>
+  ) -> Regex<(Substring, C1, C2, C3, C4, C5, C6, C7, C8)> {
     let factory = makeFactory()
     return factory.accumulate(ignoringOutputTypeOf: accumulated, next)
   }
@@ -96,9 +106,10 @@ extension RegexComponentBuilder {
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
   @_alwaysEmitIntoClient
-  public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, C5, C6, C7, C8, C9, R0: RegexComponent, R1: RegexComponent>(
-    accumulated: R0, next: R1
-  ) -> Regex<(Substring, C1, C2, C3, C4, C5, C6, C7, C8, C9)>  where R0.RegexOutput == W0, R1.RegexOutput == (W1, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
+  public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, C5, C6, C7, C8, C9>(
+    accumulated: some RegexComponent<W0>,
+    next: some RegexComponent<(W1, C1, C2, C3, C4, C5, C6, C7, C8, C9)>
+  ) -> Regex<(Substring, C1, C2, C3, C4, C5, C6, C7, C8, C9)> {
     let factory = makeFactory()
     return factory.accumulate(ignoringOutputTypeOf: accumulated, next)
   }
@@ -106,19 +117,23 @@ extension RegexComponentBuilder {
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
   @_alwaysEmitIntoClient
-  public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, R0: RegexComponent, R1: RegexComponent>(
-    accumulated: R0, next: R1
-  ) -> Regex<(Substring, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10)>  where R0.RegexOutput == W0, R1.RegexOutput == (W1, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10) {
+  public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10>(
+    accumulated: some RegexComponent<W0>,
+    next: some RegexComponent<(W1, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10)>
+  ) -> Regex<(Substring, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10)> {
     let factory = makeFactory()
     return factory.accumulate(ignoringOutputTypeOf: accumulated, next)
   }
 }
+// MARK: - Partial block (left arity 1)
+
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
   @_alwaysEmitIntoClient
-  public static func buildPartialBlock<W0, W1, C1, C2, R0: RegexComponent, R1: RegexComponent>(
-    accumulated: R0, next: R1
-  ) -> Regex<(Substring, C1, C2)>  where R0.RegexOutput == (W0, C1), R1.RegexOutput == (W1, C2) {
+  public static func buildPartialBlock<W0, W1, C1, C2>(
+    accumulated: some RegexComponent<(W0, C1)>,
+    next: some RegexComponent<(W1, C2)>
+  ) -> Regex<(Substring, C1, C2)> {
     let factory = makeFactory()
     return factory.accumulate(accumulated, next)
   }
@@ -126,9 +141,10 @@ extension RegexComponentBuilder {
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
   @_alwaysEmitIntoClient
-  public static func buildPartialBlock<W0, W1, C1, C2, C3, R0: RegexComponent, R1: RegexComponent>(
-    accumulated: R0, next: R1
-  ) -> Regex<(Substring, C1, C2, C3)>  where R0.RegexOutput == (W0, C1), R1.RegexOutput == (W1, C2, C3) {
+  public static func buildPartialBlock<W0, W1, C1, C2, C3>(
+    accumulated: some RegexComponent<(W0, C1)>,
+    next: some RegexComponent<(W1, C2, C3)>
+  ) -> Regex<(Substring, C1, C2, C3)> {
     let factory = makeFactory()
     return factory.accumulate(accumulated, next)
   }
@@ -136,9 +152,10 @@ extension RegexComponentBuilder {
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
   @_alwaysEmitIntoClient
-  public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, R0: RegexComponent, R1: RegexComponent>(
-    accumulated: R0, next: R1
-  ) -> Regex<(Substring, C1, C2, C3, C4)>  where R0.RegexOutput == (W0, C1), R1.RegexOutput == (W1, C2, C3, C4) {
+  public static func buildPartialBlock<W0, W1, C1, C2, C3, C4>(
+    accumulated: some RegexComponent<(W0, C1)>,
+    next: some RegexComponent<(W1, C2, C3, C4)>
+  ) -> Regex<(Substring, C1, C2, C3, C4)> {
     let factory = makeFactory()
     return factory.accumulate(accumulated, next)
   }
@@ -146,9 +163,10 @@ extension RegexComponentBuilder {
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
   @_alwaysEmitIntoClient
-  public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, C5, R0: RegexComponent, R1: RegexComponent>(
-    accumulated: R0, next: R1
-  ) -> Regex<(Substring, C1, C2, C3, C4, C5)>  where R0.RegexOutput == (W0, C1), R1.RegexOutput == (W1, C2, C3, C4, C5) {
+  public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, C5>(
+    accumulated: some RegexComponent<(W0, C1)>,
+    next: some RegexComponent<(W1, C2, C3, C4, C5)>
+  ) -> Regex<(Substring, C1, C2, C3, C4, C5)> {
     let factory = makeFactory()
     return factory.accumulate(accumulated, next)
   }
@@ -156,9 +174,10 @@ extension RegexComponentBuilder {
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
   @_alwaysEmitIntoClient
-  public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, C5, C6, R0: RegexComponent, R1: RegexComponent>(
-    accumulated: R0, next: R1
-  ) -> Regex<(Substring, C1, C2, C3, C4, C5, C6)>  where R0.RegexOutput == (W0, C1), R1.RegexOutput == (W1, C2, C3, C4, C5, C6) {
+  public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, C5, C6>(
+    accumulated: some RegexComponent<(W0, C1)>,
+    next: some RegexComponent<(W1, C2, C3, C4, C5, C6)>
+  ) -> Regex<(Substring, C1, C2, C3, C4, C5, C6)> {
     let factory = makeFactory()
     return factory.accumulate(accumulated, next)
   }
@@ -166,9 +185,10 @@ extension RegexComponentBuilder {
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
   @_alwaysEmitIntoClient
-  public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, C5, C6, C7, R0: RegexComponent, R1: RegexComponent>(
-    accumulated: R0, next: R1
-  ) -> Regex<(Substring, C1, C2, C3, C4, C5, C6, C7)>  where R0.RegexOutput == (W0, C1), R1.RegexOutput == (W1, C2, C3, C4, C5, C6, C7) {
+  public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, C5, C6, C7>(
+    accumulated: some RegexComponent<(W0, C1)>,
+    next: some RegexComponent<(W1, C2, C3, C4, C5, C6, C7)>
+  ) -> Regex<(Substring, C1, C2, C3, C4, C5, C6, C7)> {
     let factory = makeFactory()
     return factory.accumulate(accumulated, next)
   }
@@ -176,9 +196,10 @@ extension RegexComponentBuilder {
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
   @_alwaysEmitIntoClient
-  public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, C5, C6, C7, C8, R0: RegexComponent, R1: RegexComponent>(
-    accumulated: R0, next: R1
-  ) -> Regex<(Substring, C1, C2, C3, C4, C5, C6, C7, C8)>  where R0.RegexOutput == (W0, C1), R1.RegexOutput == (W1, C2, C3, C4, C5, C6, C7, C8) {
+  public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, C5, C6, C7, C8>(
+    accumulated: some RegexComponent<(W0, C1)>,
+    next: some RegexComponent<(W1, C2, C3, C4, C5, C6, C7, C8)>
+  ) -> Regex<(Substring, C1, C2, C3, C4, C5, C6, C7, C8)> {
     let factory = makeFactory()
     return factory.accumulate(accumulated, next)
   }
@@ -186,9 +207,10 @@ extension RegexComponentBuilder {
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
   @_alwaysEmitIntoClient
-  public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, C5, C6, C7, C8, C9, R0: RegexComponent, R1: RegexComponent>(
-    accumulated: R0, next: R1
-  ) -> Regex<(Substring, C1, C2, C3, C4, C5, C6, C7, C8, C9)>  where R0.RegexOutput == (W0, C1), R1.RegexOutput == (W1, C2, C3, C4, C5, C6, C7, C8, C9) {
+  public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, C5, C6, C7, C8, C9>(
+    accumulated: some RegexComponent<(W0, C1)>,
+    next: some RegexComponent<(W1, C2, C3, C4, C5, C6, C7, C8, C9)>
+  ) -> Regex<(Substring, C1, C2, C3, C4, C5, C6, C7, C8, C9)> {
     let factory = makeFactory()
     return factory.accumulate(accumulated, next)
   }
@@ -196,9 +218,23 @@ extension RegexComponentBuilder {
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
   @_alwaysEmitIntoClient
-  public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, R0: RegexComponent, R1: RegexComponent>(
-    accumulated: R0, next: R1
-  ) -> Regex<(Substring, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10)>  where R0.RegexOutput == (W0, C1), R1.RegexOutput == (W1, C2, C3, C4, C5, C6, C7, C8, C9, C10) {
+  public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10>(
+    accumulated: some RegexComponent<(W0, C1)>,
+    next: some RegexComponent<(W1, C2, C3, C4, C5, C6, C7, C8, C9, C10)>
+  ) -> Regex<(Substring, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10)> {
+    let factory = makeFactory()
+    return factory.accumulate(accumulated, next)
+  }
+}
+// MARK: - Partial block (left arity 2)
+
+@available(SwiftStdlib 5.7, *)
+extension RegexComponentBuilder {
+  @_alwaysEmitIntoClient
+  public static func buildPartialBlock<W0, W1, C1, C2, C3>(
+    accumulated: some RegexComponent<(W0, C1, C2)>,
+    next: some RegexComponent<(W1, C3)>
+  ) -> Regex<(Substring, C1, C2, C3)> {
     let factory = makeFactory()
     return factory.accumulate(accumulated, next)
   }
@@ -206,9 +242,10 @@ extension RegexComponentBuilder {
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
   @_alwaysEmitIntoClient
-  public static func buildPartialBlock<W0, W1, C1, C2, C3, R0: RegexComponent, R1: RegexComponent>(
-    accumulated: R0, next: R1
-  ) -> Regex<(Substring, C1, C2, C3)>  where R0.RegexOutput == (W0, C1, C2), R1.RegexOutput == (W1, C3) {
+  public static func buildPartialBlock<W0, W1, C1, C2, C3, C4>(
+    accumulated: some RegexComponent<(W0, C1, C2)>,
+    next: some RegexComponent<(W1, C3, C4)>
+  ) -> Regex<(Substring, C1, C2, C3, C4)> {
     let factory = makeFactory()
     return factory.accumulate(accumulated, next)
   }
@@ -216,9 +253,10 @@ extension RegexComponentBuilder {
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
   @_alwaysEmitIntoClient
-  public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, R0: RegexComponent, R1: RegexComponent>(
-    accumulated: R0, next: R1
-  ) -> Regex<(Substring, C1, C2, C3, C4)>  where R0.RegexOutput == (W0, C1, C2), R1.RegexOutput == (W1, C3, C4) {
+  public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, C5>(
+    accumulated: some RegexComponent<(W0, C1, C2)>,
+    next: some RegexComponent<(W1, C3, C4, C5)>
+  ) -> Regex<(Substring, C1, C2, C3, C4, C5)> {
     let factory = makeFactory()
     return factory.accumulate(accumulated, next)
   }
@@ -226,9 +264,10 @@ extension RegexComponentBuilder {
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
   @_alwaysEmitIntoClient
-  public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, C5, R0: RegexComponent, R1: RegexComponent>(
-    accumulated: R0, next: R1
-  ) -> Regex<(Substring, C1, C2, C3, C4, C5)>  where R0.RegexOutput == (W0, C1, C2), R1.RegexOutput == (W1, C3, C4, C5) {
+  public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, C5, C6>(
+    accumulated: some RegexComponent<(W0, C1, C2)>,
+    next: some RegexComponent<(W1, C3, C4, C5, C6)>
+  ) -> Regex<(Substring, C1, C2, C3, C4, C5, C6)> {
     let factory = makeFactory()
     return factory.accumulate(accumulated, next)
   }
@@ -236,9 +275,10 @@ extension RegexComponentBuilder {
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
   @_alwaysEmitIntoClient
-  public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, C5, C6, R0: RegexComponent, R1: RegexComponent>(
-    accumulated: R0, next: R1
-  ) -> Regex<(Substring, C1, C2, C3, C4, C5, C6)>  where R0.RegexOutput == (W0, C1, C2), R1.RegexOutput == (W1, C3, C4, C5, C6) {
+  public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, C5, C6, C7>(
+    accumulated: some RegexComponent<(W0, C1, C2)>,
+    next: some RegexComponent<(W1, C3, C4, C5, C6, C7)>
+  ) -> Regex<(Substring, C1, C2, C3, C4, C5, C6, C7)> {
     let factory = makeFactory()
     return factory.accumulate(accumulated, next)
   }
@@ -246,9 +286,10 @@ extension RegexComponentBuilder {
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
   @_alwaysEmitIntoClient
-  public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, C5, C6, C7, R0: RegexComponent, R1: RegexComponent>(
-    accumulated: R0, next: R1
-  ) -> Regex<(Substring, C1, C2, C3, C4, C5, C6, C7)>  where R0.RegexOutput == (W0, C1, C2), R1.RegexOutput == (W1, C3, C4, C5, C6, C7) {
+  public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, C5, C6, C7, C8>(
+    accumulated: some RegexComponent<(W0, C1, C2)>,
+    next: some RegexComponent<(W1, C3, C4, C5, C6, C7, C8)>
+  ) -> Regex<(Substring, C1, C2, C3, C4, C5, C6, C7, C8)> {
     let factory = makeFactory()
     return factory.accumulate(accumulated, next)
   }
@@ -256,9 +297,10 @@ extension RegexComponentBuilder {
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
   @_alwaysEmitIntoClient
-  public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, C5, C6, C7, C8, R0: RegexComponent, R1: RegexComponent>(
-    accumulated: R0, next: R1
-  ) -> Regex<(Substring, C1, C2, C3, C4, C5, C6, C7, C8)>  where R0.RegexOutput == (W0, C1, C2), R1.RegexOutput == (W1, C3, C4, C5, C6, C7, C8) {
+  public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, C5, C6, C7, C8, C9>(
+    accumulated: some RegexComponent<(W0, C1, C2)>,
+    next: some RegexComponent<(W1, C3, C4, C5, C6, C7, C8, C9)>
+  ) -> Regex<(Substring, C1, C2, C3, C4, C5, C6, C7, C8, C9)> {
     let factory = makeFactory()
     return factory.accumulate(accumulated, next)
   }
@@ -266,9 +308,23 @@ extension RegexComponentBuilder {
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
   @_alwaysEmitIntoClient
-  public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, C5, C6, C7, C8, C9, R0: RegexComponent, R1: RegexComponent>(
-    accumulated: R0, next: R1
-  ) -> Regex<(Substring, C1, C2, C3, C4, C5, C6, C7, C8, C9)>  where R0.RegexOutput == (W0, C1, C2), R1.RegexOutput == (W1, C3, C4, C5, C6, C7, C8, C9) {
+  public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10>(
+    accumulated: some RegexComponent<(W0, C1, C2)>,
+    next: some RegexComponent<(W1, C3, C4, C5, C6, C7, C8, C9, C10)>
+  ) -> Regex<(Substring, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10)> {
+    let factory = makeFactory()
+    return factory.accumulate(accumulated, next)
+  }
+}
+// MARK: - Partial block (left arity 3)
+
+@available(SwiftStdlib 5.7, *)
+extension RegexComponentBuilder {
+  @_alwaysEmitIntoClient
+  public static func buildPartialBlock<W0, W1, C1, C2, C3, C4>(
+    accumulated: some RegexComponent<(W0, C1, C2, C3)>,
+    next: some RegexComponent<(W1, C4)>
+  ) -> Regex<(Substring, C1, C2, C3, C4)> {
     let factory = makeFactory()
     return factory.accumulate(accumulated, next)
   }
@@ -276,9 +332,10 @@ extension RegexComponentBuilder {
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
   @_alwaysEmitIntoClient
-  public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, R0: RegexComponent, R1: RegexComponent>(
-    accumulated: R0, next: R1
-  ) -> Regex<(Substring, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10)>  where R0.RegexOutput == (W0, C1, C2), R1.RegexOutput == (W1, C3, C4, C5, C6, C7, C8, C9, C10) {
+  public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, C5>(
+    accumulated: some RegexComponent<(W0, C1, C2, C3)>,
+    next: some RegexComponent<(W1, C4, C5)>
+  ) -> Regex<(Substring, C1, C2, C3, C4, C5)> {
     let factory = makeFactory()
     return factory.accumulate(accumulated, next)
   }
@@ -286,9 +343,10 @@ extension RegexComponentBuilder {
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
   @_alwaysEmitIntoClient
-  public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, R0: RegexComponent, R1: RegexComponent>(
-    accumulated: R0, next: R1
-  ) -> Regex<(Substring, C1, C2, C3, C4)>  where R0.RegexOutput == (W0, C1, C2, C3), R1.RegexOutput == (W1, C4) {
+  public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, C5, C6>(
+    accumulated: some RegexComponent<(W0, C1, C2, C3)>,
+    next: some RegexComponent<(W1, C4, C5, C6)>
+  ) -> Regex<(Substring, C1, C2, C3, C4, C5, C6)> {
     let factory = makeFactory()
     return factory.accumulate(accumulated, next)
   }
@@ -296,9 +354,10 @@ extension RegexComponentBuilder {
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
   @_alwaysEmitIntoClient
-  public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, C5, R0: RegexComponent, R1: RegexComponent>(
-    accumulated: R0, next: R1
-  ) -> Regex<(Substring, C1, C2, C3, C4, C5)>  where R0.RegexOutput == (W0, C1, C2, C3), R1.RegexOutput == (W1, C4, C5) {
+  public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, C5, C6, C7>(
+    accumulated: some RegexComponent<(W0, C1, C2, C3)>,
+    next: some RegexComponent<(W1, C4, C5, C6, C7)>
+  ) -> Regex<(Substring, C1, C2, C3, C4, C5, C6, C7)> {
     let factory = makeFactory()
     return factory.accumulate(accumulated, next)
   }
@@ -306,9 +365,10 @@ extension RegexComponentBuilder {
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
   @_alwaysEmitIntoClient
-  public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, C5, C6, R0: RegexComponent, R1: RegexComponent>(
-    accumulated: R0, next: R1
-  ) -> Regex<(Substring, C1, C2, C3, C4, C5, C6)>  where R0.RegexOutput == (W0, C1, C2, C3), R1.RegexOutput == (W1, C4, C5, C6) {
+  public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, C5, C6, C7, C8>(
+    accumulated: some RegexComponent<(W0, C1, C2, C3)>,
+    next: some RegexComponent<(W1, C4, C5, C6, C7, C8)>
+  ) -> Regex<(Substring, C1, C2, C3, C4, C5, C6, C7, C8)> {
     let factory = makeFactory()
     return factory.accumulate(accumulated, next)
   }
@@ -316,9 +376,10 @@ extension RegexComponentBuilder {
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
   @_alwaysEmitIntoClient
-  public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, C5, C6, C7, R0: RegexComponent, R1: RegexComponent>(
-    accumulated: R0, next: R1
-  ) -> Regex<(Substring, C1, C2, C3, C4, C5, C6, C7)>  where R0.RegexOutput == (W0, C1, C2, C3), R1.RegexOutput == (W1, C4, C5, C6, C7) {
+  public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, C5, C6, C7, C8, C9>(
+    accumulated: some RegexComponent<(W0, C1, C2, C3)>,
+    next: some RegexComponent<(W1, C4, C5, C6, C7, C8, C9)>
+  ) -> Regex<(Substring, C1, C2, C3, C4, C5, C6, C7, C8, C9)> {
     let factory = makeFactory()
     return factory.accumulate(accumulated, next)
   }
@@ -326,9 +387,23 @@ extension RegexComponentBuilder {
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
   @_alwaysEmitIntoClient
-  public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, C5, C6, C7, C8, R0: RegexComponent, R1: RegexComponent>(
-    accumulated: R0, next: R1
-  ) -> Regex<(Substring, C1, C2, C3, C4, C5, C6, C7, C8)>  where R0.RegexOutput == (W0, C1, C2, C3), R1.RegexOutput == (W1, C4, C5, C6, C7, C8) {
+  public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10>(
+    accumulated: some RegexComponent<(W0, C1, C2, C3)>,
+    next: some RegexComponent<(W1, C4, C5, C6, C7, C8, C9, C10)>
+  ) -> Regex<(Substring, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10)> {
+    let factory = makeFactory()
+    return factory.accumulate(accumulated, next)
+  }
+}
+// MARK: - Partial block (left arity 4)
+
+@available(SwiftStdlib 5.7, *)
+extension RegexComponentBuilder {
+  @_alwaysEmitIntoClient
+  public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, C5>(
+    accumulated: some RegexComponent<(W0, C1, C2, C3, C4)>,
+    next: some RegexComponent<(W1, C5)>
+  ) -> Regex<(Substring, C1, C2, C3, C4, C5)> {
     let factory = makeFactory()
     return factory.accumulate(accumulated, next)
   }
@@ -336,9 +411,10 @@ extension RegexComponentBuilder {
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
   @_alwaysEmitIntoClient
-  public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, C5, C6, C7, C8, C9, R0: RegexComponent, R1: RegexComponent>(
-    accumulated: R0, next: R1
-  ) -> Regex<(Substring, C1, C2, C3, C4, C5, C6, C7, C8, C9)>  where R0.RegexOutput == (W0, C1, C2, C3), R1.RegexOutput == (W1, C4, C5, C6, C7, C8, C9) {
+  public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, C5, C6>(
+    accumulated: some RegexComponent<(W0, C1, C2, C3, C4)>,
+    next: some RegexComponent<(W1, C5, C6)>
+  ) -> Regex<(Substring, C1, C2, C3, C4, C5, C6)> {
     let factory = makeFactory()
     return factory.accumulate(accumulated, next)
   }
@@ -346,9 +422,10 @@ extension RegexComponentBuilder {
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
   @_alwaysEmitIntoClient
-  public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, R0: RegexComponent, R1: RegexComponent>(
-    accumulated: R0, next: R1
-  ) -> Regex<(Substring, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10)>  where R0.RegexOutput == (W0, C1, C2, C3), R1.RegexOutput == (W1, C4, C5, C6, C7, C8, C9, C10) {
+  public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, C5, C6, C7>(
+    accumulated: some RegexComponent<(W0, C1, C2, C3, C4)>,
+    next: some RegexComponent<(W1, C5, C6, C7)>
+  ) -> Regex<(Substring, C1, C2, C3, C4, C5, C6, C7)> {
     let factory = makeFactory()
     return factory.accumulate(accumulated, next)
   }
@@ -356,9 +433,10 @@ extension RegexComponentBuilder {
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
   @_alwaysEmitIntoClient
-  public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, C5, R0: RegexComponent, R1: RegexComponent>(
-    accumulated: R0, next: R1
-  ) -> Regex<(Substring, C1, C2, C3, C4, C5)>  where R0.RegexOutput == (W0, C1, C2, C3, C4), R1.RegexOutput == (W1, C5) {
+  public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, C5, C6, C7, C8>(
+    accumulated: some RegexComponent<(W0, C1, C2, C3, C4)>,
+    next: some RegexComponent<(W1, C5, C6, C7, C8)>
+  ) -> Regex<(Substring, C1, C2, C3, C4, C5, C6, C7, C8)> {
     let factory = makeFactory()
     return factory.accumulate(accumulated, next)
   }
@@ -366,9 +444,10 @@ extension RegexComponentBuilder {
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
   @_alwaysEmitIntoClient
-  public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, C5, C6, R0: RegexComponent, R1: RegexComponent>(
-    accumulated: R0, next: R1
-  ) -> Regex<(Substring, C1, C2, C3, C4, C5, C6)>  where R0.RegexOutput == (W0, C1, C2, C3, C4), R1.RegexOutput == (W1, C5, C6) {
+  public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, C5, C6, C7, C8, C9>(
+    accumulated: some RegexComponent<(W0, C1, C2, C3, C4)>,
+    next: some RegexComponent<(W1, C5, C6, C7, C8, C9)>
+  ) -> Regex<(Substring, C1, C2, C3, C4, C5, C6, C7, C8, C9)> {
     let factory = makeFactory()
     return factory.accumulate(accumulated, next)
   }
@@ -376,9 +455,23 @@ extension RegexComponentBuilder {
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
   @_alwaysEmitIntoClient
-  public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, C5, C6, C7, R0: RegexComponent, R1: RegexComponent>(
-    accumulated: R0, next: R1
-  ) -> Regex<(Substring, C1, C2, C3, C4, C5, C6, C7)>  where R0.RegexOutput == (W0, C1, C2, C3, C4), R1.RegexOutput == (W1, C5, C6, C7) {
+  public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10>(
+    accumulated: some RegexComponent<(W0, C1, C2, C3, C4)>,
+    next: some RegexComponent<(W1, C5, C6, C7, C8, C9, C10)>
+  ) -> Regex<(Substring, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10)> {
+    let factory = makeFactory()
+    return factory.accumulate(accumulated, next)
+  }
+}
+// MARK: - Partial block (left arity 5)
+
+@available(SwiftStdlib 5.7, *)
+extension RegexComponentBuilder {
+  @_alwaysEmitIntoClient
+  public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, C5, C6>(
+    accumulated: some RegexComponent<(W0, C1, C2, C3, C4, C5)>,
+    next: some RegexComponent<(W1, C6)>
+  ) -> Regex<(Substring, C1, C2, C3, C4, C5, C6)> {
     let factory = makeFactory()
     return factory.accumulate(accumulated, next)
   }
@@ -386,9 +479,10 @@ extension RegexComponentBuilder {
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
   @_alwaysEmitIntoClient
-  public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, C5, C6, C7, C8, R0: RegexComponent, R1: RegexComponent>(
-    accumulated: R0, next: R1
-  ) -> Regex<(Substring, C1, C2, C3, C4, C5, C6, C7, C8)>  where R0.RegexOutput == (W0, C1, C2, C3, C4), R1.RegexOutput == (W1, C5, C6, C7, C8) {
+  public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, C5, C6, C7>(
+    accumulated: some RegexComponent<(W0, C1, C2, C3, C4, C5)>,
+    next: some RegexComponent<(W1, C6, C7)>
+  ) -> Regex<(Substring, C1, C2, C3, C4, C5, C6, C7)> {
     let factory = makeFactory()
     return factory.accumulate(accumulated, next)
   }
@@ -396,9 +490,10 @@ extension RegexComponentBuilder {
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
   @_alwaysEmitIntoClient
-  public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, C5, C6, C7, C8, C9, R0: RegexComponent, R1: RegexComponent>(
-    accumulated: R0, next: R1
-  ) -> Regex<(Substring, C1, C2, C3, C4, C5, C6, C7, C8, C9)>  where R0.RegexOutput == (W0, C1, C2, C3, C4), R1.RegexOutput == (W1, C5, C6, C7, C8, C9) {
+  public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, C5, C6, C7, C8>(
+    accumulated: some RegexComponent<(W0, C1, C2, C3, C4, C5)>,
+    next: some RegexComponent<(W1, C6, C7, C8)>
+  ) -> Regex<(Substring, C1, C2, C3, C4, C5, C6, C7, C8)> {
     let factory = makeFactory()
     return factory.accumulate(accumulated, next)
   }
@@ -406,9 +501,10 @@ extension RegexComponentBuilder {
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
   @_alwaysEmitIntoClient
-  public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, R0: RegexComponent, R1: RegexComponent>(
-    accumulated: R0, next: R1
-  ) -> Regex<(Substring, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10)>  where R0.RegexOutput == (W0, C1, C2, C3, C4), R1.RegexOutput == (W1, C5, C6, C7, C8, C9, C10) {
+  public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, C5, C6, C7, C8, C9>(
+    accumulated: some RegexComponent<(W0, C1, C2, C3, C4, C5)>,
+    next: some RegexComponent<(W1, C6, C7, C8, C9)>
+  ) -> Regex<(Substring, C1, C2, C3, C4, C5, C6, C7, C8, C9)> {
     let factory = makeFactory()
     return factory.accumulate(accumulated, next)
   }
@@ -416,9 +512,23 @@ extension RegexComponentBuilder {
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
   @_alwaysEmitIntoClient
-  public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, C5, C6, R0: RegexComponent, R1: RegexComponent>(
-    accumulated: R0, next: R1
-  ) -> Regex<(Substring, C1, C2, C3, C4, C5, C6)>  where R0.RegexOutput == (W0, C1, C2, C3, C4, C5), R1.RegexOutput == (W1, C6) {
+  public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10>(
+    accumulated: some RegexComponent<(W0, C1, C2, C3, C4, C5)>,
+    next: some RegexComponent<(W1, C6, C7, C8, C9, C10)>
+  ) -> Regex<(Substring, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10)> {
+    let factory = makeFactory()
+    return factory.accumulate(accumulated, next)
+  }
+}
+// MARK: - Partial block (left arity 6)
+
+@available(SwiftStdlib 5.7, *)
+extension RegexComponentBuilder {
+  @_alwaysEmitIntoClient
+  public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, C5, C6, C7>(
+    accumulated: some RegexComponent<(W0, C1, C2, C3, C4, C5, C6)>,
+    next: some RegexComponent<(W1, C7)>
+  ) -> Regex<(Substring, C1, C2, C3, C4, C5, C6, C7)> {
     let factory = makeFactory()
     return factory.accumulate(accumulated, next)
   }
@@ -426,9 +536,10 @@ extension RegexComponentBuilder {
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
   @_alwaysEmitIntoClient
-  public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, C5, C6, C7, R0: RegexComponent, R1: RegexComponent>(
-    accumulated: R0, next: R1
-  ) -> Regex<(Substring, C1, C2, C3, C4, C5, C6, C7)>  where R0.RegexOutput == (W0, C1, C2, C3, C4, C5), R1.RegexOutput == (W1, C6, C7) {
+  public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, C5, C6, C7, C8>(
+    accumulated: some RegexComponent<(W0, C1, C2, C3, C4, C5, C6)>,
+    next: some RegexComponent<(W1, C7, C8)>
+  ) -> Regex<(Substring, C1, C2, C3, C4, C5, C6, C7, C8)> {
     let factory = makeFactory()
     return factory.accumulate(accumulated, next)
   }
@@ -436,9 +547,10 @@ extension RegexComponentBuilder {
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
   @_alwaysEmitIntoClient
-  public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, C5, C6, C7, C8, R0: RegexComponent, R1: RegexComponent>(
-    accumulated: R0, next: R1
-  ) -> Regex<(Substring, C1, C2, C3, C4, C5, C6, C7, C8)>  where R0.RegexOutput == (W0, C1, C2, C3, C4, C5), R1.RegexOutput == (W1, C6, C7, C8) {
+  public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, C5, C6, C7, C8, C9>(
+    accumulated: some RegexComponent<(W0, C1, C2, C3, C4, C5, C6)>,
+    next: some RegexComponent<(W1, C7, C8, C9)>
+  ) -> Regex<(Substring, C1, C2, C3, C4, C5, C6, C7, C8, C9)> {
     let factory = makeFactory()
     return factory.accumulate(accumulated, next)
   }
@@ -446,9 +558,23 @@ extension RegexComponentBuilder {
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
   @_alwaysEmitIntoClient
-  public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, C5, C6, C7, C8, C9, R0: RegexComponent, R1: RegexComponent>(
-    accumulated: R0, next: R1
-  ) -> Regex<(Substring, C1, C2, C3, C4, C5, C6, C7, C8, C9)>  where R0.RegexOutput == (W0, C1, C2, C3, C4, C5), R1.RegexOutput == (W1, C6, C7, C8, C9) {
+  public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10>(
+    accumulated: some RegexComponent<(W0, C1, C2, C3, C4, C5, C6)>,
+    next: some RegexComponent<(W1, C7, C8, C9, C10)>
+  ) -> Regex<(Substring, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10)> {
+    let factory = makeFactory()
+    return factory.accumulate(accumulated, next)
+  }
+}
+// MARK: - Partial block (left arity 7)
+
+@available(SwiftStdlib 5.7, *)
+extension RegexComponentBuilder {
+  @_alwaysEmitIntoClient
+  public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, C5, C6, C7, C8>(
+    accumulated: some RegexComponent<(W0, C1, C2, C3, C4, C5, C6, C7)>,
+    next: some RegexComponent<(W1, C8)>
+  ) -> Regex<(Substring, C1, C2, C3, C4, C5, C6, C7, C8)> {
     let factory = makeFactory()
     return factory.accumulate(accumulated, next)
   }
@@ -456,9 +582,10 @@ extension RegexComponentBuilder {
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
   @_alwaysEmitIntoClient
-  public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, R0: RegexComponent, R1: RegexComponent>(
-    accumulated: R0, next: R1
-  ) -> Regex<(Substring, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10)>  where R0.RegexOutput == (W0, C1, C2, C3, C4, C5), R1.RegexOutput == (W1, C6, C7, C8, C9, C10) {
+  public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, C5, C6, C7, C8, C9>(
+    accumulated: some RegexComponent<(W0, C1, C2, C3, C4, C5, C6, C7)>,
+    next: some RegexComponent<(W1, C8, C9)>
+  ) -> Regex<(Substring, C1, C2, C3, C4, C5, C6, C7, C8, C9)> {
     let factory = makeFactory()
     return factory.accumulate(accumulated, next)
   }
@@ -466,9 +593,23 @@ extension RegexComponentBuilder {
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
   @_alwaysEmitIntoClient
-  public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, C5, C6, C7, R0: RegexComponent, R1: RegexComponent>(
-    accumulated: R0, next: R1
-  ) -> Regex<(Substring, C1, C2, C3, C4, C5, C6, C7)>  where R0.RegexOutput == (W0, C1, C2, C3, C4, C5, C6), R1.RegexOutput == (W1, C7) {
+  public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10>(
+    accumulated: some RegexComponent<(W0, C1, C2, C3, C4, C5, C6, C7)>,
+    next: some RegexComponent<(W1, C8, C9, C10)>
+  ) -> Regex<(Substring, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10)> {
+    let factory = makeFactory()
+    return factory.accumulate(accumulated, next)
+  }
+}
+// MARK: - Partial block (left arity 8)
+
+@available(SwiftStdlib 5.7, *)
+extension RegexComponentBuilder {
+  @_alwaysEmitIntoClient
+  public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, C5, C6, C7, C8, C9>(
+    accumulated: some RegexComponent<(W0, C1, C2, C3, C4, C5, C6, C7, C8)>,
+    next: some RegexComponent<(W1, C9)>
+  ) -> Regex<(Substring, C1, C2, C3, C4, C5, C6, C7, C8, C9)> {
     let factory = makeFactory()
     return factory.accumulate(accumulated, next)
   }
@@ -476,99 +617,36 @@ extension RegexComponentBuilder {
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
   @_alwaysEmitIntoClient
-  public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, C5, C6, C7, C8, R0: RegexComponent, R1: RegexComponent>(
-    accumulated: R0, next: R1
-  ) -> Regex<(Substring, C1, C2, C3, C4, C5, C6, C7, C8)>  where R0.RegexOutput == (W0, C1, C2, C3, C4, C5, C6), R1.RegexOutput == (W1, C7, C8) {
+  public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10>(
+    accumulated: some RegexComponent<(W0, C1, C2, C3, C4, C5, C6, C7, C8)>,
+    next: some RegexComponent<(W1, C9, C10)>
+  ) -> Regex<(Substring, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10)> {
     let factory = makeFactory()
     return factory.accumulate(accumulated, next)
   }
 }
+// MARK: - Partial block (left arity 9)
+
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
   @_alwaysEmitIntoClient
-  public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, C5, C6, C7, C8, C9, R0: RegexComponent, R1: RegexComponent>(
-    accumulated: R0, next: R1
-  ) -> Regex<(Substring, C1, C2, C3, C4, C5, C6, C7, C8, C9)>  where R0.RegexOutput == (W0, C1, C2, C3, C4, C5, C6), R1.RegexOutput == (W1, C7, C8, C9) {
+  public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10>(
+    accumulated: some RegexComponent<(W0, C1, C2, C3, C4, C5, C6, C7, C8, C9)>,
+    next: some RegexComponent<(W1, C10)>
+  ) -> Regex<(Substring, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10)> {
     let factory = makeFactory()
     return factory.accumulate(accumulated, next)
   }
 }
+// MARK: - Partial block (empty)
+
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
   @_alwaysEmitIntoClient
-  public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, R0: RegexComponent, R1: RegexComponent>(
-    accumulated: R0, next: R1
-  ) -> Regex<(Substring, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10)>  where R0.RegexOutput == (W0, C1, C2, C3, C4, C5, C6), R1.RegexOutput == (W1, C7, C8, C9, C10) {
-    let factory = makeFactory()
-    return factory.accumulate(accumulated, next)
-  }
-}
-@available(SwiftStdlib 5.7, *)
-extension RegexComponentBuilder {
-  @_alwaysEmitIntoClient
-  public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, C5, C6, C7, C8, R0: RegexComponent, R1: RegexComponent>(
-    accumulated: R0, next: R1
-  ) -> Regex<(Substring, C1, C2, C3, C4, C5, C6, C7, C8)>  where R0.RegexOutput == (W0, C1, C2, C3, C4, C5, C6, C7), R1.RegexOutput == (W1, C8) {
-    let factory = makeFactory()
-    return factory.accumulate(accumulated, next)
-  }
-}
-@available(SwiftStdlib 5.7, *)
-extension RegexComponentBuilder {
-  @_alwaysEmitIntoClient
-  public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, C5, C6, C7, C8, C9, R0: RegexComponent, R1: RegexComponent>(
-    accumulated: R0, next: R1
-  ) -> Regex<(Substring, C1, C2, C3, C4, C5, C6, C7, C8, C9)>  where R0.RegexOutput == (W0, C1, C2, C3, C4, C5, C6, C7), R1.RegexOutput == (W1, C8, C9) {
-    let factory = makeFactory()
-    return factory.accumulate(accumulated, next)
-  }
-}
-@available(SwiftStdlib 5.7, *)
-extension RegexComponentBuilder {
-  @_alwaysEmitIntoClient
-  public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, R0: RegexComponent, R1: RegexComponent>(
-    accumulated: R0, next: R1
-  ) -> Regex<(Substring, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10)>  where R0.RegexOutput == (W0, C1, C2, C3, C4, C5, C6, C7), R1.RegexOutput == (W1, C8, C9, C10) {
-    let factory = makeFactory()
-    return factory.accumulate(accumulated, next)
-  }
-}
-@available(SwiftStdlib 5.7, *)
-extension RegexComponentBuilder {
-  @_alwaysEmitIntoClient
-  public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, C5, C6, C7, C8, C9, R0: RegexComponent, R1: RegexComponent>(
-    accumulated: R0, next: R1
-  ) -> Regex<(Substring, C1, C2, C3, C4, C5, C6, C7, C8, C9)>  where R0.RegexOutput == (W0, C1, C2, C3, C4, C5, C6, C7, C8), R1.RegexOutput == (W1, C9) {
-    let factory = makeFactory()
-    return factory.accumulate(accumulated, next)
-  }
-}
-@available(SwiftStdlib 5.7, *)
-extension RegexComponentBuilder {
-  @_alwaysEmitIntoClient
-  public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, R0: RegexComponent, R1: RegexComponent>(
-    accumulated: R0, next: R1
-  ) -> Regex<(Substring, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10)>  where R0.RegexOutput == (W0, C1, C2, C3, C4, C5, C6, C7, C8), R1.RegexOutput == (W1, C9, C10) {
-    let factory = makeFactory()
-    return factory.accumulate(accumulated, next)
-  }
-}
-@available(SwiftStdlib 5.7, *)
-extension RegexComponentBuilder {
-  @_alwaysEmitIntoClient
-  public static func buildPartialBlock<W0, W1, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, R0: RegexComponent, R1: RegexComponent>(
-    accumulated: R0, next: R1
-  ) -> Regex<(Substring, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10)>  where R0.RegexOutput == (W0, C1, C2, C3, C4, C5, C6, C7, C8, C9), R1.RegexOutput == (W1, C10) {
-    let factory = makeFactory()
-    return factory.accumulate(accumulated, next)
-  }
-}
-@available(SwiftStdlib 5.7, *)
-extension RegexComponentBuilder {
-  @_alwaysEmitIntoClient
-  public static func buildPartialBlock<W0, R0: RegexComponent, R1: RegexComponent>(
-    accumulated: R0, next: R1
-  ) -> Regex<Substring> where R0.RegexOutput == W0  {
+  public static func buildPartialBlock<W0>(
+    accumulated: some RegexComponent<W0>,
+    next: some RegexComponent
+  ) -> Regex<Substring> {
     let factory = makeFactory()
     return factory.accumulate(ignoringOutputTypeOf: accumulated, andAlso: next)
   }
@@ -576,9 +654,10 @@ extension RegexComponentBuilder {
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
   @_alwaysEmitIntoClient
-  public static func buildPartialBlock<W0, C0, R0: RegexComponent, R1: RegexComponent>(
-    accumulated: R0, next: R1
-  ) -> Regex<(Substring, C0)> where R0.RegexOutput == (W0, C0)  {
+  public static func buildPartialBlock<W0, C0>(
+    accumulated: some RegexComponent<(W0, C0)>,
+    next: some RegexComponent
+  ) -> Regex<(Substring, C0)> {
     let factory = makeFactory()
     return factory.accumulate(accumulated, ignoringOutputTypeOf: next)
   }
@@ -586,9 +665,10 @@ extension RegexComponentBuilder {
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
   @_alwaysEmitIntoClient
-  public static func buildPartialBlock<W0, C0, C1, R0: RegexComponent, R1: RegexComponent>(
-    accumulated: R0, next: R1
-  ) -> Regex<(Substring, C0, C1)> where R0.RegexOutput == (W0, C0, C1)  {
+  public static func buildPartialBlock<W0, C0, C1>(
+    accumulated: some RegexComponent<(W0, C0, C1)>,
+    next: some RegexComponent
+  ) -> Regex<(Substring, C0, C1)> {
     let factory = makeFactory()
     return factory.accumulate(accumulated, ignoringOutputTypeOf: next)
   }
@@ -596,9 +676,10 @@ extension RegexComponentBuilder {
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
   @_alwaysEmitIntoClient
-  public static func buildPartialBlock<W0, C0, C1, C2, R0: RegexComponent, R1: RegexComponent>(
-    accumulated: R0, next: R1
-  ) -> Regex<(Substring, C0, C1, C2)> where R0.RegexOutput == (W0, C0, C1, C2)  {
+  public static func buildPartialBlock<W0, C0, C1, C2>(
+    accumulated: some RegexComponent<(W0, C0, C1, C2)>,
+    next: some RegexComponent
+  ) -> Regex<(Substring, C0, C1, C2)> {
     let factory = makeFactory()
     return factory.accumulate(accumulated, ignoringOutputTypeOf: next)
   }
@@ -606,9 +687,10 @@ extension RegexComponentBuilder {
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
   @_alwaysEmitIntoClient
-  public static func buildPartialBlock<W0, C0, C1, C2, C3, R0: RegexComponent, R1: RegexComponent>(
-    accumulated: R0, next: R1
-  ) -> Regex<(Substring, C0, C1, C2, C3)> where R0.RegexOutput == (W0, C0, C1, C2, C3)  {
+  public static func buildPartialBlock<W0, C0, C1, C2, C3>(
+    accumulated: some RegexComponent<(W0, C0, C1, C2, C3)>,
+    next: some RegexComponent
+  ) -> Regex<(Substring, C0, C1, C2, C3)> {
     let factory = makeFactory()
     return factory.accumulate(accumulated, ignoringOutputTypeOf: next)
   }
@@ -616,9 +698,10 @@ extension RegexComponentBuilder {
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
   @_alwaysEmitIntoClient
-  public static func buildPartialBlock<W0, C0, C1, C2, C3, C4, R0: RegexComponent, R1: RegexComponent>(
-    accumulated: R0, next: R1
-  ) -> Regex<(Substring, C0, C1, C2, C3, C4)> where R0.RegexOutput == (W0, C0, C1, C2, C3, C4)  {
+  public static func buildPartialBlock<W0, C0, C1, C2, C3, C4>(
+    accumulated: some RegexComponent<(W0, C0, C1, C2, C3, C4)>,
+    next: some RegexComponent
+  ) -> Regex<(Substring, C0, C1, C2, C3, C4)> {
     let factory = makeFactory()
     return factory.accumulate(accumulated, ignoringOutputTypeOf: next)
   }
@@ -626,9 +709,10 @@ extension RegexComponentBuilder {
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
   @_alwaysEmitIntoClient
-  public static func buildPartialBlock<W0, C0, C1, C2, C3, C4, C5, R0: RegexComponent, R1: RegexComponent>(
-    accumulated: R0, next: R1
-  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5)> where R0.RegexOutput == (W0, C0, C1, C2, C3, C4, C5)  {
+  public static func buildPartialBlock<W0, C0, C1, C2, C3, C4, C5>(
+    accumulated: some RegexComponent<(W0, C0, C1, C2, C3, C4, C5)>,
+    next: some RegexComponent
+  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5)> {
     let factory = makeFactory()
     return factory.accumulate(accumulated, ignoringOutputTypeOf: next)
   }
@@ -636,9 +720,10 @@ extension RegexComponentBuilder {
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
   @_alwaysEmitIntoClient
-  public static func buildPartialBlock<W0, C0, C1, C2, C3, C4, C5, C6, R0: RegexComponent, R1: RegexComponent>(
-    accumulated: R0, next: R1
-  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6)> where R0.RegexOutput == (W0, C0, C1, C2, C3, C4, C5, C6)  {
+  public static func buildPartialBlock<W0, C0, C1, C2, C3, C4, C5, C6>(
+    accumulated: some RegexComponent<(W0, C0, C1, C2, C3, C4, C5, C6)>,
+    next: some RegexComponent
+  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6)> {
     let factory = makeFactory()
     return factory.accumulate(accumulated, ignoringOutputTypeOf: next)
   }
@@ -646,9 +731,10 @@ extension RegexComponentBuilder {
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
   @_alwaysEmitIntoClient
-  public static func buildPartialBlock<W0, C0, C1, C2, C3, C4, C5, C6, C7, R0: RegexComponent, R1: RegexComponent>(
-    accumulated: R0, next: R1
-  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7)> where R0.RegexOutput == (W0, C0, C1, C2, C3, C4, C5, C6, C7)  {
+  public static func buildPartialBlock<W0, C0, C1, C2, C3, C4, C5, C6, C7>(
+    accumulated: some RegexComponent<(W0, C0, C1, C2, C3, C4, C5, C6, C7)>,
+    next: some RegexComponent
+  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7)> {
     let factory = makeFactory()
     return factory.accumulate(accumulated, ignoringOutputTypeOf: next)
   }
@@ -656,9 +742,10 @@ extension RegexComponentBuilder {
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
   @_alwaysEmitIntoClient
-  public static func buildPartialBlock<W0, C0, C1, C2, C3, C4, C5, C6, C7, C8, R0: RegexComponent, R1: RegexComponent>(
-    accumulated: R0, next: R1
-  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8)> where R0.RegexOutput == (W0, C0, C1, C2, C3, C4, C5, C6, C7, C8)  {
+  public static func buildPartialBlock<W0, C0, C1, C2, C3, C4, C5, C6, C7, C8>(
+    accumulated: some RegexComponent<(W0, C0, C1, C2, C3, C4, C5, C6, C7, C8)>,
+    next: some RegexComponent
+  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8)> {
     let factory = makeFactory()
     return factory.accumulate(accumulated, ignoringOutputTypeOf: next)
   }
@@ -666,14 +753,17 @@ extension RegexComponentBuilder {
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
   @_alwaysEmitIntoClient
-  public static func buildPartialBlock<W0, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9, R0: RegexComponent, R1: RegexComponent>(
-    accumulated: R0, next: R1
-  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9)> where R0.RegexOutput == (W0, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9)  {
+  public static func buildPartialBlock<W0, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9>(
+    accumulated: some RegexComponent<(W0, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9)>,
+    next: some RegexComponent
+  ) -> Regex<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9)> {
     let factory = makeFactory()
     return factory.accumulate(accumulated, ignoringOutputTypeOf: next)
   }
 }
 
+
+// MARK: - Quantifiers (arity 0)
 
 @available(SwiftStdlib 5.7, *)
 extension Optionally {
@@ -689,8 +779,8 @@ extension Optionally {
   ///     `Regex`.
   @_disfavoredOverload
   @_alwaysEmitIntoClient
-  public init<Component: RegexComponent>(
-    _ component: Component,
+  public init(
+    _ component: some RegexComponent,
     _ behavior: RegexRepetitionBehavior? = nil
   ) where RegexOutput == Substring {
     let factory = makeFactory()
@@ -713,9 +803,9 @@ extension Optionally {
   ///     component.
   @_disfavoredOverload
   @_alwaysEmitIntoClient
-  public init<Component: RegexComponent>(
+  public init(
     _ behavior: RegexRepetitionBehavior? = nil,
-    @RegexComponentBuilder _ componentBuilder: () -> Component
+    @RegexComponentBuilder _ componentBuilder: () -> some RegexComponent
   ) where RegexOutput == Substring {
     let factory = makeFactory()
     self.init(factory.zeroOrOne(componentBuilder(), behavior))
@@ -725,9 +815,9 @@ extension Optionally {
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
   @_alwaysEmitIntoClient
-  public static func buildLimitedAvailability<Component: RegexComponent>(
-    _ component: Component
-  ) -> Regex<Substring>  {
+  public static func buildLimitedAvailability(
+    _ component: some RegexComponent
+  ) -> Regex<Substring> {
     let factory = makeFactory()
     return factory.zeroOrOne(component, nil)
   }
@@ -746,8 +836,8 @@ extension ZeroOrMore {
   ///     `Regex`.
   @_disfavoredOverload
   @_alwaysEmitIntoClient
-  public init<Component: RegexComponent>(
-    _ component: Component,
+  public init(
+    _ component: some RegexComponent,
     _ behavior: RegexRepetitionBehavior? = nil
   ) where RegexOutput == Substring {
     let factory = makeFactory()
@@ -770,9 +860,9 @@ extension ZeroOrMore {
   ///     component.
   @_disfavoredOverload
   @_alwaysEmitIntoClient
-  public init<Component: RegexComponent>(
+  public init(
     _ behavior: RegexRepetitionBehavior? = nil,
-    @RegexComponentBuilder _ componentBuilder: () -> Component
+    @RegexComponentBuilder _ componentBuilder: () -> some RegexComponent
   ) where RegexOutput == Substring {
     let factory = makeFactory()
     self.init(factory.zeroOrMore(componentBuilder(), behavior))
@@ -794,8 +884,8 @@ extension OneOrMore {
   ///     `Regex`.
   @_disfavoredOverload
   @_alwaysEmitIntoClient
-  public init<Component: RegexComponent>(
-    _ component: Component,
+  public init(
+    _ component: some RegexComponent,
     _ behavior: RegexRepetitionBehavior? = nil
   ) where RegexOutput == Substring {
     let factory = makeFactory()
@@ -818,9 +908,9 @@ extension OneOrMore {
   ///     component.
   @_disfavoredOverload
   @_alwaysEmitIntoClient
-  public init<Component: RegexComponent>(
+  public init(
     _ behavior: RegexRepetitionBehavior? = nil,
-    @RegexComponentBuilder _ componentBuilder: () -> Component
+    @RegexComponentBuilder _ componentBuilder: () -> some RegexComponent
   ) where RegexOutput == Substring {
     let factory = makeFactory()
     self.init(factory.oneOrMore(componentBuilder(), behavior))
@@ -839,8 +929,8 @@ extension Repeat {
   ///     be greater than or equal to zero.
   @_disfavoredOverload
   @_alwaysEmitIntoClient
-  public init<Component: RegexComponent>(
-    _ component: Component,
+  public init(
+    _ component: some RegexComponent,
     count: Int
   ) where RegexOutput == Substring {
     precondition(count >= 0, "Must specify a positive count")
@@ -858,9 +948,9 @@ extension Repeat {
   ///     component to repeat.
   @_disfavoredOverload
   @_alwaysEmitIntoClient
-  public init<Component: RegexComponent>(
+  public init(
     count: Int,
-    @RegexComponentBuilder _ componentBuilder: () -> Component
+    @RegexComponentBuilder _ componentBuilder: () -> some RegexComponent
   ) where RegexOutput == Substring {
     precondition(count >= 0, "Must specify a positive count")
     let factory = makeFactory()
@@ -881,11 +971,11 @@ extension Repeat {
   ///     `Regex`.
   @_disfavoredOverload
   @_alwaysEmitIntoClient
-  public init<Component: RegexComponent, R: RangeExpression>(
-    _ component: Component,
-    _ expression: R,
+  public init(
+    _ component: some RegexComponent,
+    _ expression: some RangeExpression<Int>,
     _ behavior: RegexRepetitionBehavior? = nil
-  ) where RegexOutput == Substring, R.Bound == Int {
+  ) where RegexOutput == Substring {
     let factory = makeFactory()
     self.init(factory.repeating(expression.relative(to: 0..<Int.max), behavior, component))
   }
@@ -905,15 +995,17 @@ extension Repeat {
   ///     component to repeat.
   @_disfavoredOverload
   @_alwaysEmitIntoClient
-  public init<Component: RegexComponent, R: RangeExpression>(
-    _ expression: R,
+  public init(
+    _ expression: some RangeExpression<Int>,
     _ behavior: RegexRepetitionBehavior? = nil,
-    @RegexComponentBuilder _ componentBuilder: () -> Component
-  ) where RegexOutput == Substring, R.Bound == Int {
+    @RegexComponentBuilder _ componentBuilder: () -> some RegexComponent
+  ) where RegexOutput == Substring {
     let factory = makeFactory()
     self.init(factory.repeating(expression.relative(to: 0..<Int.max), behavior, componentBuilder()))
   }
 }
+// MARK: - Quantifiers (arity 1)
+
 @available(SwiftStdlib 5.7, *)
 extension Optionally {
   /// Creates a regex component that matches the given component
@@ -927,10 +1019,10 @@ extension Optionally {
   ///     `eager` by calling `repetitionBehavior(_:)` on the resulting
   ///     `Regex`.
   @_alwaysEmitIntoClient
-  public init<W, C1, Component: RegexComponent>(
-    _ component: Component,
+  public init<W, C1>(
+    _ component: some RegexComponent<(W, C1)>,
     _ behavior: RegexRepetitionBehavior? = nil
-  ) where RegexOutput == (Substring, C1?), Component.RegexOutput == (W, C1) {
+  ) where RegexOutput == (Substring, C1?) {
     let factory = makeFactory()
     self.init(factory.zeroOrOne(component, behavior))
   }
@@ -950,10 +1042,10 @@ extension Optionally {
   ///   - componentBuilder: A builder closure that generates a regex
   ///     component.
   @_alwaysEmitIntoClient
-  public init<W, C1, Component: RegexComponent>(
+  public init<W, C1>(
     _ behavior: RegexRepetitionBehavior? = nil,
-    @RegexComponentBuilder _ componentBuilder: () -> Component
-  ) where RegexOutput == (Substring, C1?), Component.RegexOutput == (W, C1) {
+    @RegexComponentBuilder _ componentBuilder: () -> some RegexComponent<(W, C1)>
+  ) where RegexOutput == (Substring, C1?) {
     let factory = makeFactory()
     self.init(factory.zeroOrOne(componentBuilder(), behavior))
   }
@@ -962,9 +1054,9 @@ extension Optionally {
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
   @_alwaysEmitIntoClient
-  public static func buildLimitedAvailability<W, C1, Component: RegexComponent>(
-    _ component: Component
-  ) -> Regex<(Substring, C1?)> where Component.RegexOutput == (W, C1) {
+  public static func buildLimitedAvailability<W, C1>(
+    _ component: some RegexComponent<(W, C1)>
+  ) -> Regex<(Substring, C1?)> {
     let factory = makeFactory()
     return factory.zeroOrOne(component, nil)
   }
@@ -982,10 +1074,10 @@ extension ZeroOrMore {
   ///     `eager` by calling `repetitionBehavior(_:)` on the resulting
   ///     `Regex`.
   @_alwaysEmitIntoClient
-  public init<W, C1, Component: RegexComponent>(
-    _ component: Component,
+  public init<W, C1>(
+    _ component: some RegexComponent<(W, C1)>,
     _ behavior: RegexRepetitionBehavior? = nil
-  ) where RegexOutput == (Substring, C1?), Component.RegexOutput == (W, C1) {
+  ) where RegexOutput == (Substring, C1?) {
     let factory = makeFactory()
     self.init(factory.zeroOrMore(component, behavior))
   }
@@ -1005,10 +1097,10 @@ extension ZeroOrMore {
   ///   - componentBuilder: A builder closure that generates a regex
   ///     component.
   @_alwaysEmitIntoClient
-  public init<W, C1, Component: RegexComponent>(
+  public init<W, C1>(
     _ behavior: RegexRepetitionBehavior? = nil,
-    @RegexComponentBuilder _ componentBuilder: () -> Component
-  ) where RegexOutput == (Substring, C1?), Component.RegexOutput == (W, C1) {
+    @RegexComponentBuilder _ componentBuilder: () -> some RegexComponent<(W, C1)>
+  ) where RegexOutput == (Substring, C1?) {
     let factory = makeFactory()
     self.init(factory.zeroOrMore(componentBuilder(), behavior))
   }
@@ -1028,10 +1120,10 @@ extension OneOrMore {
   ///     `eager` by calling `repetitionBehavior(_:)` on the resulting
   ///     `Regex`.
   @_alwaysEmitIntoClient
-  public init<W, C1, Component: RegexComponent>(
-    _ component: Component,
+  public init<W, C1>(
+    _ component: some RegexComponent<(W, C1)>,
     _ behavior: RegexRepetitionBehavior? = nil
-  ) where RegexOutput == (Substring, C1), Component.RegexOutput == (W, C1) {
+  ) where RegexOutput == (Substring, C1) {
     let factory = makeFactory()
     self.init(factory.oneOrMore(component, behavior))
   }
@@ -1051,10 +1143,10 @@ extension OneOrMore {
   ///   - componentBuilder: A builder closure that generates a regex
   ///     component.
   @_alwaysEmitIntoClient
-  public init<W, C1, Component: RegexComponent>(
+  public init<W, C1>(
     _ behavior: RegexRepetitionBehavior? = nil,
-    @RegexComponentBuilder _ componentBuilder: () -> Component
-  ) where RegexOutput == (Substring, C1), Component.RegexOutput == (W, C1) {
+    @RegexComponentBuilder _ componentBuilder: () -> some RegexComponent<(W, C1)>
+  ) where RegexOutput == (Substring, C1) {
     let factory = makeFactory()
     self.init(factory.oneOrMore(componentBuilder(), behavior))
   }
@@ -1071,10 +1163,10 @@ extension Repeat {
   ///   - count: The number of times to repeat `component`. `count` must
   ///     be greater than or equal to zero.
   @_alwaysEmitIntoClient
-  public init<W, C1, Component: RegexComponent>(
-    _ component: Component,
+  public init<W, C1>(
+    _ component: some RegexComponent<(W, C1)>,
     count: Int
-  ) where RegexOutput == (Substring, C1?), Component.RegexOutput == (W, C1) {
+  ) where RegexOutput == (Substring, C1?) {
     precondition(count >= 0, "Must specify a positive count")
     let factory = makeFactory()
     self.init(factory.exactly(count, component))
@@ -1089,10 +1181,10 @@ extension Repeat {
   ///   - componentBuilder: A builder closure that creates the regex
   ///     component to repeat.
   @_alwaysEmitIntoClient
-  public init<W, C1, Component: RegexComponent>(
+  public init<W, C1>(
     count: Int,
-    @RegexComponentBuilder _ componentBuilder: () -> Component
-  ) where RegexOutput == (Substring, C1?), Component.RegexOutput == (W, C1) {
+    @RegexComponentBuilder _ componentBuilder: () -> some RegexComponent<(W, C1)>
+  ) where RegexOutput == (Substring, C1?) {
     precondition(count >= 0, "Must specify a positive count")
     let factory = makeFactory()
     self.init(factory.exactly(count, componentBuilder()))
@@ -1111,11 +1203,11 @@ extension Repeat {
   ///     `eager` by calling `repetitionBehavior(_:)` on the resulting
   ///     `Regex`.
   @_alwaysEmitIntoClient
-  public init<W, C1, Component: RegexComponent, R: RangeExpression>(
-    _ component: Component,
-    _ expression: R,
+  public init<W, C1>(
+    _ component: some RegexComponent<(W, C1)>,
+    _ expression: some RangeExpression<Int>,
     _ behavior: RegexRepetitionBehavior? = nil
-  ) where RegexOutput == (Substring, C1?), Component.RegexOutput == (W, C1), R.Bound == Int {
+  ) where RegexOutput == (Substring, C1?) {
     let factory = makeFactory()
     self.init(factory.repeating(expression.relative(to: 0..<Int.max), behavior, component))
   }
@@ -1134,15 +1226,17 @@ extension Repeat {
   ///   - componentBuilder: A builder closure that creates the regex
   ///     component to repeat.
   @_alwaysEmitIntoClient
-  public init<W, C1, Component: RegexComponent, R: RangeExpression>(
-    _ expression: R,
+  public init<W, C1>(
+    _ expression: some RangeExpression<Int>,
     _ behavior: RegexRepetitionBehavior? = nil,
-    @RegexComponentBuilder _ componentBuilder: () -> Component
-  ) where RegexOutput == (Substring, C1?), Component.RegexOutput == (W, C1), R.Bound == Int {
+    @RegexComponentBuilder _ componentBuilder: () -> some RegexComponent<(W, C1)>
+  ) where RegexOutput == (Substring, C1?) {
     let factory = makeFactory()
     self.init(factory.repeating(expression.relative(to: 0..<Int.max), behavior, componentBuilder()))
   }
 }
+// MARK: - Quantifiers (arity 2)
+
 @available(SwiftStdlib 5.7, *)
 extension Optionally {
   /// Creates a regex component that matches the given component
@@ -1156,10 +1250,10 @@ extension Optionally {
   ///     `eager` by calling `repetitionBehavior(_:)` on the resulting
   ///     `Regex`.
   @_alwaysEmitIntoClient
-  public init<W, C1, C2, Component: RegexComponent>(
-    _ component: Component,
+  public init<W, C1, C2>(
+    _ component: some RegexComponent<(W, C1, C2)>,
     _ behavior: RegexRepetitionBehavior? = nil
-  ) where RegexOutput == (Substring, C1?, C2?), Component.RegexOutput == (W, C1, C2) {
+  ) where RegexOutput == (Substring, C1?, C2?) {
     let factory = makeFactory()
     self.init(factory.zeroOrOne(component, behavior))
   }
@@ -1179,10 +1273,10 @@ extension Optionally {
   ///   - componentBuilder: A builder closure that generates a regex
   ///     component.
   @_alwaysEmitIntoClient
-  public init<W, C1, C2, Component: RegexComponent>(
+  public init<W, C1, C2>(
     _ behavior: RegexRepetitionBehavior? = nil,
-    @RegexComponentBuilder _ componentBuilder: () -> Component
-  ) where RegexOutput == (Substring, C1?, C2?), Component.RegexOutput == (W, C1, C2) {
+    @RegexComponentBuilder _ componentBuilder: () -> some RegexComponent<(W, C1, C2)>
+  ) where RegexOutput == (Substring, C1?, C2?) {
     let factory = makeFactory()
     self.init(factory.zeroOrOne(componentBuilder(), behavior))
   }
@@ -1191,9 +1285,9 @@ extension Optionally {
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
   @_alwaysEmitIntoClient
-  public static func buildLimitedAvailability<W, C1, C2, Component: RegexComponent>(
-    _ component: Component
-  ) -> Regex<(Substring, C1?, C2?)> where Component.RegexOutput == (W, C1, C2) {
+  public static func buildLimitedAvailability<W, C1, C2>(
+    _ component: some RegexComponent<(W, C1, C2)>
+  ) -> Regex<(Substring, C1?, C2?)> {
     let factory = makeFactory()
     return factory.zeroOrOne(component, nil)
   }
@@ -1211,10 +1305,10 @@ extension ZeroOrMore {
   ///     `eager` by calling `repetitionBehavior(_:)` on the resulting
   ///     `Regex`.
   @_alwaysEmitIntoClient
-  public init<W, C1, C2, Component: RegexComponent>(
-    _ component: Component,
+  public init<W, C1, C2>(
+    _ component: some RegexComponent<(W, C1, C2)>,
     _ behavior: RegexRepetitionBehavior? = nil
-  ) where RegexOutput == (Substring, C1?, C2?), Component.RegexOutput == (W, C1, C2) {
+  ) where RegexOutput == (Substring, C1?, C2?) {
     let factory = makeFactory()
     self.init(factory.zeroOrMore(component, behavior))
   }
@@ -1234,10 +1328,10 @@ extension ZeroOrMore {
   ///   - componentBuilder: A builder closure that generates a regex
   ///     component.
   @_alwaysEmitIntoClient
-  public init<W, C1, C2, Component: RegexComponent>(
+  public init<W, C1, C2>(
     _ behavior: RegexRepetitionBehavior? = nil,
-    @RegexComponentBuilder _ componentBuilder: () -> Component
-  ) where RegexOutput == (Substring, C1?, C2?), Component.RegexOutput == (W, C1, C2) {
+    @RegexComponentBuilder _ componentBuilder: () -> some RegexComponent<(W, C1, C2)>
+  ) where RegexOutput == (Substring, C1?, C2?) {
     let factory = makeFactory()
     self.init(factory.zeroOrMore(componentBuilder(), behavior))
   }
@@ -1257,10 +1351,10 @@ extension OneOrMore {
   ///     `eager` by calling `repetitionBehavior(_:)` on the resulting
   ///     `Regex`.
   @_alwaysEmitIntoClient
-  public init<W, C1, C2, Component: RegexComponent>(
-    _ component: Component,
+  public init<W, C1, C2>(
+    _ component: some RegexComponent<(W, C1, C2)>,
     _ behavior: RegexRepetitionBehavior? = nil
-  ) where RegexOutput == (Substring, C1, C2), Component.RegexOutput == (W, C1, C2) {
+  ) where RegexOutput == (Substring, C1, C2) {
     let factory = makeFactory()
     self.init(factory.oneOrMore(component, behavior))
   }
@@ -1280,10 +1374,10 @@ extension OneOrMore {
   ///   - componentBuilder: A builder closure that generates a regex
   ///     component.
   @_alwaysEmitIntoClient
-  public init<W, C1, C2, Component: RegexComponent>(
+  public init<W, C1, C2>(
     _ behavior: RegexRepetitionBehavior? = nil,
-    @RegexComponentBuilder _ componentBuilder: () -> Component
-  ) where RegexOutput == (Substring, C1, C2), Component.RegexOutput == (W, C1, C2) {
+    @RegexComponentBuilder _ componentBuilder: () -> some RegexComponent<(W, C1, C2)>
+  ) where RegexOutput == (Substring, C1, C2) {
     let factory = makeFactory()
     self.init(factory.oneOrMore(componentBuilder(), behavior))
   }
@@ -1300,10 +1394,10 @@ extension Repeat {
   ///   - count: The number of times to repeat `component`. `count` must
   ///     be greater than or equal to zero.
   @_alwaysEmitIntoClient
-  public init<W, C1, C2, Component: RegexComponent>(
-    _ component: Component,
+  public init<W, C1, C2>(
+    _ component: some RegexComponent<(W, C1, C2)>,
     count: Int
-  ) where RegexOutput == (Substring, C1?, C2?), Component.RegexOutput == (W, C1, C2) {
+  ) where RegexOutput == (Substring, C1?, C2?) {
     precondition(count >= 0, "Must specify a positive count")
     let factory = makeFactory()
     self.init(factory.exactly(count, component))
@@ -1318,10 +1412,10 @@ extension Repeat {
   ///   - componentBuilder: A builder closure that creates the regex
   ///     component to repeat.
   @_alwaysEmitIntoClient
-  public init<W, C1, C2, Component: RegexComponent>(
+  public init<W, C1, C2>(
     count: Int,
-    @RegexComponentBuilder _ componentBuilder: () -> Component
-  ) where RegexOutput == (Substring, C1?, C2?), Component.RegexOutput == (W, C1, C2) {
+    @RegexComponentBuilder _ componentBuilder: () -> some RegexComponent<(W, C1, C2)>
+  ) where RegexOutput == (Substring, C1?, C2?) {
     precondition(count >= 0, "Must specify a positive count")
     let factory = makeFactory()
     self.init(factory.exactly(count, componentBuilder()))
@@ -1340,11 +1434,11 @@ extension Repeat {
   ///     `eager` by calling `repetitionBehavior(_:)` on the resulting
   ///     `Regex`.
   @_alwaysEmitIntoClient
-  public init<W, C1, C2, Component: RegexComponent, R: RangeExpression>(
-    _ component: Component,
-    _ expression: R,
+  public init<W, C1, C2>(
+    _ component: some RegexComponent<(W, C1, C2)>,
+    _ expression: some RangeExpression<Int>,
     _ behavior: RegexRepetitionBehavior? = nil
-  ) where RegexOutput == (Substring, C1?, C2?), Component.RegexOutput == (W, C1, C2), R.Bound == Int {
+  ) where RegexOutput == (Substring, C1?, C2?) {
     let factory = makeFactory()
     self.init(factory.repeating(expression.relative(to: 0..<Int.max), behavior, component))
   }
@@ -1363,15 +1457,17 @@ extension Repeat {
   ///   - componentBuilder: A builder closure that creates the regex
   ///     component to repeat.
   @_alwaysEmitIntoClient
-  public init<W, C1, C2, Component: RegexComponent, R: RangeExpression>(
-    _ expression: R,
+  public init<W, C1, C2>(
+    _ expression: some RangeExpression<Int>,
     _ behavior: RegexRepetitionBehavior? = nil,
-    @RegexComponentBuilder _ componentBuilder: () -> Component
-  ) where RegexOutput == (Substring, C1?, C2?), Component.RegexOutput == (W, C1, C2), R.Bound == Int {
+    @RegexComponentBuilder _ componentBuilder: () -> some RegexComponent<(W, C1, C2)>
+  ) where RegexOutput == (Substring, C1?, C2?) {
     let factory = makeFactory()
     self.init(factory.repeating(expression.relative(to: 0..<Int.max), behavior, componentBuilder()))
   }
 }
+// MARK: - Quantifiers (arity 3)
+
 @available(SwiftStdlib 5.7, *)
 extension Optionally {
   /// Creates a regex component that matches the given component
@@ -1385,10 +1481,10 @@ extension Optionally {
   ///     `eager` by calling `repetitionBehavior(_:)` on the resulting
   ///     `Regex`.
   @_alwaysEmitIntoClient
-  public init<W, C1, C2, C3, Component: RegexComponent>(
-    _ component: Component,
+  public init<W, C1, C2, C3>(
+    _ component: some RegexComponent<(W, C1, C2, C3)>,
     _ behavior: RegexRepetitionBehavior? = nil
-  ) where RegexOutput == (Substring, C1?, C2?, C3?), Component.RegexOutput == (W, C1, C2, C3) {
+  ) where RegexOutput == (Substring, C1?, C2?, C3?) {
     let factory = makeFactory()
     self.init(factory.zeroOrOne(component, behavior))
   }
@@ -1408,10 +1504,10 @@ extension Optionally {
   ///   - componentBuilder: A builder closure that generates a regex
   ///     component.
   @_alwaysEmitIntoClient
-  public init<W, C1, C2, C3, Component: RegexComponent>(
+  public init<W, C1, C2, C3>(
     _ behavior: RegexRepetitionBehavior? = nil,
-    @RegexComponentBuilder _ componentBuilder: () -> Component
-  ) where RegexOutput == (Substring, C1?, C2?, C3?), Component.RegexOutput == (W, C1, C2, C3) {
+    @RegexComponentBuilder _ componentBuilder: () -> some RegexComponent<(W, C1, C2, C3)>
+  ) where RegexOutput == (Substring, C1?, C2?, C3?) {
     let factory = makeFactory()
     self.init(factory.zeroOrOne(componentBuilder(), behavior))
   }
@@ -1420,9 +1516,9 @@ extension Optionally {
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
   @_alwaysEmitIntoClient
-  public static func buildLimitedAvailability<W, C1, C2, C3, Component: RegexComponent>(
-    _ component: Component
-  ) -> Regex<(Substring, C1?, C2?, C3?)> where Component.RegexOutput == (W, C1, C2, C3) {
+  public static func buildLimitedAvailability<W, C1, C2, C3>(
+    _ component: some RegexComponent<(W, C1, C2, C3)>
+  ) -> Regex<(Substring, C1?, C2?, C3?)> {
     let factory = makeFactory()
     return factory.zeroOrOne(component, nil)
   }
@@ -1440,10 +1536,10 @@ extension ZeroOrMore {
   ///     `eager` by calling `repetitionBehavior(_:)` on the resulting
   ///     `Regex`.
   @_alwaysEmitIntoClient
-  public init<W, C1, C2, C3, Component: RegexComponent>(
-    _ component: Component,
+  public init<W, C1, C2, C3>(
+    _ component: some RegexComponent<(W, C1, C2, C3)>,
     _ behavior: RegexRepetitionBehavior? = nil
-  ) where RegexOutput == (Substring, C1?, C2?, C3?), Component.RegexOutput == (W, C1, C2, C3) {
+  ) where RegexOutput == (Substring, C1?, C2?, C3?) {
     let factory = makeFactory()
     self.init(factory.zeroOrMore(component, behavior))
   }
@@ -1463,10 +1559,10 @@ extension ZeroOrMore {
   ///   - componentBuilder: A builder closure that generates a regex
   ///     component.
   @_alwaysEmitIntoClient
-  public init<W, C1, C2, C3, Component: RegexComponent>(
+  public init<W, C1, C2, C3>(
     _ behavior: RegexRepetitionBehavior? = nil,
-    @RegexComponentBuilder _ componentBuilder: () -> Component
-  ) where RegexOutput == (Substring, C1?, C2?, C3?), Component.RegexOutput == (W, C1, C2, C3) {
+    @RegexComponentBuilder _ componentBuilder: () -> some RegexComponent<(W, C1, C2, C3)>
+  ) where RegexOutput == (Substring, C1?, C2?, C3?) {
     let factory = makeFactory()
     self.init(factory.zeroOrMore(componentBuilder(), behavior))
   }
@@ -1486,10 +1582,10 @@ extension OneOrMore {
   ///     `eager` by calling `repetitionBehavior(_:)` on the resulting
   ///     `Regex`.
   @_alwaysEmitIntoClient
-  public init<W, C1, C2, C3, Component: RegexComponent>(
-    _ component: Component,
+  public init<W, C1, C2, C3>(
+    _ component: some RegexComponent<(W, C1, C2, C3)>,
     _ behavior: RegexRepetitionBehavior? = nil
-  ) where RegexOutput == (Substring, C1, C2, C3), Component.RegexOutput == (W, C1, C2, C3) {
+  ) where RegexOutput == (Substring, C1, C2, C3) {
     let factory = makeFactory()
     self.init(factory.oneOrMore(component, behavior))
   }
@@ -1509,10 +1605,10 @@ extension OneOrMore {
   ///   - componentBuilder: A builder closure that generates a regex
   ///     component.
   @_alwaysEmitIntoClient
-  public init<W, C1, C2, C3, Component: RegexComponent>(
+  public init<W, C1, C2, C3>(
     _ behavior: RegexRepetitionBehavior? = nil,
-    @RegexComponentBuilder _ componentBuilder: () -> Component
-  ) where RegexOutput == (Substring, C1, C2, C3), Component.RegexOutput == (W, C1, C2, C3) {
+    @RegexComponentBuilder _ componentBuilder: () -> some RegexComponent<(W, C1, C2, C3)>
+  ) where RegexOutput == (Substring, C1, C2, C3) {
     let factory = makeFactory()
     self.init(factory.oneOrMore(componentBuilder(), behavior))
   }
@@ -1529,10 +1625,10 @@ extension Repeat {
   ///   - count: The number of times to repeat `component`. `count` must
   ///     be greater than or equal to zero.
   @_alwaysEmitIntoClient
-  public init<W, C1, C2, C3, Component: RegexComponent>(
-    _ component: Component,
+  public init<W, C1, C2, C3>(
+    _ component: some RegexComponent<(W, C1, C2, C3)>,
     count: Int
-  ) where RegexOutput == (Substring, C1?, C2?, C3?), Component.RegexOutput == (W, C1, C2, C3) {
+  ) where RegexOutput == (Substring, C1?, C2?, C3?) {
     precondition(count >= 0, "Must specify a positive count")
     let factory = makeFactory()
     self.init(factory.exactly(count, component))
@@ -1547,10 +1643,10 @@ extension Repeat {
   ///   - componentBuilder: A builder closure that creates the regex
   ///     component to repeat.
   @_alwaysEmitIntoClient
-  public init<W, C1, C2, C3, Component: RegexComponent>(
+  public init<W, C1, C2, C3>(
     count: Int,
-    @RegexComponentBuilder _ componentBuilder: () -> Component
-  ) where RegexOutput == (Substring, C1?, C2?, C3?), Component.RegexOutput == (W, C1, C2, C3) {
+    @RegexComponentBuilder _ componentBuilder: () -> some RegexComponent<(W, C1, C2, C3)>
+  ) where RegexOutput == (Substring, C1?, C2?, C3?) {
     precondition(count >= 0, "Must specify a positive count")
     let factory = makeFactory()
     self.init(factory.exactly(count, componentBuilder()))
@@ -1569,11 +1665,11 @@ extension Repeat {
   ///     `eager` by calling `repetitionBehavior(_:)` on the resulting
   ///     `Regex`.
   @_alwaysEmitIntoClient
-  public init<W, C1, C2, C3, Component: RegexComponent, R: RangeExpression>(
-    _ component: Component,
-    _ expression: R,
+  public init<W, C1, C2, C3>(
+    _ component: some RegexComponent<(W, C1, C2, C3)>,
+    _ expression: some RangeExpression<Int>,
     _ behavior: RegexRepetitionBehavior? = nil
-  ) where RegexOutput == (Substring, C1?, C2?, C3?), Component.RegexOutput == (W, C1, C2, C3), R.Bound == Int {
+  ) where RegexOutput == (Substring, C1?, C2?, C3?) {
     let factory = makeFactory()
     self.init(factory.repeating(expression.relative(to: 0..<Int.max), behavior, component))
   }
@@ -1592,15 +1688,17 @@ extension Repeat {
   ///   - componentBuilder: A builder closure that creates the regex
   ///     component to repeat.
   @_alwaysEmitIntoClient
-  public init<W, C1, C2, C3, Component: RegexComponent, R: RangeExpression>(
-    _ expression: R,
+  public init<W, C1, C2, C3>(
+    _ expression: some RangeExpression<Int>,
     _ behavior: RegexRepetitionBehavior? = nil,
-    @RegexComponentBuilder _ componentBuilder: () -> Component
-  ) where RegexOutput == (Substring, C1?, C2?, C3?), Component.RegexOutput == (W, C1, C2, C3), R.Bound == Int {
+    @RegexComponentBuilder _ componentBuilder: () -> some RegexComponent<(W, C1, C2, C3)>
+  ) where RegexOutput == (Substring, C1?, C2?, C3?) {
     let factory = makeFactory()
     self.init(factory.repeating(expression.relative(to: 0..<Int.max), behavior, componentBuilder()))
   }
 }
+// MARK: - Quantifiers (arity 4)
+
 @available(SwiftStdlib 5.7, *)
 extension Optionally {
   /// Creates a regex component that matches the given component
@@ -1614,10 +1712,10 @@ extension Optionally {
   ///     `eager` by calling `repetitionBehavior(_:)` on the resulting
   ///     `Regex`.
   @_alwaysEmitIntoClient
-  public init<W, C1, C2, C3, C4, Component: RegexComponent>(
-    _ component: Component,
+  public init<W, C1, C2, C3, C4>(
+    _ component: some RegexComponent<(W, C1, C2, C3, C4)>,
     _ behavior: RegexRepetitionBehavior? = nil
-  ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?), Component.RegexOutput == (W, C1, C2, C3, C4) {
+  ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?) {
     let factory = makeFactory()
     self.init(factory.zeroOrOne(component, behavior))
   }
@@ -1637,10 +1735,10 @@ extension Optionally {
   ///   - componentBuilder: A builder closure that generates a regex
   ///     component.
   @_alwaysEmitIntoClient
-  public init<W, C1, C2, C3, C4, Component: RegexComponent>(
+  public init<W, C1, C2, C3, C4>(
     _ behavior: RegexRepetitionBehavior? = nil,
-    @RegexComponentBuilder _ componentBuilder: () -> Component
-  ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?), Component.RegexOutput == (W, C1, C2, C3, C4) {
+    @RegexComponentBuilder _ componentBuilder: () -> some RegexComponent<(W, C1, C2, C3, C4)>
+  ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?) {
     let factory = makeFactory()
     self.init(factory.zeroOrOne(componentBuilder(), behavior))
   }
@@ -1649,9 +1747,9 @@ extension Optionally {
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
   @_alwaysEmitIntoClient
-  public static func buildLimitedAvailability<W, C1, C2, C3, C4, Component: RegexComponent>(
-    _ component: Component
-  ) -> Regex<(Substring, C1?, C2?, C3?, C4?)> where Component.RegexOutput == (W, C1, C2, C3, C4) {
+  public static func buildLimitedAvailability<W, C1, C2, C3, C4>(
+    _ component: some RegexComponent<(W, C1, C2, C3, C4)>
+  ) -> Regex<(Substring, C1?, C2?, C3?, C4?)> {
     let factory = makeFactory()
     return factory.zeroOrOne(component, nil)
   }
@@ -1669,10 +1767,10 @@ extension ZeroOrMore {
   ///     `eager` by calling `repetitionBehavior(_:)` on the resulting
   ///     `Regex`.
   @_alwaysEmitIntoClient
-  public init<W, C1, C2, C3, C4, Component: RegexComponent>(
-    _ component: Component,
+  public init<W, C1, C2, C3, C4>(
+    _ component: some RegexComponent<(W, C1, C2, C3, C4)>,
     _ behavior: RegexRepetitionBehavior? = nil
-  ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?), Component.RegexOutput == (W, C1, C2, C3, C4) {
+  ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?) {
     let factory = makeFactory()
     self.init(factory.zeroOrMore(component, behavior))
   }
@@ -1692,10 +1790,10 @@ extension ZeroOrMore {
   ///   - componentBuilder: A builder closure that generates a regex
   ///     component.
   @_alwaysEmitIntoClient
-  public init<W, C1, C2, C3, C4, Component: RegexComponent>(
+  public init<W, C1, C2, C3, C4>(
     _ behavior: RegexRepetitionBehavior? = nil,
-    @RegexComponentBuilder _ componentBuilder: () -> Component
-  ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?), Component.RegexOutput == (W, C1, C2, C3, C4) {
+    @RegexComponentBuilder _ componentBuilder: () -> some RegexComponent<(W, C1, C2, C3, C4)>
+  ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?) {
     let factory = makeFactory()
     self.init(factory.zeroOrMore(componentBuilder(), behavior))
   }
@@ -1715,10 +1813,10 @@ extension OneOrMore {
   ///     `eager` by calling `repetitionBehavior(_:)` on the resulting
   ///     `Regex`.
   @_alwaysEmitIntoClient
-  public init<W, C1, C2, C3, C4, Component: RegexComponent>(
-    _ component: Component,
+  public init<W, C1, C2, C3, C4>(
+    _ component: some RegexComponent<(W, C1, C2, C3, C4)>,
     _ behavior: RegexRepetitionBehavior? = nil
-  ) where RegexOutput == (Substring, C1, C2, C3, C4), Component.RegexOutput == (W, C1, C2, C3, C4) {
+  ) where RegexOutput == (Substring, C1, C2, C3, C4) {
     let factory = makeFactory()
     self.init(factory.oneOrMore(component, behavior))
   }
@@ -1738,10 +1836,10 @@ extension OneOrMore {
   ///   - componentBuilder: A builder closure that generates a regex
   ///     component.
   @_alwaysEmitIntoClient
-  public init<W, C1, C2, C3, C4, Component: RegexComponent>(
+  public init<W, C1, C2, C3, C4>(
     _ behavior: RegexRepetitionBehavior? = nil,
-    @RegexComponentBuilder _ componentBuilder: () -> Component
-  ) where RegexOutput == (Substring, C1, C2, C3, C4), Component.RegexOutput == (W, C1, C2, C3, C4) {
+    @RegexComponentBuilder _ componentBuilder: () -> some RegexComponent<(W, C1, C2, C3, C4)>
+  ) where RegexOutput == (Substring, C1, C2, C3, C4) {
     let factory = makeFactory()
     self.init(factory.oneOrMore(componentBuilder(), behavior))
   }
@@ -1758,10 +1856,10 @@ extension Repeat {
   ///   - count: The number of times to repeat `component`. `count` must
   ///     be greater than or equal to zero.
   @_alwaysEmitIntoClient
-  public init<W, C1, C2, C3, C4, Component: RegexComponent>(
-    _ component: Component,
+  public init<W, C1, C2, C3, C4>(
+    _ component: some RegexComponent<(W, C1, C2, C3, C4)>,
     count: Int
-  ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?), Component.RegexOutput == (W, C1, C2, C3, C4) {
+  ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?) {
     precondition(count >= 0, "Must specify a positive count")
     let factory = makeFactory()
     self.init(factory.exactly(count, component))
@@ -1776,10 +1874,10 @@ extension Repeat {
   ///   - componentBuilder: A builder closure that creates the regex
   ///     component to repeat.
   @_alwaysEmitIntoClient
-  public init<W, C1, C2, C3, C4, Component: RegexComponent>(
+  public init<W, C1, C2, C3, C4>(
     count: Int,
-    @RegexComponentBuilder _ componentBuilder: () -> Component
-  ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?), Component.RegexOutput == (W, C1, C2, C3, C4) {
+    @RegexComponentBuilder _ componentBuilder: () -> some RegexComponent<(W, C1, C2, C3, C4)>
+  ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?) {
     precondition(count >= 0, "Must specify a positive count")
     let factory = makeFactory()
     self.init(factory.exactly(count, componentBuilder()))
@@ -1798,11 +1896,11 @@ extension Repeat {
   ///     `eager` by calling `repetitionBehavior(_:)` on the resulting
   ///     `Regex`.
   @_alwaysEmitIntoClient
-  public init<W, C1, C2, C3, C4, Component: RegexComponent, R: RangeExpression>(
-    _ component: Component,
-    _ expression: R,
+  public init<W, C1, C2, C3, C4>(
+    _ component: some RegexComponent<(W, C1, C2, C3, C4)>,
+    _ expression: some RangeExpression<Int>,
     _ behavior: RegexRepetitionBehavior? = nil
-  ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?), Component.RegexOutput == (W, C1, C2, C3, C4), R.Bound == Int {
+  ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?) {
     let factory = makeFactory()
     self.init(factory.repeating(expression.relative(to: 0..<Int.max), behavior, component))
   }
@@ -1821,15 +1919,17 @@ extension Repeat {
   ///   - componentBuilder: A builder closure that creates the regex
   ///     component to repeat.
   @_alwaysEmitIntoClient
-  public init<W, C1, C2, C3, C4, Component: RegexComponent, R: RangeExpression>(
-    _ expression: R,
+  public init<W, C1, C2, C3, C4>(
+    _ expression: some RangeExpression<Int>,
     _ behavior: RegexRepetitionBehavior? = nil,
-    @RegexComponentBuilder _ componentBuilder: () -> Component
-  ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?), Component.RegexOutput == (W, C1, C2, C3, C4), R.Bound == Int {
+    @RegexComponentBuilder _ componentBuilder: () -> some RegexComponent<(W, C1, C2, C3, C4)>
+  ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?) {
     let factory = makeFactory()
     self.init(factory.repeating(expression.relative(to: 0..<Int.max), behavior, componentBuilder()))
   }
 }
+// MARK: - Quantifiers (arity 5)
+
 @available(SwiftStdlib 5.7, *)
 extension Optionally {
   /// Creates a regex component that matches the given component
@@ -1843,10 +1943,10 @@ extension Optionally {
   ///     `eager` by calling `repetitionBehavior(_:)` on the resulting
   ///     `Regex`.
   @_alwaysEmitIntoClient
-  public init<W, C1, C2, C3, C4, C5, Component: RegexComponent>(
-    _ component: Component,
+  public init<W, C1, C2, C3, C4, C5>(
+    _ component: some RegexComponent<(W, C1, C2, C3, C4, C5)>,
     _ behavior: RegexRepetitionBehavior? = nil
-  ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?), Component.RegexOutput == (W, C1, C2, C3, C4, C5) {
+  ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?) {
     let factory = makeFactory()
     self.init(factory.zeroOrOne(component, behavior))
   }
@@ -1866,10 +1966,10 @@ extension Optionally {
   ///   - componentBuilder: A builder closure that generates a regex
   ///     component.
   @_alwaysEmitIntoClient
-  public init<W, C1, C2, C3, C4, C5, Component: RegexComponent>(
+  public init<W, C1, C2, C3, C4, C5>(
     _ behavior: RegexRepetitionBehavior? = nil,
-    @RegexComponentBuilder _ componentBuilder: () -> Component
-  ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?), Component.RegexOutput == (W, C1, C2, C3, C4, C5) {
+    @RegexComponentBuilder _ componentBuilder: () -> some RegexComponent<(W, C1, C2, C3, C4, C5)>
+  ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?) {
     let factory = makeFactory()
     self.init(factory.zeroOrOne(componentBuilder(), behavior))
   }
@@ -1878,9 +1978,9 @@ extension Optionally {
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
   @_alwaysEmitIntoClient
-  public static func buildLimitedAvailability<W, C1, C2, C3, C4, C5, Component: RegexComponent>(
-    _ component: Component
-  ) -> Regex<(Substring, C1?, C2?, C3?, C4?, C5?)> where Component.RegexOutput == (W, C1, C2, C3, C4, C5) {
+  public static func buildLimitedAvailability<W, C1, C2, C3, C4, C5>(
+    _ component: some RegexComponent<(W, C1, C2, C3, C4, C5)>
+  ) -> Regex<(Substring, C1?, C2?, C3?, C4?, C5?)> {
     let factory = makeFactory()
     return factory.zeroOrOne(component, nil)
   }
@@ -1898,10 +1998,10 @@ extension ZeroOrMore {
   ///     `eager` by calling `repetitionBehavior(_:)` on the resulting
   ///     `Regex`.
   @_alwaysEmitIntoClient
-  public init<W, C1, C2, C3, C4, C5, Component: RegexComponent>(
-    _ component: Component,
+  public init<W, C1, C2, C3, C4, C5>(
+    _ component: some RegexComponent<(W, C1, C2, C3, C4, C5)>,
     _ behavior: RegexRepetitionBehavior? = nil
-  ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?), Component.RegexOutput == (W, C1, C2, C3, C4, C5) {
+  ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?) {
     let factory = makeFactory()
     self.init(factory.zeroOrMore(component, behavior))
   }
@@ -1921,10 +2021,10 @@ extension ZeroOrMore {
   ///   - componentBuilder: A builder closure that generates a regex
   ///     component.
   @_alwaysEmitIntoClient
-  public init<W, C1, C2, C3, C4, C5, Component: RegexComponent>(
+  public init<W, C1, C2, C3, C4, C5>(
     _ behavior: RegexRepetitionBehavior? = nil,
-    @RegexComponentBuilder _ componentBuilder: () -> Component
-  ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?), Component.RegexOutput == (W, C1, C2, C3, C4, C5) {
+    @RegexComponentBuilder _ componentBuilder: () -> some RegexComponent<(W, C1, C2, C3, C4, C5)>
+  ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?) {
     let factory = makeFactory()
     self.init(factory.zeroOrMore(componentBuilder(), behavior))
   }
@@ -1944,10 +2044,10 @@ extension OneOrMore {
   ///     `eager` by calling `repetitionBehavior(_:)` on the resulting
   ///     `Regex`.
   @_alwaysEmitIntoClient
-  public init<W, C1, C2, C3, C4, C5, Component: RegexComponent>(
-    _ component: Component,
+  public init<W, C1, C2, C3, C4, C5>(
+    _ component: some RegexComponent<(W, C1, C2, C3, C4, C5)>,
     _ behavior: RegexRepetitionBehavior? = nil
-  ) where RegexOutput == (Substring, C1, C2, C3, C4, C5), Component.RegexOutput == (W, C1, C2, C3, C4, C5) {
+  ) where RegexOutput == (Substring, C1, C2, C3, C4, C5) {
     let factory = makeFactory()
     self.init(factory.oneOrMore(component, behavior))
   }
@@ -1967,10 +2067,10 @@ extension OneOrMore {
   ///   - componentBuilder: A builder closure that generates a regex
   ///     component.
   @_alwaysEmitIntoClient
-  public init<W, C1, C2, C3, C4, C5, Component: RegexComponent>(
+  public init<W, C1, C2, C3, C4, C5>(
     _ behavior: RegexRepetitionBehavior? = nil,
-    @RegexComponentBuilder _ componentBuilder: () -> Component
-  ) where RegexOutput == (Substring, C1, C2, C3, C4, C5), Component.RegexOutput == (W, C1, C2, C3, C4, C5) {
+    @RegexComponentBuilder _ componentBuilder: () -> some RegexComponent<(W, C1, C2, C3, C4, C5)>
+  ) where RegexOutput == (Substring, C1, C2, C3, C4, C5) {
     let factory = makeFactory()
     self.init(factory.oneOrMore(componentBuilder(), behavior))
   }
@@ -1987,10 +2087,10 @@ extension Repeat {
   ///   - count: The number of times to repeat `component`. `count` must
   ///     be greater than or equal to zero.
   @_alwaysEmitIntoClient
-  public init<W, C1, C2, C3, C4, C5, Component: RegexComponent>(
-    _ component: Component,
+  public init<W, C1, C2, C3, C4, C5>(
+    _ component: some RegexComponent<(W, C1, C2, C3, C4, C5)>,
     count: Int
-  ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?), Component.RegexOutput == (W, C1, C2, C3, C4, C5) {
+  ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?) {
     precondition(count >= 0, "Must specify a positive count")
     let factory = makeFactory()
     self.init(factory.exactly(count, component))
@@ -2005,10 +2105,10 @@ extension Repeat {
   ///   - componentBuilder: A builder closure that creates the regex
   ///     component to repeat.
   @_alwaysEmitIntoClient
-  public init<W, C1, C2, C3, C4, C5, Component: RegexComponent>(
+  public init<W, C1, C2, C3, C4, C5>(
     count: Int,
-    @RegexComponentBuilder _ componentBuilder: () -> Component
-  ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?), Component.RegexOutput == (W, C1, C2, C3, C4, C5) {
+    @RegexComponentBuilder _ componentBuilder: () -> some RegexComponent<(W, C1, C2, C3, C4, C5)>
+  ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?) {
     precondition(count >= 0, "Must specify a positive count")
     let factory = makeFactory()
     self.init(factory.exactly(count, componentBuilder()))
@@ -2027,11 +2127,11 @@ extension Repeat {
   ///     `eager` by calling `repetitionBehavior(_:)` on the resulting
   ///     `Regex`.
   @_alwaysEmitIntoClient
-  public init<W, C1, C2, C3, C4, C5, Component: RegexComponent, R: RangeExpression>(
-    _ component: Component,
-    _ expression: R,
+  public init<W, C1, C2, C3, C4, C5>(
+    _ component: some RegexComponent<(W, C1, C2, C3, C4, C5)>,
+    _ expression: some RangeExpression<Int>,
     _ behavior: RegexRepetitionBehavior? = nil
-  ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?), Component.RegexOutput == (W, C1, C2, C3, C4, C5), R.Bound == Int {
+  ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?) {
     let factory = makeFactory()
     self.init(factory.repeating(expression.relative(to: 0..<Int.max), behavior, component))
   }
@@ -2050,15 +2150,17 @@ extension Repeat {
   ///   - componentBuilder: A builder closure that creates the regex
   ///     component to repeat.
   @_alwaysEmitIntoClient
-  public init<W, C1, C2, C3, C4, C5, Component: RegexComponent, R: RangeExpression>(
-    _ expression: R,
+  public init<W, C1, C2, C3, C4, C5>(
+    _ expression: some RangeExpression<Int>,
     _ behavior: RegexRepetitionBehavior? = nil,
-    @RegexComponentBuilder _ componentBuilder: () -> Component
-  ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?), Component.RegexOutput == (W, C1, C2, C3, C4, C5), R.Bound == Int {
+    @RegexComponentBuilder _ componentBuilder: () -> some RegexComponent<(W, C1, C2, C3, C4, C5)>
+  ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?) {
     let factory = makeFactory()
     self.init(factory.repeating(expression.relative(to: 0..<Int.max), behavior, componentBuilder()))
   }
 }
+// MARK: - Quantifiers (arity 6)
+
 @available(SwiftStdlib 5.7, *)
 extension Optionally {
   /// Creates a regex component that matches the given component
@@ -2072,10 +2174,10 @@ extension Optionally {
   ///     `eager` by calling `repetitionBehavior(_:)` on the resulting
   ///     `Regex`.
   @_alwaysEmitIntoClient
-  public init<W, C1, C2, C3, C4, C5, C6, Component: RegexComponent>(
-    _ component: Component,
+  public init<W, C1, C2, C3, C4, C5, C6>(
+    _ component: some RegexComponent<(W, C1, C2, C3, C4, C5, C6)>,
     _ behavior: RegexRepetitionBehavior? = nil
-  ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?, C6?), Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6) {
+  ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?, C6?) {
     let factory = makeFactory()
     self.init(factory.zeroOrOne(component, behavior))
   }
@@ -2095,10 +2197,10 @@ extension Optionally {
   ///   - componentBuilder: A builder closure that generates a regex
   ///     component.
   @_alwaysEmitIntoClient
-  public init<W, C1, C2, C3, C4, C5, C6, Component: RegexComponent>(
+  public init<W, C1, C2, C3, C4, C5, C6>(
     _ behavior: RegexRepetitionBehavior? = nil,
-    @RegexComponentBuilder _ componentBuilder: () -> Component
-  ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?, C6?), Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6) {
+    @RegexComponentBuilder _ componentBuilder: () -> some RegexComponent<(W, C1, C2, C3, C4, C5, C6)>
+  ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?, C6?) {
     let factory = makeFactory()
     self.init(factory.zeroOrOne(componentBuilder(), behavior))
   }
@@ -2107,9 +2209,9 @@ extension Optionally {
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
   @_alwaysEmitIntoClient
-  public static func buildLimitedAvailability<W, C1, C2, C3, C4, C5, C6, Component: RegexComponent>(
-    _ component: Component
-  ) -> Regex<(Substring, C1?, C2?, C3?, C4?, C5?, C6?)> where Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6) {
+  public static func buildLimitedAvailability<W, C1, C2, C3, C4, C5, C6>(
+    _ component: some RegexComponent<(W, C1, C2, C3, C4, C5, C6)>
+  ) -> Regex<(Substring, C1?, C2?, C3?, C4?, C5?, C6?)> {
     let factory = makeFactory()
     return factory.zeroOrOne(component, nil)
   }
@@ -2127,10 +2229,10 @@ extension ZeroOrMore {
   ///     `eager` by calling `repetitionBehavior(_:)` on the resulting
   ///     `Regex`.
   @_alwaysEmitIntoClient
-  public init<W, C1, C2, C3, C4, C5, C6, Component: RegexComponent>(
-    _ component: Component,
+  public init<W, C1, C2, C3, C4, C5, C6>(
+    _ component: some RegexComponent<(W, C1, C2, C3, C4, C5, C6)>,
     _ behavior: RegexRepetitionBehavior? = nil
-  ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?, C6?), Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6) {
+  ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?, C6?) {
     let factory = makeFactory()
     self.init(factory.zeroOrMore(component, behavior))
   }
@@ -2150,10 +2252,10 @@ extension ZeroOrMore {
   ///   - componentBuilder: A builder closure that generates a regex
   ///     component.
   @_alwaysEmitIntoClient
-  public init<W, C1, C2, C3, C4, C5, C6, Component: RegexComponent>(
+  public init<W, C1, C2, C3, C4, C5, C6>(
     _ behavior: RegexRepetitionBehavior? = nil,
-    @RegexComponentBuilder _ componentBuilder: () -> Component
-  ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?, C6?), Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6) {
+    @RegexComponentBuilder _ componentBuilder: () -> some RegexComponent<(W, C1, C2, C3, C4, C5, C6)>
+  ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?, C6?) {
     let factory = makeFactory()
     self.init(factory.zeroOrMore(componentBuilder(), behavior))
   }
@@ -2173,10 +2275,10 @@ extension OneOrMore {
   ///     `eager` by calling `repetitionBehavior(_:)` on the resulting
   ///     `Regex`.
   @_alwaysEmitIntoClient
-  public init<W, C1, C2, C3, C4, C5, C6, Component: RegexComponent>(
-    _ component: Component,
+  public init<W, C1, C2, C3, C4, C5, C6>(
+    _ component: some RegexComponent<(W, C1, C2, C3, C4, C5, C6)>,
     _ behavior: RegexRepetitionBehavior? = nil
-  ) where RegexOutput == (Substring, C1, C2, C3, C4, C5, C6), Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6) {
+  ) where RegexOutput == (Substring, C1, C2, C3, C4, C5, C6) {
     let factory = makeFactory()
     self.init(factory.oneOrMore(component, behavior))
   }
@@ -2196,10 +2298,10 @@ extension OneOrMore {
   ///   - componentBuilder: A builder closure that generates a regex
   ///     component.
   @_alwaysEmitIntoClient
-  public init<W, C1, C2, C3, C4, C5, C6, Component: RegexComponent>(
+  public init<W, C1, C2, C3, C4, C5, C6>(
     _ behavior: RegexRepetitionBehavior? = nil,
-    @RegexComponentBuilder _ componentBuilder: () -> Component
-  ) where RegexOutput == (Substring, C1, C2, C3, C4, C5, C6), Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6) {
+    @RegexComponentBuilder _ componentBuilder: () -> some RegexComponent<(W, C1, C2, C3, C4, C5, C6)>
+  ) where RegexOutput == (Substring, C1, C2, C3, C4, C5, C6) {
     let factory = makeFactory()
     self.init(factory.oneOrMore(componentBuilder(), behavior))
   }
@@ -2216,10 +2318,10 @@ extension Repeat {
   ///   - count: The number of times to repeat `component`. `count` must
   ///     be greater than or equal to zero.
   @_alwaysEmitIntoClient
-  public init<W, C1, C2, C3, C4, C5, C6, Component: RegexComponent>(
-    _ component: Component,
+  public init<W, C1, C2, C3, C4, C5, C6>(
+    _ component: some RegexComponent<(W, C1, C2, C3, C4, C5, C6)>,
     count: Int
-  ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?, C6?), Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6) {
+  ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?, C6?) {
     precondition(count >= 0, "Must specify a positive count")
     let factory = makeFactory()
     self.init(factory.exactly(count, component))
@@ -2234,10 +2336,10 @@ extension Repeat {
   ///   - componentBuilder: A builder closure that creates the regex
   ///     component to repeat.
   @_alwaysEmitIntoClient
-  public init<W, C1, C2, C3, C4, C5, C6, Component: RegexComponent>(
+  public init<W, C1, C2, C3, C4, C5, C6>(
     count: Int,
-    @RegexComponentBuilder _ componentBuilder: () -> Component
-  ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?, C6?), Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6) {
+    @RegexComponentBuilder _ componentBuilder: () -> some RegexComponent<(W, C1, C2, C3, C4, C5, C6)>
+  ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?, C6?) {
     precondition(count >= 0, "Must specify a positive count")
     let factory = makeFactory()
     self.init(factory.exactly(count, componentBuilder()))
@@ -2256,11 +2358,11 @@ extension Repeat {
   ///     `eager` by calling `repetitionBehavior(_:)` on the resulting
   ///     `Regex`.
   @_alwaysEmitIntoClient
-  public init<W, C1, C2, C3, C4, C5, C6, Component: RegexComponent, R: RangeExpression>(
-    _ component: Component,
-    _ expression: R,
+  public init<W, C1, C2, C3, C4, C5, C6>(
+    _ component: some RegexComponent<(W, C1, C2, C3, C4, C5, C6)>,
+    _ expression: some RangeExpression<Int>,
     _ behavior: RegexRepetitionBehavior? = nil
-  ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?, C6?), Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6), R.Bound == Int {
+  ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?, C6?) {
     let factory = makeFactory()
     self.init(factory.repeating(expression.relative(to: 0..<Int.max), behavior, component))
   }
@@ -2279,15 +2381,17 @@ extension Repeat {
   ///   - componentBuilder: A builder closure that creates the regex
   ///     component to repeat.
   @_alwaysEmitIntoClient
-  public init<W, C1, C2, C3, C4, C5, C6, Component: RegexComponent, R: RangeExpression>(
-    _ expression: R,
+  public init<W, C1, C2, C3, C4, C5, C6>(
+    _ expression: some RangeExpression<Int>,
     _ behavior: RegexRepetitionBehavior? = nil,
-    @RegexComponentBuilder _ componentBuilder: () -> Component
-  ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?, C6?), Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6), R.Bound == Int {
+    @RegexComponentBuilder _ componentBuilder: () -> some RegexComponent<(W, C1, C2, C3, C4, C5, C6)>
+  ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?, C6?) {
     let factory = makeFactory()
     self.init(factory.repeating(expression.relative(to: 0..<Int.max), behavior, componentBuilder()))
   }
 }
+// MARK: - Quantifiers (arity 7)
+
 @available(SwiftStdlib 5.7, *)
 extension Optionally {
   /// Creates a regex component that matches the given component
@@ -2301,10 +2405,10 @@ extension Optionally {
   ///     `eager` by calling `repetitionBehavior(_:)` on the resulting
   ///     `Regex`.
   @_alwaysEmitIntoClient
-  public init<W, C1, C2, C3, C4, C5, C6, C7, Component: RegexComponent>(
-    _ component: Component,
+  public init<W, C1, C2, C3, C4, C5, C6, C7>(
+    _ component: some RegexComponent<(W, C1, C2, C3, C4, C5, C6, C7)>,
     _ behavior: RegexRepetitionBehavior? = nil
-  ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?, C6?, C7?), Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7) {
+  ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?, C6?, C7?) {
     let factory = makeFactory()
     self.init(factory.zeroOrOne(component, behavior))
   }
@@ -2324,10 +2428,10 @@ extension Optionally {
   ///   - componentBuilder: A builder closure that generates a regex
   ///     component.
   @_alwaysEmitIntoClient
-  public init<W, C1, C2, C3, C4, C5, C6, C7, Component: RegexComponent>(
+  public init<W, C1, C2, C3, C4, C5, C6, C7>(
     _ behavior: RegexRepetitionBehavior? = nil,
-    @RegexComponentBuilder _ componentBuilder: () -> Component
-  ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?, C6?, C7?), Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7) {
+    @RegexComponentBuilder _ componentBuilder: () -> some RegexComponent<(W, C1, C2, C3, C4, C5, C6, C7)>
+  ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?, C6?, C7?) {
     let factory = makeFactory()
     self.init(factory.zeroOrOne(componentBuilder(), behavior))
   }
@@ -2336,9 +2440,9 @@ extension Optionally {
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
   @_alwaysEmitIntoClient
-  public static func buildLimitedAvailability<W, C1, C2, C3, C4, C5, C6, C7, Component: RegexComponent>(
-    _ component: Component
-  ) -> Regex<(Substring, C1?, C2?, C3?, C4?, C5?, C6?, C7?)> where Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7) {
+  public static func buildLimitedAvailability<W, C1, C2, C3, C4, C5, C6, C7>(
+    _ component: some RegexComponent<(W, C1, C2, C3, C4, C5, C6, C7)>
+  ) -> Regex<(Substring, C1?, C2?, C3?, C4?, C5?, C6?, C7?)> {
     let factory = makeFactory()
     return factory.zeroOrOne(component, nil)
   }
@@ -2356,10 +2460,10 @@ extension ZeroOrMore {
   ///     `eager` by calling `repetitionBehavior(_:)` on the resulting
   ///     `Regex`.
   @_alwaysEmitIntoClient
-  public init<W, C1, C2, C3, C4, C5, C6, C7, Component: RegexComponent>(
-    _ component: Component,
+  public init<W, C1, C2, C3, C4, C5, C6, C7>(
+    _ component: some RegexComponent<(W, C1, C2, C3, C4, C5, C6, C7)>,
     _ behavior: RegexRepetitionBehavior? = nil
-  ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?, C6?, C7?), Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7) {
+  ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?, C6?, C7?) {
     let factory = makeFactory()
     self.init(factory.zeroOrMore(component, behavior))
   }
@@ -2379,10 +2483,10 @@ extension ZeroOrMore {
   ///   - componentBuilder: A builder closure that generates a regex
   ///     component.
   @_alwaysEmitIntoClient
-  public init<W, C1, C2, C3, C4, C5, C6, C7, Component: RegexComponent>(
+  public init<W, C1, C2, C3, C4, C5, C6, C7>(
     _ behavior: RegexRepetitionBehavior? = nil,
-    @RegexComponentBuilder _ componentBuilder: () -> Component
-  ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?, C6?, C7?), Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7) {
+    @RegexComponentBuilder _ componentBuilder: () -> some RegexComponent<(W, C1, C2, C3, C4, C5, C6, C7)>
+  ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?, C6?, C7?) {
     let factory = makeFactory()
     self.init(factory.zeroOrMore(componentBuilder(), behavior))
   }
@@ -2402,10 +2506,10 @@ extension OneOrMore {
   ///     `eager` by calling `repetitionBehavior(_:)` on the resulting
   ///     `Regex`.
   @_alwaysEmitIntoClient
-  public init<W, C1, C2, C3, C4, C5, C6, C7, Component: RegexComponent>(
-    _ component: Component,
+  public init<W, C1, C2, C3, C4, C5, C6, C7>(
+    _ component: some RegexComponent<(W, C1, C2, C3, C4, C5, C6, C7)>,
     _ behavior: RegexRepetitionBehavior? = nil
-  ) where RegexOutput == (Substring, C1, C2, C3, C4, C5, C6, C7), Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7) {
+  ) where RegexOutput == (Substring, C1, C2, C3, C4, C5, C6, C7) {
     let factory = makeFactory()
     self.init(factory.oneOrMore(component, behavior))
   }
@@ -2425,10 +2529,10 @@ extension OneOrMore {
   ///   - componentBuilder: A builder closure that generates a regex
   ///     component.
   @_alwaysEmitIntoClient
-  public init<W, C1, C2, C3, C4, C5, C6, C7, Component: RegexComponent>(
+  public init<W, C1, C2, C3, C4, C5, C6, C7>(
     _ behavior: RegexRepetitionBehavior? = nil,
-    @RegexComponentBuilder _ componentBuilder: () -> Component
-  ) where RegexOutput == (Substring, C1, C2, C3, C4, C5, C6, C7), Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7) {
+    @RegexComponentBuilder _ componentBuilder: () -> some RegexComponent<(W, C1, C2, C3, C4, C5, C6, C7)>
+  ) where RegexOutput == (Substring, C1, C2, C3, C4, C5, C6, C7) {
     let factory = makeFactory()
     self.init(factory.oneOrMore(componentBuilder(), behavior))
   }
@@ -2445,10 +2549,10 @@ extension Repeat {
   ///   - count: The number of times to repeat `component`. `count` must
   ///     be greater than or equal to zero.
   @_alwaysEmitIntoClient
-  public init<W, C1, C2, C3, C4, C5, C6, C7, Component: RegexComponent>(
-    _ component: Component,
+  public init<W, C1, C2, C3, C4, C5, C6, C7>(
+    _ component: some RegexComponent<(W, C1, C2, C3, C4, C5, C6, C7)>,
     count: Int
-  ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?, C6?, C7?), Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7) {
+  ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?, C6?, C7?) {
     precondition(count >= 0, "Must specify a positive count")
     let factory = makeFactory()
     self.init(factory.exactly(count, component))
@@ -2463,10 +2567,10 @@ extension Repeat {
   ///   - componentBuilder: A builder closure that creates the regex
   ///     component to repeat.
   @_alwaysEmitIntoClient
-  public init<W, C1, C2, C3, C4, C5, C6, C7, Component: RegexComponent>(
+  public init<W, C1, C2, C3, C4, C5, C6, C7>(
     count: Int,
-    @RegexComponentBuilder _ componentBuilder: () -> Component
-  ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?, C6?, C7?), Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7) {
+    @RegexComponentBuilder _ componentBuilder: () -> some RegexComponent<(W, C1, C2, C3, C4, C5, C6, C7)>
+  ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?, C6?, C7?) {
     precondition(count >= 0, "Must specify a positive count")
     let factory = makeFactory()
     self.init(factory.exactly(count, componentBuilder()))
@@ -2485,11 +2589,11 @@ extension Repeat {
   ///     `eager` by calling `repetitionBehavior(_:)` on the resulting
   ///     `Regex`.
   @_alwaysEmitIntoClient
-  public init<W, C1, C2, C3, C4, C5, C6, C7, Component: RegexComponent, R: RangeExpression>(
-    _ component: Component,
-    _ expression: R,
+  public init<W, C1, C2, C3, C4, C5, C6, C7>(
+    _ component: some RegexComponent<(W, C1, C2, C3, C4, C5, C6, C7)>,
+    _ expression: some RangeExpression<Int>,
     _ behavior: RegexRepetitionBehavior? = nil
-  ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?, C6?, C7?), Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7), R.Bound == Int {
+  ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?, C6?, C7?) {
     let factory = makeFactory()
     self.init(factory.repeating(expression.relative(to: 0..<Int.max), behavior, component))
   }
@@ -2508,15 +2612,17 @@ extension Repeat {
   ///   - componentBuilder: A builder closure that creates the regex
   ///     component to repeat.
   @_alwaysEmitIntoClient
-  public init<W, C1, C2, C3, C4, C5, C6, C7, Component: RegexComponent, R: RangeExpression>(
-    _ expression: R,
+  public init<W, C1, C2, C3, C4, C5, C6, C7>(
+    _ expression: some RangeExpression<Int>,
     _ behavior: RegexRepetitionBehavior? = nil,
-    @RegexComponentBuilder _ componentBuilder: () -> Component
-  ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?, C6?, C7?), Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7), R.Bound == Int {
+    @RegexComponentBuilder _ componentBuilder: () -> some RegexComponent<(W, C1, C2, C3, C4, C5, C6, C7)>
+  ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?, C6?, C7?) {
     let factory = makeFactory()
     self.init(factory.repeating(expression.relative(to: 0..<Int.max), behavior, componentBuilder()))
   }
 }
+// MARK: - Quantifiers (arity 8)
+
 @available(SwiftStdlib 5.7, *)
 extension Optionally {
   /// Creates a regex component that matches the given component
@@ -2530,10 +2636,10 @@ extension Optionally {
   ///     `eager` by calling `repetitionBehavior(_:)` on the resulting
   ///     `Regex`.
   @_alwaysEmitIntoClient
-  public init<W, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexComponent>(
-    _ component: Component,
+  public init<W, C1, C2, C3, C4, C5, C6, C7, C8>(
+    _ component: some RegexComponent<(W, C1, C2, C3, C4, C5, C6, C7, C8)>,
     _ behavior: RegexRepetitionBehavior? = nil
-  ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?), Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8) {
+  ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?) {
     let factory = makeFactory()
     self.init(factory.zeroOrOne(component, behavior))
   }
@@ -2553,10 +2659,10 @@ extension Optionally {
   ///   - componentBuilder: A builder closure that generates a regex
   ///     component.
   @_alwaysEmitIntoClient
-  public init<W, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexComponent>(
+  public init<W, C1, C2, C3, C4, C5, C6, C7, C8>(
     _ behavior: RegexRepetitionBehavior? = nil,
-    @RegexComponentBuilder _ componentBuilder: () -> Component
-  ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?), Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8) {
+    @RegexComponentBuilder _ componentBuilder: () -> some RegexComponent<(W, C1, C2, C3, C4, C5, C6, C7, C8)>
+  ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?) {
     let factory = makeFactory()
     self.init(factory.zeroOrOne(componentBuilder(), behavior))
   }
@@ -2565,9 +2671,9 @@ extension Optionally {
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
   @_alwaysEmitIntoClient
-  public static func buildLimitedAvailability<W, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexComponent>(
-    _ component: Component
-  ) -> Regex<(Substring, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?)> where Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8) {
+  public static func buildLimitedAvailability<W, C1, C2, C3, C4, C5, C6, C7, C8>(
+    _ component: some RegexComponent<(W, C1, C2, C3, C4, C5, C6, C7, C8)>
+  ) -> Regex<(Substring, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?)> {
     let factory = makeFactory()
     return factory.zeroOrOne(component, nil)
   }
@@ -2585,10 +2691,10 @@ extension ZeroOrMore {
   ///     `eager` by calling `repetitionBehavior(_:)` on the resulting
   ///     `Regex`.
   @_alwaysEmitIntoClient
-  public init<W, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexComponent>(
-    _ component: Component,
+  public init<W, C1, C2, C3, C4, C5, C6, C7, C8>(
+    _ component: some RegexComponent<(W, C1, C2, C3, C4, C5, C6, C7, C8)>,
     _ behavior: RegexRepetitionBehavior? = nil
-  ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?), Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8) {
+  ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?) {
     let factory = makeFactory()
     self.init(factory.zeroOrMore(component, behavior))
   }
@@ -2608,10 +2714,10 @@ extension ZeroOrMore {
   ///   - componentBuilder: A builder closure that generates a regex
   ///     component.
   @_alwaysEmitIntoClient
-  public init<W, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexComponent>(
+  public init<W, C1, C2, C3, C4, C5, C6, C7, C8>(
     _ behavior: RegexRepetitionBehavior? = nil,
-    @RegexComponentBuilder _ componentBuilder: () -> Component
-  ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?), Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8) {
+    @RegexComponentBuilder _ componentBuilder: () -> some RegexComponent<(W, C1, C2, C3, C4, C5, C6, C7, C8)>
+  ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?) {
     let factory = makeFactory()
     self.init(factory.zeroOrMore(componentBuilder(), behavior))
   }
@@ -2631,10 +2737,10 @@ extension OneOrMore {
   ///     `eager` by calling `repetitionBehavior(_:)` on the resulting
   ///     `Regex`.
   @_alwaysEmitIntoClient
-  public init<W, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexComponent>(
-    _ component: Component,
+  public init<W, C1, C2, C3, C4, C5, C6, C7, C8>(
+    _ component: some RegexComponent<(W, C1, C2, C3, C4, C5, C6, C7, C8)>,
     _ behavior: RegexRepetitionBehavior? = nil
-  ) where RegexOutput == (Substring, C1, C2, C3, C4, C5, C6, C7, C8), Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8) {
+  ) where RegexOutput == (Substring, C1, C2, C3, C4, C5, C6, C7, C8) {
     let factory = makeFactory()
     self.init(factory.oneOrMore(component, behavior))
   }
@@ -2654,10 +2760,10 @@ extension OneOrMore {
   ///   - componentBuilder: A builder closure that generates a regex
   ///     component.
   @_alwaysEmitIntoClient
-  public init<W, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexComponent>(
+  public init<W, C1, C2, C3, C4, C5, C6, C7, C8>(
     _ behavior: RegexRepetitionBehavior? = nil,
-    @RegexComponentBuilder _ componentBuilder: () -> Component
-  ) where RegexOutput == (Substring, C1, C2, C3, C4, C5, C6, C7, C8), Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8) {
+    @RegexComponentBuilder _ componentBuilder: () -> some RegexComponent<(W, C1, C2, C3, C4, C5, C6, C7, C8)>
+  ) where RegexOutput == (Substring, C1, C2, C3, C4, C5, C6, C7, C8) {
     let factory = makeFactory()
     self.init(factory.oneOrMore(componentBuilder(), behavior))
   }
@@ -2674,10 +2780,10 @@ extension Repeat {
   ///   - count: The number of times to repeat `component`. `count` must
   ///     be greater than or equal to zero.
   @_alwaysEmitIntoClient
-  public init<W, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexComponent>(
-    _ component: Component,
+  public init<W, C1, C2, C3, C4, C5, C6, C7, C8>(
+    _ component: some RegexComponent<(W, C1, C2, C3, C4, C5, C6, C7, C8)>,
     count: Int
-  ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?), Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8) {
+  ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?) {
     precondition(count >= 0, "Must specify a positive count")
     let factory = makeFactory()
     self.init(factory.exactly(count, component))
@@ -2692,10 +2798,10 @@ extension Repeat {
   ///   - componentBuilder: A builder closure that creates the regex
   ///     component to repeat.
   @_alwaysEmitIntoClient
-  public init<W, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexComponent>(
+  public init<W, C1, C2, C3, C4, C5, C6, C7, C8>(
     count: Int,
-    @RegexComponentBuilder _ componentBuilder: () -> Component
-  ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?), Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8) {
+    @RegexComponentBuilder _ componentBuilder: () -> some RegexComponent<(W, C1, C2, C3, C4, C5, C6, C7, C8)>
+  ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?) {
     precondition(count >= 0, "Must specify a positive count")
     let factory = makeFactory()
     self.init(factory.exactly(count, componentBuilder()))
@@ -2714,11 +2820,11 @@ extension Repeat {
   ///     `eager` by calling `repetitionBehavior(_:)` on the resulting
   ///     `Regex`.
   @_alwaysEmitIntoClient
-  public init<W, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexComponent, R: RangeExpression>(
-    _ component: Component,
-    _ expression: R,
+  public init<W, C1, C2, C3, C4, C5, C6, C7, C8>(
+    _ component: some RegexComponent<(W, C1, C2, C3, C4, C5, C6, C7, C8)>,
+    _ expression: some RangeExpression<Int>,
     _ behavior: RegexRepetitionBehavior? = nil
-  ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?), Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8), R.Bound == Int {
+  ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?) {
     let factory = makeFactory()
     self.init(factory.repeating(expression.relative(to: 0..<Int.max), behavior, component))
   }
@@ -2737,15 +2843,17 @@ extension Repeat {
   ///   - componentBuilder: A builder closure that creates the regex
   ///     component to repeat.
   @_alwaysEmitIntoClient
-  public init<W, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexComponent, R: RangeExpression>(
-    _ expression: R,
+  public init<W, C1, C2, C3, C4, C5, C6, C7, C8>(
+    _ expression: some RangeExpression<Int>,
     _ behavior: RegexRepetitionBehavior? = nil,
-    @RegexComponentBuilder _ componentBuilder: () -> Component
-  ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?), Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8), R.Bound == Int {
+    @RegexComponentBuilder _ componentBuilder: () -> some RegexComponent<(W, C1, C2, C3, C4, C5, C6, C7, C8)>
+  ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?) {
     let factory = makeFactory()
     self.init(factory.repeating(expression.relative(to: 0..<Int.max), behavior, componentBuilder()))
   }
 }
+// MARK: - Quantifiers (arity 9)
+
 @available(SwiftStdlib 5.7, *)
 extension Optionally {
   /// Creates a regex component that matches the given component
@@ -2759,10 +2867,10 @@ extension Optionally {
   ///     `eager` by calling `repetitionBehavior(_:)` on the resulting
   ///     `Regex`.
   @_alwaysEmitIntoClient
-  public init<W, C1, C2, C3, C4, C5, C6, C7, C8, C9, Component: RegexComponent>(
-    _ component: Component,
+  public init<W, C1, C2, C3, C4, C5, C6, C7, C8, C9>(
+    _ component: some RegexComponent<(W, C1, C2, C3, C4, C5, C6, C7, C8, C9)>,
     _ behavior: RegexRepetitionBehavior? = nil
-  ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?), Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
+  ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?) {
     let factory = makeFactory()
     self.init(factory.zeroOrOne(component, behavior))
   }
@@ -2782,10 +2890,10 @@ extension Optionally {
   ///   - componentBuilder: A builder closure that generates a regex
   ///     component.
   @_alwaysEmitIntoClient
-  public init<W, C1, C2, C3, C4, C5, C6, C7, C8, C9, Component: RegexComponent>(
+  public init<W, C1, C2, C3, C4, C5, C6, C7, C8, C9>(
     _ behavior: RegexRepetitionBehavior? = nil,
-    @RegexComponentBuilder _ componentBuilder: () -> Component
-  ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?), Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
+    @RegexComponentBuilder _ componentBuilder: () -> some RegexComponent<(W, C1, C2, C3, C4, C5, C6, C7, C8, C9)>
+  ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?) {
     let factory = makeFactory()
     self.init(factory.zeroOrOne(componentBuilder(), behavior))
   }
@@ -2794,9 +2902,9 @@ extension Optionally {
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
   @_alwaysEmitIntoClient
-  public static func buildLimitedAvailability<W, C1, C2, C3, C4, C5, C6, C7, C8, C9, Component: RegexComponent>(
-    _ component: Component
-  ) -> Regex<(Substring, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?)> where Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
+  public static func buildLimitedAvailability<W, C1, C2, C3, C4, C5, C6, C7, C8, C9>(
+    _ component: some RegexComponent<(W, C1, C2, C3, C4, C5, C6, C7, C8, C9)>
+  ) -> Regex<(Substring, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?)> {
     let factory = makeFactory()
     return factory.zeroOrOne(component, nil)
   }
@@ -2814,10 +2922,10 @@ extension ZeroOrMore {
   ///     `eager` by calling `repetitionBehavior(_:)` on the resulting
   ///     `Regex`.
   @_alwaysEmitIntoClient
-  public init<W, C1, C2, C3, C4, C5, C6, C7, C8, C9, Component: RegexComponent>(
-    _ component: Component,
+  public init<W, C1, C2, C3, C4, C5, C6, C7, C8, C9>(
+    _ component: some RegexComponent<(W, C1, C2, C3, C4, C5, C6, C7, C8, C9)>,
     _ behavior: RegexRepetitionBehavior? = nil
-  ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?), Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
+  ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?) {
     let factory = makeFactory()
     self.init(factory.zeroOrMore(component, behavior))
   }
@@ -2837,10 +2945,10 @@ extension ZeroOrMore {
   ///   - componentBuilder: A builder closure that generates a regex
   ///     component.
   @_alwaysEmitIntoClient
-  public init<W, C1, C2, C3, C4, C5, C6, C7, C8, C9, Component: RegexComponent>(
+  public init<W, C1, C2, C3, C4, C5, C6, C7, C8, C9>(
     _ behavior: RegexRepetitionBehavior? = nil,
-    @RegexComponentBuilder _ componentBuilder: () -> Component
-  ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?), Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
+    @RegexComponentBuilder _ componentBuilder: () -> some RegexComponent<(W, C1, C2, C3, C4, C5, C6, C7, C8, C9)>
+  ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?) {
     let factory = makeFactory()
     self.init(factory.zeroOrMore(componentBuilder(), behavior))
   }
@@ -2860,10 +2968,10 @@ extension OneOrMore {
   ///     `eager` by calling `repetitionBehavior(_:)` on the resulting
   ///     `Regex`.
   @_alwaysEmitIntoClient
-  public init<W, C1, C2, C3, C4, C5, C6, C7, C8, C9, Component: RegexComponent>(
-    _ component: Component,
+  public init<W, C1, C2, C3, C4, C5, C6, C7, C8, C9>(
+    _ component: some RegexComponent<(W, C1, C2, C3, C4, C5, C6, C7, C8, C9)>,
     _ behavior: RegexRepetitionBehavior? = nil
-  ) where RegexOutput == (Substring, C1, C2, C3, C4, C5, C6, C7, C8, C9), Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
+  ) where RegexOutput == (Substring, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
     let factory = makeFactory()
     self.init(factory.oneOrMore(component, behavior))
   }
@@ -2883,10 +2991,10 @@ extension OneOrMore {
   ///   - componentBuilder: A builder closure that generates a regex
   ///     component.
   @_alwaysEmitIntoClient
-  public init<W, C1, C2, C3, C4, C5, C6, C7, C8, C9, Component: RegexComponent>(
+  public init<W, C1, C2, C3, C4, C5, C6, C7, C8, C9>(
     _ behavior: RegexRepetitionBehavior? = nil,
-    @RegexComponentBuilder _ componentBuilder: () -> Component
-  ) where RegexOutput == (Substring, C1, C2, C3, C4, C5, C6, C7, C8, C9), Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
+    @RegexComponentBuilder _ componentBuilder: () -> some RegexComponent<(W, C1, C2, C3, C4, C5, C6, C7, C8, C9)>
+  ) where RegexOutput == (Substring, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
     let factory = makeFactory()
     self.init(factory.oneOrMore(componentBuilder(), behavior))
   }
@@ -2903,10 +3011,10 @@ extension Repeat {
   ///   - count: The number of times to repeat `component`. `count` must
   ///     be greater than or equal to zero.
   @_alwaysEmitIntoClient
-  public init<W, C1, C2, C3, C4, C5, C6, C7, C8, C9, Component: RegexComponent>(
-    _ component: Component,
+  public init<W, C1, C2, C3, C4, C5, C6, C7, C8, C9>(
+    _ component: some RegexComponent<(W, C1, C2, C3, C4, C5, C6, C7, C8, C9)>,
     count: Int
-  ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?), Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
+  ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?) {
     precondition(count >= 0, "Must specify a positive count")
     let factory = makeFactory()
     self.init(factory.exactly(count, component))
@@ -2921,10 +3029,10 @@ extension Repeat {
   ///   - componentBuilder: A builder closure that creates the regex
   ///     component to repeat.
   @_alwaysEmitIntoClient
-  public init<W, C1, C2, C3, C4, C5, C6, C7, C8, C9, Component: RegexComponent>(
+  public init<W, C1, C2, C3, C4, C5, C6, C7, C8, C9>(
     count: Int,
-    @RegexComponentBuilder _ componentBuilder: () -> Component
-  ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?), Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
+    @RegexComponentBuilder _ componentBuilder: () -> some RegexComponent<(W, C1, C2, C3, C4, C5, C6, C7, C8, C9)>
+  ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?) {
     precondition(count >= 0, "Must specify a positive count")
     let factory = makeFactory()
     self.init(factory.exactly(count, componentBuilder()))
@@ -2943,11 +3051,11 @@ extension Repeat {
   ///     `eager` by calling `repetitionBehavior(_:)` on the resulting
   ///     `Regex`.
   @_alwaysEmitIntoClient
-  public init<W, C1, C2, C3, C4, C5, C6, C7, C8, C9, Component: RegexComponent, R: RangeExpression>(
-    _ component: Component,
-    _ expression: R,
+  public init<W, C1, C2, C3, C4, C5, C6, C7, C8, C9>(
+    _ component: some RegexComponent<(W, C1, C2, C3, C4, C5, C6, C7, C8, C9)>,
+    _ expression: some RangeExpression<Int>,
     _ behavior: RegexRepetitionBehavior? = nil
-  ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?), Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8, C9), R.Bound == Int {
+  ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?) {
     let factory = makeFactory()
     self.init(factory.repeating(expression.relative(to: 0..<Int.max), behavior, component))
   }
@@ -2966,15 +3074,17 @@ extension Repeat {
   ///   - componentBuilder: A builder closure that creates the regex
   ///     component to repeat.
   @_alwaysEmitIntoClient
-  public init<W, C1, C2, C3, C4, C5, C6, C7, C8, C9, Component: RegexComponent, R: RangeExpression>(
-    _ expression: R,
+  public init<W, C1, C2, C3, C4, C5, C6, C7, C8, C9>(
+    _ expression: some RangeExpression<Int>,
     _ behavior: RegexRepetitionBehavior? = nil,
-    @RegexComponentBuilder _ componentBuilder: () -> Component
-  ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?), Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8, C9), R.Bound == Int {
+    @RegexComponentBuilder _ componentBuilder: () -> some RegexComponent<(W, C1, C2, C3, C4, C5, C6, C7, C8, C9)>
+  ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?) {
     let factory = makeFactory()
     self.init(factory.repeating(expression.relative(to: 0..<Int.max), behavior, componentBuilder()))
   }
 }
+// MARK: - Quantifiers (arity 10)
+
 @available(SwiftStdlib 5.7, *)
 extension Optionally {
   /// Creates a regex component that matches the given component
@@ -2988,10 +3098,10 @@ extension Optionally {
   ///     `eager` by calling `repetitionBehavior(_:)` on the resulting
   ///     `Regex`.
   @_alwaysEmitIntoClient
-  public init<W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, Component: RegexComponent>(
-    _ component: Component,
+  public init<W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10>(
+    _ component: some RegexComponent<(W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10)>,
     _ behavior: RegexRepetitionBehavior? = nil
-  ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?, C10?), Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10) {
+  ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?, C10?) {
     let factory = makeFactory()
     self.init(factory.zeroOrOne(component, behavior))
   }
@@ -3011,10 +3121,10 @@ extension Optionally {
   ///   - componentBuilder: A builder closure that generates a regex
   ///     component.
   @_alwaysEmitIntoClient
-  public init<W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, Component: RegexComponent>(
+  public init<W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10>(
     _ behavior: RegexRepetitionBehavior? = nil,
-    @RegexComponentBuilder _ componentBuilder: () -> Component
-  ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?, C10?), Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10) {
+    @RegexComponentBuilder _ componentBuilder: () -> some RegexComponent<(W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10)>
+  ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?, C10?) {
     let factory = makeFactory()
     self.init(factory.zeroOrOne(componentBuilder(), behavior))
   }
@@ -3023,9 +3133,9 @@ extension Optionally {
 @available(SwiftStdlib 5.7, *)
 extension RegexComponentBuilder {
   @_alwaysEmitIntoClient
-  public static func buildLimitedAvailability<W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, Component: RegexComponent>(
-    _ component: Component
-  ) -> Regex<(Substring, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?, C10?)> where Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10) {
+  public static func buildLimitedAvailability<W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10>(
+    _ component: some RegexComponent<(W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10)>
+  ) -> Regex<(Substring, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?, C10?)> {
     let factory = makeFactory()
     return factory.zeroOrOne(component, nil)
   }
@@ -3043,10 +3153,10 @@ extension ZeroOrMore {
   ///     `eager` by calling `repetitionBehavior(_:)` on the resulting
   ///     `Regex`.
   @_alwaysEmitIntoClient
-  public init<W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, Component: RegexComponent>(
-    _ component: Component,
+  public init<W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10>(
+    _ component: some RegexComponent<(W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10)>,
     _ behavior: RegexRepetitionBehavior? = nil
-  ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?, C10?), Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10) {
+  ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?, C10?) {
     let factory = makeFactory()
     self.init(factory.zeroOrMore(component, behavior))
   }
@@ -3066,10 +3176,10 @@ extension ZeroOrMore {
   ///   - componentBuilder: A builder closure that generates a regex
   ///     component.
   @_alwaysEmitIntoClient
-  public init<W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, Component: RegexComponent>(
+  public init<W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10>(
     _ behavior: RegexRepetitionBehavior? = nil,
-    @RegexComponentBuilder _ componentBuilder: () -> Component
-  ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?, C10?), Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10) {
+    @RegexComponentBuilder _ componentBuilder: () -> some RegexComponent<(W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10)>
+  ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?, C10?) {
     let factory = makeFactory()
     self.init(factory.zeroOrMore(componentBuilder(), behavior))
   }
@@ -3089,10 +3199,10 @@ extension OneOrMore {
   ///     `eager` by calling `repetitionBehavior(_:)` on the resulting
   ///     `Regex`.
   @_alwaysEmitIntoClient
-  public init<W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, Component: RegexComponent>(
-    _ component: Component,
+  public init<W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10>(
+    _ component: some RegexComponent<(W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10)>,
     _ behavior: RegexRepetitionBehavior? = nil
-  ) where RegexOutput == (Substring, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10), Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10) {
+  ) where RegexOutput == (Substring, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10) {
     let factory = makeFactory()
     self.init(factory.oneOrMore(component, behavior))
   }
@@ -3112,10 +3222,10 @@ extension OneOrMore {
   ///   - componentBuilder: A builder closure that generates a regex
   ///     component.
   @_alwaysEmitIntoClient
-  public init<W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, Component: RegexComponent>(
+  public init<W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10>(
     _ behavior: RegexRepetitionBehavior? = nil,
-    @RegexComponentBuilder _ componentBuilder: () -> Component
-  ) where RegexOutput == (Substring, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10), Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10) {
+    @RegexComponentBuilder _ componentBuilder: () -> some RegexComponent<(W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10)>
+  ) where RegexOutput == (Substring, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10) {
     let factory = makeFactory()
     self.init(factory.oneOrMore(componentBuilder(), behavior))
   }
@@ -3132,10 +3242,10 @@ extension Repeat {
   ///   - count: The number of times to repeat `component`. `count` must
   ///     be greater than or equal to zero.
   @_alwaysEmitIntoClient
-  public init<W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, Component: RegexComponent>(
-    _ component: Component,
+  public init<W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10>(
+    _ component: some RegexComponent<(W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10)>,
     count: Int
-  ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?, C10?), Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10) {
+  ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?, C10?) {
     precondition(count >= 0, "Must specify a positive count")
     let factory = makeFactory()
     self.init(factory.exactly(count, component))
@@ -3150,10 +3260,10 @@ extension Repeat {
   ///   - componentBuilder: A builder closure that creates the regex
   ///     component to repeat.
   @_alwaysEmitIntoClient
-  public init<W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, Component: RegexComponent>(
+  public init<W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10>(
     count: Int,
-    @RegexComponentBuilder _ componentBuilder: () -> Component
-  ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?, C10?), Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10) {
+    @RegexComponentBuilder _ componentBuilder: () -> some RegexComponent<(W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10)>
+  ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?, C10?) {
     precondition(count >= 0, "Must specify a positive count")
     let factory = makeFactory()
     self.init(factory.exactly(count, componentBuilder()))
@@ -3172,11 +3282,11 @@ extension Repeat {
   ///     `eager` by calling `repetitionBehavior(_:)` on the resulting
   ///     `Regex`.
   @_alwaysEmitIntoClient
-  public init<W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, Component: RegexComponent, R: RangeExpression>(
-    _ component: Component,
-    _ expression: R,
+  public init<W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10>(
+    _ component: some RegexComponent<(W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10)>,
+    _ expression: some RangeExpression<Int>,
     _ behavior: RegexRepetitionBehavior? = nil
-  ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?, C10?), Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10), R.Bound == Int {
+  ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?, C10?) {
     let factory = makeFactory()
     self.init(factory.repeating(expression.relative(to: 0..<Int.max), behavior, component))
   }
@@ -3195,15 +3305,17 @@ extension Repeat {
   ///   - componentBuilder: A builder closure that creates the regex
   ///     component to repeat.
   @_alwaysEmitIntoClient
-  public init<W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, Component: RegexComponent, R: RangeExpression>(
-    _ expression: R,
+  public init<W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10>(
+    _ expression: some RangeExpression<Int>,
     _ behavior: RegexRepetitionBehavior? = nil,
-    @RegexComponentBuilder _ componentBuilder: () -> Component
-  ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?, C10?), Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10), R.Bound == Int {
+    @RegexComponentBuilder _ componentBuilder: () -> some RegexComponent<(W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10)>
+  ) where RegexOutput == (Substring, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?, C10?) {
     let factory = makeFactory()
     self.init(factory.repeating(expression.relative(to: 0..<Int.max), behavior, componentBuilder()))
   }
 }
+// MARK: - Atomic groups
+
 @available(SwiftStdlib 5.7, *)
 extension Local {
   /// Creates an atomic group with the given regex component.
@@ -3213,8 +3325,8 @@ extension Local {
   @available(SwiftStdlib 5.7, *)
   @_disfavoredOverload
   @_alwaysEmitIntoClient
-  public init<Component: RegexComponent>(
-    _ component: Component
+  public init(
+    _ component: some RegexComponent
   ) where RegexOutput == Substring {
     let factory = makeFactory()
     self.init(factory.atomicNonCapturing(component))
@@ -3230,8 +3342,8 @@ extension Local {
   @available(SwiftStdlib 5.7, *)
   @_disfavoredOverload
   @_alwaysEmitIntoClient
-  public init<Component: RegexComponent>(
-    @RegexComponentBuilder _ componentBuilder: () -> Component
+  public init(
+    @RegexComponentBuilder _ componentBuilder: () -> some RegexComponent
   ) where RegexOutput == Substring {
     let factory = makeFactory()
     self.init(factory.atomicNonCapturing(componentBuilder()))
@@ -3245,9 +3357,9 @@ extension Local {
   ///   group.
   @available(SwiftStdlib 5.7, *)
   @_alwaysEmitIntoClient
-  public init<W, C1, Component: RegexComponent>(
-    _ component: Component
-  ) where RegexOutput == (Substring, C1), Component.RegexOutput == (W, C1) {
+  public init<W, C1>(
+    _ component: some RegexComponent<(W, C1)>
+  ) where RegexOutput == (Substring, C1) {
     let factory = makeFactory()
     self.init(factory.atomicNonCapturing(component))
   }
@@ -3261,9 +3373,9 @@ extension Local {
   ///   regex component to wrap in an atomic group.
   @available(SwiftStdlib 5.7, *)
   @_alwaysEmitIntoClient
-  public init<W, C1, Component: RegexComponent>(
-    @RegexComponentBuilder _ componentBuilder: () -> Component
-  ) where RegexOutput == (Substring, C1), Component.RegexOutput == (W, C1) {
+  public init<W, C1>(
+    @RegexComponentBuilder _ componentBuilder: () -> some RegexComponent<(W, C1)>
+  ) where RegexOutput == (Substring, C1) {
     let factory = makeFactory()
     self.init(factory.atomicNonCapturing(componentBuilder()))
   }
@@ -3276,9 +3388,9 @@ extension Local {
   ///   group.
   @available(SwiftStdlib 5.7, *)
   @_alwaysEmitIntoClient
-  public init<W, C1, C2, Component: RegexComponent>(
-    _ component: Component
-  ) where RegexOutput == (Substring, C1, C2), Component.RegexOutput == (W, C1, C2) {
+  public init<W, C1, C2>(
+    _ component: some RegexComponent<(W, C1, C2)>
+  ) where RegexOutput == (Substring, C1, C2) {
     let factory = makeFactory()
     self.init(factory.atomicNonCapturing(component))
   }
@@ -3292,9 +3404,9 @@ extension Local {
   ///   regex component to wrap in an atomic group.
   @available(SwiftStdlib 5.7, *)
   @_alwaysEmitIntoClient
-  public init<W, C1, C2, Component: RegexComponent>(
-    @RegexComponentBuilder _ componentBuilder: () -> Component
-  ) where RegexOutput == (Substring, C1, C2), Component.RegexOutput == (W, C1, C2) {
+  public init<W, C1, C2>(
+    @RegexComponentBuilder _ componentBuilder: () -> some RegexComponent<(W, C1, C2)>
+  ) where RegexOutput == (Substring, C1, C2) {
     let factory = makeFactory()
     self.init(factory.atomicNonCapturing(componentBuilder()))
   }
@@ -3307,9 +3419,9 @@ extension Local {
   ///   group.
   @available(SwiftStdlib 5.7, *)
   @_alwaysEmitIntoClient
-  public init<W, C1, C2, C3, Component: RegexComponent>(
-    _ component: Component
-  ) where RegexOutput == (Substring, C1, C2, C3), Component.RegexOutput == (W, C1, C2, C3) {
+  public init<W, C1, C2, C3>(
+    _ component: some RegexComponent<(W, C1, C2, C3)>
+  ) where RegexOutput == (Substring, C1, C2, C3) {
     let factory = makeFactory()
     self.init(factory.atomicNonCapturing(component))
   }
@@ -3323,9 +3435,9 @@ extension Local {
   ///   regex component to wrap in an atomic group.
   @available(SwiftStdlib 5.7, *)
   @_alwaysEmitIntoClient
-  public init<W, C1, C2, C3, Component: RegexComponent>(
-    @RegexComponentBuilder _ componentBuilder: () -> Component
-  ) where RegexOutput == (Substring, C1, C2, C3), Component.RegexOutput == (W, C1, C2, C3) {
+  public init<W, C1, C2, C3>(
+    @RegexComponentBuilder _ componentBuilder: () -> some RegexComponent<(W, C1, C2, C3)>
+  ) where RegexOutput == (Substring, C1, C2, C3) {
     let factory = makeFactory()
     self.init(factory.atomicNonCapturing(componentBuilder()))
   }
@@ -3338,9 +3450,9 @@ extension Local {
   ///   group.
   @available(SwiftStdlib 5.7, *)
   @_alwaysEmitIntoClient
-  public init<W, C1, C2, C3, C4, Component: RegexComponent>(
-    _ component: Component
-  ) where RegexOutput == (Substring, C1, C2, C3, C4), Component.RegexOutput == (W, C1, C2, C3, C4) {
+  public init<W, C1, C2, C3, C4>(
+    _ component: some RegexComponent<(W, C1, C2, C3, C4)>
+  ) where RegexOutput == (Substring, C1, C2, C3, C4) {
     let factory = makeFactory()
     self.init(factory.atomicNonCapturing(component))
   }
@@ -3354,9 +3466,9 @@ extension Local {
   ///   regex component to wrap in an atomic group.
   @available(SwiftStdlib 5.7, *)
   @_alwaysEmitIntoClient
-  public init<W, C1, C2, C3, C4, Component: RegexComponent>(
-    @RegexComponentBuilder _ componentBuilder: () -> Component
-  ) where RegexOutput == (Substring, C1, C2, C3, C4), Component.RegexOutput == (W, C1, C2, C3, C4) {
+  public init<W, C1, C2, C3, C4>(
+    @RegexComponentBuilder _ componentBuilder: () -> some RegexComponent<(W, C1, C2, C3, C4)>
+  ) where RegexOutput == (Substring, C1, C2, C3, C4) {
     let factory = makeFactory()
     self.init(factory.atomicNonCapturing(componentBuilder()))
   }
@@ -3369,9 +3481,9 @@ extension Local {
   ///   group.
   @available(SwiftStdlib 5.7, *)
   @_alwaysEmitIntoClient
-  public init<W, C1, C2, C3, C4, C5, Component: RegexComponent>(
-    _ component: Component
-  ) where RegexOutput == (Substring, C1, C2, C3, C4, C5), Component.RegexOutput == (W, C1, C2, C3, C4, C5) {
+  public init<W, C1, C2, C3, C4, C5>(
+    _ component: some RegexComponent<(W, C1, C2, C3, C4, C5)>
+  ) where RegexOutput == (Substring, C1, C2, C3, C4, C5) {
     let factory = makeFactory()
     self.init(factory.atomicNonCapturing(component))
   }
@@ -3385,9 +3497,9 @@ extension Local {
   ///   regex component to wrap in an atomic group.
   @available(SwiftStdlib 5.7, *)
   @_alwaysEmitIntoClient
-  public init<W, C1, C2, C3, C4, C5, Component: RegexComponent>(
-    @RegexComponentBuilder _ componentBuilder: () -> Component
-  ) where RegexOutput == (Substring, C1, C2, C3, C4, C5), Component.RegexOutput == (W, C1, C2, C3, C4, C5) {
+  public init<W, C1, C2, C3, C4, C5>(
+    @RegexComponentBuilder _ componentBuilder: () -> some RegexComponent<(W, C1, C2, C3, C4, C5)>
+  ) where RegexOutput == (Substring, C1, C2, C3, C4, C5) {
     let factory = makeFactory()
     self.init(factory.atomicNonCapturing(componentBuilder()))
   }
@@ -3400,9 +3512,9 @@ extension Local {
   ///   group.
   @available(SwiftStdlib 5.7, *)
   @_alwaysEmitIntoClient
-  public init<W, C1, C2, C3, C4, C5, C6, Component: RegexComponent>(
-    _ component: Component
-  ) where RegexOutput == (Substring, C1, C2, C3, C4, C5, C6), Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6) {
+  public init<W, C1, C2, C3, C4, C5, C6>(
+    _ component: some RegexComponent<(W, C1, C2, C3, C4, C5, C6)>
+  ) where RegexOutput == (Substring, C1, C2, C3, C4, C5, C6) {
     let factory = makeFactory()
     self.init(factory.atomicNonCapturing(component))
   }
@@ -3416,9 +3528,9 @@ extension Local {
   ///   regex component to wrap in an atomic group.
   @available(SwiftStdlib 5.7, *)
   @_alwaysEmitIntoClient
-  public init<W, C1, C2, C3, C4, C5, C6, Component: RegexComponent>(
-    @RegexComponentBuilder _ componentBuilder: () -> Component
-  ) where RegexOutput == (Substring, C1, C2, C3, C4, C5, C6), Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6) {
+  public init<W, C1, C2, C3, C4, C5, C6>(
+    @RegexComponentBuilder _ componentBuilder: () -> some RegexComponent<(W, C1, C2, C3, C4, C5, C6)>
+  ) where RegexOutput == (Substring, C1, C2, C3, C4, C5, C6) {
     let factory = makeFactory()
     self.init(factory.atomicNonCapturing(componentBuilder()))
   }
@@ -3431,9 +3543,9 @@ extension Local {
   ///   group.
   @available(SwiftStdlib 5.7, *)
   @_alwaysEmitIntoClient
-  public init<W, C1, C2, C3, C4, C5, C6, C7, Component: RegexComponent>(
-    _ component: Component
-  ) where RegexOutput == (Substring, C1, C2, C3, C4, C5, C6, C7), Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7) {
+  public init<W, C1, C2, C3, C4, C5, C6, C7>(
+    _ component: some RegexComponent<(W, C1, C2, C3, C4, C5, C6, C7)>
+  ) where RegexOutput == (Substring, C1, C2, C3, C4, C5, C6, C7) {
     let factory = makeFactory()
     self.init(factory.atomicNonCapturing(component))
   }
@@ -3447,9 +3559,9 @@ extension Local {
   ///   regex component to wrap in an atomic group.
   @available(SwiftStdlib 5.7, *)
   @_alwaysEmitIntoClient
-  public init<W, C1, C2, C3, C4, C5, C6, C7, Component: RegexComponent>(
-    @RegexComponentBuilder _ componentBuilder: () -> Component
-  ) where RegexOutput == (Substring, C1, C2, C3, C4, C5, C6, C7), Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7) {
+  public init<W, C1, C2, C3, C4, C5, C6, C7>(
+    @RegexComponentBuilder _ componentBuilder: () -> some RegexComponent<(W, C1, C2, C3, C4, C5, C6, C7)>
+  ) where RegexOutput == (Substring, C1, C2, C3, C4, C5, C6, C7) {
     let factory = makeFactory()
     self.init(factory.atomicNonCapturing(componentBuilder()))
   }
@@ -3462,9 +3574,9 @@ extension Local {
   ///   group.
   @available(SwiftStdlib 5.7, *)
   @_alwaysEmitIntoClient
-  public init<W, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexComponent>(
-    _ component: Component
-  ) where RegexOutput == (Substring, C1, C2, C3, C4, C5, C6, C7, C8), Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8) {
+  public init<W, C1, C2, C3, C4, C5, C6, C7, C8>(
+    _ component: some RegexComponent<(W, C1, C2, C3, C4, C5, C6, C7, C8)>
+  ) where RegexOutput == (Substring, C1, C2, C3, C4, C5, C6, C7, C8) {
     let factory = makeFactory()
     self.init(factory.atomicNonCapturing(component))
   }
@@ -3478,9 +3590,9 @@ extension Local {
   ///   regex component to wrap in an atomic group.
   @available(SwiftStdlib 5.7, *)
   @_alwaysEmitIntoClient
-  public init<W, C1, C2, C3, C4, C5, C6, C7, C8, Component: RegexComponent>(
-    @RegexComponentBuilder _ componentBuilder: () -> Component
-  ) where RegexOutput == (Substring, C1, C2, C3, C4, C5, C6, C7, C8), Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8) {
+  public init<W, C1, C2, C3, C4, C5, C6, C7, C8>(
+    @RegexComponentBuilder _ componentBuilder: () -> some RegexComponent<(W, C1, C2, C3, C4, C5, C6, C7, C8)>
+  ) where RegexOutput == (Substring, C1, C2, C3, C4, C5, C6, C7, C8) {
     let factory = makeFactory()
     self.init(factory.atomicNonCapturing(componentBuilder()))
   }
@@ -3493,9 +3605,9 @@ extension Local {
   ///   group.
   @available(SwiftStdlib 5.7, *)
   @_alwaysEmitIntoClient
-  public init<W, C1, C2, C3, C4, C5, C6, C7, C8, C9, Component: RegexComponent>(
-    _ component: Component
-  ) where RegexOutput == (Substring, C1, C2, C3, C4, C5, C6, C7, C8, C9), Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
+  public init<W, C1, C2, C3, C4, C5, C6, C7, C8, C9>(
+    _ component: some RegexComponent<(W, C1, C2, C3, C4, C5, C6, C7, C8, C9)>
+  ) where RegexOutput == (Substring, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
     let factory = makeFactory()
     self.init(factory.atomicNonCapturing(component))
   }
@@ -3509,9 +3621,9 @@ extension Local {
   ///   regex component to wrap in an atomic group.
   @available(SwiftStdlib 5.7, *)
   @_alwaysEmitIntoClient
-  public init<W, C1, C2, C3, C4, C5, C6, C7, C8, C9, Component: RegexComponent>(
-    @RegexComponentBuilder _ componentBuilder: () -> Component
-  ) where RegexOutput == (Substring, C1, C2, C3, C4, C5, C6, C7, C8, C9), Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
+  public init<W, C1, C2, C3, C4, C5, C6, C7, C8, C9>(
+    @RegexComponentBuilder _ componentBuilder: () -> some RegexComponent<(W, C1, C2, C3, C4, C5, C6, C7, C8, C9)>
+  ) where RegexOutput == (Substring, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
     let factory = makeFactory()
     self.init(factory.atomicNonCapturing(componentBuilder()))
   }
@@ -3524,9 +3636,9 @@ extension Local {
   ///   group.
   @available(SwiftStdlib 5.7, *)
   @_alwaysEmitIntoClient
-  public init<W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, Component: RegexComponent>(
-    _ component: Component
-  ) where RegexOutput == (Substring, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10), Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10) {
+  public init<W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10>(
+    _ component: some RegexComponent<(W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10)>
+  ) where RegexOutput == (Substring, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10) {
     let factory = makeFactory()
     self.init(factory.atomicNonCapturing(component))
   }
@@ -3540,19 +3652,22 @@ extension Local {
   ///   regex component to wrap in an atomic group.
   @available(SwiftStdlib 5.7, *)
   @_alwaysEmitIntoClient
-  public init<W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, Component: RegexComponent>(
-    @RegexComponentBuilder _ componentBuilder: () -> Component
-  ) where RegexOutput == (Substring, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10), Component.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10) {
+  public init<W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10>(
+    @RegexComponentBuilder _ componentBuilder: () -> some RegexComponent<(W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10)>
+  ) where RegexOutput == (Substring, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10) {
     let factory = makeFactory()
     self.init(factory.atomicNonCapturing(componentBuilder()))
   }
 }
+// MARK: - Alternation builder (arity 0)
+
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
   @_alwaysEmitIntoClient
-  public static func buildPartialBlock<R0, R1>(
-    accumulated: R0, next: R1
-  ) -> ChoiceOf<Substring> where R0: RegexComponent, R1: RegexComponent {
+  public static func buildPartialBlock(
+    accumulated: some RegexComponent,
+    next: some RegexComponent
+  ) -> ChoiceOf<Substring> {
     let factory = makeFactory()
     return .init(factory.accumulateAlternation(accumulated, next))
   }
@@ -3560,9 +3675,10 @@ extension AlternationBuilder {
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
   @_alwaysEmitIntoClient
-  public static func buildPartialBlock<R0, R1, W1, C0>(
-    accumulated: R0, next: R1
-  ) -> ChoiceOf<(Substring, C0?)> where R0: RegexComponent, R1: RegexComponent, R1.RegexOutput == (W1, C0) {
+  public static func buildPartialBlock<W1, C1>(
+    accumulated: some RegexComponent,
+    next: some RegexComponent<(W1, C1)>
+  ) -> ChoiceOf<(Substring, C1?)> {
     let factory = makeFactory()
     return .init(factory.accumulateAlternation(accumulated, next))
   }
@@ -3570,9 +3686,10 @@ extension AlternationBuilder {
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
   @_alwaysEmitIntoClient
-  public static func buildPartialBlock<R0, R1, W1, C0, C1>(
-    accumulated: R0, next: R1
-  ) -> ChoiceOf<(Substring, C0?, C1?)> where R0: RegexComponent, R1: RegexComponent, R1.RegexOutput == (W1, C0, C1) {
+  public static func buildPartialBlock<W1, C1, C2>(
+    accumulated: some RegexComponent,
+    next: some RegexComponent<(W1, C1, C2)>
+  ) -> ChoiceOf<(Substring, C1?, C2?)> {
     let factory = makeFactory()
     return .init(factory.accumulateAlternation(accumulated, next))
   }
@@ -3580,9 +3697,10 @@ extension AlternationBuilder {
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
   @_alwaysEmitIntoClient
-  public static func buildPartialBlock<R0, R1, W1, C0, C1, C2>(
-    accumulated: R0, next: R1
-  ) -> ChoiceOf<(Substring, C0?, C1?, C2?)> where R0: RegexComponent, R1: RegexComponent, R1.RegexOutput == (W1, C0, C1, C2) {
+  public static func buildPartialBlock<W1, C1, C2, C3>(
+    accumulated: some RegexComponent,
+    next: some RegexComponent<(W1, C1, C2, C3)>
+  ) -> ChoiceOf<(Substring, C1?, C2?, C3?)> {
     let factory = makeFactory()
     return .init(factory.accumulateAlternation(accumulated, next))
   }
@@ -3590,9 +3708,10 @@ extension AlternationBuilder {
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
   @_alwaysEmitIntoClient
-  public static func buildPartialBlock<R0, R1, W1, C0, C1, C2, C3>(
-    accumulated: R0, next: R1
-  ) -> ChoiceOf<(Substring, C0?, C1?, C2?, C3?)> where R0: RegexComponent, R1: RegexComponent, R1.RegexOutput == (W1, C0, C1, C2, C3) {
+  public static func buildPartialBlock<W1, C1, C2, C3, C4>(
+    accumulated: some RegexComponent,
+    next: some RegexComponent<(W1, C1, C2, C3, C4)>
+  ) -> ChoiceOf<(Substring, C1?, C2?, C3?, C4?)> {
     let factory = makeFactory()
     return .init(factory.accumulateAlternation(accumulated, next))
   }
@@ -3600,9 +3719,10 @@ extension AlternationBuilder {
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
   @_alwaysEmitIntoClient
-  public static func buildPartialBlock<R0, R1, W1, C0, C1, C2, C3, C4>(
-    accumulated: R0, next: R1
-  ) -> ChoiceOf<(Substring, C0?, C1?, C2?, C3?, C4?)> where R0: RegexComponent, R1: RegexComponent, R1.RegexOutput == (W1, C0, C1, C2, C3, C4) {
+  public static func buildPartialBlock<W1, C1, C2, C3, C4, C5>(
+    accumulated: some RegexComponent,
+    next: some RegexComponent<(W1, C1, C2, C3, C4, C5)>
+  ) -> ChoiceOf<(Substring, C1?, C2?, C3?, C4?, C5?)> {
     let factory = makeFactory()
     return .init(factory.accumulateAlternation(accumulated, next))
   }
@@ -3610,9 +3730,10 @@ extension AlternationBuilder {
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
   @_alwaysEmitIntoClient
-  public static func buildPartialBlock<R0, R1, W1, C0, C1, C2, C3, C4, C5>(
-    accumulated: R0, next: R1
-  ) -> ChoiceOf<(Substring, C0?, C1?, C2?, C3?, C4?, C5?)> where R0: RegexComponent, R1: RegexComponent, R1.RegexOutput == (W1, C0, C1, C2, C3, C4, C5) {
+  public static func buildPartialBlock<W1, C1, C2, C3, C4, C5, C6>(
+    accumulated: some RegexComponent,
+    next: some RegexComponent<(W1, C1, C2, C3, C4, C5, C6)>
+  ) -> ChoiceOf<(Substring, C1?, C2?, C3?, C4?, C5?, C6?)> {
     let factory = makeFactory()
     return .init(factory.accumulateAlternation(accumulated, next))
   }
@@ -3620,9 +3741,10 @@ extension AlternationBuilder {
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
   @_alwaysEmitIntoClient
-  public static func buildPartialBlock<R0, R1, W1, C0, C1, C2, C3, C4, C5, C6>(
-    accumulated: R0, next: R1
-  ) -> ChoiceOf<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?)> where R0: RegexComponent, R1: RegexComponent, R1.RegexOutput == (W1, C0, C1, C2, C3, C4, C5, C6) {
+  public static func buildPartialBlock<W1, C1, C2, C3, C4, C5, C6, C7>(
+    accumulated: some RegexComponent,
+    next: some RegexComponent<(W1, C1, C2, C3, C4, C5, C6, C7)>
+  ) -> ChoiceOf<(Substring, C1?, C2?, C3?, C4?, C5?, C6?, C7?)> {
     let factory = makeFactory()
     return .init(factory.accumulateAlternation(accumulated, next))
   }
@@ -3630,9 +3752,10 @@ extension AlternationBuilder {
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
   @_alwaysEmitIntoClient
-  public static func buildPartialBlock<R0, R1, W1, C0, C1, C2, C3, C4, C5, C6, C7>(
-    accumulated: R0, next: R1
-  ) -> ChoiceOf<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?)> where R0: RegexComponent, R1: RegexComponent, R1.RegexOutput == (W1, C0, C1, C2, C3, C4, C5, C6, C7) {
+  public static func buildPartialBlock<W1, C1, C2, C3, C4, C5, C6, C7, C8>(
+    accumulated: some RegexComponent,
+    next: some RegexComponent<(W1, C1, C2, C3, C4, C5, C6, C7, C8)>
+  ) -> ChoiceOf<(Substring, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?)> {
     let factory = makeFactory()
     return .init(factory.accumulateAlternation(accumulated, next))
   }
@@ -3640,9 +3763,10 @@ extension AlternationBuilder {
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
   @_alwaysEmitIntoClient
-  public static func buildPartialBlock<R0, R1, W1, C0, C1, C2, C3, C4, C5, C6, C7, C8>(
-    accumulated: R0, next: R1
-  ) -> ChoiceOf<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?)> where R0: RegexComponent, R1: RegexComponent, R1.RegexOutput == (W1, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
+  public static func buildPartialBlock<W1, C1, C2, C3, C4, C5, C6, C7, C8, C9>(
+    accumulated: some RegexComponent,
+    next: some RegexComponent<(W1, C1, C2, C3, C4, C5, C6, C7, C8, C9)>
+  ) -> ChoiceOf<(Substring, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?)> {
     let factory = makeFactory()
     return .init(factory.accumulateAlternation(accumulated, next))
   }
@@ -3650,19 +3774,23 @@ extension AlternationBuilder {
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
   @_alwaysEmitIntoClient
-  public static func buildPartialBlock<R0, R1, W1, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9>(
-    accumulated: R0, next: R1
-  ) -> ChoiceOf<(Substring, C0?, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?)> where R0: RegexComponent, R1: RegexComponent, R1.RegexOutput == (W1, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
+  public static func buildPartialBlock<W1, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10>(
+    accumulated: some RegexComponent,
+    next: some RegexComponent<(W1, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10)>
+  ) -> ChoiceOf<(Substring, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?, C10?)> {
     let factory = makeFactory()
     return .init(factory.accumulateAlternation(accumulated, next))
   }
 }
+// MARK: - Alternation builder (arity 1)
+
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
   @_alwaysEmitIntoClient
-  public static func buildPartialBlock<R0, W0, C0, R1>(
-    accumulated: R0, next: R1
-  ) -> ChoiceOf<(Substring, C0)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0) {
+  public static func buildPartialBlock<W0, C1>(
+    accumulated: some RegexComponent<(W0, C1)>,
+    next: some RegexComponent
+  ) -> ChoiceOf<(Substring, C1)> {
     let factory = makeFactory()
     return .init(factory.accumulateAlternation(accumulated, next))
   }
@@ -3670,9 +3798,10 @@ extension AlternationBuilder {
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
   @_alwaysEmitIntoClient
-  public static func buildPartialBlock<R0, W0, C0, R1, W1, C1>(
-    accumulated: R0, next: R1
-  ) -> ChoiceOf<(Substring, C0, C1?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0), R1.RegexOutput == (W1, C1) {
+  public static func buildPartialBlock<W0, C1, W1, C2>(
+    accumulated: some RegexComponent<(W0, C1)>,
+    next: some RegexComponent<(W1, C2)>
+  ) -> ChoiceOf<(Substring, C1, C2?)> {
     let factory = makeFactory()
     return .init(factory.accumulateAlternation(accumulated, next))
   }
@@ -3680,9 +3809,10 @@ extension AlternationBuilder {
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
   @_alwaysEmitIntoClient
-  public static func buildPartialBlock<R0, W0, C0, R1, W1, C1, C2>(
-    accumulated: R0, next: R1
-  ) -> ChoiceOf<(Substring, C0, C1?, C2?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0), R1.RegexOutput == (W1, C1, C2) {
+  public static func buildPartialBlock<W0, C1, W1, C2, C3>(
+    accumulated: some RegexComponent<(W0, C1)>,
+    next: some RegexComponent<(W1, C2, C3)>
+  ) -> ChoiceOf<(Substring, C1, C2?, C3?)> {
     let factory = makeFactory()
     return .init(factory.accumulateAlternation(accumulated, next))
   }
@@ -3690,9 +3820,10 @@ extension AlternationBuilder {
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
   @_alwaysEmitIntoClient
-  public static func buildPartialBlock<R0, W0, C0, R1, W1, C1, C2, C3>(
-    accumulated: R0, next: R1
-  ) -> ChoiceOf<(Substring, C0, C1?, C2?, C3?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0), R1.RegexOutput == (W1, C1, C2, C3) {
+  public static func buildPartialBlock<W0, C1, W1, C2, C3, C4>(
+    accumulated: some RegexComponent<(W0, C1)>,
+    next: some RegexComponent<(W1, C2, C3, C4)>
+  ) -> ChoiceOf<(Substring, C1, C2?, C3?, C4?)> {
     let factory = makeFactory()
     return .init(factory.accumulateAlternation(accumulated, next))
   }
@@ -3700,9 +3831,10 @@ extension AlternationBuilder {
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
   @_alwaysEmitIntoClient
-  public static func buildPartialBlock<R0, W0, C0, R1, W1, C1, C2, C3, C4>(
-    accumulated: R0, next: R1
-  ) -> ChoiceOf<(Substring, C0, C1?, C2?, C3?, C4?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0), R1.RegexOutput == (W1, C1, C2, C3, C4) {
+  public static func buildPartialBlock<W0, C1, W1, C2, C3, C4, C5>(
+    accumulated: some RegexComponent<(W0, C1)>,
+    next: some RegexComponent<(W1, C2, C3, C4, C5)>
+  ) -> ChoiceOf<(Substring, C1, C2?, C3?, C4?, C5?)> {
     let factory = makeFactory()
     return .init(factory.accumulateAlternation(accumulated, next))
   }
@@ -3710,9 +3842,10 @@ extension AlternationBuilder {
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
   @_alwaysEmitIntoClient
-  public static func buildPartialBlock<R0, W0, C0, R1, W1, C1, C2, C3, C4, C5>(
-    accumulated: R0, next: R1
-  ) -> ChoiceOf<(Substring, C0, C1?, C2?, C3?, C4?, C5?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0), R1.RegexOutput == (W1, C1, C2, C3, C4, C5) {
+  public static func buildPartialBlock<W0, C1, W1, C2, C3, C4, C5, C6>(
+    accumulated: some RegexComponent<(W0, C1)>,
+    next: some RegexComponent<(W1, C2, C3, C4, C5, C6)>
+  ) -> ChoiceOf<(Substring, C1, C2?, C3?, C4?, C5?, C6?)> {
     let factory = makeFactory()
     return .init(factory.accumulateAlternation(accumulated, next))
   }
@@ -3720,9 +3853,10 @@ extension AlternationBuilder {
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
   @_alwaysEmitIntoClient
-  public static func buildPartialBlock<R0, W0, C0, R1, W1, C1, C2, C3, C4, C5, C6>(
-    accumulated: R0, next: R1
-  ) -> ChoiceOf<(Substring, C0, C1?, C2?, C3?, C4?, C5?, C6?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0), R1.RegexOutput == (W1, C1, C2, C3, C4, C5, C6) {
+  public static func buildPartialBlock<W0, C1, W1, C2, C3, C4, C5, C6, C7>(
+    accumulated: some RegexComponent<(W0, C1)>,
+    next: some RegexComponent<(W1, C2, C3, C4, C5, C6, C7)>
+  ) -> ChoiceOf<(Substring, C1, C2?, C3?, C4?, C5?, C6?, C7?)> {
     let factory = makeFactory()
     return .init(factory.accumulateAlternation(accumulated, next))
   }
@@ -3730,9 +3864,10 @@ extension AlternationBuilder {
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
   @_alwaysEmitIntoClient
-  public static func buildPartialBlock<R0, W0, C0, R1, W1, C1, C2, C3, C4, C5, C6, C7>(
-    accumulated: R0, next: R1
-  ) -> ChoiceOf<(Substring, C0, C1?, C2?, C3?, C4?, C5?, C6?, C7?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0), R1.RegexOutput == (W1, C1, C2, C3, C4, C5, C6, C7) {
+  public static func buildPartialBlock<W0, C1, W1, C2, C3, C4, C5, C6, C7, C8>(
+    accumulated: some RegexComponent<(W0, C1)>,
+    next: some RegexComponent<(W1, C2, C3, C4, C5, C6, C7, C8)>
+  ) -> ChoiceOf<(Substring, C1, C2?, C3?, C4?, C5?, C6?, C7?, C8?)> {
     let factory = makeFactory()
     return .init(factory.accumulateAlternation(accumulated, next))
   }
@@ -3740,9 +3875,10 @@ extension AlternationBuilder {
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
   @_alwaysEmitIntoClient
-  public static func buildPartialBlock<R0, W0, C0, R1, W1, C1, C2, C3, C4, C5, C6, C7, C8>(
-    accumulated: R0, next: R1
-  ) -> ChoiceOf<(Substring, C0, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0), R1.RegexOutput == (W1, C1, C2, C3, C4, C5, C6, C7, C8) {
+  public static func buildPartialBlock<W0, C1, W1, C2, C3, C4, C5, C6, C7, C8, C9>(
+    accumulated: some RegexComponent<(W0, C1)>,
+    next: some RegexComponent<(W1, C2, C3, C4, C5, C6, C7, C8, C9)>
+  ) -> ChoiceOf<(Substring, C1, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?)> {
     let factory = makeFactory()
     return .init(factory.accumulateAlternation(accumulated, next))
   }
@@ -3750,19 +3886,23 @@ extension AlternationBuilder {
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
   @_alwaysEmitIntoClient
-  public static func buildPartialBlock<R0, W0, C0, R1, W1, C1, C2, C3, C4, C5, C6, C7, C8, C9>(
-    accumulated: R0, next: R1
-  ) -> ChoiceOf<(Substring, C0, C1?, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0), R1.RegexOutput == (W1, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
+  public static func buildPartialBlock<W0, C1, W1, C2, C3, C4, C5, C6, C7, C8, C9, C10>(
+    accumulated: some RegexComponent<(W0, C1)>,
+    next: some RegexComponent<(W1, C2, C3, C4, C5, C6, C7, C8, C9, C10)>
+  ) -> ChoiceOf<(Substring, C1, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?, C10?)> {
     let factory = makeFactory()
     return .init(factory.accumulateAlternation(accumulated, next))
   }
 }
+// MARK: - Alternation builder (arity 2)
+
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
   @_alwaysEmitIntoClient
-  public static func buildPartialBlock<R0, W0, C0, C1, R1>(
-    accumulated: R0, next: R1
-  ) -> ChoiceOf<(Substring, C0, C1)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1) {
+  public static func buildPartialBlock<W0, C1, C2>(
+    accumulated: some RegexComponent<(W0, C1, C2)>,
+    next: some RegexComponent
+  ) -> ChoiceOf<(Substring, C1, C2)> {
     let factory = makeFactory()
     return .init(factory.accumulateAlternation(accumulated, next))
   }
@@ -3770,9 +3910,10 @@ extension AlternationBuilder {
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
   @_alwaysEmitIntoClient
-  public static func buildPartialBlock<R0, W0, C0, C1, R1, W1, C2>(
-    accumulated: R0, next: R1
-  ) -> ChoiceOf<(Substring, C0, C1, C2?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1), R1.RegexOutput == (W1, C2) {
+  public static func buildPartialBlock<W0, C1, C2, W1, C3>(
+    accumulated: some RegexComponent<(W0, C1, C2)>,
+    next: some RegexComponent<(W1, C3)>
+  ) -> ChoiceOf<(Substring, C1, C2, C3?)> {
     let factory = makeFactory()
     return .init(factory.accumulateAlternation(accumulated, next))
   }
@@ -3780,9 +3921,10 @@ extension AlternationBuilder {
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
   @_alwaysEmitIntoClient
-  public static func buildPartialBlock<R0, W0, C0, C1, R1, W1, C2, C3>(
-    accumulated: R0, next: R1
-  ) -> ChoiceOf<(Substring, C0, C1, C2?, C3?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1), R1.RegexOutput == (W1, C2, C3) {
+  public static func buildPartialBlock<W0, C1, C2, W1, C3, C4>(
+    accumulated: some RegexComponent<(W0, C1, C2)>,
+    next: some RegexComponent<(W1, C3, C4)>
+  ) -> ChoiceOf<(Substring, C1, C2, C3?, C4?)> {
     let factory = makeFactory()
     return .init(factory.accumulateAlternation(accumulated, next))
   }
@@ -3790,9 +3932,10 @@ extension AlternationBuilder {
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
   @_alwaysEmitIntoClient
-  public static func buildPartialBlock<R0, W0, C0, C1, R1, W1, C2, C3, C4>(
-    accumulated: R0, next: R1
-  ) -> ChoiceOf<(Substring, C0, C1, C2?, C3?, C4?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1), R1.RegexOutput == (W1, C2, C3, C4) {
+  public static func buildPartialBlock<W0, C1, C2, W1, C3, C4, C5>(
+    accumulated: some RegexComponent<(W0, C1, C2)>,
+    next: some RegexComponent<(W1, C3, C4, C5)>
+  ) -> ChoiceOf<(Substring, C1, C2, C3?, C4?, C5?)> {
     let factory = makeFactory()
     return .init(factory.accumulateAlternation(accumulated, next))
   }
@@ -3800,9 +3943,10 @@ extension AlternationBuilder {
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
   @_alwaysEmitIntoClient
-  public static func buildPartialBlock<R0, W0, C0, C1, R1, W1, C2, C3, C4, C5>(
-    accumulated: R0, next: R1
-  ) -> ChoiceOf<(Substring, C0, C1, C2?, C3?, C4?, C5?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1), R1.RegexOutput == (W1, C2, C3, C4, C5) {
+  public static func buildPartialBlock<W0, C1, C2, W1, C3, C4, C5, C6>(
+    accumulated: some RegexComponent<(W0, C1, C2)>,
+    next: some RegexComponent<(W1, C3, C4, C5, C6)>
+  ) -> ChoiceOf<(Substring, C1, C2, C3?, C4?, C5?, C6?)> {
     let factory = makeFactory()
     return .init(factory.accumulateAlternation(accumulated, next))
   }
@@ -3810,9 +3954,10 @@ extension AlternationBuilder {
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
   @_alwaysEmitIntoClient
-  public static func buildPartialBlock<R0, W0, C0, C1, R1, W1, C2, C3, C4, C5, C6>(
-    accumulated: R0, next: R1
-  ) -> ChoiceOf<(Substring, C0, C1, C2?, C3?, C4?, C5?, C6?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1), R1.RegexOutput == (W1, C2, C3, C4, C5, C6) {
+  public static func buildPartialBlock<W0, C1, C2, W1, C3, C4, C5, C6, C7>(
+    accumulated: some RegexComponent<(W0, C1, C2)>,
+    next: some RegexComponent<(W1, C3, C4, C5, C6, C7)>
+  ) -> ChoiceOf<(Substring, C1, C2, C3?, C4?, C5?, C6?, C7?)> {
     let factory = makeFactory()
     return .init(factory.accumulateAlternation(accumulated, next))
   }
@@ -3820,9 +3965,10 @@ extension AlternationBuilder {
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
   @_alwaysEmitIntoClient
-  public static func buildPartialBlock<R0, W0, C0, C1, R1, W1, C2, C3, C4, C5, C6, C7>(
-    accumulated: R0, next: R1
-  ) -> ChoiceOf<(Substring, C0, C1, C2?, C3?, C4?, C5?, C6?, C7?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1), R1.RegexOutput == (W1, C2, C3, C4, C5, C6, C7) {
+  public static func buildPartialBlock<W0, C1, C2, W1, C3, C4, C5, C6, C7, C8>(
+    accumulated: some RegexComponent<(W0, C1, C2)>,
+    next: some RegexComponent<(W1, C3, C4, C5, C6, C7, C8)>
+  ) -> ChoiceOf<(Substring, C1, C2, C3?, C4?, C5?, C6?, C7?, C8?)> {
     let factory = makeFactory()
     return .init(factory.accumulateAlternation(accumulated, next))
   }
@@ -3830,9 +3976,10 @@ extension AlternationBuilder {
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
   @_alwaysEmitIntoClient
-  public static func buildPartialBlock<R0, W0, C0, C1, R1, W1, C2, C3, C4, C5, C6, C7, C8>(
-    accumulated: R0, next: R1
-  ) -> ChoiceOf<(Substring, C0, C1, C2?, C3?, C4?, C5?, C6?, C7?, C8?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1), R1.RegexOutput == (W1, C2, C3, C4, C5, C6, C7, C8) {
+  public static func buildPartialBlock<W0, C1, C2, W1, C3, C4, C5, C6, C7, C8, C9>(
+    accumulated: some RegexComponent<(W0, C1, C2)>,
+    next: some RegexComponent<(W1, C3, C4, C5, C6, C7, C8, C9)>
+  ) -> ChoiceOf<(Substring, C1, C2, C3?, C4?, C5?, C6?, C7?, C8?, C9?)> {
     let factory = makeFactory()
     return .init(factory.accumulateAlternation(accumulated, next))
   }
@@ -3840,19 +3987,23 @@ extension AlternationBuilder {
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
   @_alwaysEmitIntoClient
-  public static func buildPartialBlock<R0, W0, C0, C1, R1, W1, C2, C3, C4, C5, C6, C7, C8, C9>(
-    accumulated: R0, next: R1
-  ) -> ChoiceOf<(Substring, C0, C1, C2?, C3?, C4?, C5?, C6?, C7?, C8?, C9?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1), R1.RegexOutput == (W1, C2, C3, C4, C5, C6, C7, C8, C9) {
+  public static func buildPartialBlock<W0, C1, C2, W1, C3, C4, C5, C6, C7, C8, C9, C10>(
+    accumulated: some RegexComponent<(W0, C1, C2)>,
+    next: some RegexComponent<(W1, C3, C4, C5, C6, C7, C8, C9, C10)>
+  ) -> ChoiceOf<(Substring, C1, C2, C3?, C4?, C5?, C6?, C7?, C8?, C9?, C10?)> {
     let factory = makeFactory()
     return .init(factory.accumulateAlternation(accumulated, next))
   }
 }
+// MARK: - Alternation builder (arity 3)
+
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
   @_alwaysEmitIntoClient
-  public static func buildPartialBlock<R0, W0, C0, C1, C2, R1>(
-    accumulated: R0, next: R1
-  ) -> ChoiceOf<(Substring, C0, C1, C2)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2) {
+  public static func buildPartialBlock<W0, C1, C2, C3>(
+    accumulated: some RegexComponent<(W0, C1, C2, C3)>,
+    next: some RegexComponent
+  ) -> ChoiceOf<(Substring, C1, C2, C3)> {
     let factory = makeFactory()
     return .init(factory.accumulateAlternation(accumulated, next))
   }
@@ -3860,9 +4011,10 @@ extension AlternationBuilder {
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
   @_alwaysEmitIntoClient
-  public static func buildPartialBlock<R0, W0, C0, C1, C2, R1, W1, C3>(
-    accumulated: R0, next: R1
-  ) -> ChoiceOf<(Substring, C0, C1, C2, C3?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2), R1.RegexOutput == (W1, C3) {
+  public static func buildPartialBlock<W0, C1, C2, C3, W1, C4>(
+    accumulated: some RegexComponent<(W0, C1, C2, C3)>,
+    next: some RegexComponent<(W1, C4)>
+  ) -> ChoiceOf<(Substring, C1, C2, C3, C4?)> {
     let factory = makeFactory()
     return .init(factory.accumulateAlternation(accumulated, next))
   }
@@ -3870,9 +4022,10 @@ extension AlternationBuilder {
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
   @_alwaysEmitIntoClient
-  public static func buildPartialBlock<R0, W0, C0, C1, C2, R1, W1, C3, C4>(
-    accumulated: R0, next: R1
-  ) -> ChoiceOf<(Substring, C0, C1, C2, C3?, C4?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2), R1.RegexOutput == (W1, C3, C4) {
+  public static func buildPartialBlock<W0, C1, C2, C3, W1, C4, C5>(
+    accumulated: some RegexComponent<(W0, C1, C2, C3)>,
+    next: some RegexComponent<(W1, C4, C5)>
+  ) -> ChoiceOf<(Substring, C1, C2, C3, C4?, C5?)> {
     let factory = makeFactory()
     return .init(factory.accumulateAlternation(accumulated, next))
   }
@@ -3880,9 +4033,10 @@ extension AlternationBuilder {
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
   @_alwaysEmitIntoClient
-  public static func buildPartialBlock<R0, W0, C0, C1, C2, R1, W1, C3, C4, C5>(
-    accumulated: R0, next: R1
-  ) -> ChoiceOf<(Substring, C0, C1, C2, C3?, C4?, C5?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2), R1.RegexOutput == (W1, C3, C4, C5) {
+  public static func buildPartialBlock<W0, C1, C2, C3, W1, C4, C5, C6>(
+    accumulated: some RegexComponent<(W0, C1, C2, C3)>,
+    next: some RegexComponent<(W1, C4, C5, C6)>
+  ) -> ChoiceOf<(Substring, C1, C2, C3, C4?, C5?, C6?)> {
     let factory = makeFactory()
     return .init(factory.accumulateAlternation(accumulated, next))
   }
@@ -3890,9 +4044,10 @@ extension AlternationBuilder {
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
   @_alwaysEmitIntoClient
-  public static func buildPartialBlock<R0, W0, C0, C1, C2, R1, W1, C3, C4, C5, C6>(
-    accumulated: R0, next: R1
-  ) -> ChoiceOf<(Substring, C0, C1, C2, C3?, C4?, C5?, C6?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2), R1.RegexOutput == (W1, C3, C4, C5, C6) {
+  public static func buildPartialBlock<W0, C1, C2, C3, W1, C4, C5, C6, C7>(
+    accumulated: some RegexComponent<(W0, C1, C2, C3)>,
+    next: some RegexComponent<(W1, C4, C5, C6, C7)>
+  ) -> ChoiceOf<(Substring, C1, C2, C3, C4?, C5?, C6?, C7?)> {
     let factory = makeFactory()
     return .init(factory.accumulateAlternation(accumulated, next))
   }
@@ -3900,9 +4055,10 @@ extension AlternationBuilder {
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
   @_alwaysEmitIntoClient
-  public static func buildPartialBlock<R0, W0, C0, C1, C2, R1, W1, C3, C4, C5, C6, C7>(
-    accumulated: R0, next: R1
-  ) -> ChoiceOf<(Substring, C0, C1, C2, C3?, C4?, C5?, C6?, C7?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2), R1.RegexOutput == (W1, C3, C4, C5, C6, C7) {
+  public static func buildPartialBlock<W0, C1, C2, C3, W1, C4, C5, C6, C7, C8>(
+    accumulated: some RegexComponent<(W0, C1, C2, C3)>,
+    next: some RegexComponent<(W1, C4, C5, C6, C7, C8)>
+  ) -> ChoiceOf<(Substring, C1, C2, C3, C4?, C5?, C6?, C7?, C8?)> {
     let factory = makeFactory()
     return .init(factory.accumulateAlternation(accumulated, next))
   }
@@ -3910,9 +4066,10 @@ extension AlternationBuilder {
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
   @_alwaysEmitIntoClient
-  public static func buildPartialBlock<R0, W0, C0, C1, C2, R1, W1, C3, C4, C5, C6, C7, C8>(
-    accumulated: R0, next: R1
-  ) -> ChoiceOf<(Substring, C0, C1, C2, C3?, C4?, C5?, C6?, C7?, C8?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2), R1.RegexOutput == (W1, C3, C4, C5, C6, C7, C8) {
+  public static func buildPartialBlock<W0, C1, C2, C3, W1, C4, C5, C6, C7, C8, C9>(
+    accumulated: some RegexComponent<(W0, C1, C2, C3)>,
+    next: some RegexComponent<(W1, C4, C5, C6, C7, C8, C9)>
+  ) -> ChoiceOf<(Substring, C1, C2, C3, C4?, C5?, C6?, C7?, C8?, C9?)> {
     let factory = makeFactory()
     return .init(factory.accumulateAlternation(accumulated, next))
   }
@@ -3920,19 +4077,23 @@ extension AlternationBuilder {
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
   @_alwaysEmitIntoClient
-  public static func buildPartialBlock<R0, W0, C0, C1, C2, R1, W1, C3, C4, C5, C6, C7, C8, C9>(
-    accumulated: R0, next: R1
-  ) -> ChoiceOf<(Substring, C0, C1, C2, C3?, C4?, C5?, C6?, C7?, C8?, C9?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2), R1.RegexOutput == (W1, C3, C4, C5, C6, C7, C8, C9) {
+  public static func buildPartialBlock<W0, C1, C2, C3, W1, C4, C5, C6, C7, C8, C9, C10>(
+    accumulated: some RegexComponent<(W0, C1, C2, C3)>,
+    next: some RegexComponent<(W1, C4, C5, C6, C7, C8, C9, C10)>
+  ) -> ChoiceOf<(Substring, C1, C2, C3, C4?, C5?, C6?, C7?, C8?, C9?, C10?)> {
     let factory = makeFactory()
     return .init(factory.accumulateAlternation(accumulated, next))
   }
 }
+// MARK: - Alternation builder (arity 4)
+
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
   @_alwaysEmitIntoClient
-  public static func buildPartialBlock<R0, W0, C0, C1, C2, C3, R1>(
-    accumulated: R0, next: R1
-  ) -> ChoiceOf<(Substring, C0, C1, C2, C3)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2, C3) {
+  public static func buildPartialBlock<W0, C1, C2, C3, C4>(
+    accumulated: some RegexComponent<(W0, C1, C2, C3, C4)>,
+    next: some RegexComponent
+  ) -> ChoiceOf<(Substring, C1, C2, C3, C4)> {
     let factory = makeFactory()
     return .init(factory.accumulateAlternation(accumulated, next))
   }
@@ -3940,9 +4101,10 @@ extension AlternationBuilder {
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
   @_alwaysEmitIntoClient
-  public static func buildPartialBlock<R0, W0, C0, C1, C2, C3, R1, W1, C4>(
-    accumulated: R0, next: R1
-  ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2, C3), R1.RegexOutput == (W1, C4) {
+  public static func buildPartialBlock<W0, C1, C2, C3, C4, W1, C5>(
+    accumulated: some RegexComponent<(W0, C1, C2, C3, C4)>,
+    next: some RegexComponent<(W1, C5)>
+  ) -> ChoiceOf<(Substring, C1, C2, C3, C4, C5?)> {
     let factory = makeFactory()
     return .init(factory.accumulateAlternation(accumulated, next))
   }
@@ -3950,9 +4112,10 @@ extension AlternationBuilder {
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
   @_alwaysEmitIntoClient
-  public static func buildPartialBlock<R0, W0, C0, C1, C2, C3, R1, W1, C4, C5>(
-    accumulated: R0, next: R1
-  ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4?, C5?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2, C3), R1.RegexOutput == (W1, C4, C5) {
+  public static func buildPartialBlock<W0, C1, C2, C3, C4, W1, C5, C6>(
+    accumulated: some RegexComponent<(W0, C1, C2, C3, C4)>,
+    next: some RegexComponent<(W1, C5, C6)>
+  ) -> ChoiceOf<(Substring, C1, C2, C3, C4, C5?, C6?)> {
     let factory = makeFactory()
     return .init(factory.accumulateAlternation(accumulated, next))
   }
@@ -3960,9 +4123,10 @@ extension AlternationBuilder {
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
   @_alwaysEmitIntoClient
-  public static func buildPartialBlock<R0, W0, C0, C1, C2, C3, R1, W1, C4, C5, C6>(
-    accumulated: R0, next: R1
-  ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4?, C5?, C6?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2, C3), R1.RegexOutput == (W1, C4, C5, C6) {
+  public static func buildPartialBlock<W0, C1, C2, C3, C4, W1, C5, C6, C7>(
+    accumulated: some RegexComponent<(W0, C1, C2, C3, C4)>,
+    next: some RegexComponent<(W1, C5, C6, C7)>
+  ) -> ChoiceOf<(Substring, C1, C2, C3, C4, C5?, C6?, C7?)> {
     let factory = makeFactory()
     return .init(factory.accumulateAlternation(accumulated, next))
   }
@@ -3970,9 +4134,10 @@ extension AlternationBuilder {
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
   @_alwaysEmitIntoClient
-  public static func buildPartialBlock<R0, W0, C0, C1, C2, C3, R1, W1, C4, C5, C6, C7>(
-    accumulated: R0, next: R1
-  ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4?, C5?, C6?, C7?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2, C3), R1.RegexOutput == (W1, C4, C5, C6, C7) {
+  public static func buildPartialBlock<W0, C1, C2, C3, C4, W1, C5, C6, C7, C8>(
+    accumulated: some RegexComponent<(W0, C1, C2, C3, C4)>,
+    next: some RegexComponent<(W1, C5, C6, C7, C8)>
+  ) -> ChoiceOf<(Substring, C1, C2, C3, C4, C5?, C6?, C7?, C8?)> {
     let factory = makeFactory()
     return .init(factory.accumulateAlternation(accumulated, next))
   }
@@ -3980,9 +4145,10 @@ extension AlternationBuilder {
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
   @_alwaysEmitIntoClient
-  public static func buildPartialBlock<R0, W0, C0, C1, C2, C3, R1, W1, C4, C5, C6, C7, C8>(
-    accumulated: R0, next: R1
-  ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4?, C5?, C6?, C7?, C8?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2, C3), R1.RegexOutput == (W1, C4, C5, C6, C7, C8) {
+  public static func buildPartialBlock<W0, C1, C2, C3, C4, W1, C5, C6, C7, C8, C9>(
+    accumulated: some RegexComponent<(W0, C1, C2, C3, C4)>,
+    next: some RegexComponent<(W1, C5, C6, C7, C8, C9)>
+  ) -> ChoiceOf<(Substring, C1, C2, C3, C4, C5?, C6?, C7?, C8?, C9?)> {
     let factory = makeFactory()
     return .init(factory.accumulateAlternation(accumulated, next))
   }
@@ -3990,19 +4156,23 @@ extension AlternationBuilder {
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
   @_alwaysEmitIntoClient
-  public static func buildPartialBlock<R0, W0, C0, C1, C2, C3, R1, W1, C4, C5, C6, C7, C8, C9>(
-    accumulated: R0, next: R1
-  ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4?, C5?, C6?, C7?, C8?, C9?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2, C3), R1.RegexOutput == (W1, C4, C5, C6, C7, C8, C9) {
+  public static func buildPartialBlock<W0, C1, C2, C3, C4, W1, C5, C6, C7, C8, C9, C10>(
+    accumulated: some RegexComponent<(W0, C1, C2, C3, C4)>,
+    next: some RegexComponent<(W1, C5, C6, C7, C8, C9, C10)>
+  ) -> ChoiceOf<(Substring, C1, C2, C3, C4, C5?, C6?, C7?, C8?, C9?, C10?)> {
     let factory = makeFactory()
     return .init(factory.accumulateAlternation(accumulated, next))
   }
 }
+// MARK: - Alternation builder (arity 5)
+
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
   @_alwaysEmitIntoClient
-  public static func buildPartialBlock<R0, W0, C0, C1, C2, C3, C4, R1>(
-    accumulated: R0, next: R1
-  ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2, C3, C4) {
+  public static func buildPartialBlock<W0, C1, C2, C3, C4, C5>(
+    accumulated: some RegexComponent<(W0, C1, C2, C3, C4, C5)>,
+    next: some RegexComponent
+  ) -> ChoiceOf<(Substring, C1, C2, C3, C4, C5)> {
     let factory = makeFactory()
     return .init(factory.accumulateAlternation(accumulated, next))
   }
@@ -4010,9 +4180,10 @@ extension AlternationBuilder {
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
   @_alwaysEmitIntoClient
-  public static func buildPartialBlock<R0, W0, C0, C1, C2, C3, C4, R1, W1, C5>(
-    accumulated: R0, next: R1
-  ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4, C5?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2, C3, C4), R1.RegexOutput == (W1, C5) {
+  public static func buildPartialBlock<W0, C1, C2, C3, C4, C5, W1, C6>(
+    accumulated: some RegexComponent<(W0, C1, C2, C3, C4, C5)>,
+    next: some RegexComponent<(W1, C6)>
+  ) -> ChoiceOf<(Substring, C1, C2, C3, C4, C5, C6?)> {
     let factory = makeFactory()
     return .init(factory.accumulateAlternation(accumulated, next))
   }
@@ -4020,9 +4191,10 @@ extension AlternationBuilder {
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
   @_alwaysEmitIntoClient
-  public static func buildPartialBlock<R0, W0, C0, C1, C2, C3, C4, R1, W1, C5, C6>(
-    accumulated: R0, next: R1
-  ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4, C5?, C6?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2, C3, C4), R1.RegexOutput == (W1, C5, C6) {
+  public static func buildPartialBlock<W0, C1, C2, C3, C4, C5, W1, C6, C7>(
+    accumulated: some RegexComponent<(W0, C1, C2, C3, C4, C5)>,
+    next: some RegexComponent<(W1, C6, C7)>
+  ) -> ChoiceOf<(Substring, C1, C2, C3, C4, C5, C6?, C7?)> {
     let factory = makeFactory()
     return .init(factory.accumulateAlternation(accumulated, next))
   }
@@ -4030,9 +4202,10 @@ extension AlternationBuilder {
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
   @_alwaysEmitIntoClient
-  public static func buildPartialBlock<R0, W0, C0, C1, C2, C3, C4, R1, W1, C5, C6, C7>(
-    accumulated: R0, next: R1
-  ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4, C5?, C6?, C7?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2, C3, C4), R1.RegexOutput == (W1, C5, C6, C7) {
+  public static func buildPartialBlock<W0, C1, C2, C3, C4, C5, W1, C6, C7, C8>(
+    accumulated: some RegexComponent<(W0, C1, C2, C3, C4, C5)>,
+    next: some RegexComponent<(W1, C6, C7, C8)>
+  ) -> ChoiceOf<(Substring, C1, C2, C3, C4, C5, C6?, C7?, C8?)> {
     let factory = makeFactory()
     return .init(factory.accumulateAlternation(accumulated, next))
   }
@@ -4040,9 +4213,10 @@ extension AlternationBuilder {
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
   @_alwaysEmitIntoClient
-  public static func buildPartialBlock<R0, W0, C0, C1, C2, C3, C4, R1, W1, C5, C6, C7, C8>(
-    accumulated: R0, next: R1
-  ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4, C5?, C6?, C7?, C8?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2, C3, C4), R1.RegexOutput == (W1, C5, C6, C7, C8) {
+  public static func buildPartialBlock<W0, C1, C2, C3, C4, C5, W1, C6, C7, C8, C9>(
+    accumulated: some RegexComponent<(W0, C1, C2, C3, C4, C5)>,
+    next: some RegexComponent<(W1, C6, C7, C8, C9)>
+  ) -> ChoiceOf<(Substring, C1, C2, C3, C4, C5, C6?, C7?, C8?, C9?)> {
     let factory = makeFactory()
     return .init(factory.accumulateAlternation(accumulated, next))
   }
@@ -4050,19 +4224,23 @@ extension AlternationBuilder {
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
   @_alwaysEmitIntoClient
-  public static func buildPartialBlock<R0, W0, C0, C1, C2, C3, C4, R1, W1, C5, C6, C7, C8, C9>(
-    accumulated: R0, next: R1
-  ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4, C5?, C6?, C7?, C8?, C9?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2, C3, C4), R1.RegexOutput == (W1, C5, C6, C7, C8, C9) {
+  public static func buildPartialBlock<W0, C1, C2, C3, C4, C5, W1, C6, C7, C8, C9, C10>(
+    accumulated: some RegexComponent<(W0, C1, C2, C3, C4, C5)>,
+    next: some RegexComponent<(W1, C6, C7, C8, C9, C10)>
+  ) -> ChoiceOf<(Substring, C1, C2, C3, C4, C5, C6?, C7?, C8?, C9?, C10?)> {
     let factory = makeFactory()
     return .init(factory.accumulateAlternation(accumulated, next))
   }
 }
+// MARK: - Alternation builder (arity 6)
+
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
   @_alwaysEmitIntoClient
-  public static func buildPartialBlock<R0, W0, C0, C1, C2, C3, C4, C5, R1>(
-    accumulated: R0, next: R1
-  ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4, C5)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2, C3, C4, C5) {
+  public static func buildPartialBlock<W0, C1, C2, C3, C4, C5, C6>(
+    accumulated: some RegexComponent<(W0, C1, C2, C3, C4, C5, C6)>,
+    next: some RegexComponent
+  ) -> ChoiceOf<(Substring, C1, C2, C3, C4, C5, C6)> {
     let factory = makeFactory()
     return .init(factory.accumulateAlternation(accumulated, next))
   }
@@ -4070,9 +4248,10 @@ extension AlternationBuilder {
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
   @_alwaysEmitIntoClient
-  public static func buildPartialBlock<R0, W0, C0, C1, C2, C3, C4, C5, R1, W1, C6>(
-    accumulated: R0, next: R1
-  ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4, C5, C6?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2, C3, C4, C5), R1.RegexOutput == (W1, C6) {
+  public static func buildPartialBlock<W0, C1, C2, C3, C4, C5, C6, W1, C7>(
+    accumulated: some RegexComponent<(W0, C1, C2, C3, C4, C5, C6)>,
+    next: some RegexComponent<(W1, C7)>
+  ) -> ChoiceOf<(Substring, C1, C2, C3, C4, C5, C6, C7?)> {
     let factory = makeFactory()
     return .init(factory.accumulateAlternation(accumulated, next))
   }
@@ -4080,9 +4259,10 @@ extension AlternationBuilder {
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
   @_alwaysEmitIntoClient
-  public static func buildPartialBlock<R0, W0, C0, C1, C2, C3, C4, C5, R1, W1, C6, C7>(
-    accumulated: R0, next: R1
-  ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4, C5, C6?, C7?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2, C3, C4, C5), R1.RegexOutput == (W1, C6, C7) {
+  public static func buildPartialBlock<W0, C1, C2, C3, C4, C5, C6, W1, C7, C8>(
+    accumulated: some RegexComponent<(W0, C1, C2, C3, C4, C5, C6)>,
+    next: some RegexComponent<(W1, C7, C8)>
+  ) -> ChoiceOf<(Substring, C1, C2, C3, C4, C5, C6, C7?, C8?)> {
     let factory = makeFactory()
     return .init(factory.accumulateAlternation(accumulated, next))
   }
@@ -4090,9 +4270,10 @@ extension AlternationBuilder {
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
   @_alwaysEmitIntoClient
-  public static func buildPartialBlock<R0, W0, C0, C1, C2, C3, C4, C5, R1, W1, C6, C7, C8>(
-    accumulated: R0, next: R1
-  ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4, C5, C6?, C7?, C8?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2, C3, C4, C5), R1.RegexOutput == (W1, C6, C7, C8) {
+  public static func buildPartialBlock<W0, C1, C2, C3, C4, C5, C6, W1, C7, C8, C9>(
+    accumulated: some RegexComponent<(W0, C1, C2, C3, C4, C5, C6)>,
+    next: some RegexComponent<(W1, C7, C8, C9)>
+  ) -> ChoiceOf<(Substring, C1, C2, C3, C4, C5, C6, C7?, C8?, C9?)> {
     let factory = makeFactory()
     return .init(factory.accumulateAlternation(accumulated, next))
   }
@@ -4100,19 +4281,23 @@ extension AlternationBuilder {
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
   @_alwaysEmitIntoClient
-  public static func buildPartialBlock<R0, W0, C0, C1, C2, C3, C4, C5, R1, W1, C6, C7, C8, C9>(
-    accumulated: R0, next: R1
-  ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4, C5, C6?, C7?, C8?, C9?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2, C3, C4, C5), R1.RegexOutput == (W1, C6, C7, C8, C9) {
+  public static func buildPartialBlock<W0, C1, C2, C3, C4, C5, C6, W1, C7, C8, C9, C10>(
+    accumulated: some RegexComponent<(W0, C1, C2, C3, C4, C5, C6)>,
+    next: some RegexComponent<(W1, C7, C8, C9, C10)>
+  ) -> ChoiceOf<(Substring, C1, C2, C3, C4, C5, C6, C7?, C8?, C9?, C10?)> {
     let factory = makeFactory()
     return .init(factory.accumulateAlternation(accumulated, next))
   }
 }
+// MARK: - Alternation builder (arity 7)
+
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
   @_alwaysEmitIntoClient
-  public static func buildPartialBlock<R0, W0, C0, C1, C2, C3, C4, C5, C6, R1>(
-    accumulated: R0, next: R1
-  ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4, C5, C6)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2, C3, C4, C5, C6) {
+  public static func buildPartialBlock<W0, C1, C2, C3, C4, C5, C6, C7>(
+    accumulated: some RegexComponent<(W0, C1, C2, C3, C4, C5, C6, C7)>,
+    next: some RegexComponent
+  ) -> ChoiceOf<(Substring, C1, C2, C3, C4, C5, C6, C7)> {
     let factory = makeFactory()
     return .init(factory.accumulateAlternation(accumulated, next))
   }
@@ -4120,9 +4305,10 @@ extension AlternationBuilder {
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
   @_alwaysEmitIntoClient
-  public static func buildPartialBlock<R0, W0, C0, C1, C2, C3, C4, C5, C6, R1, W1, C7>(
-    accumulated: R0, next: R1
-  ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4, C5, C6, C7?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2, C3, C4, C5, C6), R1.RegexOutput == (W1, C7) {
+  public static func buildPartialBlock<W0, C1, C2, C3, C4, C5, C6, C7, W1, C8>(
+    accumulated: some RegexComponent<(W0, C1, C2, C3, C4, C5, C6, C7)>,
+    next: some RegexComponent<(W1, C8)>
+  ) -> ChoiceOf<(Substring, C1, C2, C3, C4, C5, C6, C7, C8?)> {
     let factory = makeFactory()
     return .init(factory.accumulateAlternation(accumulated, next))
   }
@@ -4130,9 +4316,10 @@ extension AlternationBuilder {
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
   @_alwaysEmitIntoClient
-  public static func buildPartialBlock<R0, W0, C0, C1, C2, C3, C4, C5, C6, R1, W1, C7, C8>(
-    accumulated: R0, next: R1
-  ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4, C5, C6, C7?, C8?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2, C3, C4, C5, C6), R1.RegexOutput == (W1, C7, C8) {
+  public static func buildPartialBlock<W0, C1, C2, C3, C4, C5, C6, C7, W1, C8, C9>(
+    accumulated: some RegexComponent<(W0, C1, C2, C3, C4, C5, C6, C7)>,
+    next: some RegexComponent<(W1, C8, C9)>
+  ) -> ChoiceOf<(Substring, C1, C2, C3, C4, C5, C6, C7, C8?, C9?)> {
     let factory = makeFactory()
     return .init(factory.accumulateAlternation(accumulated, next))
   }
@@ -4140,19 +4327,23 @@ extension AlternationBuilder {
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
   @_alwaysEmitIntoClient
-  public static func buildPartialBlock<R0, W0, C0, C1, C2, C3, C4, C5, C6, R1, W1, C7, C8, C9>(
-    accumulated: R0, next: R1
-  ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4, C5, C6, C7?, C8?, C9?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2, C3, C4, C5, C6), R1.RegexOutput == (W1, C7, C8, C9) {
+  public static func buildPartialBlock<W0, C1, C2, C3, C4, C5, C6, C7, W1, C8, C9, C10>(
+    accumulated: some RegexComponent<(W0, C1, C2, C3, C4, C5, C6, C7)>,
+    next: some RegexComponent<(W1, C8, C9, C10)>
+  ) -> ChoiceOf<(Substring, C1, C2, C3, C4, C5, C6, C7, C8?, C9?, C10?)> {
     let factory = makeFactory()
     return .init(factory.accumulateAlternation(accumulated, next))
   }
 }
+// MARK: - Alternation builder (arity 8)
+
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
   @_alwaysEmitIntoClient
-  public static func buildPartialBlock<R0, W0, C0, C1, C2, C3, C4, C5, C6, C7, R1>(
-    accumulated: R0, next: R1
-  ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4, C5, C6, C7)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2, C3, C4, C5, C6, C7) {
+  public static func buildPartialBlock<W0, C1, C2, C3, C4, C5, C6, C7, C8>(
+    accumulated: some RegexComponent<(W0, C1, C2, C3, C4, C5, C6, C7, C8)>,
+    next: some RegexComponent
+  ) -> ChoiceOf<(Substring, C1, C2, C3, C4, C5, C6, C7, C8)> {
     let factory = makeFactory()
     return .init(factory.accumulateAlternation(accumulated, next))
   }
@@ -4160,9 +4351,10 @@ extension AlternationBuilder {
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
   @_alwaysEmitIntoClient
-  public static func buildPartialBlock<R0, W0, C0, C1, C2, C3, C4, C5, C6, C7, R1, W1, C8>(
-    accumulated: R0, next: R1
-  ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2, C3, C4, C5, C6, C7), R1.RegexOutput == (W1, C8) {
+  public static func buildPartialBlock<W0, C1, C2, C3, C4, C5, C6, C7, C8, W1, C9>(
+    accumulated: some RegexComponent<(W0, C1, C2, C3, C4, C5, C6, C7, C8)>,
+    next: some RegexComponent<(W1, C9)>
+  ) -> ChoiceOf<(Substring, C1, C2, C3, C4, C5, C6, C7, C8, C9?)> {
     let factory = makeFactory()
     return .init(factory.accumulateAlternation(accumulated, next))
   }
@@ -4170,19 +4362,23 @@ extension AlternationBuilder {
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
   @_alwaysEmitIntoClient
-  public static func buildPartialBlock<R0, W0, C0, C1, C2, C3, C4, C5, C6, C7, R1, W1, C8, C9>(
-    accumulated: R0, next: R1
-  ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8?, C9?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2, C3, C4, C5, C6, C7), R1.RegexOutput == (W1, C8, C9) {
+  public static func buildPartialBlock<W0, C1, C2, C3, C4, C5, C6, C7, C8, W1, C9, C10>(
+    accumulated: some RegexComponent<(W0, C1, C2, C3, C4, C5, C6, C7, C8)>,
+    next: some RegexComponent<(W1, C9, C10)>
+  ) -> ChoiceOf<(Substring, C1, C2, C3, C4, C5, C6, C7, C8, C9?, C10?)> {
     let factory = makeFactory()
     return .init(factory.accumulateAlternation(accumulated, next))
   }
 }
+// MARK: - Alternation builder (arity 9)
+
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
   @_alwaysEmitIntoClient
-  public static func buildPartialBlock<R0, W0, C0, C1, C2, C3, C4, C5, C6, C7, C8, R1>(
-    accumulated: R0, next: R1
-  ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2, C3, C4, C5, C6, C7, C8) {
+  public static func buildPartialBlock<W0, C1, C2, C3, C4, C5, C6, C7, C8, C9>(
+    accumulated: some RegexComponent<(W0, C1, C2, C3, C4, C5, C6, C7, C8, C9)>,
+    next: some RegexComponent
+  ) -> ChoiceOf<(Substring, C1, C2, C3, C4, C5, C6, C7, C8, C9)> {
     let factory = makeFactory()
     return .init(factory.accumulateAlternation(accumulated, next))
   }
@@ -4190,13 +4386,16 @@ extension AlternationBuilder {
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
   @_alwaysEmitIntoClient
-  public static func buildPartialBlock<R0, W0, C0, C1, C2, C3, C4, C5, C6, C7, C8, R1, W1, C9>(
-    accumulated: R0, next: R1
-  ) -> ChoiceOf<(Substring, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9?)> where R0: RegexComponent, R1: RegexComponent, R0.RegexOutput == (W0, C0, C1, C2, C3, C4, C5, C6, C7, C8), R1.RegexOutput == (W1, C9) {
+  public static func buildPartialBlock<W0, C1, C2, C3, C4, C5, C6, C7, C8, C9, W1, C10>(
+    accumulated: some RegexComponent<(W0, C1, C2, C3, C4, C5, C6, C7, C8, C9)>,
+    next: some RegexComponent<(W1, C10)>
+  ) -> ChoiceOf<(Substring, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10?)> {
     let factory = makeFactory()
     return .init(factory.accumulateAlternation(accumulated, next))
   }
 }
+// MARK: - Alternation builder buildBlock
+
 @available(SwiftStdlib 5.7, *)
 extension AlternationBuilder {
   @_alwaysEmitIntoClient
@@ -4277,7 +4476,7 @@ extension AlternationBuilder {
     return .init(factory.orderedChoice(regex))
   }
 }
-// MARK: - Non-builder capture arity 0
+// MARK: - Non-builder capture (arity 0)
 
 @available(SwiftStdlib 5.7, *)
 extension Capture {
@@ -4286,9 +4485,9 @@ extension Capture {
   /// - Parameter component: The regex component to capture.
   @_disfavoredOverload
   @_alwaysEmitIntoClient
-  public init<R: RegexComponent, W>(
-    _ component: R
-  ) where RegexOutput == (Substring, W), R.RegexOutput == W {
+  public init<W>(
+    _ component: some RegexComponent<W>
+  ) where RegexOutput == (Substring, W) {
     let factory = makeFactory()
     self.init(factory.capture(component))
   }
@@ -4302,9 +4501,10 @@ extension Capture {
   ///     `component`.
   @_disfavoredOverload
   @_alwaysEmitIntoClient
-  public init<R: RegexComponent, W>(
-    _ component: R, as reference: Reference<W>
-  ) where RegexOutput == (Substring, W), R.RegexOutput == W {
+  public init<W>(
+    _ component: some RegexComponent<W>,
+    as reference: Reference<W>
+  ) where RegexOutput == (Substring, W) {
     let factory = makeFactory()
     self.init(factory.capture(component, reference._raw))
   }
@@ -4320,10 +4520,10 @@ extension Capture {
   ///     to the caller.
   @_disfavoredOverload
   @_alwaysEmitIntoClient
-  public init<R: RegexComponent, W, NewCapture>(
-    _ component: R,
+  public init<W, NewCapture>(
+    _ component: some RegexComponent<W>,
     transform: @escaping (W) throws -> NewCapture
-  ) where RegexOutput == (Substring, NewCapture), R.RegexOutput == W {
+  ) where RegexOutput == (Substring, NewCapture) {
     let factory = makeFactory()
     self.init(factory.capture(component, nil, transform))
   }
@@ -4341,11 +4541,11 @@ extension Capture {
   ///     to the caller.
   @_disfavoredOverload
   @_alwaysEmitIntoClient
-  public init<R: RegexComponent, W, NewCapture>(
-    _ component: R,
+  public init<W, NewCapture>(
+    _ component: some RegexComponent<W>,
     as reference: Reference<NewCapture>,
     transform: @escaping (W) throws -> NewCapture
-  ) where RegexOutput == (Substring, NewCapture), R.RegexOutput == W {
+  ) where RegexOutput == (Substring, NewCapture) {
     let factory = makeFactory()
     self.init(factory.capture(component, reference._raw, transform))
   }
@@ -4365,10 +4565,10 @@ extension TryCapture {
   ///     to the caller.
   @_disfavoredOverload
   @_alwaysEmitIntoClient
-  public init<R: RegexComponent, W, NewCapture>(
-    _ component: R,
+  public init<W, NewCapture>(
+    _ component: some RegexComponent<W>,
     transform: @escaping (W) throws -> NewCapture?
-  ) where RegexOutput == (Substring, NewCapture), R.RegexOutput == W {
+  ) where RegexOutput == (Substring, NewCapture) {
     let factory = makeFactory()
     self.init(factory.captureOptional(component, nil, transform))
   }
@@ -4387,17 +4587,16 @@ extension TryCapture {
   ///     to the caller.
   @_disfavoredOverload
   @_alwaysEmitIntoClient
-  public init<R: RegexComponent, W, NewCapture>(
-    _ component: R,
+  public init<W, NewCapture>(
+    _ component: some RegexComponent<W>,
     as reference: Reference<NewCapture>,
     transform: @escaping (W) throws -> NewCapture?
-  ) where RegexOutput == (Substring, NewCapture), R.RegexOutput == W {
+  ) where RegexOutput == (Substring, NewCapture) {
     let factory = makeFactory()
     self.init(factory.captureOptional(component, reference._raw, transform))
   }
 }
-
-// MARK: - Builder capture arity 0
+// MARK: - Builder capture (arity 0)
 
 @available(SwiftStdlib 5.7, *)
 extension Capture {
@@ -4407,9 +4606,9 @@ extension Capture {
   ///   regex component to capture.
   @_disfavoredOverload
   @_alwaysEmitIntoClient
-  public init<R: RegexComponent, W>(
-    @RegexComponentBuilder _ componentBuilder: () -> R
-  ) where RegexOutput == (Substring, W), R.RegexOutput == W {
+  public init<W>(
+    @RegexComponentBuilder _ componentBuilder: () -> some RegexComponent<W>
+  ) where RegexOutput == (Substring, W) {
     let factory = makeFactory()
     self.init(factory.capture(componentBuilder()))
   }
@@ -4424,10 +4623,10 @@ extension Capture {
   ///     component to capture.
   @_disfavoredOverload
   @_alwaysEmitIntoClient
-  public init<R: RegexComponent, W>(
+  public init<W>(
     as reference: Reference<W>,
-    @RegexComponentBuilder _ componentBuilder: () -> R
-  ) where RegexOutput == (Substring, W), R.RegexOutput == W {
+    @RegexComponentBuilder _ componentBuilder: () -> some RegexComponent<W>
+  ) where RegexOutput == (Substring, W) {
     let factory = makeFactory()
     self.init(factory.capture(componentBuilder(), reference._raw))
   }
@@ -4444,10 +4643,10 @@ extension Capture {
   ///     to the caller.
   @_disfavoredOverload
   @_alwaysEmitIntoClient
-  public init<R: RegexComponent, W, NewCapture>(
-    @RegexComponentBuilder _ componentBuilder: () -> R,
+  public init<W, NewCapture>(
+    @RegexComponentBuilder _ componentBuilder: () -> some RegexComponent<W>,
     transform: @escaping (W) throws -> NewCapture
-  ) where RegexOutput == (Substring, NewCapture), R.RegexOutput == W {
+  ) where RegexOutput == (Substring, NewCapture) {
     let factory = makeFactory()
     self.init(factory.capture(componentBuilder(), nil, transform))
   }
@@ -4466,11 +4665,11 @@ extension Capture {
   ///     to the caller.
   @_disfavoredOverload
   @_alwaysEmitIntoClient
-  public init<R: RegexComponent, W, NewCapture>(
+  public init<W, NewCapture>(
     as reference: Reference<NewCapture>,
-    @RegexComponentBuilder _ componentBuilder: () -> R,
+    @RegexComponentBuilder _ componentBuilder: () -> some RegexComponent<W>,
     transform: @escaping (W) throws -> NewCapture
-  ) where RegexOutput == (Substring, NewCapture), R.RegexOutput == W {
+  ) where RegexOutput == (Substring, NewCapture) {
     let factory = makeFactory()
     self.init(factory.capture(componentBuilder(), reference._raw, transform))
   }
@@ -4491,10 +4690,10 @@ extension TryCapture {
   ///     to the caller.
   @_disfavoredOverload
   @_alwaysEmitIntoClient
-  public init<R: RegexComponent, W, NewCapture>(
-    @RegexComponentBuilder _ componentBuilder: () -> R,
+  public init<W, NewCapture>(
+    @RegexComponentBuilder _ componentBuilder: () -> some RegexComponent<W>,
     transform: @escaping (W) throws -> NewCapture?
-  ) where RegexOutput == (Substring, NewCapture), R.RegexOutput == W {
+  ) where RegexOutput == (Substring, NewCapture) {
     let factory = makeFactory()
     self.init(factory.captureOptional(componentBuilder(), nil, transform))
   }
@@ -4514,17 +4713,17 @@ extension TryCapture {
   ///     to the caller.
   @_disfavoredOverload
   @_alwaysEmitIntoClient
-  public init<R: RegexComponent, W, NewCapture>(
+  public init<W, NewCapture>(
     as reference: Reference<NewCapture>,
-    @RegexComponentBuilder _ componentBuilder: () -> R,
+    @RegexComponentBuilder _ componentBuilder: () -> some RegexComponent<W>,
     transform: @escaping (W) throws -> NewCapture?
-  ) where RegexOutput == (Substring, NewCapture), R.RegexOutput == W {
+  ) where RegexOutput == (Substring, NewCapture) {
     let factory = makeFactory()
     self.init(factory.captureOptional(componentBuilder(), reference._raw, transform))
   }
 }
 
-// MARK: - Non-builder capture arity 1
+// MARK: - Non-builder capture (arity 1)
 
 @available(SwiftStdlib 5.7, *)
 extension Capture {
@@ -4532,9 +4731,9 @@ extension Capture {
   ///
   /// - Parameter component: The regex component to capture.
   @_alwaysEmitIntoClient
-  public init<R: RegexComponent, W, C1>(
-    _ component: R
-  ) where RegexOutput == (Substring, W, C1), R.RegexOutput == (W, C1) {
+  public init<W, C1>(
+    _ component: some RegexComponent<(W, C1)>
+  ) where RegexOutput == (Substring, W, C1) {
     let factory = makeFactory()
     self.init(factory.capture(component))
   }
@@ -4547,9 +4746,10 @@ extension Capture {
   ///   - reference: The reference to use for anything captured by
   ///     `component`.
   @_alwaysEmitIntoClient
-  public init<R: RegexComponent, W, C1>(
-    _ component: R, as reference: Reference<W>
-  ) where RegexOutput == (Substring, W, C1), R.RegexOutput == (W, C1) {
+  public init<W, C1>(
+    _ component: some RegexComponent<(W, C1)>,
+    as reference: Reference<W>
+  ) where RegexOutput == (Substring, W, C1) {
     let factory = makeFactory()
     self.init(factory.capture(component, reference._raw))
   }
@@ -4564,10 +4764,10 @@ extension Capture {
   ///     throws an error, matching is abandoned and the error is returned
   ///     to the caller.
   @_alwaysEmitIntoClient
-  public init<R: RegexComponent, W, C1, NewCapture>(
-    _ component: R,
+  public init<W, C1, NewCapture>(
+    _ component: some RegexComponent<(W, C1)>,
     transform: @escaping (W) throws -> NewCapture
-  ) where RegexOutput == (Substring, NewCapture, C1), R.RegexOutput == (W, C1) {
+  ) where RegexOutput == (Substring, NewCapture, C1) {
     let factory = makeFactory()
     self.init(factory.capture(component, nil, transform))
   }
@@ -4584,11 +4784,11 @@ extension Capture {
   ///     throws an error, matching is abandoned and the error is returned
   ///     to the caller.
   @_alwaysEmitIntoClient
-  public init<R: RegexComponent, W, C1, NewCapture>(
-    _ component: R,
+  public init<W, C1, NewCapture>(
+    _ component: some RegexComponent<(W, C1)>,
     as reference: Reference<NewCapture>,
     transform: @escaping (W) throws -> NewCapture
-  ) where RegexOutput == (Substring, NewCapture, C1), R.RegexOutput == (W, C1) {
+  ) where RegexOutput == (Substring, NewCapture, C1) {
     let factory = makeFactory()
     self.init(factory.capture(component, reference._raw, transform))
   }
@@ -4607,10 +4807,10 @@ extension TryCapture {
   ///     throws an error, matching is abandoned and the error is returned
   ///     to the caller.
   @_alwaysEmitIntoClient
-  public init<R: RegexComponent, W, C1, NewCapture>(
-    _ component: R,
+  public init<W, C1, NewCapture>(
+    _ component: some RegexComponent<(W, C1)>,
     transform: @escaping (W) throws -> NewCapture?
-  ) where RegexOutput == (Substring, NewCapture, C1), R.RegexOutput == (W, C1) {
+  ) where RegexOutput == (Substring, NewCapture, C1) {
     let factory = makeFactory()
     self.init(factory.captureOptional(component, nil, transform))
   }
@@ -4628,17 +4828,16 @@ extension TryCapture {
   ///     throws an error, matching is abandoned and the error is returned
   ///     to the caller.
   @_alwaysEmitIntoClient
-  public init<R: RegexComponent, W, C1, NewCapture>(
-    _ component: R,
+  public init<W, C1, NewCapture>(
+    _ component: some RegexComponent<(W, C1)>,
     as reference: Reference<NewCapture>,
     transform: @escaping (W) throws -> NewCapture?
-  ) where RegexOutput == (Substring, NewCapture, C1), R.RegexOutput == (W, C1) {
+  ) where RegexOutput == (Substring, NewCapture, C1) {
     let factory = makeFactory()
     self.init(factory.captureOptional(component, reference._raw, transform))
   }
 }
-
-// MARK: - Builder capture arity 1
+// MARK: - Builder capture (arity 1)
 
 @available(SwiftStdlib 5.7, *)
 extension Capture {
@@ -4647,9 +4846,9 @@ extension Capture {
   /// - Parameter componentBuilder: A builder closure that generates a
   ///   regex component to capture.
   @_alwaysEmitIntoClient
-  public init<R: RegexComponent, W, C1>(
-    @RegexComponentBuilder _ componentBuilder: () -> R
-  ) where RegexOutput == (Substring, W, C1), R.RegexOutput == (W, C1) {
+  public init<W, C1>(
+    @RegexComponentBuilder _ componentBuilder: () -> some RegexComponent<(W, C1)>
+  ) where RegexOutput == (Substring, W, C1) {
     let factory = makeFactory()
     self.init(factory.capture(componentBuilder()))
   }
@@ -4663,10 +4862,10 @@ extension Capture {
   ///   - componentBuilder: A builder closure that generates a regex
   ///     component to capture.
   @_alwaysEmitIntoClient
-  public init<R: RegexComponent, W, C1>(
+  public init<W, C1>(
     as reference: Reference<W>,
-    @RegexComponentBuilder _ componentBuilder: () -> R
-  ) where RegexOutput == (Substring, W, C1), R.RegexOutput == (W, C1) {
+    @RegexComponentBuilder _ componentBuilder: () -> some RegexComponent<(W, C1)>
+  ) where RegexOutput == (Substring, W, C1) {
     let factory = makeFactory()
     self.init(factory.capture(componentBuilder(), reference._raw))
   }
@@ -4682,10 +4881,10 @@ extension Capture {
   ///     throws an error, matching is abandoned and the error is returned
   ///     to the caller.
   @_alwaysEmitIntoClient
-  public init<R: RegexComponent, W, C1, NewCapture>(
-    @RegexComponentBuilder _ componentBuilder: () -> R,
+  public init<W, C1, NewCapture>(
+    @RegexComponentBuilder _ componentBuilder: () -> some RegexComponent<(W, C1)>,
     transform: @escaping (W) throws -> NewCapture
-  ) where RegexOutput == (Substring, NewCapture, C1), R.RegexOutput == (W, C1) {
+  ) where RegexOutput == (Substring, NewCapture, C1) {
     let factory = makeFactory()
     self.init(factory.capture(componentBuilder(), nil, transform))
   }
@@ -4703,11 +4902,11 @@ extension Capture {
   ///     throws an error, matching is abandoned and the error is returned
   ///     to the caller.
   @_alwaysEmitIntoClient
-  public init<R: RegexComponent, W, C1, NewCapture>(
+  public init<W, C1, NewCapture>(
     as reference: Reference<NewCapture>,
-    @RegexComponentBuilder _ componentBuilder: () -> R,
+    @RegexComponentBuilder _ componentBuilder: () -> some RegexComponent<(W, C1)>,
     transform: @escaping (W) throws -> NewCapture
-  ) where RegexOutput == (Substring, NewCapture, C1), R.RegexOutput == (W, C1) {
+  ) where RegexOutput == (Substring, NewCapture, C1) {
     let factory = makeFactory()
     self.init(factory.capture(componentBuilder(), reference._raw, transform))
   }
@@ -4727,10 +4926,10 @@ extension TryCapture {
   ///     throws an error, matching is abandoned and the error is returned
   ///     to the caller.
   @_alwaysEmitIntoClient
-  public init<R: RegexComponent, W, C1, NewCapture>(
-    @RegexComponentBuilder _ componentBuilder: () -> R,
+  public init<W, C1, NewCapture>(
+    @RegexComponentBuilder _ componentBuilder: () -> some RegexComponent<(W, C1)>,
     transform: @escaping (W) throws -> NewCapture?
-  ) where RegexOutput == (Substring, NewCapture, C1), R.RegexOutput == (W, C1) {
+  ) where RegexOutput == (Substring, NewCapture, C1) {
     let factory = makeFactory()
     self.init(factory.captureOptional(componentBuilder(), nil, transform))
   }
@@ -4749,17 +4948,17 @@ extension TryCapture {
   ///     throws an error, matching is abandoned and the error is returned
   ///     to the caller.
   @_alwaysEmitIntoClient
-  public init<R: RegexComponent, W, C1, NewCapture>(
+  public init<W, C1, NewCapture>(
     as reference: Reference<NewCapture>,
-    @RegexComponentBuilder _ componentBuilder: () -> R,
+    @RegexComponentBuilder _ componentBuilder: () -> some RegexComponent<(W, C1)>,
     transform: @escaping (W) throws -> NewCapture?
-  ) where RegexOutput == (Substring, NewCapture, C1), R.RegexOutput == (W, C1) {
+  ) where RegexOutput == (Substring, NewCapture, C1) {
     let factory = makeFactory()
     self.init(factory.captureOptional(componentBuilder(), reference._raw, transform))
   }
 }
 
-// MARK: - Non-builder capture arity 2
+// MARK: - Non-builder capture (arity 2)
 
 @available(SwiftStdlib 5.7, *)
 extension Capture {
@@ -4767,9 +4966,9 @@ extension Capture {
   ///
   /// - Parameter component: The regex component to capture.
   @_alwaysEmitIntoClient
-  public init<R: RegexComponent, W, C1, C2>(
-    _ component: R
-  ) where RegexOutput == (Substring, W, C1, C2), R.RegexOutput == (W, C1, C2) {
+  public init<W, C1, C2>(
+    _ component: some RegexComponent<(W, C1, C2)>
+  ) where RegexOutput == (Substring, W, C1, C2) {
     let factory = makeFactory()
     self.init(factory.capture(component))
   }
@@ -4782,9 +4981,10 @@ extension Capture {
   ///   - reference: The reference to use for anything captured by
   ///     `component`.
   @_alwaysEmitIntoClient
-  public init<R: RegexComponent, W, C1, C2>(
-    _ component: R, as reference: Reference<W>
-  ) where RegexOutput == (Substring, W, C1, C2), R.RegexOutput == (W, C1, C2) {
+  public init<W, C1, C2>(
+    _ component: some RegexComponent<(W, C1, C2)>,
+    as reference: Reference<W>
+  ) where RegexOutput == (Substring, W, C1, C2) {
     let factory = makeFactory()
     self.init(factory.capture(component, reference._raw))
   }
@@ -4799,10 +4999,10 @@ extension Capture {
   ///     throws an error, matching is abandoned and the error is returned
   ///     to the caller.
   @_alwaysEmitIntoClient
-  public init<R: RegexComponent, W, C1, C2, NewCapture>(
-    _ component: R,
+  public init<W, C1, C2, NewCapture>(
+    _ component: some RegexComponent<(W, C1, C2)>,
     transform: @escaping (W) throws -> NewCapture
-  ) where RegexOutput == (Substring, NewCapture, C1, C2), R.RegexOutput == (W, C1, C2) {
+  ) where RegexOutput == (Substring, NewCapture, C1, C2) {
     let factory = makeFactory()
     self.init(factory.capture(component, nil, transform))
   }
@@ -4819,11 +5019,11 @@ extension Capture {
   ///     throws an error, matching is abandoned and the error is returned
   ///     to the caller.
   @_alwaysEmitIntoClient
-  public init<R: RegexComponent, W, C1, C2, NewCapture>(
-    _ component: R,
+  public init<W, C1, C2, NewCapture>(
+    _ component: some RegexComponent<(W, C1, C2)>,
     as reference: Reference<NewCapture>,
     transform: @escaping (W) throws -> NewCapture
-  ) where RegexOutput == (Substring, NewCapture, C1, C2), R.RegexOutput == (W, C1, C2) {
+  ) where RegexOutput == (Substring, NewCapture, C1, C2) {
     let factory = makeFactory()
     self.init(factory.capture(component, reference._raw, transform))
   }
@@ -4842,10 +5042,10 @@ extension TryCapture {
   ///     throws an error, matching is abandoned and the error is returned
   ///     to the caller.
   @_alwaysEmitIntoClient
-  public init<R: RegexComponent, W, C1, C2, NewCapture>(
-    _ component: R,
+  public init<W, C1, C2, NewCapture>(
+    _ component: some RegexComponent<(W, C1, C2)>,
     transform: @escaping (W) throws -> NewCapture?
-  ) where RegexOutput == (Substring, NewCapture, C1, C2), R.RegexOutput == (W, C1, C2) {
+  ) where RegexOutput == (Substring, NewCapture, C1, C2) {
     let factory = makeFactory()
     self.init(factory.captureOptional(component, nil, transform))
   }
@@ -4863,17 +5063,16 @@ extension TryCapture {
   ///     throws an error, matching is abandoned and the error is returned
   ///     to the caller.
   @_alwaysEmitIntoClient
-  public init<R: RegexComponent, W, C1, C2, NewCapture>(
-    _ component: R,
+  public init<W, C1, C2, NewCapture>(
+    _ component: some RegexComponent<(W, C1, C2)>,
     as reference: Reference<NewCapture>,
     transform: @escaping (W) throws -> NewCapture?
-  ) where RegexOutput == (Substring, NewCapture, C1, C2), R.RegexOutput == (W, C1, C2) {
+  ) where RegexOutput == (Substring, NewCapture, C1, C2) {
     let factory = makeFactory()
     self.init(factory.captureOptional(component, reference._raw, transform))
   }
 }
-
-// MARK: - Builder capture arity 2
+// MARK: - Builder capture (arity 2)
 
 @available(SwiftStdlib 5.7, *)
 extension Capture {
@@ -4882,9 +5081,9 @@ extension Capture {
   /// - Parameter componentBuilder: A builder closure that generates a
   ///   regex component to capture.
   @_alwaysEmitIntoClient
-  public init<R: RegexComponent, W, C1, C2>(
-    @RegexComponentBuilder _ componentBuilder: () -> R
-  ) where RegexOutput == (Substring, W, C1, C2), R.RegexOutput == (W, C1, C2) {
+  public init<W, C1, C2>(
+    @RegexComponentBuilder _ componentBuilder: () -> some RegexComponent<(W, C1, C2)>
+  ) where RegexOutput == (Substring, W, C1, C2) {
     let factory = makeFactory()
     self.init(factory.capture(componentBuilder()))
   }
@@ -4898,10 +5097,10 @@ extension Capture {
   ///   - componentBuilder: A builder closure that generates a regex
   ///     component to capture.
   @_alwaysEmitIntoClient
-  public init<R: RegexComponent, W, C1, C2>(
+  public init<W, C1, C2>(
     as reference: Reference<W>,
-    @RegexComponentBuilder _ componentBuilder: () -> R
-  ) where RegexOutput == (Substring, W, C1, C2), R.RegexOutput == (W, C1, C2) {
+    @RegexComponentBuilder _ componentBuilder: () -> some RegexComponent<(W, C1, C2)>
+  ) where RegexOutput == (Substring, W, C1, C2) {
     let factory = makeFactory()
     self.init(factory.capture(componentBuilder(), reference._raw))
   }
@@ -4917,10 +5116,10 @@ extension Capture {
   ///     throws an error, matching is abandoned and the error is returned
   ///     to the caller.
   @_alwaysEmitIntoClient
-  public init<R: RegexComponent, W, C1, C2, NewCapture>(
-    @RegexComponentBuilder _ componentBuilder: () -> R,
+  public init<W, C1, C2, NewCapture>(
+    @RegexComponentBuilder _ componentBuilder: () -> some RegexComponent<(W, C1, C2)>,
     transform: @escaping (W) throws -> NewCapture
-  ) where RegexOutput == (Substring, NewCapture, C1, C2), R.RegexOutput == (W, C1, C2) {
+  ) where RegexOutput == (Substring, NewCapture, C1, C2) {
     let factory = makeFactory()
     self.init(factory.capture(componentBuilder(), nil, transform))
   }
@@ -4938,11 +5137,11 @@ extension Capture {
   ///     throws an error, matching is abandoned and the error is returned
   ///     to the caller.
   @_alwaysEmitIntoClient
-  public init<R: RegexComponent, W, C1, C2, NewCapture>(
+  public init<W, C1, C2, NewCapture>(
     as reference: Reference<NewCapture>,
-    @RegexComponentBuilder _ componentBuilder: () -> R,
+    @RegexComponentBuilder _ componentBuilder: () -> some RegexComponent<(W, C1, C2)>,
     transform: @escaping (W) throws -> NewCapture
-  ) where RegexOutput == (Substring, NewCapture, C1, C2), R.RegexOutput == (W, C1, C2) {
+  ) where RegexOutput == (Substring, NewCapture, C1, C2) {
     let factory = makeFactory()
     self.init(factory.capture(componentBuilder(), reference._raw, transform))
   }
@@ -4962,10 +5161,10 @@ extension TryCapture {
   ///     throws an error, matching is abandoned and the error is returned
   ///     to the caller.
   @_alwaysEmitIntoClient
-  public init<R: RegexComponent, W, C1, C2, NewCapture>(
-    @RegexComponentBuilder _ componentBuilder: () -> R,
+  public init<W, C1, C2, NewCapture>(
+    @RegexComponentBuilder _ componentBuilder: () -> some RegexComponent<(W, C1, C2)>,
     transform: @escaping (W) throws -> NewCapture?
-  ) where RegexOutput == (Substring, NewCapture, C1, C2), R.RegexOutput == (W, C1, C2) {
+  ) where RegexOutput == (Substring, NewCapture, C1, C2) {
     let factory = makeFactory()
     self.init(factory.captureOptional(componentBuilder(), nil, transform))
   }
@@ -4984,17 +5183,17 @@ extension TryCapture {
   ///     throws an error, matching is abandoned and the error is returned
   ///     to the caller.
   @_alwaysEmitIntoClient
-  public init<R: RegexComponent, W, C1, C2, NewCapture>(
+  public init<W, C1, C2, NewCapture>(
     as reference: Reference<NewCapture>,
-    @RegexComponentBuilder _ componentBuilder: () -> R,
+    @RegexComponentBuilder _ componentBuilder: () -> some RegexComponent<(W, C1, C2)>,
     transform: @escaping (W) throws -> NewCapture?
-  ) where RegexOutput == (Substring, NewCapture, C1, C2), R.RegexOutput == (W, C1, C2) {
+  ) where RegexOutput == (Substring, NewCapture, C1, C2) {
     let factory = makeFactory()
     self.init(factory.captureOptional(componentBuilder(), reference._raw, transform))
   }
 }
 
-// MARK: - Non-builder capture arity 3
+// MARK: - Non-builder capture (arity 3)
 
 @available(SwiftStdlib 5.7, *)
 extension Capture {
@@ -5002,9 +5201,9 @@ extension Capture {
   ///
   /// - Parameter component: The regex component to capture.
   @_alwaysEmitIntoClient
-  public init<R: RegexComponent, W, C1, C2, C3>(
-    _ component: R
-  ) where RegexOutput == (Substring, W, C1, C2, C3), R.RegexOutput == (W, C1, C2, C3) {
+  public init<W, C1, C2, C3>(
+    _ component: some RegexComponent<(W, C1, C2, C3)>
+  ) where RegexOutput == (Substring, W, C1, C2, C3) {
     let factory = makeFactory()
     self.init(factory.capture(component))
   }
@@ -5017,9 +5216,10 @@ extension Capture {
   ///   - reference: The reference to use for anything captured by
   ///     `component`.
   @_alwaysEmitIntoClient
-  public init<R: RegexComponent, W, C1, C2, C3>(
-    _ component: R, as reference: Reference<W>
-  ) where RegexOutput == (Substring, W, C1, C2, C3), R.RegexOutput == (W, C1, C2, C3) {
+  public init<W, C1, C2, C3>(
+    _ component: some RegexComponent<(W, C1, C2, C3)>,
+    as reference: Reference<W>
+  ) where RegexOutput == (Substring, W, C1, C2, C3) {
     let factory = makeFactory()
     self.init(factory.capture(component, reference._raw))
   }
@@ -5034,10 +5234,10 @@ extension Capture {
   ///     throws an error, matching is abandoned and the error is returned
   ///     to the caller.
   @_alwaysEmitIntoClient
-  public init<R: RegexComponent, W, C1, C2, C3, NewCapture>(
-    _ component: R,
+  public init<W, C1, C2, C3, NewCapture>(
+    _ component: some RegexComponent<(W, C1, C2, C3)>,
     transform: @escaping (W) throws -> NewCapture
-  ) where RegexOutput == (Substring, NewCapture, C1, C2, C3), R.RegexOutput == (W, C1, C2, C3) {
+  ) where RegexOutput == (Substring, NewCapture, C1, C2, C3) {
     let factory = makeFactory()
     self.init(factory.capture(component, nil, transform))
   }
@@ -5054,11 +5254,11 @@ extension Capture {
   ///     throws an error, matching is abandoned and the error is returned
   ///     to the caller.
   @_alwaysEmitIntoClient
-  public init<R: RegexComponent, W, C1, C2, C3, NewCapture>(
-    _ component: R,
+  public init<W, C1, C2, C3, NewCapture>(
+    _ component: some RegexComponent<(W, C1, C2, C3)>,
     as reference: Reference<NewCapture>,
     transform: @escaping (W) throws -> NewCapture
-  ) where RegexOutput == (Substring, NewCapture, C1, C2, C3), R.RegexOutput == (W, C1, C2, C3) {
+  ) where RegexOutput == (Substring, NewCapture, C1, C2, C3) {
     let factory = makeFactory()
     self.init(factory.capture(component, reference._raw, transform))
   }
@@ -5077,10 +5277,10 @@ extension TryCapture {
   ///     throws an error, matching is abandoned and the error is returned
   ///     to the caller.
   @_alwaysEmitIntoClient
-  public init<R: RegexComponent, W, C1, C2, C3, NewCapture>(
-    _ component: R,
+  public init<W, C1, C2, C3, NewCapture>(
+    _ component: some RegexComponent<(W, C1, C2, C3)>,
     transform: @escaping (W) throws -> NewCapture?
-  ) where RegexOutput == (Substring, NewCapture, C1, C2, C3), R.RegexOutput == (W, C1, C2, C3) {
+  ) where RegexOutput == (Substring, NewCapture, C1, C2, C3) {
     let factory = makeFactory()
     self.init(factory.captureOptional(component, nil, transform))
   }
@@ -5098,17 +5298,16 @@ extension TryCapture {
   ///     throws an error, matching is abandoned and the error is returned
   ///     to the caller.
   @_alwaysEmitIntoClient
-  public init<R: RegexComponent, W, C1, C2, C3, NewCapture>(
-    _ component: R,
+  public init<W, C1, C2, C3, NewCapture>(
+    _ component: some RegexComponent<(W, C1, C2, C3)>,
     as reference: Reference<NewCapture>,
     transform: @escaping (W) throws -> NewCapture?
-  ) where RegexOutput == (Substring, NewCapture, C1, C2, C3), R.RegexOutput == (W, C1, C2, C3) {
+  ) where RegexOutput == (Substring, NewCapture, C1, C2, C3) {
     let factory = makeFactory()
     self.init(factory.captureOptional(component, reference._raw, transform))
   }
 }
-
-// MARK: - Builder capture arity 3
+// MARK: - Builder capture (arity 3)
 
 @available(SwiftStdlib 5.7, *)
 extension Capture {
@@ -5117,9 +5316,9 @@ extension Capture {
   /// - Parameter componentBuilder: A builder closure that generates a
   ///   regex component to capture.
   @_alwaysEmitIntoClient
-  public init<R: RegexComponent, W, C1, C2, C3>(
-    @RegexComponentBuilder _ componentBuilder: () -> R
-  ) where RegexOutput == (Substring, W, C1, C2, C3), R.RegexOutput == (W, C1, C2, C3) {
+  public init<W, C1, C2, C3>(
+    @RegexComponentBuilder _ componentBuilder: () -> some RegexComponent<(W, C1, C2, C3)>
+  ) where RegexOutput == (Substring, W, C1, C2, C3) {
     let factory = makeFactory()
     self.init(factory.capture(componentBuilder()))
   }
@@ -5133,10 +5332,10 @@ extension Capture {
   ///   - componentBuilder: A builder closure that generates a regex
   ///     component to capture.
   @_alwaysEmitIntoClient
-  public init<R: RegexComponent, W, C1, C2, C3>(
+  public init<W, C1, C2, C3>(
     as reference: Reference<W>,
-    @RegexComponentBuilder _ componentBuilder: () -> R
-  ) where RegexOutput == (Substring, W, C1, C2, C3), R.RegexOutput == (W, C1, C2, C3) {
+    @RegexComponentBuilder _ componentBuilder: () -> some RegexComponent<(W, C1, C2, C3)>
+  ) where RegexOutput == (Substring, W, C1, C2, C3) {
     let factory = makeFactory()
     self.init(factory.capture(componentBuilder(), reference._raw))
   }
@@ -5152,10 +5351,10 @@ extension Capture {
   ///     throws an error, matching is abandoned and the error is returned
   ///     to the caller.
   @_alwaysEmitIntoClient
-  public init<R: RegexComponent, W, C1, C2, C3, NewCapture>(
-    @RegexComponentBuilder _ componentBuilder: () -> R,
+  public init<W, C1, C2, C3, NewCapture>(
+    @RegexComponentBuilder _ componentBuilder: () -> some RegexComponent<(W, C1, C2, C3)>,
     transform: @escaping (W) throws -> NewCapture
-  ) where RegexOutput == (Substring, NewCapture, C1, C2, C3), R.RegexOutput == (W, C1, C2, C3) {
+  ) where RegexOutput == (Substring, NewCapture, C1, C2, C3) {
     let factory = makeFactory()
     self.init(factory.capture(componentBuilder(), nil, transform))
   }
@@ -5173,11 +5372,11 @@ extension Capture {
   ///     throws an error, matching is abandoned and the error is returned
   ///     to the caller.
   @_alwaysEmitIntoClient
-  public init<R: RegexComponent, W, C1, C2, C3, NewCapture>(
+  public init<W, C1, C2, C3, NewCapture>(
     as reference: Reference<NewCapture>,
-    @RegexComponentBuilder _ componentBuilder: () -> R,
+    @RegexComponentBuilder _ componentBuilder: () -> some RegexComponent<(W, C1, C2, C3)>,
     transform: @escaping (W) throws -> NewCapture
-  ) where RegexOutput == (Substring, NewCapture, C1, C2, C3), R.RegexOutput == (W, C1, C2, C3) {
+  ) where RegexOutput == (Substring, NewCapture, C1, C2, C3) {
     let factory = makeFactory()
     self.init(factory.capture(componentBuilder(), reference._raw, transform))
   }
@@ -5197,10 +5396,10 @@ extension TryCapture {
   ///     throws an error, matching is abandoned and the error is returned
   ///     to the caller.
   @_alwaysEmitIntoClient
-  public init<R: RegexComponent, W, C1, C2, C3, NewCapture>(
-    @RegexComponentBuilder _ componentBuilder: () -> R,
+  public init<W, C1, C2, C3, NewCapture>(
+    @RegexComponentBuilder _ componentBuilder: () -> some RegexComponent<(W, C1, C2, C3)>,
     transform: @escaping (W) throws -> NewCapture?
-  ) where RegexOutput == (Substring, NewCapture, C1, C2, C3), R.RegexOutput == (W, C1, C2, C3) {
+  ) where RegexOutput == (Substring, NewCapture, C1, C2, C3) {
     let factory = makeFactory()
     self.init(factory.captureOptional(componentBuilder(), nil, transform))
   }
@@ -5219,17 +5418,17 @@ extension TryCapture {
   ///     throws an error, matching is abandoned and the error is returned
   ///     to the caller.
   @_alwaysEmitIntoClient
-  public init<R: RegexComponent, W, C1, C2, C3, NewCapture>(
+  public init<W, C1, C2, C3, NewCapture>(
     as reference: Reference<NewCapture>,
-    @RegexComponentBuilder _ componentBuilder: () -> R,
+    @RegexComponentBuilder _ componentBuilder: () -> some RegexComponent<(W, C1, C2, C3)>,
     transform: @escaping (W) throws -> NewCapture?
-  ) where RegexOutput == (Substring, NewCapture, C1, C2, C3), R.RegexOutput == (W, C1, C2, C3) {
+  ) where RegexOutput == (Substring, NewCapture, C1, C2, C3) {
     let factory = makeFactory()
     self.init(factory.captureOptional(componentBuilder(), reference._raw, transform))
   }
 }
 
-// MARK: - Non-builder capture arity 4
+// MARK: - Non-builder capture (arity 4)
 
 @available(SwiftStdlib 5.7, *)
 extension Capture {
@@ -5237,9 +5436,9 @@ extension Capture {
   ///
   /// - Parameter component: The regex component to capture.
   @_alwaysEmitIntoClient
-  public init<R: RegexComponent, W, C1, C2, C3, C4>(
-    _ component: R
-  ) where RegexOutput == (Substring, W, C1, C2, C3, C4), R.RegexOutput == (W, C1, C2, C3, C4) {
+  public init<W, C1, C2, C3, C4>(
+    _ component: some RegexComponent<(W, C1, C2, C3, C4)>
+  ) where RegexOutput == (Substring, W, C1, C2, C3, C4) {
     let factory = makeFactory()
     self.init(factory.capture(component))
   }
@@ -5252,9 +5451,10 @@ extension Capture {
   ///   - reference: The reference to use for anything captured by
   ///     `component`.
   @_alwaysEmitIntoClient
-  public init<R: RegexComponent, W, C1, C2, C3, C4>(
-    _ component: R, as reference: Reference<W>
-  ) where RegexOutput == (Substring, W, C1, C2, C3, C4), R.RegexOutput == (W, C1, C2, C3, C4) {
+  public init<W, C1, C2, C3, C4>(
+    _ component: some RegexComponent<(W, C1, C2, C3, C4)>,
+    as reference: Reference<W>
+  ) where RegexOutput == (Substring, W, C1, C2, C3, C4) {
     let factory = makeFactory()
     self.init(factory.capture(component, reference._raw))
   }
@@ -5269,10 +5469,10 @@ extension Capture {
   ///     throws an error, matching is abandoned and the error is returned
   ///     to the caller.
   @_alwaysEmitIntoClient
-  public init<R: RegexComponent, W, C1, C2, C3, C4, NewCapture>(
-    _ component: R,
+  public init<W, C1, C2, C3, C4, NewCapture>(
+    _ component: some RegexComponent<(W, C1, C2, C3, C4)>,
     transform: @escaping (W) throws -> NewCapture
-  ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4), R.RegexOutput == (W, C1, C2, C3, C4) {
+  ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4) {
     let factory = makeFactory()
     self.init(factory.capture(component, nil, transform))
   }
@@ -5289,11 +5489,11 @@ extension Capture {
   ///     throws an error, matching is abandoned and the error is returned
   ///     to the caller.
   @_alwaysEmitIntoClient
-  public init<R: RegexComponent, W, C1, C2, C3, C4, NewCapture>(
-    _ component: R,
+  public init<W, C1, C2, C3, C4, NewCapture>(
+    _ component: some RegexComponent<(W, C1, C2, C3, C4)>,
     as reference: Reference<NewCapture>,
     transform: @escaping (W) throws -> NewCapture
-  ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4), R.RegexOutput == (W, C1, C2, C3, C4) {
+  ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4) {
     let factory = makeFactory()
     self.init(factory.capture(component, reference._raw, transform))
   }
@@ -5312,10 +5512,10 @@ extension TryCapture {
   ///     throws an error, matching is abandoned and the error is returned
   ///     to the caller.
   @_alwaysEmitIntoClient
-  public init<R: RegexComponent, W, C1, C2, C3, C4, NewCapture>(
-    _ component: R,
+  public init<W, C1, C2, C3, C4, NewCapture>(
+    _ component: some RegexComponent<(W, C1, C2, C3, C4)>,
     transform: @escaping (W) throws -> NewCapture?
-  ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4), R.RegexOutput == (W, C1, C2, C3, C4) {
+  ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4) {
     let factory = makeFactory()
     self.init(factory.captureOptional(component, nil, transform))
   }
@@ -5333,17 +5533,16 @@ extension TryCapture {
   ///     throws an error, matching is abandoned and the error is returned
   ///     to the caller.
   @_alwaysEmitIntoClient
-  public init<R: RegexComponent, W, C1, C2, C3, C4, NewCapture>(
-    _ component: R,
+  public init<W, C1, C2, C3, C4, NewCapture>(
+    _ component: some RegexComponent<(W, C1, C2, C3, C4)>,
     as reference: Reference<NewCapture>,
     transform: @escaping (W) throws -> NewCapture?
-  ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4), R.RegexOutput == (W, C1, C2, C3, C4) {
+  ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4) {
     let factory = makeFactory()
     self.init(factory.captureOptional(component, reference._raw, transform))
   }
 }
-
-// MARK: - Builder capture arity 4
+// MARK: - Builder capture (arity 4)
 
 @available(SwiftStdlib 5.7, *)
 extension Capture {
@@ -5352,9 +5551,9 @@ extension Capture {
   /// - Parameter componentBuilder: A builder closure that generates a
   ///   regex component to capture.
   @_alwaysEmitIntoClient
-  public init<R: RegexComponent, W, C1, C2, C3, C4>(
-    @RegexComponentBuilder _ componentBuilder: () -> R
-  ) where RegexOutput == (Substring, W, C1, C2, C3, C4), R.RegexOutput == (W, C1, C2, C3, C4) {
+  public init<W, C1, C2, C3, C4>(
+    @RegexComponentBuilder _ componentBuilder: () -> some RegexComponent<(W, C1, C2, C3, C4)>
+  ) where RegexOutput == (Substring, W, C1, C2, C3, C4) {
     let factory = makeFactory()
     self.init(factory.capture(componentBuilder()))
   }
@@ -5368,10 +5567,10 @@ extension Capture {
   ///   - componentBuilder: A builder closure that generates a regex
   ///     component to capture.
   @_alwaysEmitIntoClient
-  public init<R: RegexComponent, W, C1, C2, C3, C4>(
+  public init<W, C1, C2, C3, C4>(
     as reference: Reference<W>,
-    @RegexComponentBuilder _ componentBuilder: () -> R
-  ) where RegexOutput == (Substring, W, C1, C2, C3, C4), R.RegexOutput == (W, C1, C2, C3, C4) {
+    @RegexComponentBuilder _ componentBuilder: () -> some RegexComponent<(W, C1, C2, C3, C4)>
+  ) where RegexOutput == (Substring, W, C1, C2, C3, C4) {
     let factory = makeFactory()
     self.init(factory.capture(componentBuilder(), reference._raw))
   }
@@ -5387,10 +5586,10 @@ extension Capture {
   ///     throws an error, matching is abandoned and the error is returned
   ///     to the caller.
   @_alwaysEmitIntoClient
-  public init<R: RegexComponent, W, C1, C2, C3, C4, NewCapture>(
-    @RegexComponentBuilder _ componentBuilder: () -> R,
+  public init<W, C1, C2, C3, C4, NewCapture>(
+    @RegexComponentBuilder _ componentBuilder: () -> some RegexComponent<(W, C1, C2, C3, C4)>,
     transform: @escaping (W) throws -> NewCapture
-  ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4), R.RegexOutput == (W, C1, C2, C3, C4) {
+  ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4) {
     let factory = makeFactory()
     self.init(factory.capture(componentBuilder(), nil, transform))
   }
@@ -5408,11 +5607,11 @@ extension Capture {
   ///     throws an error, matching is abandoned and the error is returned
   ///     to the caller.
   @_alwaysEmitIntoClient
-  public init<R: RegexComponent, W, C1, C2, C3, C4, NewCapture>(
+  public init<W, C1, C2, C3, C4, NewCapture>(
     as reference: Reference<NewCapture>,
-    @RegexComponentBuilder _ componentBuilder: () -> R,
+    @RegexComponentBuilder _ componentBuilder: () -> some RegexComponent<(W, C1, C2, C3, C4)>,
     transform: @escaping (W) throws -> NewCapture
-  ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4), R.RegexOutput == (W, C1, C2, C3, C4) {
+  ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4) {
     let factory = makeFactory()
     self.init(factory.capture(componentBuilder(), reference._raw, transform))
   }
@@ -5432,10 +5631,10 @@ extension TryCapture {
   ///     throws an error, matching is abandoned and the error is returned
   ///     to the caller.
   @_alwaysEmitIntoClient
-  public init<R: RegexComponent, W, C1, C2, C3, C4, NewCapture>(
-    @RegexComponentBuilder _ componentBuilder: () -> R,
+  public init<W, C1, C2, C3, C4, NewCapture>(
+    @RegexComponentBuilder _ componentBuilder: () -> some RegexComponent<(W, C1, C2, C3, C4)>,
     transform: @escaping (W) throws -> NewCapture?
-  ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4), R.RegexOutput == (W, C1, C2, C3, C4) {
+  ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4) {
     let factory = makeFactory()
     self.init(factory.captureOptional(componentBuilder(), nil, transform))
   }
@@ -5454,17 +5653,17 @@ extension TryCapture {
   ///     throws an error, matching is abandoned and the error is returned
   ///     to the caller.
   @_alwaysEmitIntoClient
-  public init<R: RegexComponent, W, C1, C2, C3, C4, NewCapture>(
+  public init<W, C1, C2, C3, C4, NewCapture>(
     as reference: Reference<NewCapture>,
-    @RegexComponentBuilder _ componentBuilder: () -> R,
+    @RegexComponentBuilder _ componentBuilder: () -> some RegexComponent<(W, C1, C2, C3, C4)>,
     transform: @escaping (W) throws -> NewCapture?
-  ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4), R.RegexOutput == (W, C1, C2, C3, C4) {
+  ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4) {
     let factory = makeFactory()
     self.init(factory.captureOptional(componentBuilder(), reference._raw, transform))
   }
 }
 
-// MARK: - Non-builder capture arity 5
+// MARK: - Non-builder capture (arity 5)
 
 @available(SwiftStdlib 5.7, *)
 extension Capture {
@@ -5472,9 +5671,9 @@ extension Capture {
   ///
   /// - Parameter component: The regex component to capture.
   @_alwaysEmitIntoClient
-  public init<R: RegexComponent, W, C1, C2, C3, C4, C5>(
-    _ component: R
-  ) where RegexOutput == (Substring, W, C1, C2, C3, C4, C5), R.RegexOutput == (W, C1, C2, C3, C4, C5) {
+  public init<W, C1, C2, C3, C4, C5>(
+    _ component: some RegexComponent<(W, C1, C2, C3, C4, C5)>
+  ) where RegexOutput == (Substring, W, C1, C2, C3, C4, C5) {
     let factory = makeFactory()
     self.init(factory.capture(component))
   }
@@ -5487,9 +5686,10 @@ extension Capture {
   ///   - reference: The reference to use for anything captured by
   ///     `component`.
   @_alwaysEmitIntoClient
-  public init<R: RegexComponent, W, C1, C2, C3, C4, C5>(
-    _ component: R, as reference: Reference<W>
-  ) where RegexOutput == (Substring, W, C1, C2, C3, C4, C5), R.RegexOutput == (W, C1, C2, C3, C4, C5) {
+  public init<W, C1, C2, C3, C4, C5>(
+    _ component: some RegexComponent<(W, C1, C2, C3, C4, C5)>,
+    as reference: Reference<W>
+  ) where RegexOutput == (Substring, W, C1, C2, C3, C4, C5) {
     let factory = makeFactory()
     self.init(factory.capture(component, reference._raw))
   }
@@ -5504,10 +5704,10 @@ extension Capture {
   ///     throws an error, matching is abandoned and the error is returned
   ///     to the caller.
   @_alwaysEmitIntoClient
-  public init<R: RegexComponent, W, C1, C2, C3, C4, C5, NewCapture>(
-    _ component: R,
+  public init<W, C1, C2, C3, C4, C5, NewCapture>(
+    _ component: some RegexComponent<(W, C1, C2, C3, C4, C5)>,
     transform: @escaping (W) throws -> NewCapture
-  ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5), R.RegexOutput == (W, C1, C2, C3, C4, C5) {
+  ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5) {
     let factory = makeFactory()
     self.init(factory.capture(component, nil, transform))
   }
@@ -5524,11 +5724,11 @@ extension Capture {
   ///     throws an error, matching is abandoned and the error is returned
   ///     to the caller.
   @_alwaysEmitIntoClient
-  public init<R: RegexComponent, W, C1, C2, C3, C4, C5, NewCapture>(
-    _ component: R,
+  public init<W, C1, C2, C3, C4, C5, NewCapture>(
+    _ component: some RegexComponent<(W, C1, C2, C3, C4, C5)>,
     as reference: Reference<NewCapture>,
     transform: @escaping (W) throws -> NewCapture
-  ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5), R.RegexOutput == (W, C1, C2, C3, C4, C5) {
+  ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5) {
     let factory = makeFactory()
     self.init(factory.capture(component, reference._raw, transform))
   }
@@ -5547,10 +5747,10 @@ extension TryCapture {
   ///     throws an error, matching is abandoned and the error is returned
   ///     to the caller.
   @_alwaysEmitIntoClient
-  public init<R: RegexComponent, W, C1, C2, C3, C4, C5, NewCapture>(
-    _ component: R,
+  public init<W, C1, C2, C3, C4, C5, NewCapture>(
+    _ component: some RegexComponent<(W, C1, C2, C3, C4, C5)>,
     transform: @escaping (W) throws -> NewCapture?
-  ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5), R.RegexOutput == (W, C1, C2, C3, C4, C5) {
+  ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5) {
     let factory = makeFactory()
     self.init(factory.captureOptional(component, nil, transform))
   }
@@ -5568,17 +5768,16 @@ extension TryCapture {
   ///     throws an error, matching is abandoned and the error is returned
   ///     to the caller.
   @_alwaysEmitIntoClient
-  public init<R: RegexComponent, W, C1, C2, C3, C4, C5, NewCapture>(
-    _ component: R,
+  public init<W, C1, C2, C3, C4, C5, NewCapture>(
+    _ component: some RegexComponent<(W, C1, C2, C3, C4, C5)>,
     as reference: Reference<NewCapture>,
     transform: @escaping (W) throws -> NewCapture?
-  ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5), R.RegexOutput == (W, C1, C2, C3, C4, C5) {
+  ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5) {
     let factory = makeFactory()
     self.init(factory.captureOptional(component, reference._raw, transform))
   }
 }
-
-// MARK: - Builder capture arity 5
+// MARK: - Builder capture (arity 5)
 
 @available(SwiftStdlib 5.7, *)
 extension Capture {
@@ -5587,9 +5786,9 @@ extension Capture {
   /// - Parameter componentBuilder: A builder closure that generates a
   ///   regex component to capture.
   @_alwaysEmitIntoClient
-  public init<R: RegexComponent, W, C1, C2, C3, C4, C5>(
-    @RegexComponentBuilder _ componentBuilder: () -> R
-  ) where RegexOutput == (Substring, W, C1, C2, C3, C4, C5), R.RegexOutput == (W, C1, C2, C3, C4, C5) {
+  public init<W, C1, C2, C3, C4, C5>(
+    @RegexComponentBuilder _ componentBuilder: () -> some RegexComponent<(W, C1, C2, C3, C4, C5)>
+  ) where RegexOutput == (Substring, W, C1, C2, C3, C4, C5) {
     let factory = makeFactory()
     self.init(factory.capture(componentBuilder()))
   }
@@ -5603,10 +5802,10 @@ extension Capture {
   ///   - componentBuilder: A builder closure that generates a regex
   ///     component to capture.
   @_alwaysEmitIntoClient
-  public init<R: RegexComponent, W, C1, C2, C3, C4, C5>(
+  public init<W, C1, C2, C3, C4, C5>(
     as reference: Reference<W>,
-    @RegexComponentBuilder _ componentBuilder: () -> R
-  ) where RegexOutput == (Substring, W, C1, C2, C3, C4, C5), R.RegexOutput == (W, C1, C2, C3, C4, C5) {
+    @RegexComponentBuilder _ componentBuilder: () -> some RegexComponent<(W, C1, C2, C3, C4, C5)>
+  ) where RegexOutput == (Substring, W, C1, C2, C3, C4, C5) {
     let factory = makeFactory()
     self.init(factory.capture(componentBuilder(), reference._raw))
   }
@@ -5622,10 +5821,10 @@ extension Capture {
   ///     throws an error, matching is abandoned and the error is returned
   ///     to the caller.
   @_alwaysEmitIntoClient
-  public init<R: RegexComponent, W, C1, C2, C3, C4, C5, NewCapture>(
-    @RegexComponentBuilder _ componentBuilder: () -> R,
+  public init<W, C1, C2, C3, C4, C5, NewCapture>(
+    @RegexComponentBuilder _ componentBuilder: () -> some RegexComponent<(W, C1, C2, C3, C4, C5)>,
     transform: @escaping (W) throws -> NewCapture
-  ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5), R.RegexOutput == (W, C1, C2, C3, C4, C5) {
+  ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5) {
     let factory = makeFactory()
     self.init(factory.capture(componentBuilder(), nil, transform))
   }
@@ -5643,11 +5842,11 @@ extension Capture {
   ///     throws an error, matching is abandoned and the error is returned
   ///     to the caller.
   @_alwaysEmitIntoClient
-  public init<R: RegexComponent, W, C1, C2, C3, C4, C5, NewCapture>(
+  public init<W, C1, C2, C3, C4, C5, NewCapture>(
     as reference: Reference<NewCapture>,
-    @RegexComponentBuilder _ componentBuilder: () -> R,
+    @RegexComponentBuilder _ componentBuilder: () -> some RegexComponent<(W, C1, C2, C3, C4, C5)>,
     transform: @escaping (W) throws -> NewCapture
-  ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5), R.RegexOutput == (W, C1, C2, C3, C4, C5) {
+  ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5) {
     let factory = makeFactory()
     self.init(factory.capture(componentBuilder(), reference._raw, transform))
   }
@@ -5667,10 +5866,10 @@ extension TryCapture {
   ///     throws an error, matching is abandoned and the error is returned
   ///     to the caller.
   @_alwaysEmitIntoClient
-  public init<R: RegexComponent, W, C1, C2, C3, C4, C5, NewCapture>(
-    @RegexComponentBuilder _ componentBuilder: () -> R,
+  public init<W, C1, C2, C3, C4, C5, NewCapture>(
+    @RegexComponentBuilder _ componentBuilder: () -> some RegexComponent<(W, C1, C2, C3, C4, C5)>,
     transform: @escaping (W) throws -> NewCapture?
-  ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5), R.RegexOutput == (W, C1, C2, C3, C4, C5) {
+  ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5) {
     let factory = makeFactory()
     self.init(factory.captureOptional(componentBuilder(), nil, transform))
   }
@@ -5689,17 +5888,17 @@ extension TryCapture {
   ///     throws an error, matching is abandoned and the error is returned
   ///     to the caller.
   @_alwaysEmitIntoClient
-  public init<R: RegexComponent, W, C1, C2, C3, C4, C5, NewCapture>(
+  public init<W, C1, C2, C3, C4, C5, NewCapture>(
     as reference: Reference<NewCapture>,
-    @RegexComponentBuilder _ componentBuilder: () -> R,
+    @RegexComponentBuilder _ componentBuilder: () -> some RegexComponent<(W, C1, C2, C3, C4, C5)>,
     transform: @escaping (W) throws -> NewCapture?
-  ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5), R.RegexOutput == (W, C1, C2, C3, C4, C5) {
+  ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5) {
     let factory = makeFactory()
     self.init(factory.captureOptional(componentBuilder(), reference._raw, transform))
   }
 }
 
-// MARK: - Non-builder capture arity 6
+// MARK: - Non-builder capture (arity 6)
 
 @available(SwiftStdlib 5.7, *)
 extension Capture {
@@ -5707,9 +5906,9 @@ extension Capture {
   ///
   /// - Parameter component: The regex component to capture.
   @_alwaysEmitIntoClient
-  public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6>(
-    _ component: R
-  ) where RegexOutput == (Substring, W, C1, C2, C3, C4, C5, C6), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6) {
+  public init<W, C1, C2, C3, C4, C5, C6>(
+    _ component: some RegexComponent<(W, C1, C2, C3, C4, C5, C6)>
+  ) where RegexOutput == (Substring, W, C1, C2, C3, C4, C5, C6) {
     let factory = makeFactory()
     self.init(factory.capture(component))
   }
@@ -5722,9 +5921,10 @@ extension Capture {
   ///   - reference: The reference to use for anything captured by
   ///     `component`.
   @_alwaysEmitIntoClient
-  public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6>(
-    _ component: R, as reference: Reference<W>
-  ) where RegexOutput == (Substring, W, C1, C2, C3, C4, C5, C6), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6) {
+  public init<W, C1, C2, C3, C4, C5, C6>(
+    _ component: some RegexComponent<(W, C1, C2, C3, C4, C5, C6)>,
+    as reference: Reference<W>
+  ) where RegexOutput == (Substring, W, C1, C2, C3, C4, C5, C6) {
     let factory = makeFactory()
     self.init(factory.capture(component, reference._raw))
   }
@@ -5739,10 +5939,10 @@ extension Capture {
   ///     throws an error, matching is abandoned and the error is returned
   ///     to the caller.
   @_alwaysEmitIntoClient
-  public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, NewCapture>(
-    _ component: R,
+  public init<W, C1, C2, C3, C4, C5, C6, NewCapture>(
+    _ component: some RegexComponent<(W, C1, C2, C3, C4, C5, C6)>,
     transform: @escaping (W) throws -> NewCapture
-  ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6) {
+  ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6) {
     let factory = makeFactory()
     self.init(factory.capture(component, nil, transform))
   }
@@ -5759,11 +5959,11 @@ extension Capture {
   ///     throws an error, matching is abandoned and the error is returned
   ///     to the caller.
   @_alwaysEmitIntoClient
-  public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, NewCapture>(
-    _ component: R,
+  public init<W, C1, C2, C3, C4, C5, C6, NewCapture>(
+    _ component: some RegexComponent<(W, C1, C2, C3, C4, C5, C6)>,
     as reference: Reference<NewCapture>,
     transform: @escaping (W) throws -> NewCapture
-  ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6) {
+  ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6) {
     let factory = makeFactory()
     self.init(factory.capture(component, reference._raw, transform))
   }
@@ -5782,10 +5982,10 @@ extension TryCapture {
   ///     throws an error, matching is abandoned and the error is returned
   ///     to the caller.
   @_alwaysEmitIntoClient
-  public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, NewCapture>(
-    _ component: R,
+  public init<W, C1, C2, C3, C4, C5, C6, NewCapture>(
+    _ component: some RegexComponent<(W, C1, C2, C3, C4, C5, C6)>,
     transform: @escaping (W) throws -> NewCapture?
-  ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6) {
+  ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6) {
     let factory = makeFactory()
     self.init(factory.captureOptional(component, nil, transform))
   }
@@ -5803,17 +6003,16 @@ extension TryCapture {
   ///     throws an error, matching is abandoned and the error is returned
   ///     to the caller.
   @_alwaysEmitIntoClient
-  public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, NewCapture>(
-    _ component: R,
+  public init<W, C1, C2, C3, C4, C5, C6, NewCapture>(
+    _ component: some RegexComponent<(W, C1, C2, C3, C4, C5, C6)>,
     as reference: Reference<NewCapture>,
     transform: @escaping (W) throws -> NewCapture?
-  ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6) {
+  ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6) {
     let factory = makeFactory()
     self.init(factory.captureOptional(component, reference._raw, transform))
   }
 }
-
-// MARK: - Builder capture arity 6
+// MARK: - Builder capture (arity 6)
 
 @available(SwiftStdlib 5.7, *)
 extension Capture {
@@ -5822,9 +6021,9 @@ extension Capture {
   /// - Parameter componentBuilder: A builder closure that generates a
   ///   regex component to capture.
   @_alwaysEmitIntoClient
-  public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6>(
-    @RegexComponentBuilder _ componentBuilder: () -> R
-  ) where RegexOutput == (Substring, W, C1, C2, C3, C4, C5, C6), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6) {
+  public init<W, C1, C2, C3, C4, C5, C6>(
+    @RegexComponentBuilder _ componentBuilder: () -> some RegexComponent<(W, C1, C2, C3, C4, C5, C6)>
+  ) where RegexOutput == (Substring, W, C1, C2, C3, C4, C5, C6) {
     let factory = makeFactory()
     self.init(factory.capture(componentBuilder()))
   }
@@ -5838,10 +6037,10 @@ extension Capture {
   ///   - componentBuilder: A builder closure that generates a regex
   ///     component to capture.
   @_alwaysEmitIntoClient
-  public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6>(
+  public init<W, C1, C2, C3, C4, C5, C6>(
     as reference: Reference<W>,
-    @RegexComponentBuilder _ componentBuilder: () -> R
-  ) where RegexOutput == (Substring, W, C1, C2, C3, C4, C5, C6), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6) {
+    @RegexComponentBuilder _ componentBuilder: () -> some RegexComponent<(W, C1, C2, C3, C4, C5, C6)>
+  ) where RegexOutput == (Substring, W, C1, C2, C3, C4, C5, C6) {
     let factory = makeFactory()
     self.init(factory.capture(componentBuilder(), reference._raw))
   }
@@ -5857,10 +6056,10 @@ extension Capture {
   ///     throws an error, matching is abandoned and the error is returned
   ///     to the caller.
   @_alwaysEmitIntoClient
-  public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, NewCapture>(
-    @RegexComponentBuilder _ componentBuilder: () -> R,
+  public init<W, C1, C2, C3, C4, C5, C6, NewCapture>(
+    @RegexComponentBuilder _ componentBuilder: () -> some RegexComponent<(W, C1, C2, C3, C4, C5, C6)>,
     transform: @escaping (W) throws -> NewCapture
-  ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6) {
+  ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6) {
     let factory = makeFactory()
     self.init(factory.capture(componentBuilder(), nil, transform))
   }
@@ -5878,11 +6077,11 @@ extension Capture {
   ///     throws an error, matching is abandoned and the error is returned
   ///     to the caller.
   @_alwaysEmitIntoClient
-  public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, NewCapture>(
+  public init<W, C1, C2, C3, C4, C5, C6, NewCapture>(
     as reference: Reference<NewCapture>,
-    @RegexComponentBuilder _ componentBuilder: () -> R,
+    @RegexComponentBuilder _ componentBuilder: () -> some RegexComponent<(W, C1, C2, C3, C4, C5, C6)>,
     transform: @escaping (W) throws -> NewCapture
-  ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6) {
+  ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6) {
     let factory = makeFactory()
     self.init(factory.capture(componentBuilder(), reference._raw, transform))
   }
@@ -5902,10 +6101,10 @@ extension TryCapture {
   ///     throws an error, matching is abandoned and the error is returned
   ///     to the caller.
   @_alwaysEmitIntoClient
-  public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, NewCapture>(
-    @RegexComponentBuilder _ componentBuilder: () -> R,
+  public init<W, C1, C2, C3, C4, C5, C6, NewCapture>(
+    @RegexComponentBuilder _ componentBuilder: () -> some RegexComponent<(W, C1, C2, C3, C4, C5, C6)>,
     transform: @escaping (W) throws -> NewCapture?
-  ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6) {
+  ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6) {
     let factory = makeFactory()
     self.init(factory.captureOptional(componentBuilder(), nil, transform))
   }
@@ -5924,17 +6123,17 @@ extension TryCapture {
   ///     throws an error, matching is abandoned and the error is returned
   ///     to the caller.
   @_alwaysEmitIntoClient
-  public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, NewCapture>(
+  public init<W, C1, C2, C3, C4, C5, C6, NewCapture>(
     as reference: Reference<NewCapture>,
-    @RegexComponentBuilder _ componentBuilder: () -> R,
+    @RegexComponentBuilder _ componentBuilder: () -> some RegexComponent<(W, C1, C2, C3, C4, C5, C6)>,
     transform: @escaping (W) throws -> NewCapture?
-  ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6) {
+  ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6) {
     let factory = makeFactory()
     self.init(factory.captureOptional(componentBuilder(), reference._raw, transform))
   }
 }
 
-// MARK: - Non-builder capture arity 7
+// MARK: - Non-builder capture (arity 7)
 
 @available(SwiftStdlib 5.7, *)
 extension Capture {
@@ -5942,9 +6141,9 @@ extension Capture {
   ///
   /// - Parameter component: The regex component to capture.
   @_alwaysEmitIntoClient
-  public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, C7>(
-    _ component: R
-  ) where RegexOutput == (Substring, W, C1, C2, C3, C4, C5, C6, C7), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7) {
+  public init<W, C1, C2, C3, C4, C5, C6, C7>(
+    _ component: some RegexComponent<(W, C1, C2, C3, C4, C5, C6, C7)>
+  ) where RegexOutput == (Substring, W, C1, C2, C3, C4, C5, C6, C7) {
     let factory = makeFactory()
     self.init(factory.capture(component))
   }
@@ -5957,9 +6156,10 @@ extension Capture {
   ///   - reference: The reference to use for anything captured by
   ///     `component`.
   @_alwaysEmitIntoClient
-  public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, C7>(
-    _ component: R, as reference: Reference<W>
-  ) where RegexOutput == (Substring, W, C1, C2, C3, C4, C5, C6, C7), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7) {
+  public init<W, C1, C2, C3, C4, C5, C6, C7>(
+    _ component: some RegexComponent<(W, C1, C2, C3, C4, C5, C6, C7)>,
+    as reference: Reference<W>
+  ) where RegexOutput == (Substring, W, C1, C2, C3, C4, C5, C6, C7) {
     let factory = makeFactory()
     self.init(factory.capture(component, reference._raw))
   }
@@ -5974,10 +6174,10 @@ extension Capture {
   ///     throws an error, matching is abandoned and the error is returned
   ///     to the caller.
   @_alwaysEmitIntoClient
-  public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, C7, NewCapture>(
-    _ component: R,
+  public init<W, C1, C2, C3, C4, C5, C6, C7, NewCapture>(
+    _ component: some RegexComponent<(W, C1, C2, C3, C4, C5, C6, C7)>,
     transform: @escaping (W) throws -> NewCapture
-  ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6, C7), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7) {
+  ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6, C7) {
     let factory = makeFactory()
     self.init(factory.capture(component, nil, transform))
   }
@@ -5994,11 +6194,11 @@ extension Capture {
   ///     throws an error, matching is abandoned and the error is returned
   ///     to the caller.
   @_alwaysEmitIntoClient
-  public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, C7, NewCapture>(
-    _ component: R,
+  public init<W, C1, C2, C3, C4, C5, C6, C7, NewCapture>(
+    _ component: some RegexComponent<(W, C1, C2, C3, C4, C5, C6, C7)>,
     as reference: Reference<NewCapture>,
     transform: @escaping (W) throws -> NewCapture
-  ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6, C7), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7) {
+  ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6, C7) {
     let factory = makeFactory()
     self.init(factory.capture(component, reference._raw, transform))
   }
@@ -6017,10 +6217,10 @@ extension TryCapture {
   ///     throws an error, matching is abandoned and the error is returned
   ///     to the caller.
   @_alwaysEmitIntoClient
-  public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, C7, NewCapture>(
-    _ component: R,
+  public init<W, C1, C2, C3, C4, C5, C6, C7, NewCapture>(
+    _ component: some RegexComponent<(W, C1, C2, C3, C4, C5, C6, C7)>,
     transform: @escaping (W) throws -> NewCapture?
-  ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6, C7), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7) {
+  ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6, C7) {
     let factory = makeFactory()
     self.init(factory.captureOptional(component, nil, transform))
   }
@@ -6038,17 +6238,16 @@ extension TryCapture {
   ///     throws an error, matching is abandoned and the error is returned
   ///     to the caller.
   @_alwaysEmitIntoClient
-  public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, C7, NewCapture>(
-    _ component: R,
+  public init<W, C1, C2, C3, C4, C5, C6, C7, NewCapture>(
+    _ component: some RegexComponent<(W, C1, C2, C3, C4, C5, C6, C7)>,
     as reference: Reference<NewCapture>,
     transform: @escaping (W) throws -> NewCapture?
-  ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6, C7), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7) {
+  ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6, C7) {
     let factory = makeFactory()
     self.init(factory.captureOptional(component, reference._raw, transform))
   }
 }
-
-// MARK: - Builder capture arity 7
+// MARK: - Builder capture (arity 7)
 
 @available(SwiftStdlib 5.7, *)
 extension Capture {
@@ -6057,9 +6256,9 @@ extension Capture {
   /// - Parameter componentBuilder: A builder closure that generates a
   ///   regex component to capture.
   @_alwaysEmitIntoClient
-  public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, C7>(
-    @RegexComponentBuilder _ componentBuilder: () -> R
-  ) where RegexOutput == (Substring, W, C1, C2, C3, C4, C5, C6, C7), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7) {
+  public init<W, C1, C2, C3, C4, C5, C6, C7>(
+    @RegexComponentBuilder _ componentBuilder: () -> some RegexComponent<(W, C1, C2, C3, C4, C5, C6, C7)>
+  ) where RegexOutput == (Substring, W, C1, C2, C3, C4, C5, C6, C7) {
     let factory = makeFactory()
     self.init(factory.capture(componentBuilder()))
   }
@@ -6073,10 +6272,10 @@ extension Capture {
   ///   - componentBuilder: A builder closure that generates a regex
   ///     component to capture.
   @_alwaysEmitIntoClient
-  public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, C7>(
+  public init<W, C1, C2, C3, C4, C5, C6, C7>(
     as reference: Reference<W>,
-    @RegexComponentBuilder _ componentBuilder: () -> R
-  ) where RegexOutput == (Substring, W, C1, C2, C3, C4, C5, C6, C7), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7) {
+    @RegexComponentBuilder _ componentBuilder: () -> some RegexComponent<(W, C1, C2, C3, C4, C5, C6, C7)>
+  ) where RegexOutput == (Substring, W, C1, C2, C3, C4, C5, C6, C7) {
     let factory = makeFactory()
     self.init(factory.capture(componentBuilder(), reference._raw))
   }
@@ -6092,10 +6291,10 @@ extension Capture {
   ///     throws an error, matching is abandoned and the error is returned
   ///     to the caller.
   @_alwaysEmitIntoClient
-  public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, C7, NewCapture>(
-    @RegexComponentBuilder _ componentBuilder: () -> R,
+  public init<W, C1, C2, C3, C4, C5, C6, C7, NewCapture>(
+    @RegexComponentBuilder _ componentBuilder: () -> some RegexComponent<(W, C1, C2, C3, C4, C5, C6, C7)>,
     transform: @escaping (W) throws -> NewCapture
-  ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6, C7), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7) {
+  ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6, C7) {
     let factory = makeFactory()
     self.init(factory.capture(componentBuilder(), nil, transform))
   }
@@ -6113,11 +6312,11 @@ extension Capture {
   ///     throws an error, matching is abandoned and the error is returned
   ///     to the caller.
   @_alwaysEmitIntoClient
-  public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, C7, NewCapture>(
+  public init<W, C1, C2, C3, C4, C5, C6, C7, NewCapture>(
     as reference: Reference<NewCapture>,
-    @RegexComponentBuilder _ componentBuilder: () -> R,
+    @RegexComponentBuilder _ componentBuilder: () -> some RegexComponent<(W, C1, C2, C3, C4, C5, C6, C7)>,
     transform: @escaping (W) throws -> NewCapture
-  ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6, C7), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7) {
+  ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6, C7) {
     let factory = makeFactory()
     self.init(factory.capture(componentBuilder(), reference._raw, transform))
   }
@@ -6137,10 +6336,10 @@ extension TryCapture {
   ///     throws an error, matching is abandoned and the error is returned
   ///     to the caller.
   @_alwaysEmitIntoClient
-  public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, C7, NewCapture>(
-    @RegexComponentBuilder _ componentBuilder: () -> R,
+  public init<W, C1, C2, C3, C4, C5, C6, C7, NewCapture>(
+    @RegexComponentBuilder _ componentBuilder: () -> some RegexComponent<(W, C1, C2, C3, C4, C5, C6, C7)>,
     transform: @escaping (W) throws -> NewCapture?
-  ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6, C7), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7) {
+  ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6, C7) {
     let factory = makeFactory()
     self.init(factory.captureOptional(componentBuilder(), nil, transform))
   }
@@ -6159,17 +6358,17 @@ extension TryCapture {
   ///     throws an error, matching is abandoned and the error is returned
   ///     to the caller.
   @_alwaysEmitIntoClient
-  public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, C7, NewCapture>(
+  public init<W, C1, C2, C3, C4, C5, C6, C7, NewCapture>(
     as reference: Reference<NewCapture>,
-    @RegexComponentBuilder _ componentBuilder: () -> R,
+    @RegexComponentBuilder _ componentBuilder: () -> some RegexComponent<(W, C1, C2, C3, C4, C5, C6, C7)>,
     transform: @escaping (W) throws -> NewCapture?
-  ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6, C7), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7) {
+  ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6, C7) {
     let factory = makeFactory()
     self.init(factory.captureOptional(componentBuilder(), reference._raw, transform))
   }
 }
 
-// MARK: - Non-builder capture arity 8
+// MARK: - Non-builder capture (arity 8)
 
 @available(SwiftStdlib 5.7, *)
 extension Capture {
@@ -6177,9 +6376,9 @@ extension Capture {
   ///
   /// - Parameter component: The regex component to capture.
   @_alwaysEmitIntoClient
-  public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, C7, C8>(
-    _ component: R
-  ) where RegexOutput == (Substring, W, C1, C2, C3, C4, C5, C6, C7, C8), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8) {
+  public init<W, C1, C2, C3, C4, C5, C6, C7, C8>(
+    _ component: some RegexComponent<(W, C1, C2, C3, C4, C5, C6, C7, C8)>
+  ) where RegexOutput == (Substring, W, C1, C2, C3, C4, C5, C6, C7, C8) {
     let factory = makeFactory()
     self.init(factory.capture(component))
   }
@@ -6192,9 +6391,10 @@ extension Capture {
   ///   - reference: The reference to use for anything captured by
   ///     `component`.
   @_alwaysEmitIntoClient
-  public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, C7, C8>(
-    _ component: R, as reference: Reference<W>
-  ) where RegexOutput == (Substring, W, C1, C2, C3, C4, C5, C6, C7, C8), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8) {
+  public init<W, C1, C2, C3, C4, C5, C6, C7, C8>(
+    _ component: some RegexComponent<(W, C1, C2, C3, C4, C5, C6, C7, C8)>,
+    as reference: Reference<W>
+  ) where RegexOutput == (Substring, W, C1, C2, C3, C4, C5, C6, C7, C8) {
     let factory = makeFactory()
     self.init(factory.capture(component, reference._raw))
   }
@@ -6209,10 +6409,10 @@ extension Capture {
   ///     throws an error, matching is abandoned and the error is returned
   ///     to the caller.
   @_alwaysEmitIntoClient
-  public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, C7, C8, NewCapture>(
-    _ component: R,
+  public init<W, C1, C2, C3, C4, C5, C6, C7, C8, NewCapture>(
+    _ component: some RegexComponent<(W, C1, C2, C3, C4, C5, C6, C7, C8)>,
     transform: @escaping (W) throws -> NewCapture
-  ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6, C7, C8), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8) {
+  ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6, C7, C8) {
     let factory = makeFactory()
     self.init(factory.capture(component, nil, transform))
   }
@@ -6229,11 +6429,11 @@ extension Capture {
   ///     throws an error, matching is abandoned and the error is returned
   ///     to the caller.
   @_alwaysEmitIntoClient
-  public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, C7, C8, NewCapture>(
-    _ component: R,
+  public init<W, C1, C2, C3, C4, C5, C6, C7, C8, NewCapture>(
+    _ component: some RegexComponent<(W, C1, C2, C3, C4, C5, C6, C7, C8)>,
     as reference: Reference<NewCapture>,
     transform: @escaping (W) throws -> NewCapture
-  ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6, C7, C8), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8) {
+  ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6, C7, C8) {
     let factory = makeFactory()
     self.init(factory.capture(component, reference._raw, transform))
   }
@@ -6252,10 +6452,10 @@ extension TryCapture {
   ///     throws an error, matching is abandoned and the error is returned
   ///     to the caller.
   @_alwaysEmitIntoClient
-  public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, C7, C8, NewCapture>(
-    _ component: R,
+  public init<W, C1, C2, C3, C4, C5, C6, C7, C8, NewCapture>(
+    _ component: some RegexComponent<(W, C1, C2, C3, C4, C5, C6, C7, C8)>,
     transform: @escaping (W) throws -> NewCapture?
-  ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6, C7, C8), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8) {
+  ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6, C7, C8) {
     let factory = makeFactory()
     self.init(factory.captureOptional(component, nil, transform))
   }
@@ -6273,17 +6473,16 @@ extension TryCapture {
   ///     throws an error, matching is abandoned and the error is returned
   ///     to the caller.
   @_alwaysEmitIntoClient
-  public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, C7, C8, NewCapture>(
-    _ component: R,
+  public init<W, C1, C2, C3, C4, C5, C6, C7, C8, NewCapture>(
+    _ component: some RegexComponent<(W, C1, C2, C3, C4, C5, C6, C7, C8)>,
     as reference: Reference<NewCapture>,
     transform: @escaping (W) throws -> NewCapture?
-  ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6, C7, C8), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8) {
+  ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6, C7, C8) {
     let factory = makeFactory()
     self.init(factory.captureOptional(component, reference._raw, transform))
   }
 }
-
-// MARK: - Builder capture arity 8
+// MARK: - Builder capture (arity 8)
 
 @available(SwiftStdlib 5.7, *)
 extension Capture {
@@ -6292,9 +6491,9 @@ extension Capture {
   /// - Parameter componentBuilder: A builder closure that generates a
   ///   regex component to capture.
   @_alwaysEmitIntoClient
-  public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, C7, C8>(
-    @RegexComponentBuilder _ componentBuilder: () -> R
-  ) where RegexOutput == (Substring, W, C1, C2, C3, C4, C5, C6, C7, C8), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8) {
+  public init<W, C1, C2, C3, C4, C5, C6, C7, C8>(
+    @RegexComponentBuilder _ componentBuilder: () -> some RegexComponent<(W, C1, C2, C3, C4, C5, C6, C7, C8)>
+  ) where RegexOutput == (Substring, W, C1, C2, C3, C4, C5, C6, C7, C8) {
     let factory = makeFactory()
     self.init(factory.capture(componentBuilder()))
   }
@@ -6308,10 +6507,10 @@ extension Capture {
   ///   - componentBuilder: A builder closure that generates a regex
   ///     component to capture.
   @_alwaysEmitIntoClient
-  public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, C7, C8>(
+  public init<W, C1, C2, C3, C4, C5, C6, C7, C8>(
     as reference: Reference<W>,
-    @RegexComponentBuilder _ componentBuilder: () -> R
-  ) where RegexOutput == (Substring, W, C1, C2, C3, C4, C5, C6, C7, C8), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8) {
+    @RegexComponentBuilder _ componentBuilder: () -> some RegexComponent<(W, C1, C2, C3, C4, C5, C6, C7, C8)>
+  ) where RegexOutput == (Substring, W, C1, C2, C3, C4, C5, C6, C7, C8) {
     let factory = makeFactory()
     self.init(factory.capture(componentBuilder(), reference._raw))
   }
@@ -6327,10 +6526,10 @@ extension Capture {
   ///     throws an error, matching is abandoned and the error is returned
   ///     to the caller.
   @_alwaysEmitIntoClient
-  public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, C7, C8, NewCapture>(
-    @RegexComponentBuilder _ componentBuilder: () -> R,
+  public init<W, C1, C2, C3, C4, C5, C6, C7, C8, NewCapture>(
+    @RegexComponentBuilder _ componentBuilder: () -> some RegexComponent<(W, C1, C2, C3, C4, C5, C6, C7, C8)>,
     transform: @escaping (W) throws -> NewCapture
-  ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6, C7, C8), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8) {
+  ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6, C7, C8) {
     let factory = makeFactory()
     self.init(factory.capture(componentBuilder(), nil, transform))
   }
@@ -6348,11 +6547,11 @@ extension Capture {
   ///     throws an error, matching is abandoned and the error is returned
   ///     to the caller.
   @_alwaysEmitIntoClient
-  public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, C7, C8, NewCapture>(
+  public init<W, C1, C2, C3, C4, C5, C6, C7, C8, NewCapture>(
     as reference: Reference<NewCapture>,
-    @RegexComponentBuilder _ componentBuilder: () -> R,
+    @RegexComponentBuilder _ componentBuilder: () -> some RegexComponent<(W, C1, C2, C3, C4, C5, C6, C7, C8)>,
     transform: @escaping (W) throws -> NewCapture
-  ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6, C7, C8), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8) {
+  ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6, C7, C8) {
     let factory = makeFactory()
     self.init(factory.capture(componentBuilder(), reference._raw, transform))
   }
@@ -6372,10 +6571,10 @@ extension TryCapture {
   ///     throws an error, matching is abandoned and the error is returned
   ///     to the caller.
   @_alwaysEmitIntoClient
-  public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, C7, C8, NewCapture>(
-    @RegexComponentBuilder _ componentBuilder: () -> R,
+  public init<W, C1, C2, C3, C4, C5, C6, C7, C8, NewCapture>(
+    @RegexComponentBuilder _ componentBuilder: () -> some RegexComponent<(W, C1, C2, C3, C4, C5, C6, C7, C8)>,
     transform: @escaping (W) throws -> NewCapture?
-  ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6, C7, C8), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8) {
+  ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6, C7, C8) {
     let factory = makeFactory()
     self.init(factory.captureOptional(componentBuilder(), nil, transform))
   }
@@ -6394,17 +6593,17 @@ extension TryCapture {
   ///     throws an error, matching is abandoned and the error is returned
   ///     to the caller.
   @_alwaysEmitIntoClient
-  public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, C7, C8, NewCapture>(
+  public init<W, C1, C2, C3, C4, C5, C6, C7, C8, NewCapture>(
     as reference: Reference<NewCapture>,
-    @RegexComponentBuilder _ componentBuilder: () -> R,
+    @RegexComponentBuilder _ componentBuilder: () -> some RegexComponent<(W, C1, C2, C3, C4, C5, C6, C7, C8)>,
     transform: @escaping (W) throws -> NewCapture?
-  ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6, C7, C8), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8) {
+  ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6, C7, C8) {
     let factory = makeFactory()
     self.init(factory.captureOptional(componentBuilder(), reference._raw, transform))
   }
 }
 
-// MARK: - Non-builder capture arity 9
+// MARK: - Non-builder capture (arity 9)
 
 @available(SwiftStdlib 5.7, *)
 extension Capture {
@@ -6412,9 +6611,9 @@ extension Capture {
   ///
   /// - Parameter component: The regex component to capture.
   @_alwaysEmitIntoClient
-  public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, C7, C8, C9>(
-    _ component: R
-  ) where RegexOutput == (Substring, W, C1, C2, C3, C4, C5, C6, C7, C8, C9), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
+  public init<W, C1, C2, C3, C4, C5, C6, C7, C8, C9>(
+    _ component: some RegexComponent<(W, C1, C2, C3, C4, C5, C6, C7, C8, C9)>
+  ) where RegexOutput == (Substring, W, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
     let factory = makeFactory()
     self.init(factory.capture(component))
   }
@@ -6427,9 +6626,10 @@ extension Capture {
   ///   - reference: The reference to use for anything captured by
   ///     `component`.
   @_alwaysEmitIntoClient
-  public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, C7, C8, C9>(
-    _ component: R, as reference: Reference<W>
-  ) where RegexOutput == (Substring, W, C1, C2, C3, C4, C5, C6, C7, C8, C9), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
+  public init<W, C1, C2, C3, C4, C5, C6, C7, C8, C9>(
+    _ component: some RegexComponent<(W, C1, C2, C3, C4, C5, C6, C7, C8, C9)>,
+    as reference: Reference<W>
+  ) where RegexOutput == (Substring, W, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
     let factory = makeFactory()
     self.init(factory.capture(component, reference._raw))
   }
@@ -6444,10 +6644,10 @@ extension Capture {
   ///     throws an error, matching is abandoned and the error is returned
   ///     to the caller.
   @_alwaysEmitIntoClient
-  public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, C7, C8, C9, NewCapture>(
-    _ component: R,
+  public init<W, C1, C2, C3, C4, C5, C6, C7, C8, C9, NewCapture>(
+    _ component: some RegexComponent<(W, C1, C2, C3, C4, C5, C6, C7, C8, C9)>,
     transform: @escaping (W) throws -> NewCapture
-  ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6, C7, C8, C9), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
+  ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
     let factory = makeFactory()
     self.init(factory.capture(component, nil, transform))
   }
@@ -6464,11 +6664,11 @@ extension Capture {
   ///     throws an error, matching is abandoned and the error is returned
   ///     to the caller.
   @_alwaysEmitIntoClient
-  public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, C7, C8, C9, NewCapture>(
-    _ component: R,
+  public init<W, C1, C2, C3, C4, C5, C6, C7, C8, C9, NewCapture>(
+    _ component: some RegexComponent<(W, C1, C2, C3, C4, C5, C6, C7, C8, C9)>,
     as reference: Reference<NewCapture>,
     transform: @escaping (W) throws -> NewCapture
-  ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6, C7, C8, C9), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
+  ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
     let factory = makeFactory()
     self.init(factory.capture(component, reference._raw, transform))
   }
@@ -6487,10 +6687,10 @@ extension TryCapture {
   ///     throws an error, matching is abandoned and the error is returned
   ///     to the caller.
   @_alwaysEmitIntoClient
-  public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, C7, C8, C9, NewCapture>(
-    _ component: R,
+  public init<W, C1, C2, C3, C4, C5, C6, C7, C8, C9, NewCapture>(
+    _ component: some RegexComponent<(W, C1, C2, C3, C4, C5, C6, C7, C8, C9)>,
     transform: @escaping (W) throws -> NewCapture?
-  ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6, C7, C8, C9), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
+  ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
     let factory = makeFactory()
     self.init(factory.captureOptional(component, nil, transform))
   }
@@ -6508,17 +6708,16 @@ extension TryCapture {
   ///     throws an error, matching is abandoned and the error is returned
   ///     to the caller.
   @_alwaysEmitIntoClient
-  public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, C7, C8, C9, NewCapture>(
-    _ component: R,
+  public init<W, C1, C2, C3, C4, C5, C6, C7, C8, C9, NewCapture>(
+    _ component: some RegexComponent<(W, C1, C2, C3, C4, C5, C6, C7, C8, C9)>,
     as reference: Reference<NewCapture>,
     transform: @escaping (W) throws -> NewCapture?
-  ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6, C7, C8, C9), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
+  ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
     let factory = makeFactory()
     self.init(factory.captureOptional(component, reference._raw, transform))
   }
 }
-
-// MARK: - Builder capture arity 9
+// MARK: - Builder capture (arity 9)
 
 @available(SwiftStdlib 5.7, *)
 extension Capture {
@@ -6527,9 +6726,9 @@ extension Capture {
   /// - Parameter componentBuilder: A builder closure that generates a
   ///   regex component to capture.
   @_alwaysEmitIntoClient
-  public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, C7, C8, C9>(
-    @RegexComponentBuilder _ componentBuilder: () -> R
-  ) where RegexOutput == (Substring, W, C1, C2, C3, C4, C5, C6, C7, C8, C9), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
+  public init<W, C1, C2, C3, C4, C5, C6, C7, C8, C9>(
+    @RegexComponentBuilder _ componentBuilder: () -> some RegexComponent<(W, C1, C2, C3, C4, C5, C6, C7, C8, C9)>
+  ) where RegexOutput == (Substring, W, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
     let factory = makeFactory()
     self.init(factory.capture(componentBuilder()))
   }
@@ -6543,10 +6742,10 @@ extension Capture {
   ///   - componentBuilder: A builder closure that generates a regex
   ///     component to capture.
   @_alwaysEmitIntoClient
-  public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, C7, C8, C9>(
+  public init<W, C1, C2, C3, C4, C5, C6, C7, C8, C9>(
     as reference: Reference<W>,
-    @RegexComponentBuilder _ componentBuilder: () -> R
-  ) where RegexOutput == (Substring, W, C1, C2, C3, C4, C5, C6, C7, C8, C9), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
+    @RegexComponentBuilder _ componentBuilder: () -> some RegexComponent<(W, C1, C2, C3, C4, C5, C6, C7, C8, C9)>
+  ) where RegexOutput == (Substring, W, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
     let factory = makeFactory()
     self.init(factory.capture(componentBuilder(), reference._raw))
   }
@@ -6562,10 +6761,10 @@ extension Capture {
   ///     throws an error, matching is abandoned and the error is returned
   ///     to the caller.
   @_alwaysEmitIntoClient
-  public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, C7, C8, C9, NewCapture>(
-    @RegexComponentBuilder _ componentBuilder: () -> R,
+  public init<W, C1, C2, C3, C4, C5, C6, C7, C8, C9, NewCapture>(
+    @RegexComponentBuilder _ componentBuilder: () -> some RegexComponent<(W, C1, C2, C3, C4, C5, C6, C7, C8, C9)>,
     transform: @escaping (W) throws -> NewCapture
-  ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6, C7, C8, C9), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
+  ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
     let factory = makeFactory()
     self.init(factory.capture(componentBuilder(), nil, transform))
   }
@@ -6583,11 +6782,11 @@ extension Capture {
   ///     throws an error, matching is abandoned and the error is returned
   ///     to the caller.
   @_alwaysEmitIntoClient
-  public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, C7, C8, C9, NewCapture>(
+  public init<W, C1, C2, C3, C4, C5, C6, C7, C8, C9, NewCapture>(
     as reference: Reference<NewCapture>,
-    @RegexComponentBuilder _ componentBuilder: () -> R,
+    @RegexComponentBuilder _ componentBuilder: () -> some RegexComponent<(W, C1, C2, C3, C4, C5, C6, C7, C8, C9)>,
     transform: @escaping (W) throws -> NewCapture
-  ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6, C7, C8, C9), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
+  ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
     let factory = makeFactory()
     self.init(factory.capture(componentBuilder(), reference._raw, transform))
   }
@@ -6607,10 +6806,10 @@ extension TryCapture {
   ///     throws an error, matching is abandoned and the error is returned
   ///     to the caller.
   @_alwaysEmitIntoClient
-  public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, C7, C8, C9, NewCapture>(
-    @RegexComponentBuilder _ componentBuilder: () -> R,
+  public init<W, C1, C2, C3, C4, C5, C6, C7, C8, C9, NewCapture>(
+    @RegexComponentBuilder _ componentBuilder: () -> some RegexComponent<(W, C1, C2, C3, C4, C5, C6, C7, C8, C9)>,
     transform: @escaping (W) throws -> NewCapture?
-  ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6, C7, C8, C9), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
+  ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
     let factory = makeFactory()
     self.init(factory.captureOptional(componentBuilder(), nil, transform))
   }
@@ -6629,17 +6828,17 @@ extension TryCapture {
   ///     throws an error, matching is abandoned and the error is returned
   ///     to the caller.
   @_alwaysEmitIntoClient
-  public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, C7, C8, C9, NewCapture>(
+  public init<W, C1, C2, C3, C4, C5, C6, C7, C8, C9, NewCapture>(
     as reference: Reference<NewCapture>,
-    @RegexComponentBuilder _ componentBuilder: () -> R,
+    @RegexComponentBuilder _ componentBuilder: () -> some RegexComponent<(W, C1, C2, C3, C4, C5, C6, C7, C8, C9)>,
     transform: @escaping (W) throws -> NewCapture?
-  ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6, C7, C8, C9), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
+  ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6, C7, C8, C9) {
     let factory = makeFactory()
     self.init(factory.captureOptional(componentBuilder(), reference._raw, transform))
   }
 }
 
-// MARK: - Non-builder capture arity 10
+// MARK: - Non-builder capture (arity 10)
 
 @available(SwiftStdlib 5.7, *)
 extension Capture {
@@ -6647,9 +6846,9 @@ extension Capture {
   ///
   /// - Parameter component: The regex component to capture.
   @_alwaysEmitIntoClient
-  public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10>(
-    _ component: R
-  ) where RegexOutput == (Substring, W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10) {
+  public init<W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10>(
+    _ component: some RegexComponent<(W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10)>
+  ) where RegexOutput == (Substring, W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10) {
     let factory = makeFactory()
     self.init(factory.capture(component))
   }
@@ -6662,9 +6861,10 @@ extension Capture {
   ///   - reference: The reference to use for anything captured by
   ///     `component`.
   @_alwaysEmitIntoClient
-  public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10>(
-    _ component: R, as reference: Reference<W>
-  ) where RegexOutput == (Substring, W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10) {
+  public init<W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10>(
+    _ component: some RegexComponent<(W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10)>,
+    as reference: Reference<W>
+  ) where RegexOutput == (Substring, W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10) {
     let factory = makeFactory()
     self.init(factory.capture(component, reference._raw))
   }
@@ -6679,10 +6879,10 @@ extension Capture {
   ///     throws an error, matching is abandoned and the error is returned
   ///     to the caller.
   @_alwaysEmitIntoClient
-  public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, NewCapture>(
-    _ component: R,
+  public init<W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, NewCapture>(
+    _ component: some RegexComponent<(W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10)>,
     transform: @escaping (W) throws -> NewCapture
-  ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10) {
+  ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10) {
     let factory = makeFactory()
     self.init(factory.capture(component, nil, transform))
   }
@@ -6699,11 +6899,11 @@ extension Capture {
   ///     throws an error, matching is abandoned and the error is returned
   ///     to the caller.
   @_alwaysEmitIntoClient
-  public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, NewCapture>(
-    _ component: R,
+  public init<W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, NewCapture>(
+    _ component: some RegexComponent<(W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10)>,
     as reference: Reference<NewCapture>,
     transform: @escaping (W) throws -> NewCapture
-  ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10) {
+  ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10) {
     let factory = makeFactory()
     self.init(factory.capture(component, reference._raw, transform))
   }
@@ -6722,10 +6922,10 @@ extension TryCapture {
   ///     throws an error, matching is abandoned and the error is returned
   ///     to the caller.
   @_alwaysEmitIntoClient
-  public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, NewCapture>(
-    _ component: R,
+  public init<W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, NewCapture>(
+    _ component: some RegexComponent<(W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10)>,
     transform: @escaping (W) throws -> NewCapture?
-  ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10) {
+  ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10) {
     let factory = makeFactory()
     self.init(factory.captureOptional(component, nil, transform))
   }
@@ -6743,17 +6943,16 @@ extension TryCapture {
   ///     throws an error, matching is abandoned and the error is returned
   ///     to the caller.
   @_alwaysEmitIntoClient
-  public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, NewCapture>(
-    _ component: R,
+  public init<W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, NewCapture>(
+    _ component: some RegexComponent<(W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10)>,
     as reference: Reference<NewCapture>,
     transform: @escaping (W) throws -> NewCapture?
-  ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10) {
+  ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10) {
     let factory = makeFactory()
     self.init(factory.captureOptional(component, reference._raw, transform))
   }
 }
-
-// MARK: - Builder capture arity 10
+// MARK: - Builder capture (arity 10)
 
 @available(SwiftStdlib 5.7, *)
 extension Capture {
@@ -6762,9 +6961,9 @@ extension Capture {
   /// - Parameter componentBuilder: A builder closure that generates a
   ///   regex component to capture.
   @_alwaysEmitIntoClient
-  public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10>(
-    @RegexComponentBuilder _ componentBuilder: () -> R
-  ) where RegexOutput == (Substring, W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10) {
+  public init<W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10>(
+    @RegexComponentBuilder _ componentBuilder: () -> some RegexComponent<(W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10)>
+  ) where RegexOutput == (Substring, W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10) {
     let factory = makeFactory()
     self.init(factory.capture(componentBuilder()))
   }
@@ -6778,10 +6977,10 @@ extension Capture {
   ///   - componentBuilder: A builder closure that generates a regex
   ///     component to capture.
   @_alwaysEmitIntoClient
-  public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10>(
+  public init<W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10>(
     as reference: Reference<W>,
-    @RegexComponentBuilder _ componentBuilder: () -> R
-  ) where RegexOutput == (Substring, W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10) {
+    @RegexComponentBuilder _ componentBuilder: () -> some RegexComponent<(W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10)>
+  ) where RegexOutput == (Substring, W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10) {
     let factory = makeFactory()
     self.init(factory.capture(componentBuilder(), reference._raw))
   }
@@ -6797,10 +6996,10 @@ extension Capture {
   ///     throws an error, matching is abandoned and the error is returned
   ///     to the caller.
   @_alwaysEmitIntoClient
-  public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, NewCapture>(
-    @RegexComponentBuilder _ componentBuilder: () -> R,
+  public init<W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, NewCapture>(
+    @RegexComponentBuilder _ componentBuilder: () -> some RegexComponent<(W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10)>,
     transform: @escaping (W) throws -> NewCapture
-  ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10) {
+  ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10) {
     let factory = makeFactory()
     self.init(factory.capture(componentBuilder(), nil, transform))
   }
@@ -6818,11 +7017,11 @@ extension Capture {
   ///     throws an error, matching is abandoned and the error is returned
   ///     to the caller.
   @_alwaysEmitIntoClient
-  public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, NewCapture>(
+  public init<W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, NewCapture>(
     as reference: Reference<NewCapture>,
-    @RegexComponentBuilder _ componentBuilder: () -> R,
+    @RegexComponentBuilder _ componentBuilder: () -> some RegexComponent<(W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10)>,
     transform: @escaping (W) throws -> NewCapture
-  ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10) {
+  ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10) {
     let factory = makeFactory()
     self.init(factory.capture(componentBuilder(), reference._raw, transform))
   }
@@ -6842,10 +7041,10 @@ extension TryCapture {
   ///     throws an error, matching is abandoned and the error is returned
   ///     to the caller.
   @_alwaysEmitIntoClient
-  public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, NewCapture>(
-    @RegexComponentBuilder _ componentBuilder: () -> R,
+  public init<W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, NewCapture>(
+    @RegexComponentBuilder _ componentBuilder: () -> some RegexComponent<(W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10)>,
     transform: @escaping (W) throws -> NewCapture?
-  ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10) {
+  ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10) {
     let factory = makeFactory()
     self.init(factory.captureOptional(componentBuilder(), nil, transform))
   }
@@ -6864,12 +7063,16 @@ extension TryCapture {
   ///     throws an error, matching is abandoned and the error is returned
   ///     to the caller.
   @_alwaysEmitIntoClient
-  public init<R: RegexComponent, W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, NewCapture>(
+  public init<W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, NewCapture>(
     as reference: Reference<NewCapture>,
-    @RegexComponentBuilder _ componentBuilder: () -> R,
+    @RegexComponentBuilder _ componentBuilder: () -> some RegexComponent<(W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10)>,
     transform: @escaping (W) throws -> NewCapture?
-  ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10), R.RegexOutput == (W, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10) {
+  ) where RegexOutput == (Substring, NewCapture, C1, C2, C3, C4, C5, C6, C7, C8, C9, C10) {
     let factory = makeFactory()
     self.init(factory.captureOptional(componentBuilder(), reference._raw, transform))
   }
 }
+
+
+
+// END AUTO-GENERATED CONTENT

--- a/Sources/_StringProcessing/MatchingOptions.swift
+++ b/Sources/_StringProcessing/MatchingOptions.swift
@@ -14,9 +14,7 @@
 /// A type that represents the current state of regex matching options, with
 /// stack-based scoping.
 struct MatchingOptions {
-  // FIXME: Workaround for rdar://104923020
-  // fileprivate
-  var stack: [Representation]
+  fileprivate var stack: [Representation]
   
   fileprivate func _invariantCheck() {
     assert(!stack.isEmpty, "Unbalanced call to endScope")
@@ -127,9 +125,7 @@ extension MatchingOptions {
 // MARK: - Implementation
 extension MatchingOptions {
   /// An option that changes the behavior of a regular expression.
-  // FIXME: Workaround for rdar://104923020
-  // fileprivate
-  enum Option: Int {
+  fileprivate enum Option: Int {
     // PCRE options
     case caseInsensitive
     case allowDuplicateGroupNames
@@ -216,9 +212,7 @@ extension MatchingOptions {
 
 extension MatchingOptions {
   /// A set of matching options.
-  // FIXME: Workaround for rdar://104923020
-  // fileprivate
-  struct Representation: OptionSet, RawRepresentable {
+  fileprivate struct Representation: OptionSet, RawRepresentable {
     var rawValue: UInt32
 
     /// Returns `true` if the option denoted by `kind` is a member of this set.

--- a/Tests/RegexBuilderTests/AlgorithmsTests.swift
+++ b/Tests/RegexBuilderTests/AlgorithmsTests.swift
@@ -120,17 +120,17 @@ class AlgorithmsResultBuilderTests: XCTestCase {
     case trimmingPrefix
   }
 
-  func expectMatch<R: RegexComponent, MatchType>(
+  func expectMatch<MatchType, RegexOutputType>(
     _ algo: MatchAlgo,
     _ tests: (input: String, expectedCaptures: MatchType?)...,
     matchType: MatchType.Type,
     equivalence: (MatchType, MatchType) -> Bool,
     file: StaticString = #file,
     line: UInt = #line,
-    @RegexComponentBuilder _ content: () -> R
+    @RegexComponentBuilder _ content: () -> some RegexComponent<RegexOutputType>
   ) throws {
     for (input, expectedCaptures) in tests {
-      var actual: Regex<R.RegexOutput>.Match?
+      var actual: Regex<RegexOutputType>.Match?
       switch algo {
       case .whole:
         actual = input.wholeMatch(of: content)
@@ -149,12 +149,12 @@ class AlgorithmsResultBuilderTests: XCTestCase {
     }
   }
 
-  func expectEqual<R: RegexComponent, Expected: Equatable>(
+  func expectEqual<Expected: Equatable>(
     _ algo: EquatableAlgo,
     _ tests: (input: String, expected: Expected)...,
     file: StaticString = #file,
     line: UInt = #line,
-    @RegexComponentBuilder _ content: () -> R
+    @RegexComponentBuilder _ content: () -> some RegexComponent
   ) throws {
     for (input, expected) in tests {
       var actual: Expected

--- a/Tests/RegexBuilderTests/CustomTests.swift
+++ b/Tests/RegexBuilderTests/CustomTests.swift
@@ -226,7 +226,7 @@ class CustomRegexComponentTests: XCTestCase {
   // tests.
   func testCustomRegexComponents() throws {
     customTest(
-      Regex<Substring> {
+      Regex {
         Numbler()
         Asciibbler()
       },
@@ -237,7 +237,7 @@ class CustomRegexComponentTests: XCTestCase {
       ("t4", .match, nil))
 
     customTest(
-      Regex<Substring> {
+      Regex {
         OneOrMore { Numbler() }
       },
       ("ab123c", .firstMatch, "123"),
@@ -520,7 +520,7 @@ class CustomRegexComponentTests: XCTestCase {
     )
 
     customTest(
-      Regex<CurrencyParser.Currency> {
+      Regex {
         CurrencyParser()
       },
       ("USD", .usd, nil),
@@ -532,7 +532,7 @@ class CustomRegexComponentTests: XCTestCase {
 
     // No capture, two errors
     customTest(
-      Regex<Substring> {
+      Regex {
         IntParser()
         " "
         IntParser()
@@ -544,7 +544,7 @@ class CustomRegexComponentTests: XCTestCase {
     )
 
     customTest(
-      Regex<Substring> {
+      Regex {
         CurrencyParser()
         IntParser()
       },
@@ -557,7 +557,7 @@ class CustomRegexComponentTests: XCTestCase {
     // One capture, two errors: One error is thrown from inside a capture,
     // while the other one is thrown from outside
     customTest(
-      Regex<(Substring, CurrencyParser.Currency)> {
+      Regex {
         Capture { CurrencyParser() }
         IntParser()
       },
@@ -568,7 +568,7 @@ class CustomRegexComponentTests: XCTestCase {
     )
 
     customTest(
-      Regex<(Substring, Int)> {
+      Regex {
         CurrencyParser()
         Capture { IntParser() }
       },
@@ -580,7 +580,7 @@ class CustomRegexComponentTests: XCTestCase {
 
     // One capture, two errors: Both errors are thrown from inside the capture
     customTest(
-      Regex<(Substring, Substring)> {
+      Regex {
         Capture {
           CurrencyParser()
           IntParser()
@@ -594,7 +594,7 @@ class CustomRegexComponentTests: XCTestCase {
 
     // Two captures, two errors: Different erros are thrown from inside captures
     customTest(
-      Regex<(Substring, CurrencyParser.Currency, Int)> {
+      Regex {
         Capture(CurrencyParser())
         Capture(IntParser())
       },

--- a/Tests/RegexBuilderTests/MotivationTests.swift
+++ b/Tests/RegexBuilderTests/MotivationTests.swift
@@ -310,8 +310,8 @@ extension RegexDSLTests {
           "CREDIT"
           "DEBIT"
         }
-      } transform: { (s: Substring) -> TransactionKind? in
-        TransactionKind(rawValue: String(s))
+      } transform: {
+        TransactionKind(rawValue: String($0))
       }
       
       OneOrMore(.whitespace)
@@ -323,8 +323,8 @@ extension RegexDSLTests {
         Repeat(.digit, count: 2)
         Repeat(.digit, count: 2)
         Repeat(.digit, count: 4)
-      } transform: { (s: Substring) -> Date? in
-        Date(mmddyyyy: String(s))
+      } transform: {
+        Date(mmddyyyy: String($0))
       }
       
       OneOrMore(.whitespace)
@@ -346,8 +346,8 @@ extension RegexDSLTests {
         OneOrMore(.digit)
         "."
         Repeat(.digit, count: 2)
-      } transform: { (s: Substring) -> Double? in
-        Double(s)
+      } transform: {
+        Double($0)
       }
     }
     

--- a/Tests/RegexBuilderTests/RegexDSLTests.swift
+++ b/Tests/RegexBuilderTests/RegexDSLTests.swift
@@ -1254,8 +1254,8 @@ class RegexDSLTests: XCTestCase {
         TryCapture(as: b) {
           "#"
           OneOrMore(.digit)
-        } transform: { (s: Substring) in
-          Int(s.dropFirst())
+        } transform: {
+          Int($0.dropFirst())
         }
       }
       a
@@ -1272,14 +1272,14 @@ class RegexDSLTests: XCTestCase {
     do {
       let a = Reference(Substring.self)
       let b = Reference(Int.self)
-      let regex = Regex<(Substring, Substring, Int?, Int?, Substring?)> {
+      let regex = Regex {
         Capture("abc", as: a)
         ZeroOrMore {
           TryCapture(as: b) {
             "#"
             OneOrMore(.digit)
-          } transform: { (s: Substring) -> Int? in
-            Int(s.dropFirst())
+          } transform: {
+            Int($0.dropFirst())
           }
         }
         a

--- a/Tests/RegexBuilderTests/RegexDSLTests.swift
+++ b/Tests/RegexBuilderTests/RegexDSLTests.swift
@@ -16,15 +16,15 @@ import TestSupport
 
 @available(SwiftStdlib 5.7, *)
 class RegexDSLTests: XCTestCase {
-  func _testDSLCaptures<Content: RegexComponent, MatchType>(
+  func _testDSLCaptures<MatchType>(
     _ tests: (input: String, expectedCaptures: MatchType?)...,
     matchType: MatchType.Type,
     _ equivalence: (MatchType, MatchType) -> Bool,
     xfail: Bool = false,
     file: StaticString = #file,
     line: UInt = #line,
-    @RegexComponentBuilder _ content: () -> Content
-  ) throws where Content.RegexOutput == MatchType {
+    @RegexComponentBuilder _ content: () -> some RegexComponent<MatchType>
+  ) throws {
     let regex = content()
     for (input, maybeExpectedCaptures) in tests {
       let maybeMatch = input.wholeMatch(of: regex)

--- a/Tests/RegexTests/AlgorithmsTests.swift
+++ b/Tests/RegexTests/AlgorithmsTests.swift
@@ -98,10 +98,13 @@ class AlgorithmTests: XCTestCase {
     // `String.contains` get selected instead, which has inconsistent behavior.
     
     // Test that original `contains` functions are still accessible
-    let containsRef = "abcd".contains
-    XCTAssert(type(of: containsRef) == ((Character) -> Bool).self)
-    let containsParamsRef = "abcd".contains(_:)
-    XCTAssert(type(of: containsParamsRef) == ((Character) -> Bool).self)
+
+    // rdar://105502403
+    // Error: constructing SILType with type that should have been eliminated by SIL lowering
+    // let containsRef = "abcd".contains
+    // XCTAssert(type(of: containsRef) == ((Character) -> Bool).self)
+    // let containsParamsRef = "abcd".contains(_:)
+    // XCTAssert(type(of: containsParamsRef) == ((Character) -> Bool).self)
   }
   
   func testRegexRanges() {
@@ -247,10 +250,13 @@ class AlgorithmTests: XCTestCase {
     XCTAssertEqual(CountedOptionSet.arrayLiteralCreationCount, 3)
 
     // Test that original `split` functions are still accessible
-    let splitRef = "abcd".split
-    XCTAssert(type(of: splitRef) == ((Character, Int, Bool) -> [Substring]).self)
-    let splitParamsRef = "abcd".split(separator:maxSplits:omittingEmptySubsequences:)
-    XCTAssert(type(of: splitParamsRef) == ((Character, Int, Bool) -> [Substring]).self)
+    
+    // rdar://105502403
+    // Error: constructing SILType with type that should have been eliminated by SIL lowering
+    // let splitRef = "abcd".split
+    // XCTAssert(type(of: splitRef) == ((Character, Int, Bool) -> [Substring]).self)
+    // let splitParamsRef = "abcd".split(separator:maxSplits:omittingEmptySubsequences:)
+    // XCTAssert(type(of: splitParamsRef) == ((Character, Int, Bool) -> [Substring]).self)
   }
 
   func testSplitPermutations() throws {


### PR DESCRIPTION
Cherry picks of 58c6b4e2f9911df7d67e107c147f92ccf1d242f6 and bd283f9b8e7d3aa2556a828aa4c764e38935ba45 to support the type checker fix for result builder closure type inference.

rdar://105619787