### PR TITLE
Speed up general character class matching

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,7 @@ let availabilityDefinition = PackageDescription.SwiftSetting.unsafeFlags([
     "-Xfrontend",
     "-define-availability",
     "-Xfrontend",
-    "SwiftStdlib 5.7:macOS 9999, iOS 9999, watchOS 9999, tvOS 9999",
+    "SwiftStdlib 5.7:macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0",
     "-Xfrontend",
     "-define-availability",
     "-Xfrontend",

--- a/Sources/RegexBenchmark/BenchmarkRunner.swift
+++ b/Sources/RegexBenchmark/BenchmarkRunner.swift
@@ -1,6 +1,9 @@
 import Foundation
 @_spi(RegexBenchmark) import _StringProcessing
 
+/// The number of times to re-run the benchmark if results are too variang
+private var rerunCount: Int { 3 }
+
 struct BenchmarkRunner {
   let suiteName: String
   var suite: [any RegexBenchmark] = []
@@ -82,11 +85,16 @@ struct BenchmarkRunner {
     for b in suite {
       var result = measure(benchmark: b, samples: samples)
       if result.runtimeIsTooVariant {
-        print("Warning: Standard deviation > \(Stats.maxAllowedStdev*100)% for \(b.name)")
-        print(result.runtime)
-        print("Rerunning \(b.name)")
-        result = measure(benchmark: b, samples: result.runtime.samples*2)
-        print(result.runtime)
+        for _ in 0..<rerunCount {
+          print("Warning: Standard deviation > \(Stats.maxAllowedStdev*100)% for \(b.name)")
+          print(result.runtime)
+          print("Rerunning \(b.name)")
+          result = measure(benchmark: b, samples: result.runtime.samples*2)
+          print(result.runtime)
+          if !result.runtimeIsTooVariant {
+            break
+          }
+        }
         if result.runtimeIsTooVariant {
           fatalError("Benchmark \(b.name) is too variant")
         }

--- a/Sources/RegexBenchmark/BenchmarkRunner.swift
+++ b/Sources/RegexBenchmark/BenchmarkRunner.swift
@@ -1,7 +1,7 @@
 import Foundation
 @_spi(RegexBenchmark) import _StringProcessing
 
-/// The number of times to re-run the benchmark if results are too variang
+/// The number of times to re-run the benchmark if results are too varying
 private var rerunCount: Int { 3 }
 
 struct BenchmarkRunner {

--- a/Sources/_StringProcessing/Engine/MEBuiltins.swift
+++ b/Sources/_StringProcessing/Engine/MEBuiltins.swift
@@ -38,9 +38,9 @@ extension Processor {
       return nil
     }
 
-    let asciiCheck = (char.isASCII && !isScalarSemantics)
+    let asciiCheck = !isStrictASCII
       || (scalar.isASCII && isScalarSemantics)
-      || !isStrictASCII
+      || char.isASCII
 
     var matched: Bool
     var next: Input.Index

--- a/Sources/_StringProcessing/_CharacterClassModel.swift
+++ b/Sources/_StringProcessing/_CharacterClassModel.swift
@@ -81,9 +81,10 @@ struct _CharacterClassModel: Hashable {
     let char = input[currentPosition]
     let scalar = input.unicodeScalars[currentPosition]
     let isScalarSemantics = matchLevel == .unicodeScalar
-    let asciiCheck = (char.isASCII && !isScalarSemantics)
+
+    let asciiCheck = !isStrictASCII
       || (scalar.isASCII && isScalarSemantics)
-      || !isStrictASCII
+      || char.isASCII
     
     var matched: Bool
     var next: String.Index


### PR DESCRIPTION
Speed up the character class matching general path by re-ordering expressions, short-circuiting prior to needing to invoke `Character.isASCII`.

The regressions are minor and inconsistent across runs, while the improvements are robust across runs.

```
=== Regressions ======================================================================
- CompilerMessagesAll                     119ms	118ms	1.27ms		1.1%
- EmailRFCNoMatchesAll                    134ms	133ms	1.12ms		0.8%
- symDiffCCC                              48.6ms	47.8ms	713µs		1.5%
- IntersectionCCC                         22.1ms	21.5ms	613µs		2.9%
- SubtractionCCC                          21.6ms	21ms	612µs		2.9%
- EmojiRegexAll                           71.5ms	71.1ms	362µs		0.5%
- InvertedCCC                             21ms	20.7ms	272µs		1.3%
- BasicCCC                                10.7ms	10.5ms	242µs		2.3%
- CaseInsensitiveCCC                      11.8ms	11.6ms	216µs		1.9%
- BasicRangeCCC                           11ms	10.8ms	202µs		1.9%
- HangulSyllableAll                       6.85ms	6.66ms	191µs		2.9%
- LiteralSearchAll                        6.59ms	6.42ms	164µs		2.6%
- LiteralSearchNotFoundAll                6.37ms	6.25ms	120µs		1.9%
- HangulSyllableFirst                     3.29ms	3.18ms	106µs		3.3%
- AnchoredNotFoundWhole                   8.93ms	8.83ms	103µs		1.2%
- ReluctantQuantWithTerminalWhole         9.07ms	8.99ms	78.9µs		0.9%
- CssAll                                  3.98ms	3.94ms	44.1µs		1.1%
- MACAddress                              3.02ms	2.98ms	35.8µs		1.2%
=== Improvements =====================================================================
- DiceRollsInTextAll                      62.6ms	66ms	-3.39ms		-5.1%
- EmailBuiltinCharacterClassAll           24.3ms	26ms	-1.76ms		-6.8%
- BasicBuiltinCharacterClassAll           14.6ms	15.9ms	-1.28ms		-8.0%
- NumbersAll                              11.6ms	12.6ms	-976µs		-7.8%
- WordsAll                                21.8ms	22.6ms	-823µs		-3.6%
- DiceNotation                            6.74ms	7.08ms	-345µs		-4.9%
- GraphemeBreakNoCapAll                   6.72ms	6.95ms	-234µs		-3.4%
- IPv6Address                             3.97ms	4.02ms	-48.5µs		-1.2%
```

These percentages don't seem like much, but that's because while this change is signficant relative to the internal running of the regex engine for those benchmarks, there's even greater overhead elsewhere that we have yet to tackle (such as excessive ARC).
