### PR TITLE
[swift/main] Resolve `switch covers known cases, but 'Enum' may have additional unknown values` warnings

### DIFF
--- a/Sources/_StringProcessing/ByteCodeGen.swift
+++ b/Sources/_StringProcessing/ByteCodeGen.swift
@@ -156,6 +156,10 @@ fileprivate extension Compiler.ByteCodeGen {
         name, isScalarMode: options.semanticLevel == .unicodeScalar)
     case .relative:
       throw Unsupported("Backreference kind: \(ref)")
+    #if RESILIENT_LIBRARIES
+    @unknown default:
+      fatalError()
+    #endif
     }
   }
 
@@ -657,6 +661,10 @@ fileprivate extension Compiler.ByteCodeGen {
       // quantification break if trying to restore to a prior
       // iteration because the register got overwritten?
       //
+    #if RESILIENT_LIBRARIES
+    @unknown default:
+      fatalError()
+    #endif
     }
 
     builder.label(exit)

--- a/Sources/_StringProcessing/ConsumerInterface.swift
+++ b/Sources/_StringProcessing/ConsumerInterface.swift
@@ -324,6 +324,11 @@ extension AST.Atom {
         .backtrackingDirective, .changeMatchingOptions, .invalid:
       // FIXME: implement
       return nil
+
+    #if RESILIENT_LIBRARIES
+    @unknown default:
+      fatalError()
+    #endif
     }
   }
 }
@@ -686,7 +691,13 @@ extension AST.Atom.CharacterProperty {
 
       case .invalid:
         throw Unreachable("Expected valid property")
+
+      #if RESILIENT_LIBRARIES
+      @unknown default:
+        throw Unreachable("Unknown kind \(kind)")
+      #endif
       }
+
     }()
 
     if !isInverted { return preInversion }
@@ -856,6 +867,10 @@ extension Unicode.BinaryProperty {
     case .expandsOnNFC, .expandsOnNFD, .expandsOnNFKD,
         .expandsOnNFKC:
       throw Unsupported("Unicode-deprecated: \(self)")
+    #if RESILIENT_LIBRARIES
+    @unknown default:
+      break
+    #endif
     }
 
     throw Unsupported("TODO: map prop \(self)")
@@ -906,6 +921,10 @@ extension Unicode.POSIXProperty {
     case .xdigit:
       return consume(propertyScalarPredicate(\.isHexDigit)) // or number
 
+    #if RESILIENT_LIBRARIES
+    @unknown default:
+      fatalError()
+    #endif
     }
   }
 }
@@ -1024,6 +1043,11 @@ extension Unicode.ExtendedGeneralCategory {
       return consume(categoryScalarPredicate(.paragraphSeparator))
     case .spaceSeparator:
       return consume(categoryScalarPredicate(.spaceSeparator))
+
+    #if RESILIENT_LIBRARIES
+    @unknown default:
+      fatalError()
+    #endif
     }
   }
 }

--- a/Sources/_StringProcessing/Engine/InstPayload.swift
+++ b/Sources/_StringProcessing/Engine/InstPayload.swift
@@ -423,6 +423,10 @@ struct QuantifyPayload: RawRepresentable {
       kindVal = 1
     case .possessive:
       kindVal = 2
+    #if RESILIENT_LIBRARIES
+    @unknown default:
+      fatalError()
+    #endif
     }
     // TODO: refactor / reimplement
     let maxExtraTripsVal: UInt64 = maxExtraTrips == nil ? 1 : UInt64(maxExtraTrips!) << 1

--- a/Sources/_StringProcessing/LiteralPrinter.swift
+++ b/Sources/_StringProcessing/LiteralPrinter.swift
@@ -216,6 +216,10 @@ extension LiteralPrinter {
       output("{,\(n.value!)}")
     case let .range(low, high):
       output("{\(low.value!),\(high.value!)}")
+    #if RESILIENT_LIBRARIES
+    @unknown default:
+      fatalError()
+    #endif
     }
     
     outputQuantificationKind(kind)
@@ -235,6 +239,10 @@ extension LiteralPrinter {
         output(options.isReluctantByDefault ? "" : "?")
       case .possessive:
         output("+")
+      #if RESILIENT_LIBRARIES
+      @unknown default:
+        fatalError()
+      #endif
       }
     case let .syntax(kind):
       // Syntactically-specified quantification modifiers can stay as-is.
@@ -245,6 +253,10 @@ extension LiteralPrinter {
         output("?")
       case .possessive:
         output("+")
+      #if RESILIENT_LIBRARIES
+      @unknown default:
+        fatalError()
+      #endif
       }
     }
   }
