### PR TITLE
DRAFT: Fast paths for large, native strings

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,7 @@ let availabilityDefinition = PackageDescription.SwiftSetting.unsafeFlags([
     "-Xfrontend",
     "-define-availability",
     "-Xfrontend",
-    "SwiftStdlib 5.7:macOS 9999, iOS 9999, watchOS 9999, tvOS 9999",
+    "SwiftStdlib 5.7:macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0",
     "-Xfrontend",
     "-define-availability",
     "-Xfrontend",

--- a/Sources/RegexBenchmark/BenchmarkRunner.swift
+++ b/Sources/RegexBenchmark/BenchmarkRunner.swift
@@ -1,6 +1,9 @@
 import Foundation
 @_spi(RegexBenchmark) import _StringProcessing
 
+/// The number of times to re-run the benchmark if results are too variang
+private var rerunCount: Int { 3 }
+
 struct BenchmarkRunner {
   let suiteName: String
   var suite: [any RegexBenchmark] = []
@@ -82,11 +85,16 @@ struct BenchmarkRunner {
     for b in suite {
       var result = measure(benchmark: b, samples: samples)
       if result.runtimeIsTooVariant {
-        print("Warning: Standard deviation > \(Stats.maxAllowedStdev*100)% for \(b.name)")
-        print(result.runtime)
-        print("Rerunning \(b.name)")
-        result = measure(benchmark: b, samples: result.runtime.samples*2)
-        print(result.runtime)
+        for _ in 0..<rerunCount {
+          print("Warning: Standard deviation > \(Stats.maxAllowedStdev*100)% for \(b.name)")
+          print(result.runtime)
+          print("Rerunning \(b.name)")
+          result = measure(benchmark: b, samples: result.runtime.samples*2)
+          print(result.runtime)
+          if !result.runtimeIsTooVariant {
+            break
+          }
+        }
         if result.runtimeIsTooVariant {
           fatalError("Benchmark \(b.name) is too variant")
         }

--- a/Sources/_StringProcessing/Engine/MEBuiltins.swift
+++ b/Sources/_StringProcessing/Engine/MEBuiltins.swift
@@ -34,6 +34,14 @@ extension Processor {
     _ isStrictASCII: Bool,
     _ isScalarSemantics: Bool
   ) -> Input.Index? {
+
+    // ASCII fast-path
+    if let (next, result) = input._quickMatch(
+      cc, at: currentPosition, isScalarSemantics: isScalarSemantics
+    ) {
+      return result == isInverted ? nil : next
+    }
+
     guard let char = load(), let scalar = loadScalar() else {
       return nil
     }

--- a/Sources/_StringProcessing/Engine/MEBuiltins.swift
+++ b/Sources/_StringProcessing/Engine/MEBuiltins.swift
@@ -38,9 +38,9 @@ extension Processor {
       return nil
     }
 
-    let asciiCheck = (char.isASCII && !isScalarSemantics)
+    let asciiCheck = !isStrictASCII
       || (scalar.isASCII && isScalarSemantics)
-      || !isStrictASCII
+      || char.isASCII
 
     var matched: Bool
     var next: Input.Index

--- a/Sources/_StringProcessing/Engine/Metrics.swift
+++ b/Sources/_StringProcessing/Engine/Metrics.swift
@@ -1,4 +1,5 @@
 extension Processor {
+#if PROCESSOR_MEASUREMENTS_ENABLED
   struct ProcessorMetrics {
     var instructionCounts: [Instruction.OpCode: Int] = [:]
     var backtracks: Int = 0
@@ -7,8 +8,61 @@ extension Processor {
 
     var isTracingEnabled: Bool = false
     var shouldMeasureMetrics: Bool = false
+
+    init(isTracingEnabled: Bool, shouldMeasureMetrics: Bool) {
+      self.isTracingEnabled = isTracingEnabled
+      self.shouldMeasureMetrics = shouldMeasureMetrics
+    }
   }
-  
+#else
+  struct ProcessorMetrics {
+    var isTracingEnabled: Bool { false }
+    var shouldMeasureMetrics: Bool { false }
+    var cycleCount: Int { 0 }
+
+    init(isTracingEnabled: Bool, shouldMeasureMetrics: Bool) { }
+  }
+#endif
+}
+
+extension Processor {
+
+  mutating func startCycleMetrics() {
+#if PROCESSOR_MEASUREMENTS_ENABLED
+    if metrics.cycleCount == 0 {
+      trace()
+      measureMetrics()
+    }
+#endif
+  }
+
+  mutating func endCycleMetrics() {
+#if PROCESSOR_MEASUREMENTS_ENABLED
+    metrics.cycleCount += 1
+    trace()
+    measureMetrics()
+    _checkInvariants()
+#endif
+  }
+}
+
+extension Processor.ProcessorMetrics {
+
+  mutating func addReset() {
+#if PROCESSOR_MEASUREMENTS_ENABLED
+    self.resets += 1
+#endif
+  }
+
+  mutating func addBacktrack() {
+#if PROCESSOR_MEASUREMENTS_ENABLED
+    self.backtracks += 1
+#endif
+  }
+}
+
+extension Processor {
+#if PROCESSOR_MEASUREMENTS_ENABLED
   func printMetrics() {
     print("===")
     print("Total cycle count: \(metrics.cycleCount)")
@@ -38,4 +92,5 @@ extension Processor {
       measure()
     }
   }
+#endif
 }

--- a/Sources/_StringProcessing/Engine/Metrics.swift
+++ b/Sources/_StringProcessing/Engine/Metrics.swift
@@ -3,11 +3,15 @@ extension Processor {
     var instructionCounts: [Instruction.OpCode: Int] = [:]
     var backtracks: Int = 0
     var resets: Int = 0
+    var cycleCount: Int = 0
+
+    var isTracingEnabled: Bool = false
+    var shouldMeasureMetrics: Bool = false
   }
   
   func printMetrics() {
     print("===")
-    print("Total cycle count: \(cycleCount)")
+    print("Total cycle count: \(metrics.cycleCount)")
     print("Backtracks: \(metrics.backtracks)")
     print("Resets: \(metrics.resets)")
     print("Instructions:")
@@ -30,7 +34,7 @@ extension Processor {
   }
   
   mutating func measureMetrics() {
-    if shouldMeasureMetrics {
+    if metrics.shouldMeasureMetrics {
       measure()
     }
   }

--- a/Sources/_StringProcessing/Engine/Processor.swift
+++ b/Sources/_StringProcessing/Engine/Processor.swift
@@ -89,7 +89,7 @@ struct Processor {
   var metrics: ProcessorMetrics
 
   /// Set if the string has fast contiguous UTF-8 available
-  let fastUTF8: UnsafeRawBufferPointer? = nil
+  let fastUTF8: UnsafeRawBufferPointer?
 }
 
 extension Processor {
@@ -128,6 +128,7 @@ extension Processor {
        repeating: .init(), count: program.registerInfo.captures)
 
     // print(MemoryLayout<Processor>.size)
+    self.fastUTF8 = input._unsafeFastUTF8
 
     _checkInvariants()
   }
@@ -160,6 +161,16 @@ extension Processor {
     assert(subjectBounds.upperBound <= input.endIndex)
     assert(currentPosition >= searchBounds.lowerBound)
     assert(currentPosition <= searchBounds.upperBound)
+
+    assert({
+      guard let utf8 = self.fastUTF8 else { return true }
+      var copy = input
+      return copy.withUTF8 {
+        let base = UnsafeRawPointer($0.baseAddress!)
+        return utf8.baseAddress == base
+      }
+    }())
+
   }
 }
 

--- a/Sources/_StringProcessing/Engine/Processor.swift
+++ b/Sources/_StringProcessing/Engine/Processor.swift
@@ -86,10 +86,6 @@ struct Processor {
 
   var failureReason: Error? = nil
 
-  // MARK: Metrics, debugging, etc.
-  var cycleCount = 0
-  var isTracingEnabled: Bool
-  let shouldMeasureMetrics: Bool
   var metrics: ProcessorMetrics = ProcessorMetrics()
 }
 
@@ -116,8 +112,11 @@ extension Processor {
     self.subjectBounds = subjectBounds
     self.searchBounds = searchBounds
     self.matchMode = matchMode
-    self.isTracingEnabled = isTracingEnabled
-    self.shouldMeasureMetrics = shouldMeasureMetrics
+
+    self.metrics = ProcessorMetrics(
+      isTracingEnabled: isTracingEnabled,
+      shouldMeasureMetrics: shouldMeasureMetrics)
+
     self.currentPosition = searchBounds.lowerBound
 
     // Initialize registers with end of search bounds
@@ -145,7 +144,7 @@ extension Processor {
     self.state = .inProgress
     self.failureReason = nil
     
-    if shouldMeasureMetrics { metrics.resets += 1 }
+    if metrics.shouldMeasureMetrics { metrics.resets += 1 }
     _checkInvariants()
   }
 
@@ -402,7 +401,7 @@ extension Processor {
     registers.ints = intRegisters
     registers.positions = posRegisters
     
-    if shouldMeasureMetrics { metrics.backtracks += 1 }
+    if metrics.shouldMeasureMetrics { metrics.backtracks += 1 }
   }
 
   mutating func abort(_ e: Error? = nil) {

--- a/Sources/_StringProcessing/Engine/Processor.swift
+++ b/Sources/_StringProcessing/Engine/Processor.swift
@@ -87,6 +87,9 @@ struct Processor {
   var failureReason: Error? = nil
 
   var metrics: ProcessorMetrics
+
+  /// Set if the string has fast contiguous UTF-8 available
+  let fastUTF8: UnsafeRawBufferPointer? = nil
 }
 
 extension Processor {
@@ -123,6 +126,8 @@ extension Processor {
     self.registers = Registers(program, searchBounds.upperBound)
     self.storedCaptures = Array(
        repeating: .init(), count: program.registerInfo.captures)
+
+    // print(MemoryLayout<Processor>.size)
 
     _checkInvariants()
   }
@@ -264,6 +269,8 @@ extension Processor {
     return true
   }
 
+  @inline(never)
+  @_effects(releasenone)
   func loadScalar() -> Unicode.Scalar? {
     currentPosition < end ? input.unicodeScalars[currentPosition] : nil
   }

--- a/Sources/_StringProcessing/Engine/Tracing.swift
+++ b/Sources/_StringProcessing/Engine/Tracing.swift
@@ -9,7 +9,12 @@
 //
 //===----------------------------------------------------------------------===//
 
+
+// TODO: Remove this protocol (and/or reuse it for something like a FastProcessor)
 extension Processor: TracedProcessor {
+  var cycleCount: Int { metrics.cycleCount }
+  var isTracingEnabled: Bool { metrics.isTracingEnabled }
+
   var isFailState: Bool { state == .fail }
   var isAcceptState: Bool { state == .accept }
 

--- a/Sources/_StringProcessing/Executor.swift
+++ b/Sources/_StringProcessing/Executor.swift
@@ -31,7 +31,7 @@ struct Executor {
       subjectBounds: subjectBounds,
       searchBounds: searchBounds)
 #if PROCESSOR_MEASUREMENTS_ENABLED
-    defer { if cpu.shouldMeasureMetrics { cpu.printMetrics() } }
+    defer { if cpu.metrics.shouldMeasureMetrics { cpu.printMetrics() } }
 #endif
     var low = searchBounds.lowerBound
     let high = searchBounds.upperBound
@@ -60,7 +60,7 @@ struct Executor {
     var cpu = engine.makeProcessor(
       input: input, bounds: subjectBounds, matchMode: mode)
 #if PROCESSOR_MEASUREMENTS_ENABLED
-    defer { if cpu.shouldMeasureMetrics { cpu.printMetrics() } }
+    defer { if cpu.metrics.shouldMeasureMetrics { cpu.printMetrics() } }
 #endif
     return try _match(input, from: subjectBounds.lowerBound, using: &cpu)
   }

--- a/Sources/_StringProcessing/StringExtras.swift
+++ b/Sources/_StringProcessing/StringExtras.swift
@@ -304,3 +304,9 @@ extension _StringObject.CountAndFlags {
     return 0 != _storage & _StringObject.CountAndFlags.isTailAllocatedMask
   }
 }
+
+extension UnsafeRawPointer {
+  func loadByte(_ offset: String.Index) -> UInt8 {
+    self.load(fromByteOffset: offset.encodedOffset, as: UInt8.self)
+  }
+}

--- a/Sources/_StringProcessing/StringExtras.swift
+++ b/Sources/_StringProcessing/StringExtras.swift
@@ -223,7 +223,7 @@ internal struct _StringObject {
   /// exclude shared strings.
   @inline(__always)
   var fastUTF8IfAvailable: UnsafeRawBufferPointer? {
-    guard self.largeFastIsTailAllocated else {
+    guard self.isLarge && self.providesFastUTF8 && self.largeFastIsTailAllocated else {
       return nil
     }
     return UnsafeRawBufferPointer(

--- a/Sources/_StringProcessing/StringExtras.swift
+++ b/Sources/_StringProcessing/StringExtras.swift
@@ -1,0 +1,130 @@
+
+/// TODO: better description
+/// Whether this is the starting byte of a sub-300 (i.e. pre-combining scalar) scalars
+private func _isSub300StartingByte(_ x: UInt8) -> Bool {
+  x < 0xCC
+}
+private func _isASCII(_ x: UInt8) -> Bool {
+  x < 0x80
+}
+
+private var _lineFeed: UInt8 { 0x0A }
+private var _carriageReturn: UInt8 { 0x0D }
+private var _lineTab: UInt8 { 0x0B }
+private var _formFeed: UInt8 { 0x0C }
+private var _space: UInt8 { 0x20 }
+private var _tab: UInt8 { 0x09 }
+
+
+
+private var _0: UInt8 { 0x30 }
+private var _9: UInt8 { 0x39 }
+private func _isASCIINumber(_ x: UInt8) -> Bool {
+  return (_0..._9).contains(x)
+}
+
+private var _a: UInt8 { 0x61 }
+private var _z: UInt8 { 0x7A }
+private var _A: UInt8 { 0x41 }
+private var _Z: UInt8 { 0x5A }
+private func _isASCIILetter(_ x: UInt8) -> Bool {
+  return (_a..._z).contains(x) || (_A..._Z).contains(x)
+}
+
+private var _underscore: UInt8 { 0x5F }
+
+
+extension String {
+
+
+  /// TODO: detailed description of nuanced semantics
+  func _asciiCharacter(
+    at idx: Index
+  ) -> (first: UInt8, next: Index, crLF: Bool)? {
+    // TODO: fastUTF8 version
+
+    if idx == endIndex {
+      return nil
+    }
+    let base = utf8[idx]
+    guard _isASCII(base) else { return nil }
+
+    var next = utf8.index(after: idx)
+    if next == utf8.endIndex {
+      return (first: base, next: next, crLF: false)
+    }
+
+    let tail = utf8[next]
+    guard _isSub300StartingByte(tail) else { return nil }
+
+    // Handle CR-LF:
+    if base == _carriageReturn && tail == _lineFeed {
+      utf8.formIndex(after: &next)
+      guard next == endIndex || _isSub300StartingByte(utf8[next]) else {
+        return nil
+      }
+      return (first: base, next: next, crLF: true)
+    }
+
+    return (first: base, next: next, crLF: false)
+  }
+
+  func _quickMatch(
+    _ cc: _CharacterClassModel.Representation,
+    at idx: Index,
+    isScalarSemantics: Bool
+  ) -> (next: Index, matchResult: Bool)? {
+    /// ASCII fast-paths
+    guard let (asciiValue, next, isCRLF) = _asciiCharacter(
+      at: idx
+    ) else {
+      return nil
+    }
+
+    // TODO: bitvectors
+    switch cc {
+    case .any, .anyGrapheme, .anyScalar:
+      // TODO: should any scalar not consume CR-LF in scalar semantic mode?
+      return (next, true)
+
+    case .digit:
+      if _isASCIINumber(asciiValue) {
+        return (next, true)
+      }
+      return (next, false)
+
+    case .horizontalWhitespace:
+      switch asciiValue {
+        case _space, _tab: return (next, true)
+        default: return (next, false)
+      }
+
+    case .verticalWhitespace, .newlineSequence:
+      switch asciiValue {
+        case _lineFeed, _carriageReturn, _lineTab, _formFeed:
+        // Scalar semantics: For `\v`, only advance past the CR instead of CR-LF
+        if isScalarSemantics && isCRLF && cc == .verticalWhitespace {
+          return (utf8.index(before: next), true)
+        }
+        return (next, true)
+
+        default:
+          return (next, false)
+      }
+
+    case .whitespace:
+      switch asciiValue {
+        case _space, _tab, _lineFeed, _lineTab, _formFeed, _carriageReturn:
+          return (next, true)
+        default:
+          return (next, false)
+      }
+
+    case .word:
+      let matches = _isASCIINumber(asciiValue) || _isASCIILetter(asciiValue) || asciiValue == _underscore
+      return (next, matches)
+    }
+  }
+
+}
+

--- a/Sources/_StringProcessing/Utility/Traced.swift
+++ b/Sources/_StringProcessing/Utility/Traced.swift
@@ -13,7 +13,7 @@
 // TODO: Place shared formatting and trace infrastructure here
 
 protocol Traced {
-  var isTracingEnabled: Bool { get set }
+  var isTracingEnabled: Bool { get }
 }
 
 protocol TracedProcessor: ProcessorProtocol, Traced {

--- a/Sources/_StringProcessing/_CharacterClassModel.swift
+++ b/Sources/_StringProcessing/_CharacterClassModel.swift
@@ -81,9 +81,10 @@ struct _CharacterClassModel: Hashable {
     let char = input[currentPosition]
     let scalar = input.unicodeScalars[currentPosition]
     let isScalarSemantics = matchLevel == .unicodeScalar
-    let asciiCheck = (char.isASCII && !isScalarSemantics)
+
+    let asciiCheck = !isStrictASCII
       || (scalar.isASCII && isScalarSemantics)
-      || !isStrictASCII
+      || char.isASCII
     
     var matched: Bool
     var next: String.Index

--- a/Sources/_StringProcessing/_CharacterClassModel.swift
+++ b/Sources/_StringProcessing/_CharacterClassModel.swift
@@ -78,9 +78,18 @@ struct _CharacterClassModel: Hashable {
     guard currentPosition != input.endIndex else {
       return nil
     }
+
+    let isScalarSemantics = matchLevel == .unicodeScalar
+
+    // ASCII fast-path
+    if let (next, result) = input._quickMatch(
+      cc, at: currentPosition, isScalarSemantics: isScalarSemantics
+    ) {
+      return result == isInverted ? nil : next
+    }
+
     let char = input[currentPosition]
     let scalar = input.unicodeScalars[currentPosition]
-    let isScalarSemantics = matchLevel == .unicodeScalar
 
     let asciiCheck = !isStrictASCII
       || (scalar.isASCII && isScalarSemantics)


### PR DESCRIPTION
Pulls in a bunch of String-internal bit fiddly code in order to quickly get a pointer to contiguous UTF-8 if we're a (large) native string.

Extract out the Metrics data (unused in release builds), as it seems like having `Processor` surpass the 256-byte size causes significant regressions for some reason. (see https://github.com/milseman/swift-experimental-string-processing/pull/1).

The below results are post- https://github.com/apple/swift-experimental-string-processing/pull/642 and post- https://github.com/apple/swift-experimental-string-processing/pull/644


=== Regressions ======================================================================
- EmojiRegexAll                           72.9ms	71.9ms	1.03ms		1.4%
- SubtractionCCC                          21.7ms	21.3ms	314µs		1.5%
- BasicCCC                                10.8ms	10.5ms	261µs		2.5%
- CaseInsensitiveCCC                      12ms	11.7ms	255µs		2.2%
- IntersectionCCC                         22.1ms	21.9ms	206µs		0.9%
- BasicRangeCCC                           11.1ms	11ms	196µs		1.8%
- IPv4Address                             2.64ms	2.54ms	99.2µs		3.9%
=== Improvements =====================================================================
- CompilerMessagesAll                     113ms	116ms	-2.71ms		-2.3%
- DiceRollsInTextAll                      47.3ms	49.6ms	-2.23ms		-4.5%
- AnchoredNotFoundWhole                   7.44ms	9.18ms	-1.74ms		-18.9%
- NotFoundAll                             6.29ms	7.09ms	-797µs		-11.2%
- EmailLookaheadAll                       39.3ms	39.9ms	-683µs		-1.7%
- EmailBuiltinCharacterClassAll           14.8ms	15.5ms	-663µs		-4.3%
- ReluctantQuantWithTerminalWhole         8.77ms	9.3ms	-525µs		-5.6%
- LiteralSearchAll                        6.17ms	6.65ms	-478µs		-7.2%
- HangulSyllableAll                       6.35ms	6.76ms	-412µs		-6.1%
- LiteralSearchNotFoundAll                6.05ms	6.42ms	-369µs		-5.8%
- GraphemeBreakNoCapAll                   5.26ms	5.52ms	-264µs		-4.8%
- WordsAll                                14.2ms	14.5ms	-264µs		-1.8%
- symDiffCCC                              48.7ms	49ms	-240µs		-0.5%
- EmailLookaheadList                      9.65ms	9.88ms	-230µs		-2.3%
- CssAll                                  3.63ms	3.85ms	-222µs		-5.8%
- EmailLookaheadNoMatchesAll              40.6ms	40.8ms	-204µs		-0.5%
- HangulSyllableFirst                     3.06ms	3.25ms	-194µs		-6.0%
- DiceNotation                            5.21ms	5.39ms	-179µs		-3.3%
- BasicBuiltinCharacterClassAll           9.02ms	9.13ms	-108µs		-1.2%
- EagarQuantWithTerminalWhole             2.55ms	2.61ms	-62.8µs		-2.4%
- LinesAll                                3.05ms	3.1ms	-42.7µs		-1.4%
- MACAddress                              3ms	3.02ms	-24.7µs		-0.8%
