### PR TITLE
Provide unique generic method parameter names

### DIFF
--- a/Sources/_RegexParser/Utility/TypeConstruction.swift
+++ b/Sources/_RegexParser/Utility/TypeConstruction.swift
@@ -107,15 +107,15 @@ public enum TypeConstruction {
       var currentElementAddressUnaligned = UnsafeMutableRawPointer(baseAddress)
       for element in elements {
         // Open existential on each element type.
-        func initializeElement<T>(_ element: T) {
+        func initializeElement<U>(_ element: U) {
           currentElementAddressUnaligned =
-            currentElementAddressUnaligned.roundedUp(toAlignmentOf: T.self)
+            currentElementAddressUnaligned.roundedUp(toAlignmentOf: U.self)
           currentElementAddressUnaligned.bindMemory(
-            to: T.self, capacity: MemoryLayout<T>.size
+            to: U.self, capacity: MemoryLayout<U>.size
           ).initialize(to: element)
           // Advance to the next element (unaligned).
           currentElementAddressUnaligned =
-            currentElementAddressUnaligned.advanced(by: MemoryLayout<T>.size)
+            currentElementAddressUnaligned.advanced(by: MemoryLayout<U>.size)
         }
         _openExistential(element, do: initializeElement)
       }
@@ -175,8 +175,8 @@ extension MemoryLayout {
     if byteOffset == 0 { return 0 }
     var currentOffset = 0
     for (index, type) in elementTypes.enumerated() {
-      func sizeAndAlignMask<T>(_: T.Type) -> (Int, Int) {
-        (MemoryLayout<T>.size, MemoryLayout<T>.alignment - 1)
+      func sizeAndAlignMask<U>(_: U.Type) -> (Int, Int) {
+        (MemoryLayout<U>.size, MemoryLayout<U>.alignment - 1)
       }
       // The ABI of an offset-based key path only stores the byte offset, so
       // this doesn't work if there's a 0-sized element, e.g. `Void`,

--- a/Sources/_StringProcessing/Regex/AnyRegexOutput.swift
+++ b/Sources/_StringProcessing/Regex/AnyRegexOutput.swift
@@ -283,7 +283,7 @@ extension Regex where Output == AnyRegexOutput {
   ///
   /// - Parameter regex: A regular expression to convert to use a dynamic
   ///   capture list.
-  public init<Output>(_ regex: Regex<Output>) {
+  public init<OtherOutput>(_ regex: Regex<OtherOutput>) {
     self.init(node: regex.root)
   }
 }
@@ -299,7 +299,7 @@ extension Regex.Match where Output == AnyRegexOutput {
   ///
   /// - Parameter match: A regular expression match to convert to a match with
   ///   type-erased captures.
-  public init<Output>(_ match: Regex<Output>.Match) {
+  public init<OtherOutput>(_ match: Regex<OtherOutput>.Match) {
     self.init(
       anyRegexOutput: match.anyRegexOutput,
       range: match.range


### PR DESCRIPTION
This is getting warned on in the 5.9 compiler, will be an error starting in Swift 6.