@@ -351,6 +363,10 @@ extension LiteralPrinter {
       output("\\g{\(prefix)\(abs(value))}")
     case .named(let name):
       output("\\g{\(name)}")
+    #if RESILIENT_LIBRARIES
+    @unknown default:
+      fatalError()
+    #endif
     }
   }
   
@@ -558,6 +574,11 @@ extension AST.MatchingOption.Kind {
       
     // NSRE Compatibility option; no literal representation
     case .nsreCompatibleDot: return nil
+
+    #if RESILIENT_LIBRARIES
+    @unknown default:
+      fatalError()
+    #endif
     }
   }
 }
@@ -597,6 +618,11 @@ extension DSLTree._AST.GroupKind {
       
     case let .changeMatchingOptions(sequence):
       return sequence._patternString + ":"
+
+    #if RESILIENT_LIBRARIES
+    @unknown default:
+      fatalError()
+    #endif
     }
   }
 }

--- a/Sources/_StringProcessing/MatchingOptions.swift
+++ b/Sources/_StringProcessing/MatchingOptions.swift
@@ -217,6 +217,10 @@ extension MatchingOptions {
         self = .extended
       case .extraExtended:
         self = .extraExtended
+      #if RESILIENT_LIBRARIES
+      @unknown default:
+        fatalError()
+      #endif
       }
     }
     

--- a/Sources/_StringProcessing/PrintAsPattern.swift
+++ b/Sources/_StringProcessing/PrintAsPattern.swift
@@ -1105,6 +1105,11 @@ extension AST.Atom {
       
     case .changeMatchingOptions:
       return "/* TODO: change matching options */"
+
+    #if RESILIENT_LIBRARIES
+    @unknown default:
+      fatalError()
+    #endif
     }
   }
 }
@@ -1125,6 +1130,9 @@ extension AST.Quantification.Amount {
     case let .nOrMore(n):  return "Repeat(\(n._patternBase)...)"
     case let .upToN(n):    return "Repeat(...\(n._patternBase))"
     case let .range(n, m): return "Repeat(\(n._patternBase)...\(m._patternBase))"
+    #if RESILIENT_LIBRARIES
+    @unknown default: fatalError()
+    #endif
     }
   }
   
@@ -1144,6 +1152,9 @@ extension AST.Quantification.Kind {
     case .eager: return ".eager"
     case .reluctant: return ".reluctant"
     case .possessive: return ".possessive"
+    #if RESILIENT_LIBRARIES
+    @unknown default: fatalError()
+    #endif
     }
   }
 }

--- a/Sources/_StringProcessing/Regex/ASTConversion.swift
+++ b/Sources/_StringProcessing/Regex/ASTConversion.swift
@@ -97,6 +97,11 @@ extension AST.Node {
       case let .absentFunction(abs):
         // TODO: What should this map to?
         return .absentFunction(.init(ast: abs))
+
+      #if RESILIENT_LIBRARIES
+      @unknown default:
+        fatalError()
+      #endif
       }
     }
 
@@ -141,9 +146,18 @@ extension AST.CustomCharacterClass {
           return .intersection(lhs, rhs)
         case .symmetricDifference:
           return .symmetricDifference(lhs, rhs)
+        #if RESILIENT_LIBRARIES
+        @unknown default:
+          fatalError()
+        #endif
         }
       case let .trivia(t):
         return .trivia(t.contents)
+
+      #if RESILIENT_LIBRARIES
+      @unknown default:
+        fatalError()
+      #endif
       }
     }
 

--- a/Sources/_StringProcessing/Regex/DSLTree.swift
+++ b/Sources/_StringProcessing/Regex/DSLTree.swift
@@ -651,6 +651,10 @@ extension CaptureList.Builder {
         addCaptures(of: child, optionalNesting: nesting, visibleInTypedOutput: visibleInTypedOutput)
       case .clearer, .repeater, .stopper:
         break
+      #if RESILIENT_LIBRARIES
+      @unknown default:
+        fatalError()
+      #endif
       }
 
     case let .convertedRegexLiteral(n, _):
@@ -926,6 +930,10 @@ extension DSLTree {
           return true
         case .exactly(let num), .nOrMore(let num), .range(let num, _):
           return num.value.map { $0 > 0 } ?? false
+        #if RESILIENT_LIBRARIES
+        @unknown default:
+          fatalError()
+        #endif
         }
       }
     }


### PR DESCRIPTION
When building with CMake during the Swift compiler build, the libraries in this package are built with library evolution enabled. That causes the compiler to emit diagnostics that encourage use of `@unknown default` to handle unknown cases that might be added in the future. Silence these warnings by adding `@unknown default` cases where they are missing. Guard these with the `RESILIENT_LIBRARIES` compilation condition to avoid triggering a `Default will never be executed` diagnostic during the package build.

Note that this would not be required if `_RegexParser` could always build without library evolution, but that change had to be reverted (rdar://124541877).