### PR TITLE
Suppress compiler warnings about Errors with non-Sendable members

### DIFF
--- a/Sources/_RegexParser/Regex/Parse/CompilerInterface.swift
+++ b/Sources/_RegexParser/Regex/Parse/CompilerInterface.swift
@@ -17,9 +17,19 @@ public let currentRegexLiteralFormatVersion = 1
 
 @_spi(CompilerInterface)
 public struct CompilerLexError: Error {
+  var underlyingLocation: UnsafeSourceLocation
+
   public var message: String
-  public var location: UnsafeRawPointer
+  public var location: UnsafeRawPointer { return underlyingLocation.ptr }
   public var completelyErroneous: Bool
+
+  init(
+    message: String, location: UnsafeRawPointer, completelyErroneous: Bool
+  ) {
+    self.message = message
+    self.underlyingLocation = UnsafeSourceLocation(location)
+    self.completelyErroneous = completelyErroneous
+  }
 }
 
 /// Interface for the Swift compiler.

--- a/Sources/_StringProcessing/Engine/MEBuiltins.swift
+++ b/Sources/_StringProcessing/Engine/MEBuiltins.swift
@@ -297,9 +297,10 @@ extension String {
   ) -> String.Index? {
     // TODO: Branch here on scalar semantics
     // Don't want to pay character cost if unnecessary
-    guard var (char, next) =
+    guard let (char, nextIndex) =
             characterAndEnd(at: currentPosition, limitedBy: end)
     else { return nil }
+    var next = nextIndex
     let scalar = unicodeScalars[currentPosition]
 
     let asciiCheck = !isStrictASCII


### PR DESCRIPTION
A type conforming to `Error` must be `Sendable`, but `DelimiterLexError` and `CompilerLexError` carry source locations represented by `UnsafeRawPointer`, which is inherently non-`Sendable`. The compiler diagnoses the failure to meet `Sendable` requirements on these error types, which will prevent Swift 6 adoption in `_RegexParser` and also generates build log spam every time the compiler and standard library are built. There are a couple ways to resolve this problem:
    
1. Refactor so that the errors do not need to carry source locations.
2. Refactor to avoid using `Error` (the code using these errors would not require `Sendable` if it were not for `Error`'s inherent `Sendable` requirement).
3. Suppress the warnings with an `@unchecked Sendable` wrapper.
    
Option 1 probably requires significant refactoring and option 2 seems undesirable since it means that the implementation must forgo the convenience of Swift's error handling model. Therefore this PR implements option 3 as the most expedient way to stop the diagnostic spam, leaving improvement on the status quo as a future exercise.

Also includes a drive-by fix for a trivial, unrelated warning.
