### PR TITLE
Refactor quick ascii character

### DIFF
--- a/Sources/_StringProcessing/Engine/InstPayload.swift
+++ b/Sources/_StringProcessing/Engine/InstPayload.swift
@@ -378,7 +378,7 @@ extension Instruction.Payload {
 struct QuantifyPayload: RawRepresentable {
   let rawValue: UInt64
   enum PayloadType: UInt64 {
-    case bitset = 0
+    case asciiBitset = 0
     case asciiChar = 1
     case any = 2
     case builtin = 4
@@ -448,7 +448,7 @@ struct QuantifyPayload: RawRepresentable {
   ) {
     assert(bitset.bits <= _payloadMask)
     self.rawValue = bitset.bits
-      + QuantifyPayload.packInfoValues(kind, minTrips, maxExtraTrips, .bitset, isScalarSemantics: isScalarSemantics)
+      + QuantifyPayload.packInfoValues(kind, minTrips, maxExtraTrips, .asciiBitset, isScalarSemantics: isScalarSemantics)
   }
 
   init(

--- a/Sources/_StringProcessing/Engine/MEBuiltins.swift
+++ b/Sources/_StringProcessing/Engine/MEBuiltins.swift
@@ -191,8 +191,10 @@ extension String {
     isScalarSemantics: Bool
   ) -> QuickResult<String.Index?> {
     assert(currentPosition < end)
-    guard let (asciiValue, next, isCRLF) = _quickASCIICharacter(
-      at: currentPosition, limitedBy: end
+    guard let (asciiValue, isCRLF: isCRLF, next) = _quickASCIICharacter(
+      at: currentPosition,
+      limitedBy: end,
+      isScalarSemantics: isScalarSemantics
     ) else {
       return .unknown
     }

--- a/Sources/_StringProcessing/Engine/MEQuantify.swift
+++ b/Sources/_StringProcessing/Engine/MEQuantify.swift
@@ -3,8 +3,8 @@ extension Processor {
     let isScalarSemantics = payload.isScalarSemantics
 
     switch payload.type {
-    case .bitset:
-      return input.matchBitset(
+    case .asciiBitset:
+      return input.matchASCIIBitset(
         registers[payload.bitset],
         at: currentPosition,
         limitedBy: end,

--- a/Sources/_StringProcessing/Engine/Processor.swift
+++ b/Sources/_StringProcessing/Engine/Processor.swift
@@ -737,11 +737,10 @@ extension String {
     // meanings in some code paths.
     let isInverted = bitset.isInverted
 
-    // TODO: More fodder for refactoring `_quickASCIICharacter`, see the comment 
-    // there
-    guard let (asciiByte, next, isCRLF) = _quickASCIICharacter(
+    guard let (asciiByte, isCRLF: isCRLF, next) = _quickASCIICharacter(
       at: pos,
-      limitedBy: end
+      limitedBy: end,
+      isScalarSemantics: isScalarSemantics
     ) else {
       if isScalarSemantics {
         guard pos < end else { return nil }
@@ -760,13 +759,7 @@ extension String {
     }
 
     // CR-LF should only match `[\r]` in scalar semantic mode or if inverted
-    if isCRLF {
-      if isScalarSemantics {
-        return self.unicodeScalars.index(before: next)
-      }
-      if isInverted {
-        return next
-      }
+    if isCRLF && !isScalarSemantics && !isInverted {
       return nil
     }
 

--- a/Sources/_StringProcessing/Utility/AsciiBitset.swift
+++ b/Sources/_StringProcessing/Utility/AsciiBitset.swift
@@ -1,3 +1,4 @@
+// TODO: Probably refactor out of DSLTree
 extension DSLTree.CustomCharacterClass {
   internal struct AsciiBitset {
     let isInverted: Bool
@@ -49,7 +50,7 @@ extension DSLTree.CustomCharacterClass {
       }
     }
 
-    private func matches(_ val: UInt8) -> Bool {
+    private func _matchesWithoutInversionCheck(_ val: UInt8) -> Bool {
       if val < 64 {
         return (a >> val) & 1 == 1
       } else {
@@ -57,10 +58,15 @@ extension DSLTree.CustomCharacterClass {
       }
     }
 
+    internal func matches(_ byte: UInt8) -> Bool {
+      guard byte < 128 else { return isInverted }
+      return _matchesWithoutInversionCheck(byte) == !isInverted
+    }
+
     internal func matches(_ char: Character) -> Bool {
       let matched: Bool
       if let val = char._singleScalarAsciiValue {
-        matched = matches(val)
+        matched = _matchesWithoutInversionCheck(val)
       } else {
         matched = false
       }
@@ -75,7 +81,7 @@ extension DSLTree.CustomCharacterClass {
       let matched: Bool
       if scalar.isASCII {
         let val = UInt8(ascii: scalar)
-        matched = matches(val)
+        matched = _matchesWithoutInversionCheck(val)
       } else {
         matched = false
       }


### PR DESCRIPTION
Adds the `isScalarSemantics` check, but doesn't seem to improve performance. We probably want to add the `withContiguousStorageIfAvailable` on `UTF8View` fast path, though that will complicate testing without more refactoring.