### PR TITLE
Avoid long expression type checks

### DIFF
--- a/Tests/RegexBuilderTests/AlgorithmsTests.swift
+++ b/Tests/RegexBuilderTests/AlgorithmsTests.swift
@@ -16,7 +16,7 @@ import RegexBuilder
 @available(SwiftStdlib 5.7, *)
 class RegexConsumerTests: XCTestCase {
   func testMatches() {
-    let regex = Capture(OneOrMore(.digit)) { 2 * Int($0)! }
+    let regex = Capture<(Substring, Int)>(OneOrMore(.digit)) { 2 * Int($0)! }
     let str = "foo 160 bar 99 baz"
     XCTAssertEqual(str.matches(of: regex).map(\.output.1), [320, 198])
   }

--- a/Tests/RegexBuilderTests/CustomTests.swift
+++ b/Tests/RegexBuilderTests/CustomTests.swift
@@ -64,7 +64,7 @@ private struct IntParser: CustomConsumingRegexComponent {
     guard index != bounds.upperBound else { return nil }
 
     let r = Regex {
-      Capture(OneOrMore(.digit)) { Int($0) }
+      Capture<(Substring, Int?)>(OneOrMore(.digit)) { Int($0) }
     }
 
     guard let match = input[index..<bounds.upperBound].prefixMatch(of: r),
@@ -694,7 +694,7 @@ class CustomRegexComponentTests: XCTestCase {
       OneOrMore {
         CharacterClass("A"..."Z")
         OneOrMore(CharacterClass("a"..."z"))
-        Capture(Repeat(.digit, count: 2)) { Int($0) }
+        Capture<(Substring, Int?)>(Repeat(.digit, count: 2)) { Int($0) }
       }
     }
 

--- a/Tests/RegexBuilderTests/RegexDSLTests.swift
+++ b/Tests/RegexBuilderTests/RegexDSLTests.swift
@@ -1091,7 +1091,7 @@ class RegexDSLTests: XCTestCase {
       OneOrMore("a")
       Capture {
         TryCapture("b", transform: { Int($0) })
-        ZeroOrMore(
+        ZeroOrMore<(Substring, Double?)>(
           TryCapture("c", transform: { Double($0) })
         )
         Optionally("e")
@@ -1542,12 +1542,12 @@ class RegexDSLTests: XCTestCase {
       in bounds: Range<String.Index>
     ) throws -> (upperBound: String.Index, output: SemanticVersion)? {
       let regex = Regex {
-        TryCapture(OneOrMore(.digit)) { Int($0) }
+        TryCapture<(Substring, Int)>(OneOrMore(.digit)) { Int($0) }
         "."
-        TryCapture(OneOrMore(.digit)) { Int($0) }
+        TryCapture<(Substring, Int)>(OneOrMore(.digit)) { Int($0) }
         Optionally {
           "."
-          TryCapture(OneOrMore(.digit)) { Int($0) }
+          TryCapture<(Substring, Int)>(OneOrMore(.digit)) { Int($0) }
         }
         Optionally {
           "-"
@@ -1876,7 +1876,7 @@ extension RegexDSLTests {
       ":"
       regexWithTooManyCaptures
       ":"
-      TryCapture(OneOrMore(.word)) { Int($0) }
+      TryCapture<(Substring, Int)>(OneOrMore(.word)) { Int($0) }
       #/:(\d+):/#
     }
     XCTAssert(type(of: dslWithTooManyCaptures).self


### PR DESCRIPTION
These changes remove several seconds of type-checking time from the RegexBuilder test cases, bringing all expressions under 150ms (on the tested computer).