### PR TITLE
Fast-path ASCII character class matching

### DIFF
--- a/Sources/_StringProcessing/Engine/InstPayload.swift
+++ b/Sources/_StringProcessing/Engine/InstPayload.swift
@@ -378,7 +378,7 @@ extension Instruction.Payload {
 struct QuantifyPayload: RawRepresentable {
   let rawValue: UInt64
   enum PayloadType: UInt64 {
-    case bitset = 0
+    case asciiBitset = 0
     case asciiChar = 1
     case any = 2
     case builtin = 4
@@ -448,7 +448,7 @@ struct QuantifyPayload: RawRepresentable {
   ) {
     assert(bitset.bits <= _payloadMask)
     self.rawValue = bitset.bits
-      + QuantifyPayload.packInfoValues(kind, minTrips, maxExtraTrips, .bitset, isScalarSemantics: isScalarSemantics)
+      + QuantifyPayload.packInfoValues(kind, minTrips, maxExtraTrips, .asciiBitset, isScalarSemantics: isScalarSemantics)
   }
 
   init(

--- a/Sources/_StringProcessing/Engine/MEQuantify.swift
+++ b/Sources/_StringProcessing/Engine/MEQuantify.swift
@@ -3,8 +3,8 @@ extension Processor {
     let isScalarSemantics = payload.isScalarSemantics
 
     switch payload.type {
-    case .bitset:
-      return input.matchBitset(
+    case .asciiBitset:
+      return input.matchASCIIBitset(
         registers[payload.bitset],
         at: currentPosition,
         limitedBy: end,

--- a/Sources/_StringProcessing/Utility/AsciiBitset.swift
+++ b/Sources/_StringProcessing/Utility/AsciiBitset.swift
@@ -1,3 +1,4 @@
+// TODO: Probably refactor out of DSLTree
 extension DSLTree.CustomCharacterClass {
   internal struct AsciiBitset {
     let isInverted: Bool
@@ -49,7 +50,7 @@ extension DSLTree.CustomCharacterClass {
       }
     }
 
-    private func matches(_ val: UInt8) -> Bool {
+    private func _matchesWithoutInversionCheck(_ val: UInt8) -> Bool {
       if val < 64 {
         return (a >> val) & 1 == 1
       } else {
@@ -57,10 +58,15 @@ extension DSLTree.CustomCharacterClass {
       }
     }
 
+    internal func matches(_ byte: UInt8) -> Bool {
+      guard byte < 128 else { return isInverted }
+      return _matchesWithoutInversionCheck(byte) == !isInverted
+    }
+
     internal func matches(_ char: Character) -> Bool {
       let matched: Bool
       if let val = char._singleScalarAsciiValue {
-        matched = matches(val)
+        matched = _matchesWithoutInversionCheck(val)
       } else {
         matched = false
       }
@@ -75,7 +81,7 @@ extension DSLTree.CustomCharacterClass {
       let matched: Bool
       if scalar.isASCII {
         let val = UInt8(ascii: scalar)
-        matched = matches(val)
+        matched = _matchesWithoutInversionCheck(val)
       } else {
         matched = false
       }


### PR DESCRIPTION
Based on top of https://github.com/apple/swift-experimental-string-processing/pull/689.

- Needs the same bounds checking story fixed as https://github.com/apple/swift-experimental-string-processing/pull/689
- Need to refactor `AsciiBitset`
	- Inverting a bitset and inverting the semantics are two separate things
	- E.g. 😀 never matches an ASCII bitset no matter what bits are set or inverted, but it will match an inverted ASCII character class because that inversion affects the semantics of a match
	- String processing logic doesn't really belong on the type, this is the only usage place
- Need to refactor some of the `quickASCIICharacter` for more refined semantics
	- Take `isScalarSemantics`, take allow-CR-LF, etc.

Performance relative to https://github.com/apple/swift-experimental-string-processing/pull/689 (which in turn is a significant improvement over main):

```
=== Regressions ======================================================================
- symDiffCCC_All                          48.5ms	48.2ms	342µs		0.7%
- SubtractionCCC_All                      21.2ms	20.9ms	243µs		1.2%
- Words_All_Scalar                        12.4ms	12.3ms	117µs		0.9%
- LiteralSearchNotFound_All               6.6ms	6.51ms	90.9µs		1.4%
- LiteralSearchNotFound_All_Scalar        5.88ms	5.83ms	48.5µs		0.8%
- EagarQuantWithTerminal_Whole_Scalar     845µs	812µs	33.5µs		4.1%
=== Improvements =====================================================================
- EmailLookahead_All                      19.9ms	39.1ms	-19.2ms		-49.2%
- EmailLookaheadNoMatches_All             24.9ms	39.1ms	-14.2ms		-36.2%
- EmailLookaheadList                      4ms	9.35ms	-5.35ms		-57.2%
- EmailRFC_All                            59.4ms	63.4ms	-4.04ms		-6.4%
- EmailLookahead_All_Scalar               17.8ms	21.7ms	-3.85ms		-17.8%
- CaseInsensitiveCCC_All_Scalar           6.32ms	10.1ms	-3.73ms		-37.1%
- CaseInsensitiveCCC_All                  6.36ms	9.95ms	-3.59ms		-36.1%
- EmailLookaheadNoMatches_All_Scalar      22.7ms	26.1ms	-3.4ms		-13.0%
- InvertedCCC_All                         16.8ms	20.1ms	-3.24ms		-16.1%
- InvertedCCC_All_Scalar                  16.8ms	20ms	-3.15ms		-15.8%
- BasicRangeCCC_All                       6.36ms	9.14ms	-2.77ms		-30.3%
- BasicCCC_All                            5.93ms	8.68ms	-2.75ms		-31.6%
- BasicCCC_All_Scalar                     5.94ms	8.65ms	-2.71ms		-31.3%
- BasicRangeCCC_All_Scalar                6.43ms	9.13ms	-2.7ms		-29.5%
- EmailRFCNoMatches_All_Scalar            124ms	126ms	-2.66ms		-2.1%
- EmailRFC_All_Scalar                     45.7ms	47.1ms	-1.4ms		-3.0%
- IPv6Address                             2.58ms	3.77ms	-1.19ms		-31.5%
- EmojiRegex_All                          71.6ms	72.7ms	-1.09ms		-1.5%
- EmailLookaheadList_Scalar               3.9ms	4.92ms	-1.02ms		-20.8%
- MACAddress                              2.37ms	2.8ms	-429µs		-15.3%
- Css_All                                 3.31ms	3.7ms	-392µs		-10.6%
- GraphemeBreakNoCap_All                  3.39ms	3.76ms	-370µs		-9.8%
- LiteralSearch_All                       6.77ms	7.13ms	-363µs		-5.1%
- BasicBuiltinCharacterClass_All          8.26ms	8.49ms	-225µs		-2.7%
- HangulSyllable_All                      6.91ms	7.14ms	-224µs		-3.1%
- GraphemeBreakNoCap_All_Scalar           3.16ms	3.38ms	-221µs		-6.5%
- IPv4Address                             2.34ms	2.55ms	-203µs		-8.0%
- IPv6Address_Scalar                      2.41ms	2.61ms	-202µs		-7.7%
- ReluctantQuantWithTerminal_Whole_Scalar 6.42ms	6.59ms	-169µs		-2.6%
- MACAddress_Scalar                       2.29ms	2.42ms	-135µs		-5.6%
- HangulSyllable_All_Scalar               6.24ms	6.37ms	-133µs		-2.1%
- LiteralSearch_All_Scalar                5.99ms	6.1ms	-103µs		-1.7%
- Css_All_Scalar                          3.05ms	3.15ms	-97µs		-3.1%
- ReluctantQuantWithTerminal_Whole        6.46ms	6.56ms	-95.5µs		-1.5%
- AnchoredNotFound_Whole_Scalar           5.44ms	5.5ms	-56µs		-1.0%
- IPv4Address_Scalar                      2.2ms	2.25ms	-51µs		-2.3%
- Lines_All_Scalar                        1.71ms	1.74ms	-35.2µs		-2.0%
- Lines_All                               1.73ms	1.76ms	-25.7µs		-1.5%
- EagarQuantWithTerminal_Whole            815µs	834µs	-18.7µs		-2.2%

```