### PR TITLE
Add `@_effects(readnone)` to string-based Regex inits

### DIFF
--- a/Sources/_StringProcessing/Regex/AnyRegexOutput.swift
+++ b/Sources/_StringProcessing/Regex/AnyRegexOutput.swift
@@ -178,10 +178,12 @@ extension Regex where Output == AnyRegexOutput {
   /// ``init(_:as:)`` initializer instead.
   ///
   /// - Parameter pattern: A string with regular expression syntax.
+  @_effects(readnone)
   public init(_ pattern: String) throws {
     self.init(ast: try parse(pattern, .traditional))
   }
   
+  @_effects(readnone)
   internal init(_ pattern: String, syntax: SyntaxOptions) throws {
     self.init(ast: try parse(pattern, syntax))
   }
@@ -212,6 +214,7 @@ extension Regex {
   /// - Parameters:
   ///   - pattern: A string with regular expression syntax.
   ///   - outputType: The desired type for the output captures.
+  @_effects(readnone)
   public init(
     _ pattern: String,
     as outputType: Output.Type = Output.self

--- a/Sources/_StringProcessing/Regex/Core.swift
+++ b/Sources/_StringProcessing/Regex/Core.swift
@@ -103,6 +103,7 @@ public struct Regex<Output>: RegexComponent {
   }
 
   // Compiler interface. Do not change independently.
+  @_effects(readnone)
   @usableFromInline
   init(_regexString pattern: String) {
     self.init(ast: try! parse(pattern, .traditional))


### PR DESCRIPTION
It doesn't seem like regex instantiation is being hoisted out of loops, which means that both the parsing (which happens at runtime) and compilation (which happens on first use) are being lost for string-based and possibly literal regexes. This may address the issue.

There are at least two other initializers that could/should have this attribute ([1](https://github.com/swiftlang/swift-experimental-string-processing/blob/main/Sources/_StringProcessing/Regex/AnyRegexOutput.swift#L250) [2](https://github.com/swiftlang/swift-experimental-string-processing/blob/main/Sources/_StringProcessing/Regex/Core.swift#L113)), but adding it causes a compiler crash.