### PR TITLE
Fix release mode testing issue

### DIFF
--- a/Tests/RegexTests/MatchTests.swift
+++ b/Tests/RegexTests/MatchTests.swift
@@ -137,7 +137,7 @@ func _firstMatch(
   }
 
   if validateOptimizations {
-    assert(regex._forceAction(.addOptions(.disableOptimizations)))
+    precondition(regex._forceAction(.addOptions(.disableOptimizations)))
     let unoptResult = try regex.firstMatch(in: input)
     if result != nil && unoptResult == nil {
       throw MatchError("match not found for unoptimized \(regexStr) in \(input)")


### PR DESCRIPTION
The call to disable optimizations during testing was in an assert call, so it was elided in release builds, even though the code that expected optimizations to be disabled was still used. This created spurious failures during release mode testing, which appears to have recently been enabled in CI.