### PR TITLE
Handle boundaries when matching in substrings

### DIFF
--- a/Sources/_StringProcessing/Engine/MEBuiltins.swift
+++ b/Sources/_StringProcessing/Engine/MEBuiltins.swift
@@ -190,7 +190,7 @@ extension String {
     limitedBy end: String.Index,
     isScalarSemantics: Bool
   ) -> QuickResult<String.Index?> {
-    guard currentPosition < end else { return .definite(nil) }
+    assert(currentPosition < end)
     guard let (asciiValue, next, isCRLF) = _quickASCIICharacter(
       at: currentPosition, limitedBy: end
     ) else {
@@ -273,7 +273,7 @@ extension String {
     isStrictASCII: Bool,
     isScalarSemantics: Bool
   ) -> QuickResult<String.Index?> {
-    guard currentPosition < end else { return .definite(nil) }
+    assert(currentPosition < end)
     guard let (next, result) = _quickMatch(
       cc,
       at: currentPosition,
@@ -336,7 +336,7 @@ extension String {
       if isScalarSemantics {
         matched = scalar.isNewline && asciiCheck
         if matched && scalar == "\r"
-            && next != end && unicodeScalars[next] == "\n" {
+            && next < end && unicodeScalars[next] == "\n" {
           // Match a full CR-LF sequence even in scalar semantics
           unicodeScalars.formIndex(after: &next)
         }

--- a/Sources/_StringProcessing/Engine/MEBuiltins.swift
+++ b/Sources/_StringProcessing/Engine/MEBuiltins.swift
@@ -15,7 +15,7 @@ extension Processor {
     isStrictASCII: Bool,
     isScalarSemantics: Bool
   ) -> Bool {
-    guard let next = input.matchBuiltinCC(
+    guard currentPosition < end, let next = input.matchBuiltinCC(
       cc,
       at: currentPosition,
       isInverted: isInverted,
@@ -102,18 +102,16 @@ extension Processor {
 
     case .wordBoundary:
       if payload.usesSimpleUnicodeBoundaries {
-        // TODO: How should we handle bounds?
         return atSimpleBoundary(payload.usesASCIIWord, payload.semanticLevel)
       } else {
-        return input.isOnWordBoundary(at: currentPosition, using: &wordIndexCache, &wordIndexMaxIndex)
+        return input.isOnWordBoundary(at: currentPosition, in: searchBounds, using: &wordIndexCache, &wordIndexMaxIndex)
       }
 
     case .notWordBoundary:
       if payload.usesSimpleUnicodeBoundaries {
-        // TODO: How should we handle bounds?
         return !atSimpleBoundary(payload.usesASCIIWord, payload.semanticLevel)
       } else {
-        return !input.isOnWordBoundary(at: currentPosition, using: &wordIndexCache, &wordIndexMaxIndex)
+        return !input.isOnWordBoundary(at: currentPosition, in: searchBounds, using: &wordIndexCache, &wordIndexMaxIndex)
       }
     }
   }
@@ -127,9 +125,7 @@ extension String {
     at currentPosition: String.Index,
     isScalarSemantics: Bool
   ) -> String.Index? {
-    guard currentPosition < endIndex else {
-      return nil
-    }
+    assert(currentPosition < endIndex)
     if case .definite(let result) = _quickMatchAnyNonNewline(
       at: currentPosition,
       isScalarSemantics: isScalarSemantics
@@ -194,9 +190,7 @@ extension String {
     isStrictASCII: Bool,
     isScalarSemantics: Bool
   ) -> String.Index? {
-    guard currentPosition < endIndex else {
-      return nil
-    }
+    assert(currentPosition < endIndex)
     if case .definite(let result) = _quickMatchBuiltinCC(
       cc,
       at: currentPosition,

--- a/Sources/_StringProcessing/Engine/MEBuiltins.swift
+++ b/Sources/_StringProcessing/Engine/MEBuiltins.swift
@@ -125,11 +125,7 @@ extension String {
   ///
   /// This function handles loading a character from a string while respecting
   /// an end boundary, even if that end boundary is sub-character or sub-scalar.
-  ///
-  /// - Parameters:
-  ///   - pos: The position to load a character from.
-  ///   - end: The limit for the character at `pos`.
-  /// - Returns:
+
   ///   - If `pos` is at or past `end`, this function returns `nil`.
   ///   - If `end` is between `pos` and the next grapheme cluster boundary (i.e.,
   ///     `end` is before `self.index(after: pos)`, then the returned character
@@ -139,11 +135,20 @@ extension String {
   ///     is not on a Unicode scalar boundary, the partial scalar is dropped. This
   ///     can result in a `nil` return or a character that includes only part of
   ///     the `self[pos]` character.
+  ///
+  /// - Parameters:
+  ///   - pos: The position to load a character from.
+  ///   - end: The limit for the character at `pos`.
+  /// - Returns: The character at `pos`, bounded by `end`, if it exists, along
+  ///   with the upper bound of that character. The upper bound is always
+  ///   scalar-aligned.
   func characterAndEnd(at pos: String.Index, limitedBy end: String.Index) -> (Character, String.Index)? {
     // FIXME: Sink into the stdlib to avoid multiple boundary calculations
     guard pos < end else { return nil }
     let next = index(pos, offsetBy: 1, limitedBy: end) ?? end
-    return self[pos..<next].first.map { ($0, next) }
+    // Substring will round down non-scalar aligned indices
+    let substr = self[pos..<next]
+    return substr.first.map { ($0, substr.endIndex) }
   }
   
   func matchAnyNonNewline(

--- a/Sources/_StringProcessing/Engine/MEBuiltins.swift
+++ b/Sources/_StringProcessing/Engine/MEBuiltins.swift
@@ -120,7 +120,27 @@ extension Processor {
 
 // MARK: Matching `.`
 extension String {
+  /// Returns the character at `pos`, bounded by `end`, as well as the upper
+  /// boundary of the returned character.
+  ///
+  /// This function handles loading a character from a string while respecting
+  /// an end boundary, even if that end boundary is sub-character or sub-scalar.
+  ///
+  /// - Parameters:
+  ///   - pos: The position to load a character from.
+  ///   - end: The limit for the character at `pos`.
+  /// - Returns:
+  ///   - If `pos` is at or past `end`, this function returns `nil`.
+  ///   - If `end` is between `pos` and the next grapheme cluster boundary (i.e.,
+  ///     `end` is before `self.index(after: pos)`, then the returned character
+  ///     is smaller than the one that would be produced by `self[pos]` and the
+  ///     returned index is at the end of that character.
+  ///   - If `end` is between `pos` and the next grapheme cluster boundary, and
+  ///     is not on a Unicode scalar boundary, the partial scalar is dropped. This
+  ///     can result in a `nil` return or a character that includes only part of
+  ///     the `self[pos]` character.
   func characterAndEnd(at pos: String.Index, limitedBy end: String.Index) -> (Character, String.Index)? {
+    // FIXME: Sink into the stdlib to avoid multiple boundary calculations
     guard pos < end else { return nil }
     let next = index(pos, offsetBy: 1, limitedBy: end) ?? end
     return self[pos..<next].first.map { ($0, next) }

--- a/Sources/_StringProcessing/Engine/MEQuantify.swift
+++ b/Sources/_StringProcessing/Engine/MEQuantify.swift
@@ -17,7 +17,7 @@ extension Processor {
         boundaryCheck: !isScalarSemantics,
         isCaseInsensitive: false)
     case .builtin:
-      // FIXME: bounds check? endIndex or end?
+      guard currentPosition < end else { return nil }
 
       // We only emit .quantify if it consumes a single character
       return input.matchBuiltinCC(
@@ -27,8 +27,7 @@ extension Processor {
         isStrictASCII: payload.builtinIsStrict,
         isScalarSemantics: isScalarSemantics)
     case .any:
-      // FIXME: endIndex or end?
-      guard currentPosition < input.endIndex else { return nil }
+      guard currentPosition < end else { return nil }
 
       if payload.anyMatchesNewline {
         if isScalarSemantics {

--- a/Sources/_StringProcessing/Engine/MEQuantify.swift
+++ b/Sources/_StringProcessing/Engine/MEQuantify.swift
@@ -23,6 +23,7 @@ extension Processor {
       return input.matchBuiltinCC(
         payload.builtin,
         at: currentPosition,
+        limitedBy: end,
         isInverted: payload.builtinIsInverted,
         isStrictASCII: payload.builtinIsStrict,
         isScalarSemantics: isScalarSemantics)
@@ -37,7 +38,9 @@ extension Processor {
       }
 
       return input.matchAnyNonNewline(
-        at: currentPosition, isScalarSemantics: isScalarSemantics)
+        at: currentPosition,
+        limitedBy: end,
+        isScalarSemantics: isScalarSemantics)
     }
   }
 

--- a/Sources/_StringProcessing/Engine/Processor.swift
+++ b/Sources/_StringProcessing/Engine/Processor.swift
@@ -715,10 +715,8 @@ extension String {
       guard curScalar == scalar else { return nil }
     }
 
-    // TODO: Is this the correct behavior for a sub-scalar substring end?
-    // Can a malformed Unicode scalar match anything?
     let idx = unicodeScalars.index(after: pos)
-    guard idx <= end else { return nil }
+    assert(idx <= end, "Input is a substring with a sub-scalar endIndex.")
 
     if boundaryCheck && !isOnGraphemeClusterBoundary(idx) {
       return nil

--- a/Sources/_StringProcessing/Engine/Processor.swift
+++ b/Sources/_StringProcessing/Engine/Processor.swift
@@ -232,7 +232,7 @@ extension Processor {
   mutating func match(
     _ e: Element, isCaseInsensitive: Bool
   ) -> Bool {
-    guard let next = input.match(
+    guard currentPosition < end, let next = input.match(
       e,
       at: currentPosition,
       limitedBy: end,
@@ -251,7 +251,7 @@ extension Processor {
     _ seq: Substring,
     isScalarSemantics: Bool
   ) -> Bool  {
-    guard let next = input.matchSeq(
+    guard currentPosition < end, let next = input.matchSeq(
       seq,
       at: currentPosition,
       limitedBy: end,
@@ -270,7 +270,7 @@ extension Processor {
     boundaryCheck: Bool,
     isCaseInsensitive: Bool
   ) -> Bool {
-    guard let next = input.matchScalar(
+    guard currentPosition < end, let next = input.matchScalar(
       s,
       at: currentPosition,
       limitedBy: end,
@@ -291,7 +291,7 @@ extension Processor {
     _ bitset: DSLTree.CustomCharacterClass.AsciiBitset,
     isScalarSemantics: Bool
   ) -> Bool {
-    guard let next = input.matchBitset(
+    guard currentPosition < end, let next = input.matchBitset(
       bitset,
       at: currentPosition,
       limitedBy: end,
@@ -308,7 +308,7 @@ extension Processor {
   mutating func matchAnyNonNewline(
     isScalarSemantics: Bool
   ) -> Bool {
-    guard let next = input.matchAnyNonNewline(
+    guard currentPosition < end, let next = input.matchAnyNonNewline(
       at: currentPosition,
       isScalarSemantics: isScalarSemantics
     ) else {
@@ -538,7 +538,8 @@ extension Processor {
       let reg = payload.consumer
       guard currentPosition < searchBounds.upperBound,
             let nextIndex = registers[reg](
-              input, currentPosition..<searchBounds.upperBound)
+              input, currentPosition..<searchBounds.upperBound),
+            nextIndex <= end
       else {
         signalFailure()
         return
@@ -565,7 +566,7 @@ extension Processor {
       do {
         guard let (nextIdx, val) = try matcher(
           input, currentPosition, searchBounds
-        ) else {
+        ), nextIdx <= end else {
           signalFailure()
           return
         }

--- a/Sources/_StringProcessing/Executor.swift
+++ b/Sources/_StringProcessing/Executor.swift
@@ -43,7 +43,8 @@ struct Executor {
       }
       if low >= high { return nil }
       if graphemeSemantic {
-        input.formIndex(after: &low)
+        low = input.index(
+          low, offsetBy: 1, limitedBy: searchBounds.upperBound) ?? searchBounds.upperBound
       } else {
         input.unicodeScalars.formIndex(after: &low)
       }

--- a/Sources/_StringProcessing/Unicode/ASCII.swift
+++ b/Sources/_StringProcessing/Unicode/ASCII.swift
@@ -103,7 +103,6 @@ extension String {
 
     var next = utf8.index(after: idx)
     if next == end {
-      // assert(self[idx].isASCII)
       return (first: base, next: next, crLF: false)
     }
 
@@ -116,7 +115,6 @@ extension String {
       guard next == end || utf8[next]._isSub300StartingByte else {
         return nil
       }
-      // assert(self[idx] == "\r\n")
       return (first: base, next: next, crLF: true)
     }
 

--- a/Sources/_StringProcessing/Unicode/ASCII.swift
+++ b/Sources/_StringProcessing/Unicode/ASCII.swift
@@ -85,11 +85,14 @@ extension String {
   /// and we can give the right `next` index, not requiring the caller to re-adjust it
   /// TODO: detailed description of nuanced semantics
   func _quickASCIICharacter(
-    at idx: Index
+    at idx: Index,
+    limitedBy end: Index
   ) -> (first: UInt8, next: Index, crLF: Bool)? {
     // TODO: fastUTF8 version
-
-    if idx == endIndex {
+    assert(String.Index(idx, within: unicodeScalars) != nil)
+    assert(idx <= end)
+    
+    if idx == end {
       return nil
     }
     let base = utf8[idx]
@@ -99,8 +102,8 @@ extension String {
     }
 
     var next = utf8.index(after: idx)
-    if next == utf8.endIndex {
-      assert(self[idx].isASCII)
+    if next == end {
+      // assert(self[idx].isASCII)
       return (first: base, next: next, crLF: false)
     }
 
@@ -110,10 +113,10 @@ extension String {
     // Handle CR-LF:
     if base == ._carriageReturn && tail == ._lineFeed {
       utf8.formIndex(after: &next)
-      guard next == endIndex || utf8[next]._isSub300StartingByte else {
+      guard next == end || utf8[next]._isSub300StartingByte else {
         return nil
       }
-      assert(self[idx] == "\r\n")
+      // assert(self[idx] == "\r\n")
       return (first: base, next: next, crLF: true)
     }
 
@@ -124,11 +127,12 @@ extension String {
   func _quickMatch(
     _ cc: _CharacterClassModel.Representation,
     at idx: Index,
+    limitedBy end: Index,
     isScalarSemantics: Bool
   ) -> (next: Index, matchResult: Bool)? {
     /// ASCII fast-paths
     guard let (asciiValue, next, isCRLF) = _quickASCIICharacter(
-      at: idx
+      at: idx, limitedBy: end
     ) else {
       return nil
     }

--- a/Sources/_StringProcessing/Unicode/WordBreaking.swift
+++ b/Sources/_StringProcessing/Unicode/WordBreaking.swift
@@ -61,7 +61,8 @@ extension String {
     guard i != range.lowerBound, i != range.upperBound else {
       return true
     }
-    
+    assert(range.contains(i))
+
     // If our index is already in our cache, then this is obviously on a
     // boundary.
     if let cache = cache, cache.contains(i) {

--- a/Sources/_StringProcessing/Unicode/WordBreaking.swift
+++ b/Sources/_StringProcessing/Unicode/WordBreaking.swift
@@ -37,7 +37,9 @@ extension Processor {
     if currentPosition == subjectBounds.lowerBound {
       return matchesWord(at: currentPosition)
     }
-    let priorIdx = input.index(before: currentPosition)
+    let priorIdx = semanticLevel == .graphemeCluster
+      ? input.index(before: currentPosition)
+      : input.unicodeScalars.index(before: currentPosition)
     if currentPosition == subjectBounds.upperBound {
       return matchesWord(at: priorIdx)
     }
@@ -51,11 +53,12 @@ extension Processor {
 extension String {
   func isOnWordBoundary(
     at i: String.Index,
+    in range: Range<String.Index>,
     using cache: inout Set<String.Index>?,
     _ maxIndex: inout String.Index?
   ) -> Bool {
     // TODO: needs benchmark coverage
-    guard i != startIndex, i != endIndex else {
+    guard i != range.lowerBound, i != range.upperBound else {
       return true
     }
     
@@ -76,9 +79,9 @@ extension String {
     
     if #available(SwiftStdlib 5.7, *) {
       var indices: Set<String.Index> = []
-      var j = maxIndex ?? startIndex
+      var j = maxIndex ?? range.lowerBound
       
-      while j < endIndex, j <= i {
+      while j < range.upperBound, j <= i {
         indices.insert(j)
         j = _wordIndex(after: j)
       }

--- a/Sources/_StringProcessing/_CharacterClassModel.swift
+++ b/Sources/_StringProcessing/_CharacterClassModel.swift
@@ -68,12 +68,13 @@ struct _CharacterClassModel: Hashable {
   /// - Returns: The index of the end of the match, or `nil` if there is no match.
   func matches(
     in input: String,
-    at currentPosition: String.Index
+    at currentPosition: String.Index,
+    limitedBy end: String.Index
   ) -> String.Index? {
     // FIXME: This is only called in custom character classes that contain builtin
     // character classes as members (ie: [a\w] or set operations), is there
     // any way to avoid that? Can we remove this somehow?
-    guard currentPosition != input.endIndex else {
+    guard currentPosition < end else {
       return nil
     }
 
@@ -82,6 +83,7 @@ struct _CharacterClassModel: Hashable {
     return input.matchBuiltinCC(
       cc,
       at: currentPosition,
+      limitedBy: end,
       isInverted: isInverted,
       isStrictASCII: isStrictASCII,
       isScalarSemantics: isScalarSemantics)

--- a/Tests/RegexTests/MatchTests.swift
+++ b/Tests/RegexTests/MatchTests.swift
@@ -77,14 +77,13 @@ func _firstMatch(
   }
   try validateSubstring("\(input)\n".dropLast())
   try validateSubstring("A\(input)Z".dropFirst().dropLast())
-
-// This is causing out-of-bounds indexing errors:
-//  do {
-//    // Test sub-character slicing
-//    let substr = input + "\n"
-//    let prevIndex = substr.unicodeScalars.index(substr.endIndex, offsetBy: -1)
-//    try validateSubstring(substr[..<prevIndex])
-//  }
+  do {
+    // Test sub-character slicing
+    // TODO: Test sub-scalar slicing
+    let substr = input + "\n"
+    let prevIndex = substr.unicodeScalars.index(substr.endIndex, offsetBy: -1)
+    try validateSubstring(substr[..<prevIndex])
+  }
 
   if validateOptimizations {
     assert(regex._forceAction(.addOptions(.disableOptimizations)))

--- a/Tests/RegexTests/MatchTests.swift
+++ b/Tests/RegexTests/MatchTests.swift
@@ -79,10 +79,18 @@ func _firstMatch(
   try validateSubstring("A\(input)Z".dropFirst().dropLast())
   do {
     // Test sub-character slicing
-    // TODO: Test sub-scalar slicing
-    let substr = input + "\n"
-    let prevIndex = substr.unicodeScalars.index(substr.endIndex, offsetBy: -1)
-    try validateSubstring(substr[..<prevIndex])
+    let str = input + "\n"
+    let prevIndex = str.unicodeScalars.index(str.endIndex, offsetBy: -1)
+    try validateSubstring(str[..<prevIndex])
+  }
+  do {
+    // Validate that we don't crash when sub-scalar slicing is used
+    // Actual matching behavior is untested here
+    let str = "\u{e9}\(input)e\u{e9}"
+    let upper = str.utf8.index(before: str.endIndex)
+    _ = try regex.firstMatch(in: str[..<upper])
+    let lower = str.utf8.index(after: str.startIndex)
+    _ = try regex.firstMatch(in: str[lower...])
   }
 
   if validateOptimizations {


### PR DESCRIPTION
Some of our existing matching routines use the start/endIndex of the input, which is basically never the right thing to do.

This change revises those checks to use the search bounds, by either moving the boundary check out of the matching method, or if the boundary is a part of what needs to be matched (e.g. word boundaries have different behavior at the start/end than in the middle of a string) the search bounds are passed into the matching method.

Testing is currently handled by piggy-backing on the existing match tests; we should add more tests to handle substring- specific edge cases.