### PR TITLE
Add a string-specific search algorithm

### DIFF
--- a/Sources/_StringProcessing/Algorithms/Algorithms/FirstRange.swift
+++ b/Sources/_StringProcessing/Algorithms/Algorithms/FirstRange.swift
@@ -21,8 +21,25 @@ extension Collection {
 }
 
 // MARK: Fixed pattern algorithms
+extension Substring {
+  @usableFromInline
+  func _firstRangeSubstring(
+    of other: Substring
+  ) -> Range<String.Index>? {
+    var searcher = SubstringSearcher(text: self, pattern: other)
+    return searcher.next()
+  }
+}
 
 extension Collection where Element: Equatable {
+  @usableFromInline
+  func _firstRangeGeneric<C: Collection>(
+    of other: C
+  ) -> Range<Index>? where C.Element == Element {
+    let searcher = ZSearcher<SubSequence>(pattern: Array(other), by: ==)
+    return searcher.search(self[...], in: startIndex..<endIndex)
+  }
+
   /// Finds and returns the range of the first occurrence of a given collection
   /// within this collection.
   ///
@@ -30,12 +47,23 @@ extension Collection where Element: Equatable {
   /// - Returns: A range in the collection of the first occurrence of `sequence`.
   /// Returns nil if `sequence` is not found.
   @available(SwiftStdlib 5.7, *)
+  @inline(__always)
   public func firstRange<C: Collection>(
     of other: C
   ) -> Range<Index>? where C.Element == Element {
-    // TODO: Use a more efficient search algorithm
-    let searcher = ZSearcher<SubSequence>(pattern: Array(other), by: ==)
-    return searcher.search(self[...], in: startIndex..<endIndex)
+    switch (self, other) {
+    case (let str as String, let other as String):
+      return str[...]._firstRangeSubstring(of: other[...]) as! Range<Index>?
+    case (let str as Substring, let other as String):
+      return str._firstRangeSubstring(of: other[...]) as! Range<Index>?
+    case (let str as String, let other as Substring):
+      return str[...]._firstRangeSubstring(of: other) as! Range<Index>?
+    case (let str as Substring, let other as Substring):
+      return str._firstRangeSubstring(of: other) as! Range<Index>?
+      
+    default:
+      return _firstRangeGeneric(of: other)
+    }
   }
 }
 
@@ -47,11 +75,23 @@ extension BidirectionalCollection where Element: Comparable {
   /// - Returns: A range in the collection of the first occurrence of `sequence`.
   /// Returns `nil` if `sequence` is not found.
   @available(SwiftStdlib 5.7, *)
+  @inline(__always)
   public func firstRange<C: Collection>(
     of other: C
   ) -> Range<Index>? where C.Element == Element {
-    let searcher = ZSearcher<SubSequence>(pattern: Array(other), by: ==)
-    return searcher.search(self[...], in: startIndex..<endIndex)
+    switch (self, other) {
+    case (let str as String, let other as String):
+      return str[...]._firstRangeSubstring(of: other[...]) as! Range<Index>?
+    case (let str as Substring, let other as String):
+      return str._firstRangeSubstring(of: other[...]) as! Range<Index>?
+    case (let str as String, let other as Substring):
+      return str[...]._firstRangeSubstring(of: other) as! Range<Index>?
+    case (let str as Substring, let other as Substring):
+      return str._firstRangeSubstring(of: other) as! Range<Index>?
+      
+    default:
+      return _firstRangeGeneric(of: other)
+    }
   }
 }
 

--- a/Sources/_StringProcessing/Algorithms/Algorithms/FirstRange.swift
+++ b/Sources/_StringProcessing/Algorithms/Algorithms/FirstRange.swift
@@ -22,7 +22,6 @@ extension Collection {
 
 // MARK: Fixed pattern algorithms
 extension Substring {
-  @usableFromInline
   func _firstRangeSubstring(
     of other: Substring
   ) -> Range<String.Index>? {
@@ -32,7 +31,6 @@ extension Substring {
 }
 
 extension Collection where Element: Equatable {
-  @usableFromInline
   func _firstRangeGeneric<C: Collection>(
     of other: C
   ) -> Range<Index>? where C.Element == Element {
@@ -47,7 +45,6 @@ extension Collection where Element: Equatable {
   /// - Returns: A range in the collection of the first occurrence of `sequence`.
   /// Returns nil if `sequence` is not found.
   @available(SwiftStdlib 5.7, *)
-  @inline(__always)
   public func firstRange<C: Collection>(
     of other: C
   ) -> Range<Index>? where C.Element == Element {
@@ -75,7 +72,6 @@ extension BidirectionalCollection where Element: Comparable {
   /// - Returns: A range in the collection of the first occurrence of `sequence`.
   /// Returns `nil` if `sequence` is not found.
   @available(SwiftStdlib 5.7, *)
-  @inline(__always)
   public func firstRange<C: Collection>(
     of other: C
   ) -> Range<Index>? where C.Element == Element {

--- a/Sources/_StringProcessing/Algorithms/Algorithms/Ranges.swift
+++ b/Sources/_StringProcessing/Algorithms/Algorithms/Ranges.swift
@@ -136,13 +136,6 @@ extension Collection where Element: Equatable {
     _ranges(of: ZSearcher(pattern: Array(other), by: ==))
   }
   
-  @usableFromInline
-  func _rangesGeneric<C: Collection>(
-    of other: C
-  ) -> [Range<Index>] where C.Element == Element {
-    Array(_ranges(of: other))
-  }
-
   // FIXME: Return `some Collection<Range<Index>>` for SE-0346
   /// Finds and returns the ranges of the all occurrences of a given sequence
   /// within the collection.
@@ -150,7 +143,6 @@ extension Collection where Element: Equatable {
   /// - Returns: A collection of ranges of all occurrences of `other`. Returns
   ///  an empty collection if `other` is not found.
   @available(SwiftStdlib 5.7, *)
-  @inline(__always)
   public func ranges<C: Collection>(
     of other: C
   ) -> [Range<Index>] where C.Element == Element {
@@ -165,7 +157,7 @@ extension Collection where Element: Equatable {
       return Array(SubstringSearcher(text: str, pattern: other)) as! [Range<Index>]
       
     default:
-      return _rangesGeneric(of: other)
+      return Array(_ranges(of: other))
     }
   }
 }

--- a/Sources/_StringProcessing/Algorithms/Algorithms/Replace.swift
+++ b/Sources/_StringProcessing/Algorithms/Algorithms/Replace.swift
@@ -91,11 +91,11 @@ extension RangeReplaceableCollection where Element: Equatable {
                                 maxReplacements: maxReplacements) as! Self
     case (let str as Substring, let other as Substring, let repl as Substring):
       return str._replacingSubstring(other, with: repl,
-                                maxReplacements: maxReplacements) as! Self
+                                maxReplacements: maxReplacements)[...] as! Self
 
     case (let str as Substring, let other as String, let repl as String):
       return str[...]._replacingSubstring(other[...], with: repl[...],
-                                maxReplacements: maxReplacements) as! Self
+                                maxReplacements: maxReplacements)[...] as! Self
     case (let str as String, let other as Substring, let repl as String):
       return str[...]._replacingSubstring(other[...], with: repl[...],
                                 maxReplacements: maxReplacements) as! Self
@@ -108,10 +108,10 @@ extension RangeReplaceableCollection where Element: Equatable {
                                 maxReplacements: maxReplacements) as! Self
     case (let str as Substring, let other as String, let repl as Substring):
       return str[...]._replacingSubstring(other[...], with: repl[...],
-                                maxReplacements: maxReplacements) as! Self
+                                maxReplacements: maxReplacements)[...] as! Self
     case (let str as Substring, let other as Substring, let repl as String):
       return str[...]._replacingSubstring(other[...], with: repl[...],
-                                maxReplacements: maxReplacements) as! Self
+                                maxReplacements: maxReplacements)[...] as! Self
 
     default:
       return _replacing(

--- a/Sources/_StringProcessing/Algorithms/Algorithms/Replace.swift
+++ b/Sources/_StringProcessing/Algorithms/Algorithms/Replace.swift
@@ -11,6 +11,34 @@
 
 // MARK: `CollectionSearcher` algorithms
 
+extension Substring {
+  func _replacingSubstring(
+    _ other: Substring,
+    with replacement: Substring,
+    maxReplacements: Int = .max
+  ) -> String {
+    precondition(maxReplacements >= 0)
+    
+    var result = String()
+    var index = startIndex
+    
+    // `maxRanges` is a workaround for https://github.com/apple/swift/issues/59522
+    var rangeIterator = SubstringSearcher(text: self, pattern: other)
+    var replacementCount = 0
+    while let range = rangeIterator.next() {
+      result.append(contentsOf: self[index..<range.lowerBound])
+      result.append(contentsOf: replacement)
+      index = range.upperBound
+      
+      replacementCount += 1
+      if replacementCount == maxReplacements { break }
+    }
+    
+    result.append(contentsOf: self[index...])
+    return result
+  }
+}
+
 extension RangeReplaceableCollection {
   func _replacing<Ranges: Collection, Replacement: Collection>(
     _ ranges: Ranges,
@@ -35,19 +63,6 @@ extension RangeReplaceableCollection {
     result.append(contentsOf: self[index...])
     return result
   }
-  
-  mutating func _replace<
-    Ranges: Collection, Replacement: Collection
-  >(
-    _ ranges: Ranges,
-    with replacement: Replacement,
-    maxReplacements: Int = .max
-  ) where Ranges.Element == Range<Index>, Replacement.Element == Element {
-    self = _replacing(
-      ranges,
-      with: replacement,
-      maxReplacements: maxReplacements)
-  }
 }
 
 // MARK: Fixed pattern algorithms
@@ -70,10 +85,40 @@ extension RangeReplaceableCollection where Element: Equatable {
     subrange: Range<Index>,
     maxReplacements: Int = .max
   ) -> Self where C.Element == Element, Replacement.Element == Element {
-    _replacing(
-      self[subrange]._ranges(of: other),
-      with: replacement,
-      maxReplacements: maxReplacements)
+    switch (self, other, replacement) {
+    case (let str as String, let other as String, let repl as String):
+      return str[...]._replacingSubstring(other[...], with: repl[...],
+                                maxReplacements: maxReplacements) as! Self
+    case (let str as Substring, let other as Substring, let repl as Substring):
+      return str._replacingSubstring(other, with: repl,
+                                maxReplacements: maxReplacements) as! Self
+
+    case (let str as Substring, let other as String, let repl as String):
+      return str[...]._replacingSubstring(other[...], with: repl[...],
+                                maxReplacements: maxReplacements) as! Self
+    case (let str as String, let other as Substring, let repl as String):
+      return str[...]._replacingSubstring(other[...], with: repl[...],
+                                maxReplacements: maxReplacements) as! Self
+    case (let str as String, let other as String, let repl as Substring):
+      return str[...]._replacingSubstring(other[...], with: repl[...],
+                                maxReplacements: maxReplacements) as! Self
+
+    case (let str as String, let other as Substring, let repl as Substring):
+      return str[...]._replacingSubstring(other[...], with: repl[...],
+                                maxReplacements: maxReplacements) as! Self
+    case (let str as Substring, let other as String, let repl as Substring):
+      return str[...]._replacingSubstring(other[...], with: repl[...],
+                                maxReplacements: maxReplacements) as! Self
+    case (let str as Substring, let other as Substring, let repl as String):
+      return str[...]._replacingSubstring(other[...], with: repl[...],
+                                maxReplacements: maxReplacements) as! Self
+
+    default:
+      return _replacing(
+        self[subrange]._ranges(of: other),
+        with: replacement,
+        maxReplacements: maxReplacements)
+    }
   }
 
   /// Returns a new collection in which all occurrences of a target sequence

--- a/Sources/_StringProcessing/Algorithms/Algorithms/Replace.swift
+++ b/Sources/_StringProcessing/Algorithms/Algorithms/Replace.swift
@@ -22,16 +22,14 @@ extension Substring {
     var result = String()
     var index = startIndex
     
-    // `maxRanges` is a workaround for https://github.com/apple/swift/issues/59522
     var rangeIterator = SubstringSearcher(text: self, pattern: other)
     var replacementCount = 0
-    while let range = rangeIterator.next() {
+    while replacementCount < maxReplacements, let range = rangeIterator.next() {
       result.append(contentsOf: self[index..<range.lowerBound])
       result.append(contentsOf: replacement)
       index = range.upperBound
       
       replacementCount += 1
-      if replacementCount == maxReplacements { break }
     }
     
     result.append(contentsOf: self[index...])

--- a/Sources/_StringProcessing/Algorithms/Algorithms/Split.swift
+++ b/Sources/_StringProcessing/Algorithms/Algorithms/Split.swift
@@ -150,9 +150,9 @@ extension Collection where Element: Equatable {
   ) -> [SubSequence] where C.Element == Element {
     switch (self, separator) {
     case (let str as String, let sep as String):
-      return str._split(separator: sep, maxSplits: maxSplits, omittingEmptySubsequences: omittingEmptySubsequences) as! [SubSequence]
+      return str[...]._split(separator: sep, maxSplits: maxSplits, omittingEmptySubsequences: omittingEmptySubsequences) as! [SubSequence]
     case (let str as String, let sep as Substring):
-      return str._split(separator: sep, maxSplits: maxSplits, omittingEmptySubsequences: omittingEmptySubsequences) as! [SubSequence]
+      return str[...]._split(separator: sep, maxSplits: maxSplits, omittingEmptySubsequences: omittingEmptySubsequences) as! [SubSequence]
     case (let str as Substring, let sep as String):
       return str._split(separator: sep, maxSplits: maxSplits, omittingEmptySubsequences: omittingEmptySubsequences) as! [SubSequence]
     case (let str as Substring, let sep as Substring):
@@ -186,8 +186,8 @@ extension StringProtocol where SubSequence == Substring {
     maxSplits: Int = .max,
     omittingEmptySubsequences: Bool = true
   ) -> [Substring] {
-    Array(split(
-      by: SubstringSearcher(text: "" as Self, pattern: separator[...]),
+    Array(self[...].split(
+      by: SubstringSearcher(text: "" as Substring, pattern: separator[...]),
       maxSplits: maxSplits,
       omittingEmptySubsequences: omittingEmptySubsequences))
   }
@@ -199,8 +199,8 @@ extension StringProtocol where SubSequence == Substring {
     maxSplits: Int = .max,
     omittingEmptySubsequences: Bool = true
   ) -> [Substring] {
-    Array(split(
-      by: SubstringSearcher(text: "" as Self, pattern: separator[...]),
+    Array(self[...].split(
+      by: SubstringSearcher(text: "" as Substring, pattern: separator[...]),
       maxSplits: maxSplits,
       omittingEmptySubsequences: omittingEmptySubsequences))
   }

--- a/Sources/_StringProcessing/Algorithms/Algorithms/Split.swift
+++ b/Sources/_StringProcessing/Algorithms/Algorithms/Split.swift
@@ -175,7 +175,7 @@ extension StringProtocol where SubSequence == Substring {
     omittingEmptySubsequences: Bool = true
   ) -> [Substring] {
     Array(split(
-      by: ZSearcher(pattern: Array(separator), by: ==),
+      by: SubstringSearcher(text: "" as Self, pattern: separator[...]),
       maxSplits: maxSplits,
       omittingEmptySubsequences: omittingEmptySubsequences))
   }
@@ -188,7 +188,7 @@ extension StringProtocol where SubSequence == Substring {
     omittingEmptySubsequences: Bool = true
   ) -> [Substring] {
     Array(split(
-      by: ZSearcher(pattern: Array(separator), by: ==),
+      by: SubstringSearcher(text: "" as Self, pattern: separator[...]),
       maxSplits: maxSplits,
       omittingEmptySubsequences: omittingEmptySubsequences))
   }

--- a/Sources/_StringProcessing/Algorithms/Algorithms/Split.swift
+++ b/Sources/_StringProcessing/Algorithms/Algorithms/Split.swift
@@ -148,10 +148,22 @@ extension Collection where Element: Equatable {
     maxSplits: Int = .max,
     omittingEmptySubsequences: Bool = true
   ) -> [SubSequence] where C.Element == Element {
-    Array(split(
-      by: ZSearcher(pattern: Array(separator), by: ==),
-      maxSplits: maxSplits,
-      omittingEmptySubsequences: omittingEmptySubsequences))
+    switch (self, separator) {
+    case (let str as String, let sep as String):
+      return str._split(separator: sep, maxSplits: maxSplits, omittingEmptySubsequences: omittingEmptySubsequences) as! [SubSequence]
+    case (let str as String, let sep as Substring):
+      return str._split(separator: sep, maxSplits: maxSplits, omittingEmptySubsequences: omittingEmptySubsequences) as! [SubSequence]
+    case (let str as Substring, let sep as String):
+      return str._split(separator: sep, maxSplits: maxSplits, omittingEmptySubsequences: omittingEmptySubsequences) as! [SubSequence]
+    case (let str as Substring, let sep as Substring):
+      return str._split(separator: sep, maxSplits: maxSplits, omittingEmptySubsequences: omittingEmptySubsequences) as! [SubSequence]
+      
+    default:
+      return Array(split(
+        by: ZSearcher(pattern: Array(separator), by: ==),
+        maxSplits: maxSplits,
+        omittingEmptySubsequences: omittingEmptySubsequences))
+    }
   }
 }
 

--- a/Sources/_StringProcessing/Algorithms/Algorithms/SubstringSearcher.swift
+++ b/Sources/_StringProcessing/Algorithms/Algorithms/SubstringSearcher.swift
@@ -1,0 +1,81 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2021-2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+/// An implementation of the Boyer-Moore algorithm, for string-specific
+/// searching.
+@usableFromInline
+struct SubstringSearcher: Sequence, IteratorProtocol {
+  @usableFromInline
+  let text: Substring
+  @usableFromInline
+  let pattern: Substring
+  @usableFromInline
+  let badCharacterOffsets: [Character: Int]
+  @usableFromInline
+  let patternCount: Int
+  @usableFromInline
+  var endOfSearch: String.Index?
+  
+  @usableFromInline
+  init(text: Substring, pattern: Substring) {
+    self.text = text
+    self.pattern = pattern
+    self.patternCount = pattern.count
+    self.endOfSearch = text.index(
+      text.startIndex, offsetBy: patternCount, limitedBy: text.endIndex)
+    self.badCharacterOffsets = Dictionary(
+      zip(pattern, 0...), uniquingKeysWith: { _, last in last })
+  }
+
+  @inlinable
+  mutating func next() -> Range<String.Index>? {
+    while let end = endOfSearch {
+      // Empty pattern matches at every position.
+      if patternCount == 0 {
+        endOfSearch = end == text.endIndex ? nil : text.index(after: end)
+        return end..<end
+      }
+      
+      var patternOffset = patternCount - 1
+      var patternCursor = pattern.index(before: pattern.endIndex)
+      var textCursor = text.index(before: end)
+      
+      // Search backwards from `end` to the start of the pattern
+      while patternCursor >= pattern.startIndex
+              && pattern[patternCursor] == text[textCursor]
+      {
+        patternOffset -= 1
+        
+        // Success!
+        if patternCursor == pattern.startIndex {
+          // Calculate the offset for the next search.
+          endOfSearch = text.index(end, offsetBy: patternCount, limitedBy: text.endIndex)
+          return textCursor..<end
+        }
+        
+        precondition(textCursor > text.startIndex)
+        text.formIndex(before: &textCursor)
+        pattern.formIndex(before: &patternCursor)
+      }
+      
+      // Match failed - calculate the end index of the next possible
+      // candidate, based on the `badCharacterOffsets` table and the
+      // current position in the pattern.
+      let shiftOffset = Swift.max(
+        1,
+        patternOffset - (badCharacterOffsets[text[textCursor]] ?? 0))
+      endOfSearch = text.index(
+        end, offsetBy: shiftOffset, limitedBy: text.endIndex)
+    }
+    return nil
+  }
+}
+

--- a/Sources/_StringProcessing/Algorithms/Algorithms/SubstringSearcher.swift
+++ b/Sources/_StringProcessing/Algorithms/Algorithms/SubstringSearcher.swift
@@ -9,7 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-/// An implementation of the Boyer-Moore algorithm, for string-specific
+/// An implementation of the Boyer-Moore-Horspool algorithm, for string-specific
 /// searching.
 @usableFromInline
 struct SubstringSearcher: Sequence, IteratorProtocol {
@@ -22,60 +22,152 @@ struct SubstringSearcher: Sequence, IteratorProtocol {
   @usableFromInline
   let patternCount: Int
   @usableFromInline
-  var endOfSearch: String.Index?
+  var endOfNextPotentialMatch: String.Index?
   
   @usableFromInline
   init(text: Substring, pattern: Substring) {
     self.text = text
     self.pattern = pattern
     self.patternCount = pattern.count
-    self.endOfSearch = text.index(
+    self.endOfNextPotentialMatch = text.index(
       text.startIndex, offsetBy: patternCount, limitedBy: text.endIndex)
     self.badCharacterOffsets = Dictionary(
       zip(pattern, 0...), uniquingKeysWith: { _, last in last })
   }
 
   @inlinable
-  mutating func next() -> Range<String.Index>? {
-    while let end = endOfSearch {
-      // Empty pattern matches at every position.
-      if patternCount == 0 {
-        endOfSearch = end == text.endIndex ? nil : text.index(after: end)
-        return end..<end
-      }
-      
-      var patternOffset = patternCount - 1
-      var patternCursor = pattern.index(before: pattern.endIndex)
-      var textCursor = text.index(before: end)
-      
-      // Search backwards from `end` to the start of the pattern
-      while patternCursor >= pattern.startIndex
-              && pattern[patternCursor] == text[textCursor]
-      {
-        patternOffset -= 1
-        
-        // Success!
-        if patternCursor == pattern.startIndex {
-          // Calculate the offset for the next search.
-          endOfSearch = text.index(end, offsetBy: patternCount, limitedBy: text.endIndex)
-          return textCursor..<end
-        }
-        
-        precondition(textCursor > text.startIndex)
-        text.formIndex(before: &textCursor)
-        pattern.formIndex(before: &patternCursor)
-      }
-      
-      // Match failed - calculate the end index of the next possible
-      // candidate, based on the `badCharacterOffsets` table and the
-      // current position in the pattern.
-      let shiftOffset = Swift.max(
-        1,
-        patternOffset - (badCharacterOffsets[text[textCursor]] ?? 0))
-      endOfSearch = text.index(
-        end, offsetBy: shiftOffset, limitedBy: text.endIndex)
+  func nextRange(searchFromEnd end: String.Index) 
+    -> (result: Range<String.Index>?, nextEnd: String.Index?)
+  {
+    // Empty pattern matches at every position.
+    if patternCount == 0 {
+      return (
+        end..<end,
+        end == text.endIndex ? nil : text.index(after: end))
     }
-    return nil
+    
+    var patternOffset = patternCount - 1
+    var patternCursor = pattern.index(before: pattern.endIndex)
+    var textCursor = text.index(before: end)
+    
+    // Search backwards from `end` to the start of the pattern
+    while patternCursor >= pattern.startIndex
+            && pattern[patternCursor] == text[textCursor]
+    {
+      patternOffset -= 1
+      
+      // Success!
+      if patternCursor == pattern.startIndex {
+        // Calculate the offset for the next search.
+        return (
+          textCursor..<end,
+          text.index(end, offsetBy: patternCount, limitedBy: text.endIndex))
+      }
+      
+      precondition(textCursor > text.startIndex)
+      text.formIndex(before: &textCursor)
+      pattern.formIndex(before: &patternCursor)
+    }
+    
+    // Match failed - calculate the end index of the next possible
+    // candidate, based on the `badCharacterOffsets` table and the
+    // current position in the pattern.
+    let shiftOffset = Swift.max(
+      1,
+      patternOffset - (badCharacterOffsets[text[textCursor]] ?? 0))
+    let nextEnd = text.index(
+      end, offsetBy: shiftOffset, limitedBy: text.endIndex)
+    guard let nextEnd else { return (nil, nil) }
+    return nextRange(searchFromEnd: nextEnd)
+  }
+  
+  @inlinable
+  mutating func next() -> Range<String.Index>? {
+    guard let end = endOfNextPotentialMatch else { return nil }
+    let (result, nextEnd) = nextRange(searchFromEnd: end)
+    endOfNextPotentialMatch = nextEnd
+    return result
+//    while let end = endOfSearch {
+//      // Empty pattern matches at every position.
+//      if patternCount == 0 {
+//        endOfSearch = end == text.endIndex ? nil : text.index(after: end)
+//        return end..<end
+//      }
+//      
+//      var patternOffset = patternCount - 1
+//      var patternCursor = pattern.index(before: pattern.endIndex)
+//      var textCursor = text.index(before: end)
+//      
+//      // Search backwards from `end` to the start of the pattern
+//      while patternCursor >= pattern.startIndex
+//              && pattern[patternCursor] == text[textCursor]
+//      {
+//        patternOffset -= 1
+//        
+//        // Success!
+//        if patternCursor == pattern.startIndex {
+//          // Calculate the offset for the next search.
+//          endOfSearch = text.index(end, offsetBy: patternCount, limitedBy: text.endIndex)
+//          return textCursor..<end
+//        }
+//        
+//        precondition(textCursor > text.startIndex)
+//        text.formIndex(before: &textCursor)
+//        pattern.formIndex(before: &patternCursor)
+//      }
+//      
+//      // Match failed - calculate the end index of the next possible
+//      // candidate, based on the `badCharacterOffsets` table and the
+//      // current position in the pattern.
+//      let shiftOffset = Swift.max(
+//        1,
+//        patternOffset - (badCharacterOffsets[text[textCursor]] ?? 0))
+//      endOfSearch = text.index(
+//        end, offsetBy: shiftOffset, limitedBy: text.endIndex)
+//    }
+//    return nil
   }
 }
 
+extension SubstringSearcher {
+  struct Coll: Collection {
+    var iterator: SubstringSearcher
+    var startIndex: Index
+    
+    var endIndex: Index { Index() }
+    
+    init(iterator: SubstringSearcher) {
+      var iterator = iterator
+      self.startIndex = Index(range: iterator.next())
+      self.iterator = iterator
+    }
+    
+    struct Index: Comparable {
+      var range: Range<String.Index>?
+      var endOfNextPotentialMatch: String.Index?
+
+      static func < (lhs: Index, rhs: Index) -> Bool {
+        switch (lhs.range, rhs.range) {
+        case (nil, _): false
+        case (_, nil): true
+        case let (lhs?, rhs?):
+          lhs.lowerBound < rhs.lowerBound
+        }
+      }
+    }
+    
+    subscript(index: Index) -> Range<String.Index> {
+      index.range!
+    }
+    
+    func index(after index: Index) -> Index {
+      let (range, next) = iterator.nextRange(
+        searchFromEnd: index.endOfNextPotentialMatch!)
+      return Index(range: range, endOfNextPotentialMatch: next)
+    }
+  }
+  
+  var collection: Coll {
+    .init(iterator: self)
+  }
+}

--- a/Sources/_StringProcessing/Algorithms/Algorithms/SubstringSearcher.swift
+++ b/Sources/_StringProcessing/Algorithms/Algorithms/SubstringSearcher.swift
@@ -12,9 +12,7 @@
 /// An implementation of the Boyer-Moore-Horspool algorithm, for string-specific
 /// searching.
 @usableFromInline
-struct SubstringSearcher<Searched: StringProtocol>: Sequence, IteratorProtocol
-  where Searched.SubSequence == Substring
-{
+struct SubstringSearcher: Sequence, IteratorProtocol {
   @usableFromInline
   struct State {
     @usableFromInline
@@ -40,6 +38,9 @@ struct SubstringSearcher<Searched: StringProtocol>: Sequence, IteratorProtocol
       }
     }
   }
+  
+  @usableFromInline
+  typealias Searched = Substring
   
   @usableFromInline
   let text: Searched

--- a/Sources/_StringProcessing/Algorithms/Algorithms/SubstringSearcher.swift
+++ b/Sources/_StringProcessing/Algorithms/Algorithms/SubstringSearcher.swift
@@ -11,15 +11,10 @@
 
 /// An implementation of the Boyer-Moore-Horspool algorithm, for string-specific
 /// searching.
-@usableFromInline
 struct SubstringSearcher: Sequence, IteratorProtocol {
-  @usableFromInline
   struct State {
-    @usableFromInline
     let badCharacterOffsets: [Character: Int]
-    @usableFromInline
     let patternCount: Int
-    @usableFromInline
     var endOfNextPotentialMatch: String.Index?
     
     init(text: Substring? = nil, pattern: Substring) {
@@ -39,24 +34,18 @@ struct SubstringSearcher: Sequence, IteratorProtocol {
     }
   }
   
-  @usableFromInline
   typealias Searched = Substring
   
-  @usableFromInline
   let text: Searched
-  @usableFromInline
   let pattern: Substring
-  @usableFromInline
   var state: State
   
-  @usableFromInline
   init(text: Searched, pattern: Substring) {
     self.text = text
     self.pattern = pattern
     self.state = .init(text: text[...], pattern: pattern)
   }
 
-  @inlinable
   func nextRange(in text: Searched, searchFromEnd end: String.Index)
     -> (result: Range<String.Index>?, nextEnd: String.Index?)
   {
@@ -107,7 +96,6 @@ struct SubstringSearcher: Sequence, IteratorProtocol {
     }
   }
   
-  @inlinable
   mutating func next() -> Range<String.Index>? {
     guard let end = state.endOfNextPotentialMatch else { return nil }
     let (result, nextEnd) = nextRange(in: text, searchFromEnd: end)

--- a/Tests/RegexTests/AlgorithmsTests.swift
+++ b/Tests/RegexTests/AlgorithmsTests.swift
@@ -67,6 +67,12 @@ class AlgorithmTests: XCTestCase {
     XCTAssertTrue("bbababacabababa".contains("abababa"))
     XCTAssertFalse("bbababacbbababa".contains("abababa"))
     
+    let str = "abcde"
+    let pattern = "bcde"
+    XCTAssertTrue(str[...].contains(pattern))
+    XCTAssertTrue(str.contains(pattern[...]))
+    XCTAssertTrue(str[...].contains(pattern[...]))
+
     XCTAssertFalse("".contains("abcd"))
     
     for start in 0..<9 {
@@ -163,6 +169,13 @@ class AlgorithmTests: XCTestCase {
       let actualSeq: [Range<Int>] = input.ranges(of: pattern).map(input.offsets(of:))
       XCTAssertEqual(actualSeq, expected, file: file, line: line)
 
+      let a1: [Range<Int>] = input[...].ranges(of: pattern).map(input.offsets(of:))
+      let a2: [Range<Int>] = input.ranges(of: pattern[...]).map(input.offsets(of:))
+      let a3: [Range<Int>] = input[...].ranges(of: pattern[...]).map(input.offsets(of:))
+      XCTAssertEqual(a1, expected, file: file, line: line)
+      XCTAssertEqual(a2, expected, file: file, line: line)
+      XCTAssertEqual(a3, expected, file: file, line: line)
+
       // `IndexingIterator` tests the collection conformance
       let actualCol: [Range<Int>] = input.ranges(of: pattern)[...].map(input.offsets(of:))
       XCTAssertEqual(actualCol, expected, file: file, line: line)
@@ -173,6 +186,13 @@ class AlgorithmTests: XCTestCase {
         let secondRange = input[upperBound...].firstRange(of: pattern).map(input.offsets(of:))
         XCTAssertEqual(secondRange, expected.dropFirst().first, file: file, line: line)
       }
+      
+      let r1 = input[...].firstRange(of: pattern)
+      let r2 = input.firstRange(of: pattern[...])
+      let r3 = input[...].firstRange(of: pattern[...])
+      XCTAssertEqual(r1.map(input.offsets(of:)), expected.first, file: file, line: line)
+      XCTAssertEqual(r2.map(input.offsets(of:)), expected.first, file: file, line: line)
+      XCTAssertEqual(r3.map(input.offsets(of:)), expected.first, file: file, line: line)
     }
 
     expectRanges("", "", [0..<0])
@@ -227,6 +247,13 @@ class AlgorithmTests: XCTestCase {
     ) {
       let actual = Array(string.split(separator: separator, omittingEmptySubsequences: false))
       XCTAssertEqual(actual, expected, file: file, line: line)
+      
+      let a1 = Array(string[...].split(separator: separator, omittingEmptySubsequences: false))
+      let a2 = Array(string.split(separator: separator[...], omittingEmptySubsequences: false))
+      let a3 = Array(string[...].split(separator: separator[...], omittingEmptySubsequences: false))
+      XCTAssertEqual(a1, expected, file: file, line: line)
+      XCTAssertEqual(a2, expected, file: file, line: line)
+      XCTAssertEqual(a3, expected, file: file, line: line)
     }
 
     expectSplit("", "", [""])
@@ -506,6 +533,15 @@ class AlgorithmTests: XCTestCase {
     XCTAssertEqual(s.replacing(regex, with: ""), " |  | ")
     XCTAssertEqual(s1.replacing(regex, with: ""), " | ")
     XCTAssertEqual(s2.replacing(regex, with: ""), "")
+
+    XCTAssertEqual(s.replacing("aa", with: "Z"), "Za | ZZZ | ZZZZZ")
+    XCTAssertEqual(s.replacing("aa" as Substring, with: "Z"), "Za | ZZZ | ZZZZZ")
+    XCTAssertEqual(s.replacing("aa", with: "Z" as Substring), "Za | ZZZ | ZZZZZ")
+    XCTAssertEqual(s.replacing("aa" as Substring, with: "Z" as Substring), "Za | ZZZ | ZZZZZ")
+    XCTAssertEqual(s1.replacing("aa", with: "Z"), "ZZZ | ZZZZZ")
+    XCTAssertEqual(s1.replacing("aa", with: "Z" as Substring), "ZZZ | ZZZZZ")
+    XCTAssertEqual(s1.replacing("aa" as Substring, with: "Z"), "ZZZ | ZZZZZ")
+    XCTAssertEqual(s1.replacing("aa" as Substring, with: "Z" as Substring), "ZZZ | ZZZZZ")
 
     XCTAssertEqual(
       s.matches(of: regex).map(\.0),

--- a/Tests/RegexTests/AlgorithmsTests.swift
+++ b/Tests/RegexTests/AlgorithmsTests.swift
@@ -507,7 +507,22 @@ class AlgorithmTests: XCTestCase {
     expectReplace("a", "a", "X", "X")
     expectReplace("aab", "a", "X", "XXb")
     
-    // FIXME: Test maxReplacements
+    let str = "aabaaabaab"
+    XCTAssertEqual(
+        str.replacing("aab", with: "Z", maxReplacements: 1000),
+        "ZaZZ")
+    XCTAssertEqual(
+        str.replacing("aab", with: "Z", maxReplacements: 3),
+        "ZaZZ")
+    XCTAssertEqual(
+        str.replacing("aab", with: "Z", maxReplacements: 2),
+        "ZaZaab")
+    XCTAssertEqual(
+        str.replacing("aab", with: "Z", maxReplacements: 1),
+        "Zaaabaab")
+    XCTAssertEqual(
+        str.replacing("aab", with: "Z", maxReplacements: 0),
+        str)
   }
   
   func testSubstring() throws {

--- a/Tests/RegexTests/AlgorithmsTests.swift
+++ b/Tests/RegexTests/AlgorithmsTests.swift
@@ -64,6 +64,8 @@ class AlgorithmTests: XCTestCase {
     XCTAssertTrue("abcde".contains("bcde"))
     XCTAssertTrue("abcde".contains("bcd"))
     XCTAssertTrue("ababacabababa".contains("abababa"))
+    XCTAssertTrue("bbababacabababa".contains("abababa"))
+    XCTAssertFalse("bbababacbbababa".contains("abababa"))
     
     XCTAssertFalse("".contains("abcd"))
     
@@ -340,7 +342,7 @@ class AlgorithmTests: XCTestCase {
       XCTAssertEqual(stringActual, expected, """
         Mismatch in string split of '\(str)', maxSplits: \(maxSplits), omitEmpty: \(omitEmpty)
           expected: \(expected.map(String.init))
-          actual:   \(regexActual.map(String.init))
+          actual:   \(stringActual.map(String.init))
         """)
     }
   }


### PR DESCRIPTION
This adds a Boyer-Moore substring search algorithm, and updates the `firstRange(of:)`, `ranges(of:)`, `split(...)`, and `replacing` methods to use that when both pieces of the search are strings/substrings.