### PR TITLE
Support change matching options in Regex refactoring

### DIFF
--- a/Sources/_RegexParser/Regex/Printing/PrettyPrinter.swift
+++ b/Sources/_RegexParser/Regex/Printing/PrettyPrinter.swift
@@ -43,6 +43,9 @@ public struct PrettyPrinter {
   
   // The current default quantification behavior
   public var quantificationBehavior: AST.Quantification.Kind = .eager
+
+  // A stack of the current added inline matching options, e.g. (?s)
+  public var inlineMatchingOptions: [[AST.MatchingOption]] = []
 }
 
 // MARK: - Raw interface
@@ -141,5 +144,19 @@ extension PrettyPrinter {
     print("\(header) \(startDelimiter)")
     printIndented(f)
     print(endDelimiter)
+  }
+
+  /// Pushes the list of matching options to the current stack of other matching
+  /// options and increases the indentation level by 1.
+  public mutating func pushMatchingOptions(_ options: [AST.MatchingOption]) {
+    indentLevel += 1
+    inlineMatchingOptions.append(options)
+  }
+
+  /// Pops the most recent list of matching options from the printer and
+  /// decreases the indentation level by 1.
+  public mutating func popMatchingOptions() -> [AST.MatchingOption] {
+    indentLevel -= 1
+    return inlineMatchingOptions.removeLast()
   }
 }

--- a/Sources/_RegexParser/Regex/Printing/PrettyPrinter.swift
+++ b/Sources/_RegexParser/Regex/Printing/PrettyPrinter.swift
@@ -44,8 +44,9 @@ public struct PrettyPrinter {
   // The current default quantification behavior
   public var quantificationBehavior: AST.Quantification.Kind = .eager
 
-  // A stack of the current added inline matching options, e.g. (?s)
-  public var inlineMatchingOptions: [[AST.MatchingOption]] = []
+  // A stack of the current added inline matching options, e.g. (?s) and a
+  // boolean indicating true = added (?s) and false = removed (?-s).
+  public var inlineMatchingOptions: [([AST.MatchingOption], Bool)] = []
 }
 
 // MARK: - Raw interface
