### PR TITLE
Fix literal pattern availability

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,15 @@ let availabilityDefinition = PackageDescription.SwiftSetting.unsafeFlags([
     "-Xfrontend",
     "-define-availability",
     "-Xfrontend",
-    "SwiftStdlib 5.9:macOS 9999, iOS 9999, watchOS 9999, tvOS 9999",
+    "SwiftStdlib 5.9:macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0",
+    "-Xfrontend",
+    "-define-availability",
+    "-Xfrontend",
+    "SwiftStdlib 5.10:macOS 9999, iOS 9999, watchOS 9999, tvOS 9999",
+    "-Xfrontend",
+    "-define-availability",
+    "-Xfrontend",
+    "SwiftStdlib 5.11:macOS 9999, iOS 9999, watchOS 9999, tvOS 9999",
 ])
 
 /// Swift settings for building a private stdlib-like module that is to be used

--- a/Package.swift
+++ b/Package.swift
@@ -97,7 +97,7 @@ let package = Package(
             name: "RegexTests",
             dependencies: ["_StringProcessing", "TestSupport"],
             swiftSettings: [
-                .unsafeFlags(["-Xfrontend", "-disable-availability-checking"]),
+                availabilityDefinition
             ]),
         .testTarget(
             name: "RegexBuilderTests",

--- a/Sources/_StringProcessing/LiteralPrinter.swift
+++ b/Sources/_StringProcessing/LiteralPrinter.swift
@@ -11,7 +11,7 @@
 
 @_implementationOnly import _RegexParser
 
-@available(SwiftStdlib 5.9, *)
+@available(SwiftStdlib 5.7, *)
 extension Regex {
   /// The literal pattern for this regex.
   ///
@@ -33,6 +33,7 @@ extension Regex {
   /// the `CustomConsumingRegexComponent` protocol, this property is `nil`.
   ///
   /// The value of this property may change between different releases of Swift.
+  @available(SwiftStdlib 5.11, *)
   public var _literalPattern: String? {
     var gen = LiteralPrinter(options: MatchingOptions())
     gen.outputNode(self.program.tree.root)

--- a/Tests/RegexTests/LiteralPrinterTests.swift
+++ b/Tests/RegexTests/LiteralPrinterTests.swift
@@ -14,6 +14,7 @@ import XCTest
 import _StringProcessing
 import RegexBuilder
 
+@available(SwiftStdlib 5.11, *)
 extension RegexTests {
   func testPrintableRegex() throws {
     let regexString = #"([a-fGH1-9[^\D]]+)?b*cd(e.+)\2\w\S+?"#
@@ -55,7 +56,7 @@ extension RegexTests {
 // MARK: - PrintableRegex
 
 // Demonstration of a guaranteed Codable/Sendable regex type.
-@available(macOS 9999, *)
+@available(SwiftStdlib 5.11, *)
 struct PrintableRegex: RegexComponent, @unchecked Sendable {
   var pattern: String
   var regex: Regex<AnyRegexOutput>
@@ -76,7 +77,7 @@ struct PrintableRegex: RegexComponent, @unchecked Sendable {
   }
 }
 
-@available(macOS 9999, *)
+@available(SwiftStdlib 5.11, *)
 extension PrintableRegex: Codable {
   init(from decoder: Decoder) throws {
     let container = try decoder.singleValueContainer()
@@ -90,7 +91,7 @@ extension PrintableRegex: Codable {
   }
 }
 
-@available(macOS 9999, *)
+@available(SwiftStdlib 5.11, *)
 extension PrintableRegex: CustomStringConvertible {
   var description: String {
     pattern

--- a/Tests/RegexTests/MatchTests.swift
+++ b/Tests/RegexTests/MatchTests.swift
@@ -138,7 +138,7 @@ func _firstMatch(
   }
 
   if validateOptimizations {
-    assert(regex._forceAction(.addOptions(.disableOptimizations)))
+    precondition(regex._forceAction(.addOptions(.disableOptimizations)))
     let unoptResult = try regex.firstMatch(in: input)
     if result != nil && unoptResult == nil {
       throw MatchError("match not found for unoptimized \(regexStr) in \(input)")

--- a/Tests/RegexTests/MatchTests.swift
+++ b/Tests/RegexTests/MatchTests.swift
@@ -23,6 +23,7 @@ struct MatchError: Error {
 
 // This just piggy-backs on the existing match testing to validate that
 // literal patterns round trip correctly.
+@available(SwiftStdlib 5.11, *)
 func _roundTripLiteral(
   _ regexStr: String,
   syntax: SyntaxOptions
@@ -87,7 +88,7 @@ func _firstMatch(
     }
   }
 
-  do {
+  if #available(SwiftStdlib 5.11, *) {
     let roundTripRegex = try? _roundTripLiteral(regexStr, syntax: syntax)
     let roundTripResult = try? roundTripRegex?
       .matchingSemantics(semanticLevel)

--- a/Tests/RegexTests/ParseTests.swift
+++ b/Tests/RegexTests/ParseTests.swift
@@ -119,7 +119,8 @@ func parseTest(
   }
   serializedCaptures.deallocate()
   
-  if !unsupported && expectedErrors.isEmpty,
+  if #available(SwiftStdlib 5.11, *),
+     !unsupported && expectedErrors.isEmpty,
      let pattern = Regex<AnyRegexOutput>(ast: ast)._literalPattern
   {
     let reparsedAST = parseWithRecovery(pattern, syntax)


### PR DESCRIPTION
This corrects the availability for the `_literalPattern` symbol, and fixes a few odd failing tests along the way!