### PR TITLE
Speed up quantification optimizations by unswitching

### DIFF
--- a/Sources/_StringProcessing/ConsumerInterface.swift
+++ b/Sources/_StringProcessing/ConsumerInterface.swift
@@ -391,9 +391,8 @@ extension DSLTree.CustomCharacterClass.Member {
       
       return { input, bounds in
         let curIdx = bounds.lowerBound
-        let nextIndex = isCharacterSemantic
-          ? input.index(after: curIdx)
-          : input.unicodeScalars.index(after: curIdx)
+        let nextIndex = input.index(
+          after: curIdx, isScalarSemantics: !isCharacterSemantic)
 
         // Under grapheme semantics, we compare based on single NFC scalars. If
         // such a character is not single scalar under NFC, the match fails. In
@@ -603,9 +602,9 @@ extension AST.Atom.CharacterProperty {
         if p(input, bounds) != nil { return nil }
 
         // TODO: bounds check
-        return opts.semanticLevel == .graphemeCluster
-          ? input.index(after: bounds.lowerBound)
-          : input.unicodeScalars.index(after: bounds.lowerBound)
+        return input.index(
+          after: bounds.lowerBound, 
+          isScalarSemantics: opts.semanticLevel == .unicodeScalar)
       }
     }
 

--- a/Sources/_StringProcessing/Engine/MEBuiltins.swift
+++ b/Sources/_StringProcessing/Engine/MEBuiltins.swift
@@ -223,6 +223,25 @@ extension String {
     else { return nil }
     return next
   }
+
+  internal func matchRegexDot(
+    at currentPosition: Index,
+    limitedBy end: Index,
+    anyMatchesNewline: Bool,
+    isScalarSemantics: Bool
+  ) -> Index? {
+    guard currentPosition < end else { return nil }
+
+    if anyMatchesNewline {
+      return index(
+        after: currentPosition, isScalarSemantics: isScalarSemantics)
+    }
+
+    return matchAnyNonNewline(
+      at: currentPosition,
+      limitedBy: end,
+      isScalarSemantics: isScalarSemantics)
+  }
 }
 
 // MARK: - Built-in character class matching