@@ -148,14 +149,17 @@ extension PrettyPrinter {
 
   /// Pushes the list of matching options to the current stack of other matching
   /// options and increases the indentation level by 1.
-  public mutating func pushMatchingOptions(_ options: [AST.MatchingOption]) {
+  public mutating func pushMatchingOptions(
+    _ options: [AST.MatchingOption],
+    isAdded: Bool
+  ) {
     indentLevel += 1
-    inlineMatchingOptions.append(options)
+    inlineMatchingOptions.append((options, isAdded))
   }
 
   /// Pops the most recent list of matching options from the printer and
   /// decreases the indentation level by 1.
-  public mutating func popMatchingOptions() -> [AST.MatchingOption] {
+  public mutating func popMatchingOptions() -> ([AST.MatchingOption], Bool) {
     indentLevel -= 1
     return inlineMatchingOptions.removeLast()
   }

--- a/Sources/_StringProcessing/PrintAsPattern.swift
+++ b/Sources/_StringProcessing/PrintAsPattern.swift
@@ -74,6 +74,51 @@ extension PrettyPrinter {
     printBlock("Regex") { printer in
       printer.printAsPattern(convertedFromAST: node, isTopLevel: true)
     }
+
+    printInlineMatchingOptions()
+  }
+
+  mutating func printInlineMatchingOptions() {
+    for matchingOptions in inlineMatchingOptions {
+      let options = popMatchingOptions()
+
+      printIndented { printer in
+        for option in options {
+          switch option.kind {
+          case .asciiOnlyDigit:
+            printer.print(".asciiOnlyDigits()")
+
+          case .asciiOnlyPOSIXProps:
+            printer.print(".asciiOnlyCharacterClasses()")
+
+          case .asciiOnlySpace:
+            printer.print(".asciiOnlyWhitespace()")
+
+          case .asciiOnlyWord:
+            printer.print(".asciiOnlyWordCharacters()")
+
+          case .caseInsensitive:
+            printer.print(".ignoresCase()")
+
+          case .multiline:
+            printer.print(".anchorsMatchLineEndings()")
+
+          case .reluctantByDefault:
+            // This is handled by altering every OneOrMore, etc by changing each
+            // individual repetition behavior instead of creating a nested regex.
+            continue
+
+          case .singleLine:
+            printer.print(".dotMatchesNewlines()")
+
+          default:
+            break
+          }
+        }
+      }
+
+      print("}")
+    }
   }
 
   // FIXME: Use of back-offs like height and depth
@@ -424,7 +469,7 @@ extension PrettyPrinter {
     // Also in the same vein, if we have a few atom members but no
     // nonAtomMembers, then we can emit a single .anyOf(...) for them.
     if !charMembers.isEmpty, nonCharMembers.isEmpty {
-      let anyOf = ".anyOf(\(charMembers))"
+      let anyOf = "CharacterClass.anyOf(\(charMembers))"
       
       indent()
       
@@ -502,7 +547,7 @@ extension PrettyPrinter {
         if wrap {
           output("One(.anyOf(\(String(c)._quoted)))")
         } else {
-          output(".anyOf(\(String(c)._quoted))")
+          output("CharacterClass.anyOf(\(String(c)._quoted))")
         }
         
       case let .scalar(s):
@@ -510,7 +555,7 @@ extension PrettyPrinter {
         if wrap {
           output("One(.anyOf(\(s._dslBase._bareQuoted)))")
         } else {
-          output(".anyOf(\(s._dslBase._bareQuoted))")
+          output("CharacterClass.anyOf(\(s._dslBase._bareQuoted))")
         }
         
       case let .unconverted(a):
@@ -538,7 +583,7 @@ extension PrettyPrinter {
       if wrap {
         output("One(.anyOf(\(s._quoted)))")
       } else {
-        output(".anyOf(\(s._quoted))")
+        output("CharacterClass.anyOf(\(s._quoted))")
       }
       
     case .trivia(_):
@@ -1285,10 +1330,20 @@ extension DSLTree.Atom {
         switch add.kind {
         case .reluctantByDefault:
           printer.quantificationBehavior = .reluctant
+
+          // Don't create a nested Regex for (?U), we handle this by altering
+          // every individual repetitionBehavior for things like OneOrMore.
+          if matchingOptions.ast.adding.count == 1 {
+            return nil
+          }
+
         default:
           break
         }
       }
+
+      printer.print("Regex {")
+      printer.pushMatchingOptions(matchingOptions.ast.adding)
     }
     
     return nil

--- a/Sources/_StringProcessing/PrintAsPattern.swift
+++ b/Sources/_StringProcessing/PrintAsPattern.swift
@@ -1339,6 +1339,13 @@ extension DSLTree.Atom {
 
       for option in options {
         switch option.kind {
+        case .extended:
+          // We don't currently support (?x) in the DSL, so if we see it, just
+          // do nothing.
+          if options.count == 1 {
+            return nil
+          }
+
         case .reluctantByDefault:
           if isAdd {
             printer.quantificationBehavior = .reluctant

--- a/Tests/RegexTests/RenderDSLTests.swift
+++ b/Tests/RegexTests/RenderDSLTests.swift
@@ -230,7 +230,7 @@ extension RenderDSLTests {
       """#)
     try testConversion(#"[abc\u{301}]"#, #"""
       Regex {
-        One(.anyOf("abc\u{301}"))
+        One(CharacterClass.anyOf("abc\u{301}"))
       }
       """#)
 
@@ -248,7 +248,7 @@ extension RenderDSLTests {
 
     try testConversion(#"(?x) [ a b c \u{301} ] "#, #"""
       Regex {
-        One(.anyOf("abc\u{301}"))
+        One(CharacterClass.anyOf("abc\u{301}"))
       }
       """#)
 

--- a/Tests/RegexTests/RenderDSLTests.swift
+++ b/Tests/RegexTests/RenderDSLTests.swift
@@ -306,7 +306,7 @@ extension RenderDSLTests {
   func testCharacterClass() throws {
     try testConversion(#"[abc]+"#, #"""
       Regex {
-        OneOrMore(.anyOf("abc"))
+        OneOrMore(CharacterClass.anyOf("abc"))
       }
       """#)
 
@@ -335,6 +335,57 @@ extension RenderDSLTests {
             .whitespace
           )
         }
+      }
+      """#)
+
+    try testConversion(#"[^i]*"#, #"""
+      Regex {
+        ZeroOrMore(CharacterClass.anyOf("i").inverted)
+      }
+      """#)
+  }
+
+  func testChangeMatchingOptions() throws {
+    try testConversion(#"(?s).*(?-s).*"#, #"""
+      Regex {
+        Regex {
+          ZeroOrMore {
+            /./
+          }
+          Regex {
+            ZeroOrMore {
+              /./
+            }
+          }
+          .dotMatchesNewlines(false)
+        }
+        .dotMatchesNewlines(true)
+      }
+      """#)
+
+    try testConversion(#"(?U)a+(?-U)a+"#, #"""
+      Regex {
+        OneOrMore(.reluctant) {
+          "a"
+        }
+        OneOrMore {
+          "a"
+        }
+      }
+      """#)
+
+    try testConversion(#"(?sim)hello(?-s)world"#, #"""
+      Regex {
+        Regex {
+          "hello"
+          Regex {
+            "world"
+          }
+          .dotMatchesNewlines(false)
+        }
+        .dotMatchesNewlines(true)
+        .ignoresCase(true)
+        .anchorsMatchLineEndings(true)
       }
       """#)
   }


### PR DESCRIPTION
This adds support for tokens like `(?s)` and `(?-s)` in converting a regex literal to the pattern DSL. We need to make a new `Regex` scope to apply those options to.

Also, print out `CharacterClass.anyOf` in some situations to avoid ambiguity in the type checker.

Resolves: rdar://124965493 and rdar://119988624