### PR TITLE
[6.0] Fix word boundary matching in `matches(of:)`

### DIFF
--- a/Sources/_StringProcessing/Engine/MEBuiltins.swift
+++ b/Sources/_StringProcessing/Engine/MEBuiltins.swift
@@ -105,14 +105,14 @@ extension Processor {
       if payload.usesSimpleUnicodeBoundaries {
         return atSimpleBoundary(payload.usesASCIIWord, payload.semanticLevel)
       } else {
-        return input.isOnWordBoundary(at: currentPosition, in: searchBounds, using: &wordIndexCache, &wordIndexMaxIndex)
+        return input.isOnWordBoundary(at: currentPosition, in: subjectBounds, using: &wordIndexCache, &wordIndexMaxIndex)
       }
 
     case .notWordBoundary:
       if payload.usesSimpleUnicodeBoundaries {
         return !atSimpleBoundary(payload.usesASCIIWord, payload.semanticLevel)
       } else {
-        return !input.isOnWordBoundary(at: currentPosition, in: searchBounds, using: &wordIndexCache, &wordIndexMaxIndex)
+        return !input.isOnWordBoundary(at: currentPosition, in: subjectBounds, using: &wordIndexCache, &wordIndexMaxIndex)
       }
     }
   }

--- a/Tests/RegexTests/MatchTests.swift
+++ b/Tests/RegexTests/MatchTests.swift
@@ -256,6 +256,33 @@ func matchTest(
 
 // TODO: Adjust below to also check captures
 
+/// Test all matches in a string, using `matches(of:)`.
+func allMatchesTest(
+  _ regex: String,
+  input: String,
+  matches: [Substring],
+  xfail: Bool = false,
+  semanticLevel: RegexSemanticLevel = .graphemeCluster,
+  file: StaticString = #filePath,
+  line: UInt = #line
+) {
+  do {
+    let regex = try Regex(regex).matchingSemantics(semanticLevel)
+    let allMatches = input.matches(of: regex).map(\.0)
+
+    if xfail {
+      XCTAssertNotEqual(allMatches, matches, file: file, line: line)
+    } else {
+      XCTAssertEqual(allMatches, matches, "Incorrect match", file: file, line: line)
+    }
+  } catch {
+    if !xfail {
+      XCTFail("\(error)", file: file, line: line)
+    }
+    return
+  }
+}
+
 /// Test the first match in a string, via `firstRange(of:)`
 func firstMatchTest(
   _ regex: String,
@@ -1667,6 +1694,15 @@ extension RegexTests {
       ("123", "23"),
       (" 123", "23"),
       ("123 456", "23"))
+    
+    allMatchesTest(
+      #"\b\w"#,
+      input: "ab cd efgh",
+      matches: ["a", "c", "e"])
+    allMatchesTest(
+      #"\B\w"#,
+      input: "ab cd efgh",
+      matches: ["b", "d", "f", "g", "h"])
 
     let defaultBoundaryRegex = try Regex(#"\b.{3}X.{3}\b"#)
     // Default word boundaries match at the start/end of a string/line.


### PR DESCRIPTION
- Explanation: Fixes a regression in Swift 5.9.2 where `\b` matches at every position in a `matches(of:)` search when used at the beginning of a pattern.
- Original PR: #744
- Risk: Low. Already on main.
- Reviewed by: @milseman 
- Resolves: rdar://129417643
- Tests: Full swift-ci testing and full string-processing package testing

Cherry pick of #744 to the `swift/release/6.0` branch.