--- a/Sources/_StringProcessing/Engine/MEQuantify.swift
+++ b/Sources/_StringProcessing/Engine/MEQuantify.swift
@@ -1,5 +1,49 @@
+private typealias ASCIIBitset = DSLTree.CustomCharacterClass.AsciiBitset
+
 extension Processor {
-  func _doQuantifyMatch(_ payload: QuantifyPayload) -> Input.Index? {
+  func _doASCIIBitsetMatch(
+    _: AsciiBitsetRegister
+  ) -> Input.Index? {
+    fatalError()
+  }
+}
+
+
+extension String {
+  func index(after idx: Index, isScalarSemantics: Bool) -> Index {
+    if isScalarSemantics {
+      return unicodeScalars.index(after: idx)
+    } else {
+      return index(after: idx)
+    }
+  }
+}
+
+
+extension Processor {
+
+  internal mutating func runQuantify(_ payload: QuantifyPayload) -> Bool {
+    let matched: Bool
+    switch (payload.quantKind, payload.minTrips, payload.maxExtraTrips) {
+    case (.reluctant, _, _):
+      assertionFailure(".reluctant is not supported by .quantify")
+      // TODO: this was pre-refactoring behavior, should we fatal error
+      //       instead?
+      return false 
+    case (.eager, 0, nil):
+      runEagerZeroOrMoreQuantify(payload)
+      return true
+    case (.eager, 1, nil):
+      return runEagerOneOrMoreQuantify(payload)
+    case (_, 0, 1):
+      runZeroOrOneQuantify(payload)
+      return true
+    default:
+      return runGeneralQuantify(payload)
+    }
+  }
+
+  private func doQuantifyMatch(_ payload: QuantifyPayload) -> Input.Index? {
     let isScalarSemantics = payload.isScalarSemantics
 
     switch payload.type {
@@ -31,10 +75,8 @@ extension Processor {
       guard currentPosition < end else { return nil }
 
       if payload.anyMatchesNewline {
-        if isScalarSemantics {
-          return input.unicodeScalars.index(after: currentPosition)
-        }
-        return input.index(after: currentPosition)
+        return input.index(
+          after: currentPosition, isScalarSemantics: isScalarSemantics)
       }
 
       return input.matchAnyNonNewline(
@@ -47,14 +89,14 @@ extension Processor {
   /// Generic quantify instruction interpreter
   /// - Handles .eager and .posessive
   /// - Handles arbitrary minTrips and maxExtraTrips
-  mutating func runQuantify(_ payload: QuantifyPayload) -> Bool {
+  private mutating func runGeneralQuantify(_ payload: QuantifyPayload) -> Bool {
     assert(payload.quantKind != .reluctant)
 
     var trips = 0
     var maxExtraTrips = payload.maxExtraTrips
 
     while trips < payload.minTrips {
-      guard let next = _doQuantifyMatch(payload) else {
+      guard let next = doQuantifyMatch(payload) else {
         signalFailure()
         return false
       }
@@ -67,7 +109,7 @@ extension Processor {
       return true
     }
 
-    guard let next = _doQuantifyMatch(payload) else {
+    guard let next = doQuantifyMatch(payload) else {
       return true
     }
     maxExtraTrips = maxExtraTrips.map { $0 - 1 }
@@ -81,7 +123,7 @@ extension Processor {
     while true {
       if maxExtraTrips == 0 { break }
 
-      guard let next = _doQuantifyMatch(payload) else {
+      guard let next = doQuantifyMatch(payload) else {
         break
       }
       maxExtraTrips = maxExtraTrips.map({$0 - 1})
@@ -100,67 +142,147 @@ extension Processor {
   }
 
   /// Specialized quantify instruction interpreter for `*`, always succeeds
-  mutating func runEagerZeroOrMoreQuantify(_ payload: QuantifyPayload) {
+  private mutating func runEagerZeroOrMoreQuantify(_ payload: QuantifyPayload) {
     assert(payload.quantKind == .eager
            && payload.minTrips == 0
            && payload.maxExtraTrips == nil)
-    _doRunEagerZeroOrMoreQuantify(payload)
+    _ = doRunEagerZeroOrMoreQuantify(payload)
   }
 
-  // NOTE: So-as to inline into one-or-more call, which makes a significant
-  // performance difference
+  // Returns whether it matched at least once
+  //
+  // NOTE: inline-always so-as to inline into one-or-more call, which makes a
+  // significant performance difference
   @inline(__always)
-  mutating func _doRunEagerZeroOrMoreQuantify(_ payload: QuantifyPayload) {
-    guard let next = _doQuantifyMatch(payload) else {
-      // Consumed no input, no point saved
-      return
-    }
-
+  private mutating func doRunEagerZeroOrMoreQuantify(_ payload: QuantifyPayload) -> Bool {
     // Create a quantified save point for every part of the input matched up
     // to the final position.
+    let isScalarSemantics = payload.isScalarSemantics
     let rangeStart = currentPosition
     var rangeEnd = currentPosition
-    currentPosition = next
-    while true {
-      guard let next = _doQuantifyMatch(payload) else { break }
-      rangeEnd = currentPosition
-      currentPosition = next
+    var matchedOnce = false
+
+    switch payload.type {
+    case .asciiBitset:
+      let bitset = registers[payload.bitset]
+      while true {
+        guard let next = input.matchASCIIBitset(
+          bitset,
+          at: currentPosition,
+          limitedBy: end,
+          isScalarSemantics: isScalarSemantics)
+        else {
+          break
+        }
+        matchedOnce = true
+        rangeEnd = currentPosition
+        currentPosition = next
+        assert(currentPosition > rangeEnd)
+      }
+    case .asciiChar:
+      let asciiScalar = UnicodeScalar.init(_value: UInt32(payload.asciiChar))
+      while true {
+        guard let next = input.matchScalar(
+          asciiScalar,
+          at: currentPosition,
+          limitedBy: end,
+          boundaryCheck: !isScalarSemantics,
+          isCaseInsensitive: false)
+        else {
+          break
+        }
+        matchedOnce = true
+        rangeEnd = currentPosition
+        currentPosition = next
+        assert(currentPosition > rangeEnd)
+      }
+    case .builtin:
+      let builtin = payload.builtin
+      let isInverted = payload.builtinIsInverted
+      let isStrictASCII = payload.builtinIsStrict
+      while true {
+        guard let next = input.matchBuiltinCC(
+          builtin,
+          at: currentPosition,
+          limitedBy: end,
+          isInverted: isInverted,
+          isStrictASCII: isStrictASCII,
+          isScalarSemantics: isScalarSemantics)
+        else {
+          break
+        }
+        matchedOnce = true
+        rangeEnd = currentPosition
+        currentPosition = next
+        assert(currentPosition > rangeEnd)
+      }
+    case .any:
+      while true {
+        guard currentPosition < end else { break }
+        let next: String.Index?
+        if payload.anyMatchesNewline {
+          next = input.index(
+            after: currentPosition, isScalarSemantics: isScalarSemantics)
+        } else {
+          next = input.matchAnyNonNewline(
+            at: currentPosition,
+            limitedBy: end,
+            isScalarSemantics: isScalarSemantics)
+        }
+
+        guard let next else { break }
+        matchedOnce = true
+        rangeEnd = currentPosition
+        currentPosition = next
+        assert(currentPosition > rangeEnd)
+      }
     }
 
-    savePoints.append(makeQuantifiedSavePoint(rangeStart..<rangeEnd, isScalarSemantics: payload.isScalarSemantics))
+    guard matchedOnce else {
+      // Consumed no input, no point saved
+      return false
+    }
+
+    // NOTE: We can't assert that rangeEnd trails currentPosition by one
+    // position, because newline-sequence in scalar semantic mode still
+    // matches two scalars
+
+    savePoints.append(makeQuantifiedSavePoint(
+      rangeStart..<rangeEnd, isScalarSemantics: payload.isScalarSemantics))
+    return true
   }
 
   /// Specialized quantify instruction interpreter for `+`
-  mutating func runEagerOneOrMoreQuantify(_ payload: QuantifyPayload) -> Bool {
+  private mutating func runEagerOneOrMoreQuantify(_ payload: QuantifyPayload) -> Bool {
     assert(payload.quantKind == .eager
            && payload.minTrips == 1
            && payload.maxExtraTrips == nil)
 
     // Match at least once
-    guard let next = _doQuantifyMatch(payload) else {
+    guard let next = doQuantifyMatch(payload) else {
       signalFailure()
       return false
     }
 
     // Run `a+` as `aa*`
     currentPosition = next
-    _doRunEagerZeroOrMoreQuantify(payload)
+    doRunEagerZeroOrMoreQuantify(payload)
     return true
   }
 
   /// Specialized quantify instruction interpreter for ?
-  mutating func runZeroOrOneQuantify(_ payload: QuantifyPayload) -> Bool {
+  private mutating func runZeroOrOneQuantify(_ payload: QuantifyPayload) {
     assert(payload.minTrips == 0
            && payload.maxExtraTrips == 1)
-    let next = _doQuantifyMatch(payload)
+    let next = doQuantifyMatch(payload)
     guard let idx = next else {
-      return true // matched zero times
+      return // matched zero times
     }
     if payload.quantKind != .possessive {
       // Save the zero match
       savePoints.append(makeSavePoint(resumingAt: currentPC+1))
     }
     currentPosition = idx
-    return true
+    return
   }
 }

--- a/Sources/_StringProcessing/Engine/MEQuantify.swift
+++ b/Sources/_StringProcessing/Engine/MEQuantify.swift
@@ -226,6 +226,11 @@ extension Processor {
            && payload.maxExtraTrips == nil)
 
     // Match at least once
+    //
+    // NOTE: Due to newline-sequence in scalar-semantic mode advancing two
+    // positions, we can't just have doRunEagerZeroOrMoreQuantify return the
+    // range-end and advance the range-start ourselves. Instead, we do one
+    // call before looping.
     guard let next = doQuantifyMatch(payload) else {
       signalFailure()
       return false

--- a/Sources/_StringProcessing/Engine/Processor.swift
+++ b/Sources/_StringProcessing/Engine/Processor.swift
@@ -515,25 +515,11 @@ extension Processor {
         controller.step()
       }
     case .quantify:
-      let quantPayload = payload.quantify
-      let matched: Bool
-      switch (quantPayload.quantKind, quantPayload.minTrips, quantPayload.maxExtraTrips) {
-      case (.reluctant, _, _):
-        assertionFailure(".reluctant is not supported by .quantify")
-        return
-      case (.eager, 0, nil):
-        runEagerZeroOrMoreQuantify(quantPayload)
-        matched = true
-      case (.eager, 1, nil):
-        matched = runEagerOneOrMoreQuantify(quantPayload)
-      case (_, 0, 1):
-        matched = runZeroOrOneQuantify(quantPayload)
-      default:
-        matched = runQuantify(quantPayload)
-      }
-      if matched {
+      if runQuantify(payload.quantify) {
         controller.step()
       }
+
+
 
     case .consumeBy:
       let reg = payload.consumer

--- a/Sources/_StringProcessing/Utility/Misc.swift
+++ b/Sources/_StringProcessing/Utility/Misc.swift
@@ -65,3 +65,15 @@ enum QuickResult<R> {
   case unknown
 }
 
+extension String {
+  /// Index after in either grapheme or scalar view
+  func index(after idx: Index, isScalarSemantics: Bool) -> Index {
+    if isScalarSemantics {
+      return unicodeScalars.index(after: idx)
+    } else {
+      return index(after: idx)
+    }
+  }
+}
+
+


### PR DESCRIPTION
Unswitch the quant loop.

```
Comparing against saved benchmark result before_improvements
=== Regressions ======================================================================
- EmailRFCNoMatches_All_Scalar            124ms	122ms	1.97ms		1.6%
- Words_All_Scalar                        12.7ms	12.2ms	476µs		3.9%
- ReluctantQuantWithTerminal_Whole_Scalar 5.51ms	5.2ms	304µs		5.8%
- EmailLookaheadList                      4.07ms	3.91ms	168µs		4.3%
- Css_All                                 3.37ms	3.27ms	101µs		3.1%
- Css_All_Scalar                          2.98ms	2.92ms	56.5µs		1.9%
- EmailBuiltinCharacterClass_All_Scalar   10.1ms	10.1ms	52.2µs		0.5%
- EmailBuiltinCharacterClass_All          10.3ms	10.3ms	48µs		0.5%
- ReluctantQuantWithTerminal_Whole        5.22ms	5.18ms	40.3µs		0.8%
=== Improvements =====================================================================
- CompilerMessages_All                    86.7ms	92ms	-5.24ms		-5.7%
- CompilerMessages_All_Scalar             70ms	75.1ms	-5.14ms		-6.8%
- AnchoredNotFound_All                    13.5ms	14.6ms	-1.1ms		-7.5%
- BasicRangeCCC_All_Scalar                6.4ms	7.14ms	-736µs		-10.3%
- AnchoredNotFound_First                  9.12ms	9.85ms	-733µs		-7.4%
- DiceRollsInText_All_Scalar              38.5ms	39.2ms	-671µs		-1.7%
- EmojiRegex_All_Scalar                   40.5ms	41ms	-557µs		-1.4%
- NotFound_All                            7.18ms	7.56ms	-385µs		-5.1%
- AnchoredNotFound_First_Scalar           5.62ms	6ms	-381µs		-6.4%
- EagarQuantWithTerminal_Whole_Scalar     441µs	783µs	-342µs		-43.7%
- EagarQuantWithTerminal_Whole            446µs	780µs	-334µs		-42.9%
- SubtractionCCC_All                      20.9ms	21.2ms	-264µs		-1.2%
- Words_All                               12.4ms	12.6ms	-259µs		-2.1%
- GraphemeBreakNoCap_All_Scalar           2.83ms	3.09ms	-254µs		-8.2%
- Numbers_All                             5.83ms	6.07ms	-240µs		-3.9%
- Numbers_All_Scalar                      5.09ms	5.33ms	-237µs		-4.5%
- CaseInsensitiveCCC_All                  6.35ms	6.56ms	-218µs		-3.3%
- GraphemeBreakNoCap_All                  2.99ms	3.2ms	-209µs		-6.5%
- NotFound_All_Scalar                     6.17ms	6.35ms	-177µs		-2.8%
- BasicBuiltinCharacterClass_All          8.09ms	8.27ms	-177µs		-2.1%
- LiteralSearchNotFound_All_Scalar        5.52ms	5.67ms	-154µs		-2.7%
- LiteralSearch_All_Scalar                5.72ms	5.87ms	-151µs		-2.6%
- BasicBuiltinCharacterClass_All_Scalar   7.09ms	7.23ms	-141µs		-2.0%
- EmailLookahead_All                      19.4ms	19.6ms	-132µs		-0.7%
- BasicCCC_All                            5.92ms	6.05ms	-123µs		-2.0%
- LiteralSearch_All                       6.69ms	6.82ms	-122µs		-1.8%
- BasicRangeCCC_All                       6.4ms	6.52ms	-121µs		-1.9%
- CaseInsensitiveCCC_All_Scalar           6.35ms	6.47ms	-116µs		-1.8%
- AnchoredNotFound_All_Scalar             9.56ms	9.68ms	-115µs		-1.2%
- HangulSyllable_All_Scalar               5.91ms	6.02ms	-112µs		-1.9%
- BasicCCC_All_Scalar                     5.93ms	6.04ms	-108µs		-1.8%
- HangulSyllable_First                    3.27ms	3.37ms	-92.4µs		-2.7%
- IntersectionCCC_All_Scalar              22ms	22.1ms	-89.7µs		-0.4%
- HangulSyllable_First_Scalar             2.84ms	2.92ms	-83.7µs		-2.9%
- HangulSyllable_All                      6.69ms	6.76ms	-78µs		-1.2%
- LiteralSearchNotFound_All               6.55ms	6.62ms	-68.8µs		-1.0%
- Lines_All_Scalar                        1.66ms	1.7ms	-44.8µs		-2.6%
- IPv4Address_Scalar                      2.05ms	2.1ms	-42.7µs		-2.0%
- DiceNotation                            4.51ms	4.55ms	-39.7µs		-0.9%
- DiceNotation_Scalar                     4.26ms	4.3ms	-37.7µs		-0.9%
- IPv6Address                             2.55ms	2.59ms	-35.5µs		-1.4%
- EmailLookaheadList_Scalar               3.66ms	3.69ms	-29.5µs		-0.8%
```