### PR TITLE
Add @retroactive to conformances that need it. (#712)

### DIFF
--- a/Sources/RegexBuilder/DSL.swift
+++ b/Sources/RegexBuilder/DSL.swift
@@ -32,21 +32,21 @@ internal protocol _BuiltinRegexComponent: RegexComponent {
 // MARK: - Primitive regex components
 
 @available(SwiftStdlib 5.7, *)
-extension String: RegexComponent {
+extension String: @retroactive RegexComponent {
   public typealias Output = Substring
 
   public var regex: Regex<Output> { .init(verbatim: self) }
 }
 
 @available(SwiftStdlib 5.7, *)
-extension Substring: RegexComponent {
+extension Substring: @retroactive RegexComponent {
   public typealias Output = Substring
 
   public var regex: Regex<Output> { String(self).regex }
 }
 
 @available(SwiftStdlib 5.7, *)
-extension Character: RegexComponent {
+extension Character: @retroactive RegexComponent {
   public typealias Output = Substring
 
   public var regex: Regex<Output> {
@@ -55,7 +55,7 @@ extension Character: RegexComponent {
 }
 
 @available(SwiftStdlib 5.7, *)
-extension UnicodeScalar: RegexComponent {
+extension UnicodeScalar: @retroactive RegexComponent {
   public typealias Output = Substring
 
   public var regex: Regex<Output> {


### PR DESCRIPTION
> Note: I noticed as I was pressing the merge button that @tshortli's PR was against `swift/main` – cherry-picking back to the `main` branch

SE-0364 requires that retroactive conformance be marked with `@retroactive` to suppress warnings about the dangers of conforming types you don't own to protocols you don't own. The `RegexBuilder` module declares conformances to `RegexComponent` (from the `Regex` module) on several types from the standard library, like `String`. Since `RegexBuilder` declares neither the protocol nor the conforming type, these conformances are technically retroactive even though the modules involved are all developed and distributed together and can be trusted to organize the conformances this way safely.

The compiler warnings about these conformances are quite spammy; they get emitted every time someone builds the Swift compiler, so I'd like to suppress them.