### PR TITLE
[swift/main] Optimize search for start-anchored regexes

### DIFF
--- a/Sources/RegexBenchmark/Suite/NotFound.swift
+++ b/Sources/RegexBenchmark/Suite/NotFound.swift
@@ -13,7 +13,7 @@ extension BenchmarkRunner {
       baseName: "AnchoredNotFound",
       regex: "^ +a",
       input: input,
-      isWhole: true)
+      includeFirst: true)
     anchoredNotFound.register(&self)
   }
 }

--- a/Sources/_StringProcessing/ByteCodeGen.swift
+++ b/Sources/_StringProcessing/ByteCodeGen.swift
@@ -46,6 +46,7 @@ extension Compiler.ByteCodeGen {
     // The whole match (`.0` element of output) is equivalent to an implicit
     // capture over the entire regex.
     try emitNode(.capture(name: nil, reference: nil, root))
+    builder.canOnlyMatchAtStart = root.canOnlyMatchAtStart()
     builder.buildAccept()
     return try builder.assemble()
   }

--- a/Sources/_StringProcessing/Engine/MEBuilder.swift
+++ b/Sources/_StringProcessing/Engine/MEBuilder.swift
@@ -43,6 +43,9 @@ extension MEProgram {
     var captureList = CaptureList()
     var initialOptions = MatchingOptions()
 
+    // Starting constraint
+    var canOnlyMatchAtStart = false
+    
     // Symbolic reference resolution
     var unresolvedReferences: [ReferenceID: [InstructionAddress]] = [:]
     var referencedCaptureOffsets: [ReferenceID: Int] = [:]
@@ -404,7 +407,8 @@ extension MEProgram.Builder {
       enableMetrics: enableMetrics,
       captureList: captureList,
       referencedCaptureOffsets: referencedCaptureOffsets,
-      initialOptions: initialOptions)
+      initialOptions: initialOptions,
+      canOnlyMatchAtStart: canOnlyMatchAtStart)
   }
 
   mutating func reset() { self = Self() }

--- a/Sources/_StringProcessing/Engine/MEProgram.swift
+++ b/Sources/_StringProcessing/Engine/MEProgram.swift
@@ -38,6 +38,7 @@ struct MEProgram {
   let referencedCaptureOffsets: [ReferenceID: Int]
   
   var initialOptions: MatchingOptions
+  var canOnlyMatchAtStart: Bool
 }
 
 extension MEProgram: CustomStringConvertible {

--- a/Sources/_StringProcessing/Regex/Match.swift
+++ b/Sources/_StringProcessing/Regex/Match.swift
@@ -273,7 +273,9 @@ extension Regex {
     _ input: String,
     in subjectBounds: Range<String.Index>
   ) throws -> Regex<Output>.Match? {
-    try _firstMatch(input, subjectBounds: subjectBounds, searchBounds: subjectBounds)
+    try regex.program.loweredProgram.canOnlyMatchAtStart
+      ? _match(input, in: subjectBounds, mode: .partialFromFront)
+      : _firstMatch(input, subjectBounds: subjectBounds, searchBounds: subjectBounds)
   }
 
   func _firstMatch(

--- a/Tests/RegexBuilderTests/RegexDSLTests.swift
+++ b/Tests/RegexBuilderTests/RegexDSLTests.swift
@@ -10,7 +10,7 @@
 //===----------------------------------------------------------------------===//
 
 import XCTest
-import _StringProcessing
+@testable import _StringProcessing
 import RegexBuilder
 import TestSupport
 
@@ -969,6 +969,55 @@ class RegexDSLTests: XCTestCase {
         
         XCTAssertNil(try r.firstMatch(in: "\nbaaa\n"))
         XCTAssertNil(try r.firstMatch(in: "\naaab\n"))
+      }
+    }
+  }
+  
+  func testCanOnlyMatchAtStart() throws {
+    func expectCanOnlyMatchAtStart(
+      _ expectation: Bool,
+      file: StaticString = #file, line: UInt = #line,
+      @RegexComponentBuilder _ content: () -> some RegexComponent
+    ) {
+      let regex = content().regex
+      XCTAssertEqual(regex.program.loweredProgram.canOnlyMatchAtStart, expectation, file: file, line: line)
+    }
+    
+    expectCanOnlyMatchAtStart(true) {
+      Anchor.startOfSubject
+      "foo"
+    }
+    expectCanOnlyMatchAtStart(false) {
+      "foo"
+    }
+    expectCanOnlyMatchAtStart(true) {
+      Optionally { "foo" }
+      Anchor.startOfSubject
+      "bar"
+    }
+    
+    expectCanOnlyMatchAtStart(true) {
+      ChoiceOf {
+        Regex {
+          Anchor.startOfSubject
+          "foo"
+        }
+        Regex {
+          Anchor.startOfSubject
+          "bar"
+        }
+      }
+    }
+    expectCanOnlyMatchAtStart(false) {
+      ChoiceOf {
+        Regex {
+          Anchor.startOfSubject
+          "foo"
+        }
+        Regex {
+          Anchor.startOfLine
+          "bar"
+        }
       }
     }
   }

