### PR TITLE
Fix compiler warnings in ByteCodeGen, Compiler, and Regex

### DIFF
--- a/Sources/_StringProcessing/ByteCodeGen+DSLList.swift
+++ b/Sources/_StringProcessing/ByteCodeGen+DSLList.swift
@@ -713,13 +713,13 @@ fileprivate extension Compiler.ByteCodeGen {
       default:
         return false
       }
-    case .limitCaptureNesting(let node):
+    case .limitCaptureNesting:
       if tryEmitFastQuant(&list, kind, minTrips, maxExtraTrips) {
         return true
       } else {
         return false
       }
-    case .nonCapturingGroup(let groupKind, let node):
+    case .nonCapturingGroup(let groupKind, _):
       // .nonCapture nonCapturingGroups are ignored during compilation
       guard groupKind.ast == .nonCapture else {
         return false
@@ -796,10 +796,10 @@ fileprivate extension Compiler.ByteCodeGen {
     case let .nonCapturingGroup(kind, _):
       try emitNoncapturingGroup(kind.ast, &list)
       
-    case let .ignoreCapturesInTypedOutput(_):
+    case .ignoreCapturesInTypedOutput(_):
       try emitNode(&list)
       
-    case let .limitCaptureNesting(_):
+    case .limitCaptureNesting(_):
       return try emitNode(&list)
       
     case .conditional:
@@ -864,10 +864,10 @@ extension Compiler.ByteCodeGen {
         try skipNode(&list, preservingCaptures: preservingCaptures)
       }
 
-    case let .capture(name, refId, _, transform):
+    case let .capture(name, refId, _, _):
       options.beginScope()
       defer { options.endScope() }
-      
+
       if preservingCaptures {
         let cap = builder.makeCapture(id: refId, name: name)
         builder.buildBeginCapture(cap)
@@ -877,7 +877,7 @@ extension Compiler.ByteCodeGen {
         try skipNode(&list, preservingCaptures: preservingCaptures)
       }
       
-    case let .nonCapturingGroup(kind, _):
+    case .nonCapturingGroup(_, _):
       try skipNode(&list, preservingCaptures: preservingCaptures)
 
     case .ignoreCapturesInTypedOutput:
@@ -886,9 +886,9 @@ extension Compiler.ByteCodeGen {
     case .limitCaptureNesting:
       try skipNode(&list, preservingCaptures: preservingCaptures)
 
-    case let .quantification(amt, kind, _):
+    case .quantification(_, _, _):
       try skipNode(&list, preservingCaptures: preservingCaptures)
-      
+
     case .customCharacterClass, .atom, .quotedLiteral, .matcher:
       break
       

--- a/Sources/_StringProcessing/Compiler.swift
+++ b/Sources/_StringProcessing/Compiler.swift
@@ -46,7 +46,7 @@ class Compiler {
   
   __consuming func emitViaTree() throws -> MEProgram {
     // TODO: Handle global options
-    var codegen = ByteCodeGen(
+    _ = ByteCodeGen(
       options: options,
       compileOptions:
         compileOptions,

--- a/Sources/_StringProcessing/Regex/ASTConversion.swift
+++ b/Sources/_StringProcessing/Regex/ASTConversion.swift
@@ -25,7 +25,7 @@ extension AST.Node {
       for child in alternation.children {
         try child.convert(into: &list)
       }
-    case .concatenation(let concatenation):
+    case .concatenation(_):
       let coalesced = self.coalescedChildren
       list.append(.concatenation(Array(repeating: TEMP_FAKE_NODE, count: coalesced.count)))
       for child in coalesced {
@@ -77,6 +77,8 @@ extension AST.Node {
       list.append(.absentFunction(.init(ast: abs)))
     case .empty(_):
       list.append(.empty)
+    @unknown default:
+      throw Unsupported("Unknown AST node")
     }
   }
   
@@ -145,6 +147,8 @@ extension AST.Node {
     case .quantification(let quant):
       return [quant.child]
     case .quote, .trivia, .interpolation, .atom, .customCharacterClass, .absentFunction, .empty:
+      return []
+    @unknown default:
       return []
     }
   }

--- a/Sources/_StringProcessing/Regex/DSLTree.swift
+++ b/Sources/_StringProcessing/Regex/DSLTree.swift
@@ -802,19 +802,19 @@ extension CaptureList.Builder {
         optionalDepth: nesting.depth, visibleInTypedOutput: visibleInTypedOutput, .fake))
       addCaptures(in: &list, optionalNesting: nesting, visibleInTypedOutput: visibleInTypedOutput)
 
-    case let .nonCapturingGroup(kind, child):
+    case .nonCapturingGroup(let kind, _):
       assert(!kind.ast.isCapturing)
       addCaptures(in: &list, optionalNesting: nesting, visibleInTypedOutput: visibleInTypedOutput)
-      
-    case let .ignoreCapturesInTypedOutput(child):
+
+    case .ignoreCapturesInTypedOutput(_):
       addCaptures(in: &list, optionalNesting: nesting, visibleInTypedOutput: false)
 
-    case let .limitCaptureNesting(child):
+    case .limitCaptureNesting(_):
       addCaptures(in: &list, optionalNesting: nesting.disablingNesting, visibleInTypedOutput: visibleInTypedOutput)
-      
-    case let .conditional(cond, trueBranch, falseBranch):
+
+    case let .conditional(cond, _, _):
       switch cond.ast {
-      case .group(let g):
+      case .group(_):
         addCaptures(in: &list, optionalNesting: nesting, visibleInTypedOutput: visibleInTypedOutput)
       default:
         break
@@ -823,7 +823,7 @@ extension CaptureList.Builder {
       addCaptures(in: &list, optionalNesting: nesting.addingOptional, visibleInTypedOutput: visibleInTypedOutput)
       addCaptures(in: &list, optionalNesting: nesting.addingOptional, visibleInTypedOutput: visibleInTypedOutput)
 
-    case let .quantification(amount, _, child):
+    case let .quantification(amount, _, _):
       var optNesting = nesting
       if amount.ast.bounds.atLeast == 0 {
         optNesting = optNesting.addingOptional
@@ -832,7 +832,7 @@ extension CaptureList.Builder {
 
     case let .absentFunction(abs):
       switch abs.ast.kind {
-      case .expression(_, _, let child):
+      case .expression(_, _, _):
         addCaptures(in: &list, optionalNesting: nesting, visibleInTypedOutput: visibleInTypedOutput)
       case .clearer, .repeater, .stopper:
         break
@@ -1225,7 +1225,7 @@ extension DSLTree {
       }
       
       internal var isChangeMatchingOptions: Bool {
-        if case let .changeMatchingOptions = ast {
+        if case .changeMatchingOptions = ast {
           return true
         } else {
           return false


### PR DESCRIPTION
- Replace unused `let` bindings with `_` in ByteCodeGen+DSLList.swift
- Replace unused `var codegen` with `_ =` in Compiler.swift
- Add `@unknown default` to exhaustive switches on `AST.Node` in ASTConversion.swift since the switch enumerates cases from a library with library evolution in some build configurations
- Fix unused bindings and no-effect `let` patterns in DSLTree.swift and ASTConversion.swift