### PR TITLE
Fix misuse of `XCTSkip()`

### DIFF
--- a/Tests/RegexBuilderTests/RegexDSLTests.swift
+++ b/Tests/RegexBuilderTests/RegexDSLTests.swift
@@ -1846,8 +1846,7 @@ extension RegexDSLTests {
   
   func testLabeledCaptures_labeledCapture() throws {
     guard #available(macOS 13, *) else {
-      XCTSkip("Fix only exists on macOS 13")
-      return
+      throw XCTSkip("Fix only exists on macOS 13")
     }
     // The output type of a regex with a labeled capture is dropped.
     let dslWithLabeledCapture = Regex {
@@ -1886,8 +1885,7 @@ extension RegexDSLTests {
   
   func testLabeledCaptures_bothCapture() throws {
     guard #available(macOS 13, *) else {
-      XCTSkip("Fix only exists on macOS 13")
-      return
+      throw XCTSkip("Fix only exists on macOS 13")
     }
     // Only the output type of a regex with a labeled capture is dropped,
     // outputs of other regexes in the same DSL are concatenated.
@@ -1913,8 +1911,7 @@ extension RegexDSLTests {
   
   func testLabeledCaptures_tooManyCapture() throws {
     guard #available(macOS 13, *) else {
-      XCTSkip("Fix only exists on macOS 13")
-      return
+      throw XCTSkip("Fix only exists on macOS 13")
     }
     // The output type of a regex with too many captures is dropped.
     // "Too many" means the left and right output types would add up to >= 10.


### PR DESCRIPTION
In a few tests, `XCTSkip()` is used as a function call, but it's actually a type conforming to the `Error` protocol and is meant to be thrown. (This is an understandable mistake, since in Objective-C it is a macro that ultimately throws an exception.)