### PR TITLE
[swift/main] Avoid pointer conversions

### DIFF
--- a/Sources/_StringProcessing/Unicode/ScalarProps.swift
+++ b/Sources/_StringProcessing/Unicode/ScalarProps.swift
@@ -29,8 +29,10 @@ extension Unicode.Script {
   
   static func extensions(for scalar: Unicode.Scalar) -> [Unicode.Script] {
     var count: UInt8 = 0
-    let pointer = _swift_string_processing_getScriptExtensions(scalar.value, &count)
-    
+    let pointer = withUnsafeMutablePointer(to: &count) {
+      _swift_string_processing_getScriptExtensions(scalar.value, $0)
+    }
+
     guard let pointer = pointer else {
       return [Unicode.Script(scalar)]
     }


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift-experimental-string-processing/pull/691

I'll need this in order to get swift-ci to build a toolchain in support of the pointer-conversion [pitch](https://gist.github.com/glessard/ba1468bdc09d51ce5253cd7043ad3a78).