### PR TITLE
[swift/main] [LiteralPrinter] Use ICU-style escaping for Unicode scalars

### DIFF
--- a/Sources/_StringProcessing/LiteralPrinter.swift
+++ b/Sources/_StringProcessing/LiteralPrinter.swift
@@ -444,7 +444,17 @@ extension String {
 
 extension UnicodeScalar {
   var escapedString: String {
-    "\\u{" + String(value, radix: 16) + "}"
+    switch self {
+    case "\n": return #"\n"#
+    case "\r": return #"\r"#
+    case "\t": return #"\t"#
+    default:
+      let code = String(value, radix: 16, uppercase: true)
+      let prefix = code.count <= 4
+        ? #"\u"# + String(repeating: "0", count: 4 - code.count)
+        : #"\U"# + String(repeating: "0", count: 8 - code.count)
+      return prefix + code
+    }
   }
 }
 

--- a/Tests/RegexTests/LiteralPrinterTests.swift
+++ b/Tests/RegexTests/LiteralPrinterTests.swift
@@ -15,16 +15,34 @@ import _StringProcessing
 import RegexBuilder
 
 @available(SwiftStdlib 6.0, *)
+fileprivate func _literalTest<T>(
+  _ regex: Regex<T>,
+  expected: String?,
+  file: StaticString = #filePath,
+  line: UInt = #line
+) {
+  XCTAssertEqual(regex._literalPattern, expected, file: file, line: line)
+  if let expected {
+    let remadeRegex = try? Regex(expected)
+    XCTAssertEqual(expected, remadeRegex?._literalPattern, file: file, line: line)
+  }
+}
+
+@available(SwiftStdlib 6.0, *)
 extension RegexTests {
   func testPrintableRegex() throws {
     let regexString = #"([a-fGH1-9[^\D]]+)?b*cd(e.+)\2\w\S+?"#
-    let regex = try! Regex(regexString)
-    let pattern = try XCTUnwrap(regex._literalPattern)
+    let regex = try Regex(regexString)
     // Note: This is true for this particular regex, but not all regexes
-    XCTAssertEqual(regexString, pattern)
+    _literalTest(regex, expected: regexString)
     
     let printableRegex = try XCTUnwrap(PrintableRegex(regex))
-    XCTAssertEqual("\(printableRegex)", pattern)
+    XCTAssertEqual("\(printableRegex)", regexString)
+  }
+  
+  func testUnicodeEscapes() throws {
+    let regex = #/\r\n\t cafe\u{301} \u{1D11E}/#
+    _literalTest(regex, expected: #"\r\n\t cafe\u0301 \U0001D11E"#)
   }
   
   func testPrintableDSLRegex() throws {
@@ -39,8 +57,7 @@ extension RegexTests {
       }.dotMatchesNewlines()
       Optionally("c")
     }.ignoresCase()
-    let pattern = try XCTUnwrap(regex._literalPattern)
-    XCTAssertEqual("(?i:(?:aaa)+?(?s:(?:bbb)*|d+|e{3,})c?)", pattern)
+    _literalTest(regex, expected: "(?i:(?:aaa)+?(?s:(?:bbb)*|d+|e{3,})c?)")
 
     let nonPrintableRegex = Regex {
       OneOrMore("a")
@@ -49,7 +66,7 @@ extension RegexTests {
       } transform: { Int($0)! }
       Optionally("b")
     }
-    XCTAssertNil(nonPrintableRegex._literalPattern)
+    _literalTest(nonPrintableRegex, expected: nil)
   }
 }
 


### PR DESCRIPTION
Cherry pick of #725.