### PR TITLE
[nfc] Avoid pointer conversions

### DIFF
--- a/Sources/_StringProcessing/Regex/Core.swift
+++ b/Sources/_StringProcessing/Regex/Core.swift
@@ -126,6 +126,13 @@ extension Regex {
   /// A program representation that caches any lowered representation for
   /// execution.
   internal final class Program {
+
+    // This stored property should be stored at offset zero.  We perform atomic
+    // operations on it.
+    //
+    /// Do not access this property directly - all accesses must go through `loweredProgram`.
+    fileprivate var _loweredProgramStorage: AnyObject? = nil
+
     /// The underlying IR.
     ///
     /// FIXME: If Regex is the unit of composition, then it should be a Node instead,
@@ -141,14 +148,16 @@ extension Regex {
       init(_ value: MEProgram) { self.value = value }
     }
 
-    /// Do not use directly - all accesses must go through `loweredProgram`.
-    fileprivate var _loweredProgramStorage: AnyObject? = nil
-    
+    fileprivate var _loweredProgramStoragePtr: UnsafeMutablePointer<AnyObject?> {
+      _getUnsafePointerToStoredProperties(self)
+        .assumingMemoryBound(to: Optional<AnyObject>.self)
+    }
+
     /// The program for execution with the matching engine.
     var loweredProgram: MEProgram {
       /// Atomically loads the compiled program if it has already been stored.
       func loadProgram() -> MEProgram? {
-        guard let loweredObject = _stdlib_atomicLoadARCRef(object: &_loweredProgramStorage)
+        guard let loweredObject = _stdlib_atomicLoadARCRef(object: _loweredProgramStoragePtr)
           else { return nil }
         return unsafeDowncast(loweredObject, to: ProgramBox.self).value
       }
@@ -161,7 +170,7 @@ extension Regex {
       // Compile the DSLTree into a lowered program and store it atomically.
       let compiledProgram = try! Compiler(tree: tree, compileOptions: compileOptions).emit()
       let storedNewProgram = _stdlib_atomicInitializeARCRef(
-        object: &_loweredProgramStorage,
+        object: _loweredProgramStoragePtr,
         desired: ProgramBox(compiledProgram))
       
       // Return the winner of the storage race. We're guaranteed at this point

--- a/Sources/_StringProcessing/Regex/Core.swift
+++ b/Sources/_StringProcessing/Regex/Core.swift
@@ -130,7 +130,7 @@ extension Regex {
     // This stored property should be stored at offset zero.  We perform atomic
     // operations on it.
     //
-    /// Do not access this property directly - all accesses must go through `loweredProgram`.
+    /// Do not access this property directly - all accesses must go through `_loweredProgramStoragePtr `.
     fileprivate var _loweredProgramStorage: AnyObject? = nil
 
     /// The underlying IR.

--- a/Sources/_StringProcessing/Unicode/ScalarProps.swift
+++ b/Sources/_StringProcessing/Unicode/ScalarProps.swift
@@ -29,8 +29,10 @@ extension Unicode.Script {
   
   static func extensions(for scalar: Unicode.Scalar) -> [Unicode.Script] {
     var count: UInt8 = 0
-    let pointer = _swift_string_processing_getScriptExtensions(scalar.value, &count)
-    
+    let pointer = withUnsafeMutablePointer(to: &count) {
+      _swift_string_processing_getScriptExtensions(scalar.value, $0)
+    }
+
     guard let pointer = pointer else {
       return [Unicode.Script(scalar)]
     }


### PR DESCRIPTION
Preparing for a compiler that's less permissive about pointer conversions.
1. Use the stdlib's pattern for lazy atomic references, by explicitly declaring the pointer as a computed property.
2. Use an explicit pointer when a C function isn't detected as such by the compiler.