### PR TITLE
[Experiment] [BROKEN] Make stored captures trivial

### DIFF
--- a/Sources/_StringProcessing/Engine/MECapture.swift
+++ b/Sources/_StringProcessing/Engine/MECapture.swift
@@ -34,7 +34,7 @@ extension Processor {
   struct _StoredCapture {
     var range: Range<Position>? = nil
 
-    var value: Any? = nil
+    var value: Any? { nil }
 
     // An in-progress capture start
     fileprivate var currentCaptureBegin: Position? = nil
@@ -72,7 +72,7 @@ extension Processor {
       }
 
       range = low..<idx
-      value = nil // TODO: cleaner IPI around this...
+//      value = nil // TODO: cleaner IPI around this...
       currentCaptureBegin = nil
     }
 
@@ -83,7 +83,8 @@ extension Processor {
       _invariantCheck()
       defer { _invariantCheck() }
 
-      self.value = value
+      fatalError()
+//      self.value = value
     }
   }
 }


### PR DESCRIPTION
`_StoredCapture` stored an `Any?`, which is rarely set to anything non-`nil`, but since it could it is non-trivial. This experiment tries to see the perf overhead of this non-triviality.