### PR TITLE
Adds SPI for a NSRE compatibility mode option

### DIFF
--- a/Sources/_RegexParser/Regex/AST/MatchingOptions.swift
+++ b/Sources/_RegexParser/Regex/AST/MatchingOptions.swift
@@ -44,6 +44,9 @@ extension AST {
       
       // Swift-only default possessive quantifier
       case possessiveByDefault      // t.b.d.
+      
+      // NSRegularExpression compatibility special-case
+      case nsreCompatibleDot        // no AST representation
     }
     
     public var kind: Kind

--- a/Sources/_RegexParser/Regex/Parse/Sema.swift
+++ b/Sources/_RegexParser/Regex/Parse/Sema.swift
@@ -142,7 +142,8 @@ extension RegexValidator {
 
     case .caseInsensitive, .possessiveByDefault, .reluctantByDefault,
         .singleLine, .multiline, .namedCapturesOnly, .extended, .extraExtended,
-        .asciiOnlyDigit, .asciiOnlyWord, .asciiOnlySpace, .asciiOnlyPOSIXProps:
+        .asciiOnlyDigit, .asciiOnlyWord, .asciiOnlySpace, .asciiOnlyPOSIXProps,
+        .nsreCompatibleDot:
       break
     }
   }

--- a/Sources/_StringProcessing/ByteCodeGen.swift
+++ b/Sources/_StringProcessing/ByteCodeGen.swift
@@ -67,7 +67,7 @@ fileprivate extension Compiler.ByteCodeGen {
       emitAnyNonNewline()
 
     case .dot:
-      emitDot()
+      try emitDot()
 
     case let .char(c):
       emitCharacter(c)
@@ -238,9 +238,15 @@ fileprivate extension Compiler.ByteCodeGen {
     }
   }
 
-  mutating func emitDot() {
+  mutating func emitDot() throws {
     if options.dotMatchesNewline {
-      emitAny()
+      if options.usesNSRECompatibleDot {
+        try emitAlternation([
+          .atom(.characterClass(.newlineSequence)),
+          .atom(.anyNonNewline)])
+      } else {
+        emitAny()
+      }
     } else {
       emitAnyNonNewline()
     }
@@ -964,7 +970,7 @@ fileprivate extension Compiler.ByteCodeGen {
     case let .customCharacterClass(ccc):
       if ccc.containsDot {
         if !ccc.isInverted {
-          emitDot()
+          try emitDot()
         } else {
           throw Unsupported("Inverted any")
         }

--- a/Sources/_StringProcessing/MatchingOptions.swift
+++ b/Sources/_StringProcessing/MatchingOptions.swift
@@ -120,6 +120,10 @@ extension MatchingOptions {
       ? .graphemeCluster
       : .unicodeScalar
   }
+  
+  var usesNSRECompatibleDot: Bool {
+    stack.last!.contains(.nsreCompatibleDot)
+  }
 }
 
 // MARK: - Implementation
@@ -141,6 +145,7 @@ extension MatchingOptions {
     // Not available via regex literal flags
     case transparentBounds
     case withoutAnchoringBounds
+    case nsreCompatibleDot
 
     // Oniguruma options
     case asciiOnlyDigit
@@ -197,6 +202,8 @@ extension MatchingOptions {
         self = .byteSemantics
       case .possessiveByDefault:
         self = .possessiveByDefault
+      case .nsreCompatibleDot:
+        self = .nsreCompatibleDot
         
       // Whitespace options are only relevant during parsing, not compilation.
       case .extended, .extraExtended:

--- a/Sources/_StringProcessing/Regex/Options.swift
+++ b/Sources/_StringProcessing/Regex/Options.swift
@@ -159,6 +159,18 @@ extension Regex {
       return wrapInOption(.unicodeScalarSemantics, addingIf: true)
     }
   }
+  
+  /// Returns a regular expression that uses an NSRegularExpression
+  /// compatibility mode.
+  ///
+  /// This mode includes using Unicode scalar semantics and treating a `dot`
+  /// as matching newline sequences (when in the unrelated dot-matches-newlines
+  /// mode).
+  @_spi(Foundation)
+  public var _nsreCompatibility: Regex<RegexOutput> {
+    wrapInOption(.nsreCompatibleDot, addingIf: true)
+      .wrapInOption(.unicodeScalarSemantics, addingIf: true)
+  }
 }
 
 /// A semantic level to use during regex matching.


### PR DESCRIPTION
NSRegularExpression matches at the Unicode scalar level, but also matches `\r\n` sequences with a single `.` when single-line mode is enabled. This adds a `_nsreCompatibility` property that enables both of those behaviors, and implements support for the special case handling of `.`.