### PR TITLE
Type checker workaround: adjust test

### DIFF
--- a/Tests/RegexBuilderTests/RegexDSLTests.swift
+++ b/Tests/RegexBuilderTests/RegexDSLTests.swift
@@ -1099,8 +1099,11 @@ class RegexDSLTests: XCTestCase {
     }
     let _: (Substring, Substring, Int, Double?).Type
     = type(of: regex3).RegexOutput.self
-    
-    let regex4 = Regex {
+
+    // FIXME: Remove explicit type when type checker regression is fixed
+    let regex4: Regex<(
+      Substring, Substring, Substring, Substring, Substring?
+    )> = Regex {
       OneOrMore("a")
       Capture {
         OneOrMore {


### PR DESCRIPTION
A type checker regression is blocking our ability to run tests. This works around it