--- a/Tests/RegexTests/CompileTests.swift
+++ b/Tests/RegexTests/CompileTests.swift
@@ -484,4 +484,42 @@ extension RegexTests {
     expectProgram(for: #"(a+)*"#, doesNotContain: [.moveCurrentPosition, .condBranchSamePosition])
     expectProgram(for: #"(a{1,})*"#, doesNotContain: [.moveCurrentPosition, .condBranchSamePosition])
   }
+  
+  func testCanOnlyMatchAtStart() throws {
+    func expectCanOnlyMatchAtStart(
+      _ regexStr: String,
+      _ expectTrue: Bool,
+      file: StaticString = #file,
+      line: UInt = #line
+    ) throws {
+      let regex = try Regex(regexStr)
+      XCTAssertEqual(
+        regex.program.loweredProgram.canOnlyMatchAtStart, expectTrue,
+        file: file, line: line)
+    }
+    
+    try expectCanOnlyMatchAtStart("^foo", true)        // anchor
+    try expectCanOnlyMatchAtStart("\\Afoo", true)      // more specific anchor
+    try expectCanOnlyMatchAtStart("foo", false)        // no anchor
+
+    try expectCanOnlyMatchAtStart("(?i)^foo", true)    // unrelated option
+    try expectCanOnlyMatchAtStart("(?m)^foo", false)   // anchors match newlines
+    try expectCanOnlyMatchAtStart("(?i:^foo)", true)   // unrelated option
+    try expectCanOnlyMatchAtStart("(?m:^foo)", false)  // anchors match newlines
+
+    try expectCanOnlyMatchAtStart("(^foo|bar)", false) // one side of alternation
+    try expectCanOnlyMatchAtStart("(foo|^bar)", false) // other side of alternation
+    try expectCanOnlyMatchAtStart("(^foo|^bar)", true) // both sides of alternation
+
+    // Test quantifiers that include the anchor
+    try expectCanOnlyMatchAtStart("(^foo)?bar", false)
+    try expectCanOnlyMatchAtStart("(^foo)*bar", false)
+    try expectCanOnlyMatchAtStart("(^foo)+bar", true)
+    try expectCanOnlyMatchAtStart("(?:^foo)+bar", true)
+
+    // Test quantifiers before the anchor
+    try expectCanOnlyMatchAtStart("(foo)?^bar", true)  // The initial group must match ""
+    try expectCanOnlyMatchAtStart("(?:foo)?^bar", true)
+    try expectCanOnlyMatchAtStart("(foo)+^bar", false) // This can't actually match anywhere
+  }
 }


### PR DESCRIPTION
When a regex is anchored to the start of a subject, there's no need to search throughout a string for the pattern when searching for the first match: a prefix match is sufficient.

This adds a regex compilation-time check about whether a match can only be found at the start of a subject, and then uses that to choose whether to defer to `prefixMatch` from within `firstMatch`.

(This is a cherry-pick of #682.)