### PR TITLE
[DRAFT] Refactor quant nonmutating

### DIFF
--- a/Sources/_StringProcessing/ConsumerInterface.swift
+++ b/Sources/_StringProcessing/ConsumerInterface.swift
@@ -391,9 +391,8 @@ extension DSLTree.CustomCharacterClass.Member {
       
       return { input, bounds in
         let curIdx = bounds.lowerBound
-        let nextIndex = isCharacterSemantic
-          ? input.index(after: curIdx)
-          : input.unicodeScalars.index(after: curIdx)
+        let nextIndex = input.index(
+          after: curIdx, isScalarSemantics: !isCharacterSemantic)
 
         // Under grapheme semantics, we compare based on single NFC scalars. If
         // such a character is not single scalar under NFC, the match fails. In
@@ -603,9 +602,9 @@ extension AST.Atom.CharacterProperty {
         if p(input, bounds) != nil { return nil }
 
         // TODO: bounds check
-        return opts.semanticLevel == .graphemeCluster
-          ? input.index(after: bounds.lowerBound)
-          : input.unicodeScalars.index(after: bounds.lowerBound)
+        return input.index(
+          after: bounds.lowerBound, 
+          isScalarSemantics: opts.semanticLevel == .unicodeScalar)
       }
     }
 

--- a/Sources/_StringProcessing/Engine/MEBuiltins.swift
+++ b/Sources/_StringProcessing/Engine/MEBuiltins.swift
@@ -223,6 +223,25 @@ extension String {
     else { return nil }
     return next
   }
+
+  internal func matchRegexDot(
+    at currentPosition: Index,
+    limitedBy end: Index,
+    anyMatchesNewline: Bool,
+    isScalarSemantics: Bool
+  ) -> Index? {
+    guard currentPosition < end else { return nil }
+
+    if anyMatchesNewline {
+      return index(
+        after: currentPosition, isScalarSemantics: isScalarSemantics)
+    }
+
+    return matchAnyNonNewline(
+      at: currentPosition,
+      limitedBy: end,
+      isScalarSemantics: isScalarSemantics)
+  }
 }
 
 // MARK: - Built-in character class matching

