### PR TITLE
Remove the unsupported `anyScalar` case

### DIFF
--- a/Sources/_StringProcessing/ByteCodeGen.swift
+++ b/Sources/_StringProcessing/ByteCodeGen.swift
@@ -702,9 +702,6 @@ fileprivate extension Compiler.ByteCodeGen {
       case .characterClass(let cc):
         // Custom character class that consumes a single grapheme
         let model = cc.asRuntimeModel(options)
-        guard model.consumesSingleGrapheme else {
-          return false
-        }
         builder.buildQuantify(
           model: model,
           kind,

--- a/Sources/_StringProcessing/Engine/MEBuiltins.swift
+++ b/Sources/_StringProcessing/Engine/MEBuiltins.swift
@@ -193,8 +193,6 @@ extension String {
     switch (isScalarSemantics, cc) {
     case (_, .anyGrapheme):
       next = index(after: currentPosition)
-    case (_, .anyScalar):
-      next = unicodeScalars.index(after: currentPosition)
     case (true, _):
       next = unicodeScalars.index(after: currentPosition)
     case (false, _):
@@ -204,12 +202,6 @@ extension String {
     switch cc {
     case .any, .anyGrapheme:
       matched = true
-    case .anyScalar:
-      if isScalarSemantics {
-        matched = true
-      } else {
-        matched = isOnGraphemeClusterBoundary(next)
-      }
     case .digit:
       if isScalarSemantics {
         matched = scalar.properties.numericType != nil && asciiCheck

--- a/Sources/_StringProcessing/PrintAsPattern.swift
+++ b/Sources/_StringProcessing/PrintAsPattern.swift
@@ -760,8 +760,6 @@ extension DSLTree.Atom.CharacterClass {
     switch self {
     case .anyGrapheme:
       return ".anyGraphemeCluster"
-    case .anyUnicodeScalar:
-      return ".anyUnicodeScalar"
     case .digit:
       return ".digit"
     case .notDigit:
@@ -786,6 +784,8 @@ extension DSLTree.Atom.CharacterClass {
       return ".whitespace"
     case .notWhitespace:
       return ".whitespace.inverted"
+    case .anyUnicodeScalar:
+      fatalError("Unsupported")
     }
   }
 }

--- a/Sources/_StringProcessing/Regex/ASTConversion.swift
+++ b/Sources/_StringProcessing/Regex/ASTConversion.swift
@@ -183,7 +183,6 @@ extension AST.Atom.EscapedBuiltin {
     case .wordCharacter:            return .word
     case .notWordCharacter:         return .notWord
     case .graphemeCluster:          return .anyGrapheme
-    case .trueAnychar:              return .anyUnicodeScalar
     default: return nil
     }
   }

--- a/Sources/_StringProcessing/Regex/DSLTree.swift
+++ b/Sources/_StringProcessing/Regex/DSLTree.swift
@@ -260,7 +260,6 @@ extension DSLTree.Atom.CharacterClass {
   public var inverted: DSLTree.Atom.CharacterClass? {
     switch self {
     case .anyGrapheme: return nil
-    case .anyUnicodeScalar: return nil
     case .digit: return .notDigit
     case .notDigit: return .digit
     case .word: return .notWord
@@ -273,6 +272,8 @@ extension DSLTree.Atom.CharacterClass {
     case .notVerticalWhitespace: return .verticalWhitespace
     case .whitespace: return .notWhitespace
     case .notWhitespace: return .whitespace
+    case .anyUnicodeScalar:
+      fatalError("Unsupported")
     }
   }
 }

--- a/Sources/_StringProcessing/Unicode/ASCII.swift
+++ b/Sources/_StringProcessing/Unicode/ASCII.swift
@@ -134,8 +134,7 @@ extension String {
 
     // TODO: bitvectors
     switch cc {
-    case .any, .anyGrapheme, .anyScalar:
-      // TODO: should any scalar not consume CR-LF in scalar semantic mode?
+    case .any, .anyGrapheme:
       return (next, true)
 
     case .digit:

--- a/Sources/_StringProcessing/_CharacterClassModel.swift
+++ b/Sources/_StringProcessing/_CharacterClassModel.swift
@@ -45,8 +45,6 @@ struct _CharacterClassModel: Hashable {
     case any = 0
     /// Any grapheme cluster
     case anyGrapheme
-    /// Any Unicode scalar
-    case anyScalar
     /// Character.isDigit
     case digit
     /// Horizontal whitespace: `[:blank:]`, i.e
@@ -90,15 +88,6 @@ struct _CharacterClassModel: Hashable {
   }
 }
 
-extension _CharacterClassModel {
-  var consumesSingleGrapheme: Bool {
-   switch self.cc {
-    case .anyScalar: return false
-    default: return true
-    }
-  }
-}
-
 extension _CharacterClassModel.Representation {
   /// Returns true if this CharacterClass should be matched by strict ascii under the given options
   func isStrictAscii(options: MatchingOptions) -> Bool {
@@ -119,7 +108,6 @@ extension _CharacterClassModel.Representation: CustomStringConvertible {
     switch self {
     case .any: return "<any>"
     case .anyGrapheme: return "<any grapheme>"
-    case .anyScalar: return "<any scalar>"
     case .digit: return "<digit>"
     case .horizontalWhitespace: return "<horizontal whitespace>"
     case .newlineSequence: return "<newline sequence>"
@@ -185,7 +173,7 @@ extension DSLTree.Atom.CharacterClass {
     case .anyGrapheme:
       cc = .anyGrapheme
     case .anyUnicodeScalar:
-      cc = .anyScalar
+      fatalError("Unsupported")
     }
     return _CharacterClassModel(cc: cc, options: options, isInverted: inverted)
   }


### PR DESCRIPTION
We decided not to support the `anyScalar` character class, which would match a single Unicode scalar regardless of matching mode. However, its representation was still included in the various character class types in the regex engine, leading to unreachable code and unclear requirements when changing or adding new code. This change removes that representation where possible.

The `DSLTree.Atom.CharacterClass` enum is left unchanged, since it is marked `@_spi(RegexBuilder) public`. Any use of that enum case is handled with a `fatalError("Unsupported")`, and it isn't produced on any code path.

Fixes #647.