--- a/Sources/_StringProcessing/Engine/MEQuantify.swift
+++ b/Sources/_StringProcessing/Engine/MEQuantify.swift
@@ -1,5 +1,49 @@
+private typealias ASCIIBitset = DSLTree.CustomCharacterClass.AsciiBitset
+
 extension Processor {
-  func _doQuantifyMatch(_ payload: QuantifyPayload) -> Input.Index? {
+  func _doASCIIBitsetMatch(
+    _: AsciiBitsetRegister
+  ) -> Input.Index? {
+    fatalError()
+  }
+}
+
+
+extension String {
+  func index(after idx: Index, isScalarSemantics: Bool) -> Index {
+    if isScalarSemantics {
+      return unicodeScalars.index(after: idx)
+    } else {
+      return index(after: idx)
+    }
+  }
+}
+
+
+extension Processor {
+
+  internal mutating func runQuantify(_ payload: QuantifyPayload) -> Bool {
+    let matched: Bool
+    switch (payload.quantKind, payload.minTrips, payload.maxExtraTrips) {
+    case (.reluctant, _, _):
+      assertionFailure(".reluctant is not supported by .quantify")
+      // TODO: this was pre-refactoring behavior, should we fatal error
+      //       instead?
+      return false 
+    case (.eager, 0, nil):
+      runEagerZeroOrMoreQuantify(payload)
+      return true
+    case (.eager, 1, nil):
+      return runEagerOneOrMoreQuantify(payload)
+    case (_, 0, 1):
+      runZeroOrOneQuantify(payload)
+      return true
+    default:
+      return runGeneralQuantify(payload)
+    }
+  }
+
+  private func doQuantifyMatch(_ payload: QuantifyPayload) -> Input.Index? {
     let isScalarSemantics = payload.isScalarSemantics
 
     switch payload.type {
@@ -31,10 +75,8 @@ extension Processor {
       guard currentPosition < end else { return nil }
 
       if payload.anyMatchesNewline {
-        if isScalarSemantics {
-          return input.unicodeScalars.index(after: currentPosition)
-        }
-        return input.index(after: currentPosition)
+        return input.index(
+          after: currentPosition, isScalarSemantics: isScalarSemantics)
       }
 
       return input.matchAnyNonNewline(
@@ -47,14 +89,14 @@ extension Processor {
   /// Generic quantify instruction interpreter
   /// - Handles .eager and .posessive
   /// - Handles arbitrary minTrips and maxExtraTrips
-  mutating func runQuantify(_ payload: QuantifyPayload) -> Bool {
+  private mutating func runGeneralQuantify(_ payload: QuantifyPayload) -> Bool {
     assert(payload.quantKind != .reluctant)
 
     var trips = 0
     var maxExtraTrips = payload.maxExtraTrips
 
     while trips < payload.minTrips {
-      guard let next = _doQuantifyMatch(payload) else {
+      guard let next = doQuantifyMatch(payload) else {
         signalFailure()
         return false
       }
@@ -67,7 +109,7 @@ extension Processor {
       return true
     }
 
-    guard let next = _doQuantifyMatch(payload) else {
+    guard let next = doQuantifyMatch(payload) else {
       return true
     }
     maxExtraTrips = maxExtraTrips.map { $0 - 1 }
@@ -81,7 +123,7 @@ extension Processor {
     while true {
       if maxExtraTrips == 0 { break }
 
-      guard let next = _doQuantifyMatch(payload) else {
+      guard let next = doQuantifyMatch(payload) else {
         break
       }
       maxExtraTrips = maxExtraTrips.map({$0 - 1})
@@ -100,67 +142,147 @@ extension Processor {
   }
 
   /// Specialized quantify instruction interpreter for `*`, always succeeds
-  mutating func runEagerZeroOrMoreQuantify(_ payload: QuantifyPayload) {
+  private mutating func runEagerZeroOrMoreQuantify(_ payload: QuantifyPayload) {
     assert(payload.quantKind == .eager
            && payload.minTrips == 0
            && payload.maxExtraTrips == nil)
-    _doRunEagerZeroOrMoreQuantify(payload)
+    _ = doRunEagerZeroOrMoreQuantify(payload)
   }
 
-  // NOTE: So-as to inline into one-or-more call, which makes a significant
-  // performance difference
+  // Returns whether it matched at least once
+  //
+  // NOTE: inline-always so-as to inline into one-or-more call, which makes a
+  // significant performance difference
   @inline(__always)
-  mutating func _doRunEagerZeroOrMoreQuantify(_ payload: QuantifyPayload) {
-    guard let next = _doQuantifyMatch(payload) else {
-      // Consumed no input, no point saved
-      return
-    }
-
+  private mutating func doRunEagerZeroOrMoreQuantify(_ payload: QuantifyPayload) -> Bool {
     // Create a quantified save point for every part of the input matched up
     // to the final position.
+    let isScalarSemantics = payload.isScalarSemantics
     let rangeStart = currentPosition
     var rangeEnd = currentPosition
-    currentPosition = next
-    while true {
-      guard let next = _doQuantifyMatch(payload) else { break }
-      rangeEnd = currentPosition
-      currentPosition = next
+    var matchedOnce = false
+
+    switch payload.type {
+    case .asciiBitset:
+      let bitset = registers[payload.bitset]
+      while true {
+        guard let next = input.matchASCIIBitset(
+          bitset,
+          at: currentPosition,
+          limitedBy: end,
+          isScalarSemantics: isScalarSemantics)
+        else {
+          break
+        }
+        matchedOnce = true
+        rangeEnd = currentPosition
+        currentPosition = next
+        assert(currentPosition > rangeEnd)
+      }
+    case .asciiChar:
+      let asciiScalar = UnicodeScalar.init(_value: UInt32(payload.asciiChar))
+      while true {
+        guard let next = input.matchScalar(
+          asciiScalar,
+          at: currentPosition,
+          limitedBy: end,
+          boundaryCheck: !isScalarSemantics,
+          isCaseInsensitive: false)
+        else {
+          break
+        }
+        matchedOnce = true
+        rangeEnd = currentPosition
+        currentPosition = next
+        assert(currentPosition > rangeEnd)
+      }
+    case .builtin:
+      let builtin = payload.builtin
+      let isInverted = payload.builtinIsInverted
+      let isStrictASCII = payload.builtinIsStrict
+      while true {
+        guard let next = input.matchBuiltinCC(
+          builtin,
+          at: currentPosition,
+          limitedBy: end,
+          isInverted: isInverted,
+          isStrictASCII: isStrictASCII,
+          isScalarSemantics: isScalarSemantics)
+        else {
+          break
+        }
+        matchedOnce = true
+        rangeEnd = currentPosition
+        currentPosition = next
+        assert(currentPosition > rangeEnd)
+      }
+    case .any:
+      while true {
+        guard currentPosition < end else { break }
+        let next: String.Index?
+        if payload.anyMatchesNewline {
+          next = input.index(
+            after: currentPosition, isScalarSemantics: isScalarSemantics)
+        } else {
+          next = input.matchAnyNonNewline(
+            at: currentPosition,
+            limitedBy: end,
+            isScalarSemantics: isScalarSemantics)
+        }
+
+        guard let next else { break }
+        matchedOnce = true
+        rangeEnd = currentPosition
+        currentPosition = next
+        assert(currentPosition > rangeEnd)
+      }
     }
 
-    savePoints.append(makeQuantifiedSavePoint(rangeStart..<rangeEnd, isScalarSemantics: payload.isScalarSemantics))
+    guard matchedOnce else {
+      // Consumed no input, no point saved
+      return false
+    }
+
+    // NOTE: We can't assert that rangeEnd trails currentPosition by one
+    // position, because newline-sequence in scalar semantic mode still
+    // matches two scalars
+
+    savePoints.append(makeQuantifiedSavePoint(
+      rangeStart..<rangeEnd, isScalarSemantics: payload.isScalarSemantics))
+    return true
   }
 
   /// Specialized quantify instruction interpreter for `+`
-  mutating func runEagerOneOrMoreQuantify(_ payload: QuantifyPayload) -> Bool {
+  private mutating func runEagerOneOrMoreQuantify(_ payload: QuantifyPayload) -> Bool {
     assert(payload.quantKind == .eager
            && payload.minTrips == 1
            && payload.maxExtraTrips == nil)
 
     // Match at least once
-    guard let next = _doQuantifyMatch(payload) else {
+    guard let next = doQuantifyMatch(payload) else {
       signalFailure()
       return false
     }
 
     // Run `a+` as `aa*`
     currentPosition = next
-    _doRunEagerZeroOrMoreQuantify(payload)
+    doRunEagerZeroOrMoreQuantify(payload)
     return true
   }
 
   /// Specialized quantify instruction interpreter for ?
-  mutating func runZeroOrOneQuantify(_ payload: QuantifyPayload) -> Bool {
+  private mutating func runZeroOrOneQuantify(_ payload: QuantifyPayload) {
     assert(payload.minTrips == 0
            && payload.maxExtraTrips == 1)
-    let next = _doQuantifyMatch(payload)
+    let next = doQuantifyMatch(payload)
     guard let idx = next else {
-      return true // matched zero times
+      return // matched zero times
     }
     if payload.quantKind != .possessive {
       // Save the zero match
       savePoints.append(makeSavePoint(resumingAt: currentPC+1))
     }
     currentPosition = idx
-    return true
+    return
   }
 }

--- a/Sources/_StringProcessing/Engine/MEQuantify.swift
+++ b/Sources/_StringProcessing/Engine/MEQuantify.swift
@@ -226,6 +226,11 @@ extension Processor {
            && payload.maxExtraTrips == nil)
 
     // Match at least once
+    //
+    // NOTE: Due to newline-sequence in scalar-semantic mode advancing two
+    // positions, we can't just have doRunEagerZeroOrMoreQuantify return the
+    // range-end and advance the range-start ourselves. Instead, we do one
+    // call before looping.
     guard let next = doQuantifyMatch(payload) else {
       signalFailure()
       return false

--- a/Sources/_StringProcessing/Engine/Processor.swift
+++ b/Sources/_StringProcessing/Engine/Processor.swift
@@ -519,8 +519,6 @@ extension Processor {
         controller.step()
       }
 
-
-
     case .consumeBy:
       let reg = payload.consumer
       let consumer = registers[reg]

--- a/Sources/_StringProcessing/Engine/Processor.swift
+++ b/Sources/_StringProcessing/Engine/Processor.swift
@@ -515,25 +515,11 @@ extension Processor {
         controller.step()
       }
     case .quantify:
-      let quantPayload = payload.quantify
-      let matched: Bool
-      switch (quantPayload.quantKind, quantPayload.minTrips, quantPayload.maxExtraTrips) {
-      case (.reluctant, _, _):
-        assertionFailure(".reluctant is not supported by .quantify")
-        return
-      case (.eager, 0, nil):
-        runEagerZeroOrMoreQuantify(quantPayload)
-        matched = true
-      case (.eager, 1, nil):
-        matched = runEagerOneOrMoreQuantify(quantPayload)
-      case (_, 0, 1):
-        matched = runZeroOrOneQuantify(quantPayload)
-      default:
-        matched = runQuantify(quantPayload)
-      }
-      if matched {
+      if runQuantify(payload.quantify) {
         controller.step()
       }
+
+
 
     case .consumeBy:
       let reg = payload.consumer

--- a/Sources/_StringProcessing/Utility/Misc.swift
+++ b/Sources/_StringProcessing/Utility/Misc.swift
@@ -65,3 +65,15 @@ enum QuickResult<R> {
   case unknown
 }
 
+extension String {
+  /// Index after in either grapheme or scalar view
+  func index(after idx: Index, isScalarSemantics: Bool) -> Index {
+    if isScalarSemantics {
+      return unicodeScalars.index(after: idx)
+    } else {
+      return index(after: idx)
+    }
+  }
+}
+
+


### PR DESCRIPTION
Refactor off of mutating methods
    
Refactors mutating methods into string methods for easier unit testing and parity-checking via assertions. Prepares for more efficient implementations.
    
Doing so creates many small-to-medium regressions, unfortunately, so this should only be done in conjunction with more refactorings and improvements.

